### PR TITLE
docs: clarify Patchmill software factory framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The two main workflow stations are:
   issue, creates or reuses a plan, runs implementation, reviews or lands the
   result, and records the outcome.
 
+Planned: `patchmill run` will start the factory loop. It will keep selecting the
+next ready issue and running the same controlled production process until there
+is no eligible work left, a configured issue/budget limit is reached, or a
+blocker requires human input.
+
 The controls stay close to the work: labels decide what is ready, dry runs show
 what Patchmill would do before it mutates the issue host, plans make scope
 reviewable, run logs preserve progress, and repository skills let teams encode

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ CLI flags override environment variables, and environment variables override
 
 Patchmill uses Pi as the runtime harness for configurable agent work. Most users
 start by configuring issue hosts, labels, paths, and skills; Pi becomes relevant
-when you want to customize the runtime, agent delegation, models, tools, context
-behavior, or reusable multi-agent workflows.
+when you want to customize the runtime, delegated agent roles, models, tools, or
+context behavior.
 
 Patchmill includes `pi-subagents`; users do not install it separately.
 Implementation prompts can rely on the Pi `subagent` tool and the agents
@@ -148,12 +148,6 @@ Agent files define reusable delegated roles and can live in:
 
 - `~/.pi/agent/agents/**/*.md` for user-scope agents
 - `.pi/agents/**/*.md` for project-scope agents
-
-Chain files define reusable multi-agent sequences, such as a planning step
-followed by parallel worker/reviewer passes. They can live in:
-
-- `~/.pi/agent/chains/**/*.chain.md`
-- `.pi/chains/**/*.chain.md`
 
 Settings overrides can live in `~/.pi/agent/settings.json` or
 `.pi/settings.json`. For example:

--- a/README.md
+++ b/README.md
@@ -6,22 +6,35 @@
   </picture>
 </p>
 
-Patchmill is an agent-driven software factory where humans and agents
-collaborate through intentional, understandable patches—preserving software
-craftsmanship while making iterative engineering feel industrial and scalable.
+Patchmill is an agent-driven software factory for turning product work into
+reviewed, landed changes without hiding the engineering judgment between idea
+and production.
+
+It gives automated development an explicit production line: intake incoming
+work, sort what is ready, write or reuse a plan, implement in an isolated
+worktree, review the result, collect evidence when needed, land the change, and
+record what happened. The goal is not a black box that writes code for you; it
+is a factory floor where every station is visible, configurable, and designed to
+preserve software craftsmanship while making iterative engineering scalable.
 
 ## What Patchmill does
 
-Patchmill connects issue trackers, Pi agents, repository policy, and git
-worktrees so a repository can move from open issues to reviewed diffs with clear
-handoffs.
+Patchmill connects an issue host, repository policy, git worktrees, and
+configurable workflow instructions so a repository can move from open product
+work to reviewed diffs with clear handoffs.
 
-The two main workflows are:
+The two main workflow stations are:
 
-- `patchmill triage` classifies open issues and can apply readiness
-  labels/comments.
-- `patchmill run-once` claims one ready issue, plans the work, runs
-  implementation, reviews/lands the result, and records the outcome.
+- `patchmill triage` is the intake/sorting station. It classifies open issues
+  and can apply readiness labels or comments.
+- `patchmill run-once` is the one-issue production run. It claims one ready
+  issue, creates or reuses a plan, runs implementation, reviews or lands the
+  result, and records the outcome.
+
+The controls stay close to the work: labels decide what is ready, dry runs show
+what Patchmill would do before it mutates the issue host, plans make scope
+reviewable, run logs preserve progress, and repository skills let teams encode
+their own process.
 
 `patchmill triage` executes the configured triage skill by default and reports
 what changed. Use `patchmill triage --dry-run` to preview the labels, comments,
@@ -45,12 +58,11 @@ patchmill run-once --dry-run
 patchmill run-once --execute
 ```
 
-`patchmill init` writes a minimal local `patchmill.config.json`, reminds you how
-to change the default host login, and, when Pi provider setup is not apparent,
-can open Pi so you can run `/login` or prints install guidance if Pi is not
-available. `patchmill doctor` is read-only: it checks git, host access, labels,
-Pi, configured skills, and local paths, verifying bundled/path-like skills and
-flagging name-only skills as unverified before recommending dry runs.
+`patchmill init` writes a minimal local `patchmill.config.json` and reminds you
+how to change the default host login. `patchmill doctor` is read-only: it checks
+git, host access, labels, configured skills, runtime access, and local paths,
+verifying bundled/path-like skills and flagging name-only skills as unverified
+before recommending dry runs.
 
 ## Configuration
 
@@ -63,9 +75,6 @@ workflow looks like this:
   "host": {
     "provider": "forgejo-tea",
     "login": "triage-agent"
-  },
-  "pi": {
-    "triageThinking": "high"
   },
   "skills": {
     "triage": "patchmill-issue-triage",
@@ -90,19 +99,14 @@ The default skills keep the workflow small and explicit:
 - `superpowers:subagent-driven-development` executes approved plans with
   worker/reviewer handoffs.
 
+Accepted `host.provider` values are `forgejo-tea` for Forgejo/Gitea through
+`tea` and `github-gh` for GitHub through `gh`.
+
 Customize `skills` when your repository needs different procedures. Optional
 skill hooks include `toolchain`, `review`, `visualEvidence`, and `landing`; see
 [skills configuration](docs/skills.md) for details and
 [configuration examples](docs/configuration.md) for a fuller
 `patchmill.config.json`.
-
-Patchmill bundles `pi-subagents` for implementation delegation. The default
-implementation skill, `superpowers:subagent-driven-development`, can use
-pi-subagents builtin agents such as `worker`, `reviewer`, `scout`, `planner`,
-`context-builder`, `researcher`, `delegate`, and `oracle`. Customize those
-agents with normal pi-subagents user or project configuration when your
-repository needs different models, tools, context behavior, or nested
-delegation.
 
 ## Environment variables
 
@@ -121,18 +125,27 @@ upload credentials that should not live in `patchmill.config.json`.
 CLI flags override environment variables, and environment variables override
 `patchmill.config.json`.
 
-## Subagents
+## Runtime and subagent customization
+
+Patchmill uses Pi as the runtime harness for configurable agent work. Most users
+start by configuring issue hosts, labels, paths, and skills; Pi becomes relevant
+when you want to customize the runtime, agent delegation, models, tools, context
+behavior, or reusable multi-agent workflows.
 
 Patchmill includes `pi-subagents`; users do not install it separately.
 Implementation prompts can rely on the Pi `subagent` tool and the agents
-discovered by pi-subagents.
+discovered by pi-subagents. The default implementation skill,
+`superpowers:subagent-driven-development`, can use pi-subagents builtin agents
+such as `worker`, `reviewer`, `scout`, `planner`, `context-builder`,
+`researcher`, `delegate`, and `oracle`.
 
-Agent files can live in:
+Agent files define reusable delegated roles and can live in:
 
 - `~/.pi/agent/agents/**/*.md` for user-scope agents
 - `.pi/agents/**/*.md` for project-scope agents
 
-Chain files can live in:
+Chain files define reusable multi-agent sequences, such as a planning step
+followed by parallel worker/reviewer passes. They can live in:
 
 - `~/.pi/agent/chains/**/*.chain.md`
 - `.pi/chains/**/*.chain.md`
@@ -171,9 +184,11 @@ Follow this repository's implementation conventions. Escalate unclear product or
 architecture decisions instead of guessing.
 ```
 
-If you want a child agent to delegate further, include the `subagent` tool in
-that agent's tools and configure nesting/depth through pi-subagents settings.
-Patchmill does not override those user choices.
+Customize agents with normal pi-subagents user or project configuration when
+your repository needs different models, tools, context behavior, or nested
+delegation. If you want a child agent to delegate further, include the
+`subagent` tool in that agent's tools and configure nesting/depth through
+pi-subagents settings. Patchmill does not override those user choices.
 
 ## State paths
 
@@ -187,8 +202,8 @@ These paths are local workflow state, not source documentation.
 ## Issue-agent workflows
 
 For a deeper newcomer-friendly walkthrough,
-[issue-agent workflows](docs/issue-agent-workflows.md) explains how triage
-selects and labels issues, how `run-once` claims work, how Pi planning and
+[issue-agent workflows](docs/issue-agent-workflows.md) explains how the intake
+station selects and labels issues, how `run-once` claims work, how planning and
 implementation prompts are shaped, and where Patchmill records progress and
 safety checkpoints.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,9 @@ Patchmill fills omitted labels, paths, skills, and git policy from defaults, and
 the command output reminds you that you can later change the login in
 `patchmill.config.json` (`host.login`) or with `PATCHMILL_HOST_LOGIN`.
 
+Accepted `host.provider` values are `forgejo-tea` for Forgejo/Gitea through
+`tea` and `github-gh` for GitHub through `gh`.
+
 Run `patchmill doctor` after initialization to validate the config and local
 toolchain before dry runs.
 
@@ -135,9 +138,13 @@ pieces your repository needs.
 
 ## Host providers
 
-The default host provider is `forgejo-tea`, which uses Forgejo/Gitea through
-`tea` and supports named logins via `host.login`, `--host-login`, and
-`PATCHMILL_HOST_LOGIN`.
+`host.provider` must be one of:
+
+- `forgejo-tea`: Forgejo/Gitea through `tea`.
+- `github-gh`: GitHub through `gh`.
+
+The default host provider is `forgejo-tea`, which supports named logins via
+`host.login`, `--host-login`, and `PATCHMILL_HOST_LOGIN`.
 
 For GitHub through `gh`, configure the host like this:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,11 +211,10 @@ Patchmill defaults them to:
 Patchmill bundles `pi-subagents`, and `skills.implementation` defaults to
 `superpowers:subagent-driven-development`.
 
-Customize subagents through pi-subagents configuration rather than
-`patchmill.config.json`:
+Customize subagent roles and runtime settings through pi-subagents configuration
+rather than `patchmill.config.json`:
 
 - `.pi/agents/**/*.md`
-- `.pi/chains/**/*.chain.md`
 - `.pi/settings.json`
 
 Optional skill keys let a repository add procedure at specific workflow stages:

--- a/docs/issue-agent-workflows.md
+++ b/docs/issue-agent-workflows.md
@@ -123,7 +123,7 @@ Source files:
 - Pipeline: `src/cli/commands/run-once/pipeline.ts`
 - Prompt builders: `src/cli/commands/run-once/prompts.ts`
 - Pi runner/result parser: `src/cli/commands/run-once/pi.ts`
-- Subagent support: bundled pi-subagents and implementation prompt guidance
+- Subagent support: bundled runtime support and implementation prompt guidance
 - Issue selection: `src/cli/commands/run-once/selection.ts`
 - Progress/logging: `src/cli/commands/run-once/progress.ts`,
   `src/cli/commands/run-once/console-progress.ts`
@@ -158,7 +158,7 @@ flowchart TD
   P --> R{Plan-only or approval required?}
   P2 --> R
   R -->|yes| R1[Comment plan ready, restore ready label, finish]
-  R -->|no| S[Render pi-subagents support guidance]
+  R -->|no| S[Render subagent support guidance]
   S --> T[Ensure issue worktree and branch]
   T --> U[Run Pi implementation prompt in worktree]
   U --> V{Pi result}
@@ -252,8 +252,7 @@ asks Pi to implement from the issue worktree. The prompt includes:
 
 - issue data, labels, plan path, branch, and worktree path;
 - the untrusted issue-content boundary;
-- pi-subagents support guidance for delegated implementation and review
-  workflows;
+- subagent support guidance for delegated implementation and review roles;
 - resume context, when continuing an existing run;
 - issue body and relevant comments;
 - required project context-file instructions;
@@ -268,16 +267,13 @@ asks Pi to implement from the issue worktree. The prompt includes:
 - visual evidence requirements;
 - direct-land versus PR fallback policy.
 
-The prompt includes pi-subagents support guidance for delegated implementation
-and review workflows. It tells Pi that Patchmill bundles `pi-subagents`, that
-implementation prompts may rely on the Pi `subagent` tool, and that agent,
-chain, and settings discovery follows normal pi-subagents user and project
-locations:
+The prompt includes subagent support guidance for delegated implementation and
+review roles. It tells Pi that Patchmill bundles `pi-subagents`, that
+implementation prompts may rely on the Pi `subagent` tool, and that agent and
+settings discovery follows normal pi-subagents user and project locations:
 
 - `~/.pi/agent/agents/**/*.md`
 - `.pi/agents/**/*.md`
-- `~/.pi/agent/chains/**/*.chain.md`
-- `.pi/chains/**/*.chain.md`
 - `~/.pi/agent/settings.json`
 - `.pi/settings.json`
 
@@ -301,10 +297,10 @@ separately:
 - `Use the configured landing skill for the direct-land versus PR decision: <skills.landing>.`
 
 Patchmill does not hard-code the individual worker/reviewer task prompts in this
-repository. Instead, the implementation Pi session follows the configured skill
-lines and any pi-subagents behavior they direct. Composite behavior belongs in
-the configured skills. Patchmill observes those subagent tool calls through the
-Pi session stream and records concise progress events.
+repository. Instead, Patchmill controls the production workflow and the
+implementation Pi session follows the configured skill lines plus any delegated
+agent behavior they direct. Patchmill observes those subagent tool calls through
+the Pi session stream and records concise progress events.
 
 The implementation prompt accepts these final statuses:
 

--- a/docs/issue-agent-workflows.md
+++ b/docs/issue-agent-workflows.md
@@ -1,13 +1,15 @@
 # Issue agent workflows
 
-Patchmill has two issue-agent workflows:
+Patchmill has two issue-agent workflows. Together they act as the main stations
+of the software factory: intake/sorting for incoming work, then one-issue
+production runs for ready work.
 
-- **Triage** (`patchmill triage`) classifies open issues and, when executed,
-  runs the configured triage skill, which may apply labels/comments on the issue
-  host.
-- **Run once** (`patchmill run-once`) claims one automation-ready issue, asks Pi
-  to create or use an implementation plan, asks Pi to implement/review/land the
-  work, then updates the issue host.
+- **Triage** (`patchmill triage`) is the intake/sorting station. It classifies
+  open issues and, when executed, runs the configured triage skill, which may
+  apply labels/comments on the issue host.
+- **Run once** (`patchmill run-once`) is the one-issue production station. It
+  claims one automation-ready issue, creates or uses an implementation plan,
+  runs implementation/review/landing, then updates the issue host.
 
 Before running issue-agent workflows in a new repository, run:
 

--- a/docs/plans/2026-05-28-patchmill-readme-docs.md
+++ b/docs/plans/2026-05-28-patchmill-readme-docs.md
@@ -1,0 +1,87 @@
+# Patchmill README Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clarify Patchmill's README and supporting docs so newcomers understand
+it as a software factory before seeing runtime/customization details.
+
+**Architecture:** This is a documentation-only change. Update the README
+first-impression sections, then align provider/configuration/skill docs so
+supported hosts, provider values, and extensibility terms are easy to find.
+
+**Tech Stack:** Markdown documentation, existing project docs, markdown
+lint/rendering checks.
+
+---
+
+## Task 1: Rewrite the README first impression
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Replace the introductory product framing**
+
+Replace the current opening paragraph and `What Patchmill does` body with copy
+that explains Patchmill as an agent-driven software factory moving product work
+through intake, planning, implementation, review, evidence, and landing. Do not
+mention Pi in the opening section.
+
+- [ ] **Step 2: Make supported issue hosts explicit near the top**
+
+Add a short requirements/support paragraph near the first-use content naming
+Forgejo/Gitea through `tea` (`forgejo-tea`) and GitHub through `gh`
+(`github-gh`).
+
+- [ ] **Step 3: Move runtime/customization concepts later**
+
+Keep Pi, subagents, skills, and chain files in later customization/extensibility
+sections, not the README first impression.
+
+## Task 2: Align supporting docs
+
+**Files:**
+
+- Modify: `docs/configuration.md`
+- Modify: `docs/providers.md`
+- Modify: `docs/skills.md`
+- Modify: `docs/issue-agent-workflows.md`
+
+- [ ] **Step 1: Clarify provider values**
+
+Ensure `docs/configuration.md` and `docs/providers.md` plainly list accepted
+`host.provider` values: `forgejo-tea` and `github-gh`.
+
+- [ ] **Step 2: Clarify extensibility vocabulary**
+
+In `docs/skills.md`, add a short explanation that skills are reusable workflow
+instructions, subagents are delegated implementation/review roles, and chain
+files define reusable multi-agent sequences.
+
+- [ ] **Step 3: Improve workflow framing**
+
+In `docs/issue-agent-workflows.md`, add or adjust the opening so the workflows
+are described as stations in the software factory: intake/sorting and one-issue
+production runs.
+
+## Task 3: Verify documentation changes
+
+**Files:**
+
+- Verify: `README.md`
+- Verify: `docs/*.md`
+
+- [ ] **Step 1: Run formatting/lint checks available for markdown**
+
+Run `npm test` or the narrower documentation check if available in
+`package.json`. If no docs-only command exists, run the existing test suite and
+report the result.
+
+- [ ] **Step 2: Inspect git diff**
+
+Run
+`git diff -- README.md docs/configuration.md docs/providers.md docs/skills.md docs/issue-agent-workflows.md docs/specs/2026-05-28-patchmill-readme-docs-design.md docs/plans/2026-05-28-patchmill-readme-docs.md`
+and confirm the diff matches the approved scope.

--- a/docs/plans/2026-05-28-patchmill-readme-docs.md
+++ b/docs/plans/2026-05-28-patchmill-readme-docs.md
@@ -38,7 +38,7 @@ Forgejo/Gitea through `tea` (`forgejo-tea`) and GitHub through `gh`
 
 - [ ] **Step 3: Move runtime/customization concepts later**
 
-Keep Pi, subagents, skills, and chain files in later customization/extensibility
+Keep Pi, subagent roles, and skills in later customization/extensibility
 sections, not the README first impression.
 
 ## Task 2: Align supporting docs
@@ -58,8 +58,7 @@ Ensure `docs/configuration.md` and `docs/providers.md` plainly list accepted
 - [ ] **Step 2: Clarify extensibility vocabulary**
 
 In `docs/skills.md`, add a short explanation that skills are reusable workflow
-instructions, subagents are delegated implementation/review roles, and chain
-files define reusable multi-agent sequences.
+instructions and subagents are delegated implementation/review roles.
 
 - [ ] **Step 3: Improve workflow framing**
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,8 @@ The current built-in runtime is Pi.
 
 ## Supported issue hosts
 
+Set `host.provider` to one of these values:
+
 - `forgejo-tea`: Forgejo/Gitea through `tea`.
 - `github-gh`: GitHub through `gh`.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -3,6 +3,15 @@
 Patchmill keeps orchestration safety in code and lets repositories choose the Pi
 skills used at each workflow stage.
 
+A few terms appear throughout this page:
+
+- **Skills** are reusable workflow instructions that encode how a repository or
+  team wants a stage handled.
+- **Subagents** are delegated agent roles, such as workers, reviewers, scouts,
+  or planners, used during implementation and review.
+- **Chain files** define reusable multi-agent sequences, such as a planner step
+  followed by parallel worker and reviewer passes.
+
 ## Core contracts kept in Patchmill
 
 - untrusted issue-content boundaries

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -9,8 +9,6 @@ A few terms appear throughout this page:
   team wants a stage handled.
 - **Subagents** are delegated agent roles, such as workers, reviewers, scouts,
   or planners, used during implementation and review.
-- **Chain files** define reusable multi-agent sequences, such as a planner step
-  followed by parallel worker and reviewer passes.
 
 ## Core contracts kept in Patchmill
 
@@ -48,9 +46,10 @@ subagent workflow instructions into skills. For todos, only the removed freeform
 skills; task naming, tagging, body requirements, and done-status behavior stay
 in `projectPolicy.pi.taskContract`.
 
-Subagent workflows run through bundled `pi-subagents`. Patchmill does not define
-models or tools for `worker` and `reviewer`; pi-subagents builtin agents, user
-overrides, and project agent files control that behavior.
+Subagent execution runs through bundled `pi-subagents`. Patchmill controls the
+production workflow around those delegated roles, while pi-subagents builtin
+agents, user overrides, and project agent files control role behavior such as
+models, tools, and context.
 
 Supported keys:
 

--- a/docs/specs/2026-05-28-patchmill-readme-docs-design.md
+++ b/docs/specs/2026-05-28-patchmill-readme-docs-design.md
@@ -1,0 +1,80 @@
+# Patchmill README and Docs Clarification Design
+
+## Context
+
+Anthony's first read of the README showed that Patchmill's opening explanation
+needs to make the product idea easier to grasp before introducing implementation
+machinery. The first impression should not center on Pi or low-level agent
+configuration. It should explain Patchmill as a software factory that helps
+teams move product work through deliberate stages: intake, specification,
+planning, implementation, review, landing, and iteration.
+
+## Goals
+
+- Clarify what Patchmill does from a newcomer's perspective.
+- Present Patchmill as a careful software factory, not merely an issue-board
+  automation loop.
+- Remove first-impression mentions of Pi and defer Pi to
+  customization/extensibility sections.
+- Make supported issue hosts and provider values explicit near
+  first-use/configuration content.
+- Briefly explain extensibility concepts that appear in the README, especially
+  skills, subagents, and chain files.
+- Keep current terminology for `doctor` and `triage`, but explain them through
+  practical CLI meaning rather than relying on metaphor.
+- Record future documentation work for cost/token control, greenfield workflows,
+  and glossary/extensibility depth.
+
+## Non-goals
+
+- Do not implement new Patchmill behavior.
+- Do not rename CLI commands such as `doctor` or `triage` in this pass.
+- Do not write the full cost-control or greenfield guides now; those are tracked
+  as future docs todos.
+- Do not hide Pi entirely; explain it later where readers are ready for
+  customization and extensibility details.
+
+## README Design
+
+Revise the README opening so it answers "what is this?" in product terms:
+
+- Patchmill is an agent-driven software factory for taking product work from
+  issues to reviewed, landed changes.
+- It gives every stage of automated development an explicit station: intake,
+  readiness sorting, planning, implementation, review, evidence, and landing.
+- The user starts by connecting a repository and issue host, running safe checks
+  and dry runs, then allowing Patchmill to process one ready issue at a time.
+- The user remains in control through labels, dry runs, plans, configured
+  skills, run logs, and approval gates.
+
+The README should mention supported issue hosts early: Forgejo/Gitea through
+`tea` and GitHub through `gh`. It should avoid presenting Pi in the opening
+sections. Pi belongs later as the runtime and customization harness.
+
+## Existing Docs Design
+
+Update existing docs only where they clarify first understanding:
+
+- `docs/providers.md`: keep the provider reference concise and ensure accepted
+  `host.provider` values are obvious.
+- `docs/configuration.md`: clarify that most repositories can start with a small
+  config; accepted providers are `forgejo-tea` and `github-gh`.
+- `docs/issue-agent-workflows.md`: preserve workflow detail, but keep
+  user-facing framing around product-work stations rather than making Pi the
+  first concept.
+- `docs/skills.md`: continue to explain customization, including where Pi,
+  skills, subagents, and chain files fit.
+
+## Future Docs Captured as Todos
+
+The following future docs are intentionally not part of this pass:
+
+- Cost and token budget controls.
+- Greenfield project workflow.
+- Patchmill glossary and extensibility concepts.
+
+## Verification
+
+After editing, run repository documentation checks available in this project, at
+minimum markdown lint or README rendering checks if configured, plus the
+existing test suite if practical for the documentation-only change.

--- a/docs/specs/2026-05-28-patchmill-readme-docs-design.md
+++ b/docs/specs/2026-05-28-patchmill-readme-docs-design.md
@@ -19,7 +19,7 @@ planning, implementation, review, landing, and iteration.
 - Make supported issue hosts and provider values explicit near
   first-use/configuration content.
 - Briefly explain extensibility concepts that appear in the README, especially
-  skills, subagents, and chain files.
+  skills and subagent roles.
 - Keep current terminology for `doctor` and `triage`, but explain them through
   practical CLI meaning rather than relying on metaphor.
 - Record future documentation work for cost/token control, greenfield workflows,
@@ -63,7 +63,7 @@ Update existing docs only where they clarify first understanding:
   user-facing framing around product-work stations rather than making Pi the
   first concept.
 - `docs/skills.md`: continue to explain customization, including where Pi,
-  skills, subagents, and chain files fit.
+  skills, and subagent roles fit.
 
 ## Future Docs Captured as Todos
 


### PR DESCRIPTION
## Summary
- Reframes the README opening around Patchmill as a visible, configurable software factory.
- Moves first-impression Pi details into later runtime/customization documentation.
- Clarifies supported host providers and adds concise extensibility vocabulary.

## Test Plan
- [x] npm run lint
- [x] npm test