### PR TITLE
Install project-local default skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ patchmill run-once --execute
 `patchmill init` writes a minimal local `patchmill.config.json`, reminds you to
 change the default host login, and installs Patchmill's recommended skills into
 `.patchmill/skills/` by default so triage, planning, implementation, and
-review/validation behavior are sourced from your repository. Those files should
-be committed because they govern triage, planning, implementation, and
-review/validation behavior.
+review/validation behavior are sourced from your repository. Commit
+`patchmill.config.json` and `.patchmill/skills/` before running
+`patchmill doctor`; doctor expects a clean worktree.
 
 Alternative initialization modes:
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,26 @@ patchmill run-once --dry-run
 patchmill run-once --execute
 ```
 
-`patchmill init` writes a minimal local `patchmill.config.json` and reminds you
-how to change the default host login. `patchmill doctor` is read-only: it checks
-git, host access, labels, configured skills, runtime access, and local paths,
-verifying bundled/path-like skills and flagging name-only skills as unverified
-before recommending dry runs.
+`patchmill init` writes a minimal local `patchmill.config.json`, reminds you to
+change the default host login, and installs Patchmill's recommended skills into
+`.patchmill/skills/` by default so triage, planning, implementation, and
+review/validation behavior are sourced from your repository. Those files should
+be committed because they govern triage, planning, implementation, and
+review/validation behavior.
+
+Alternative initialization modes:
+
+```sh
+patchmill init --skills project
+patchmill init --skills global
+patchmill init --skills none
+patchmill init --skills path:project-skills
+```
+
+`patchmill doctor` is read-only: it checks git, host access, labels, configured
+skills, runtime access, and local paths, verifying bundled/path-like skills and
+flagging name-only skills as configured but unverified before recommending dry
+runs.
 
 ## Configuration
 
@@ -82,9 +97,9 @@ workflow looks like this:
     "login": "triage-agent"
   },
   "skills": {
-    "triage": "patchmill-issue-triage",
-    "planning": "superpowers:writing-plans",
-    "implementation": "superpowers:subagent-driven-development"
+    "triage": ".patchmill/skills/patchmill-issue-triage",
+    "planning": ".patchmill/skills/writing-plans",
+    "implementation": ".patchmill/skills/subagent-driven-development"
   },
   "paths": {
     "plansDir": "docs/plans",
@@ -97,11 +112,12 @@ workflow looks like this:
 
 The default skills keep the workflow small and explicit:
 
-- `patchmill-issue-triage` is the bundled default triage skill; normal triage
-  runs it (or your configured replacement) and reports observed changes, while
-  `--dry-run` uses a read-only preview JSON pass.
-- `superpowers:writing-plans` writes implementation plans before code changes.
-- `superpowers:subagent-driven-development` executes approved plans with
+- `.patchmill/skills/patchmill-issue-triage` is the default triage skill; normal
+  triage runs it (or your configured replacement) and reports observed changes,
+  while `--dry-run` uses a read-only preview JSON pass.
+- `.patchmill/skills/writing-plans` writes implementation plans before code
+  changes.
+- `.patchmill/skills/subagent-driven-development` executes approved plans with
   worker/reviewer handoffs.
 
 Accepted `host.provider` values are `forgejo-tea` for Forgejo/Gitea through
@@ -139,10 +155,12 @@ context behavior.
 
 Patchmill includes `pi-subagents`; users do not install it separately.
 Implementation prompts can rely on the Pi `subagent` tool and the agents
-discovered by pi-subagents. The default implementation skill,
-`superpowers:subagent-driven-development`, can use pi-subagents builtin agents
-such as `worker`, `reviewer`, `scout`, `planner`, `context-builder`,
-`researcher`, `delegate`, and `oracle`.
+discovered by pi-subagents. For initialized repositories, the default
+implementation skill is `.patchmill/skills/subagent-driven-development`; legacy
+setups without project-local defaults fall back to the built-in compatibility
+skill `superpowers:subagent-driven-development`, and both can use pi-subagents
+builtin agents such as `worker`, `reviewer`, `scout`, `planner`,
+`context-builder`, `researcher`, `delegate`, and `oracle`.
 
 Agent files define reusable delegated roles and can live in:
 

--- a/bin/package-files.test.ts
+++ b/bin/package-files.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+type NpmPackEntry = {
+  files?: Array<{ path: string }>;
+};
+
+test("npm pack dry-run includes bundled triage skill", () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  const result = spawnSync(
+    npmCommand,
+    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const packEntries = JSON.parse(result.stdout) as NpmPackEntry[];
+  assert.equal(
+    packEntries[0]?.files?.some(
+      (file) => file.path === "skills/patchmill-issue-triage/SKILL.md",
+    ) ?? false,
+    true,
+  );
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,10 +14,11 @@ Precedence is:
 ## Creating the initial config
 
 Use `patchmill init` to create the smallest useful `patchmill.config.json` for a
-repository. The generated file usually only needs the host provider and login;
-Patchmill fills omitted labels, paths, skills, and git policy from defaults, and
-the command output reminds you that you can later change the login in
-`patchmill.config.json` (`host.login`) or with `PATCHMILL_HOST_LOGIN`.
+repository. By default, init writes host fields and project-local skill mappings
+for required stages (`triage`, `planning`, and `implementation`); Patchmill
+fills omitted labels, paths, and git policy from defaults. The command output
+reminds you that you can later change the login in `patchmill.config.json`
+(`host.login`) or with `PATCHMILL_HOST_LOGIN`.
 
 Accepted `host.provider` values are `forgejo-tea` for Forgejo/Gitea through
 `tea` and `github-gh` for GitHub through `gh`.
@@ -62,9 +63,9 @@ pieces your repository needs.
     }
   },
   "skills": {
-    "triage": "patchmill-issue-triage",
-    "planning": "superpowers:writing-plans",
-    "implementation": "superpowers:subagent-driven-development",
+    "triage": ".patchmill/skills/patchmill-issue-triage",
+    "planning": ".patchmill/skills/writing-plans",
+    "implementation": ".patchmill/skills/subagent-driven-development",
     "toolchain": "project-toolchain",
     "review": "project-review",
     "visualEvidence": "capturing-proof-screenshots",
@@ -199,8 +200,21 @@ process shutdown.
 
 ## Skills
 
-The required skill keys are `triage`, `planning`, and `implementation`.
-Patchmill defaults them to:
+The required skill keys are `triage`, `planning`, and `implementation`. For new
+repositories, `patchmill init` defaults them to:
+
+```json
+{
+  "skills": {
+    "triage": ".patchmill/skills/patchmill-issue-triage",
+    "planning": ".patchmill/skills/writing-plans",
+    "implementation": ".patchmill/skills/subagent-driven-development"
+  }
+}
+```
+
+Older repos and no config overrides still use the built-in defaults for
+compatibility:
 
 - `patchmill-issue-triage`
 - `superpowers:writing-plans`
@@ -208,7 +222,9 @@ Patchmill defaults them to:
 
 ### Subagents
 
-Patchmill bundles `pi-subagents`, and `skills.implementation` defaults to
+Patchmill bundles `pi-subagents`; initialized repositories set
+`skills.implementation` to `.patchmill/skills/subagent-driven-development`.
+Legacy repos with no init override use the built-in compatibility default
 `superpowers:subagent-driven-development`.
 
 Customize subagent roles and runtime settings through pi-subagents configuration

--- a/docs/issue-agent-workflows.md
+++ b/docs/issue-agent-workflows.md
@@ -19,9 +19,12 @@ patchmill doctor
 ```
 
 `doctor` is read-only and verifies repository, host, label, Pi provider,
-configured skills, and path readiness before the existing `triage --dry-run` and
-`run-once` dry-run flows. It verifies bundled/path-like skills and flags
-name-only skills as configured but unverified.
+configured local skills, and path readiness before the existing
+`triage --dry-run` and `run-once` dry-run flows. For project-local defaults, it
+asks Pi to load the project-local skill pack. `doctor` verifies
+bundled/path-like skills, flags name-only skills as configured but unverified,
+and fails when required skill paths are missing or malformed. It also checks
+that `.patchmill/skills/` is not ignored by git.
 
 See also [skills configuration](skills.md) for repository-configurable skill
 selection at each workflow stage.
@@ -205,8 +208,9 @@ The plan prompt includes:
 - project context-file instructions;
 - instruction that the ready label means the issue is already clear enough to
   plan;
-- required use of configured `skills.planning`; the default is
-  `superpowers:writing-plans`;
+- required use of configured `skills.planning`; initialized repositories default
+  to `.patchmill/skills/writing-plans`, while legacy/no-override compatibility
+  defaults fall back to `superpowers:writing-plans`;
 - whether to stop for manual plan approval;
 - the project task-contract instructions for one todo per implementation-plan
   task;
@@ -257,8 +261,9 @@ asks Pi to implement from the issue worktree. The prompt includes:
 - issue body and relevant comments;
 - required project context-file instructions;
 - the implementation task-contract instructions;
-- the configured `skills.implementation` line; the default skill is
-  `superpowers:subagent-driven-development`;
+- the configured `skills.implementation` line; initialized repositories default
+  to `.patchmill/skills/subagent-driven-development`, while legacy compatibility
+  defaults use `superpowers:subagent-driven-development`;
 - when configured, separate lines for `skills.toolchain`, `skills.review`,
   `skills.visualEvidence`, and `skills.landing`;
 - Conventional Commit expectations;
@@ -284,9 +289,9 @@ It always renders:
 
 - `Use the configured implementation skill: <skills.implementation>.`
 
-By default, `skills.implementation` is
-`superpowers:subagent-driven-development`, so the required workflow names that
-skill unless repository config overrides it.
+For initialized repositories, `skills.implementation` is set to the project path
+`.patchmill/skills/subagent-driven-development`; legacy/no-override configs use
+the built-in compatibility default `superpowers:subagent-driven-development`.
 
 When present, the prompt renders these additional configured skill lines
 separately:

--- a/docs/plans/2026-05-29-project-local-default-skills.md
+++ b/docs/plans/2026-05-29-project-local-default-skills.md
@@ -103,11 +103,13 @@ Do not modify:
 Run:
 
 ```sh
-npm install superpowers@5.0.7 --save-exact
+npm install https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz --save-exact
 ```
 
 Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` include
-`superpowers` at exact version `5.0.7`.
+`superpowers` pinned to the GitHub tag tarball URL
+`https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz`, with
+lockfiles resolving that same tarball.
 
 - [ ] **Step 2: Verify the dependency exposes skills**
 
@@ -186,9 +188,11 @@ test("default pack records pinned external source", () => {
   assert.equal(PATCHMILL_RECOMMENDED_SKILL_PACK.name, "patchmill-recommended");
   assert.equal(PATCHMILL_RECOMMENDED_SKILL_PACK.version, "2026.05");
   assert.deepEqual(PATCHMILL_RECOMMENDED_SKILL_PACK.source, {
-    type: "npm",
-    package: "superpowers",
-    version: "5.0.7",
+    type: "github-release",
+    repository: "obra/superpowers",
+    tag: "v5.0.7",
+    tarballUrl:
+      "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
   });
   assert.ok(
     PATCHMILL_RECOMMENDED_SKILL_PACK.skills.some(
@@ -222,9 +226,11 @@ test("buildSkillPackMetadata records installed file hashes", () => {
       name: "patchmill-recommended",
       version: "2026.05",
       source: {
-        type: "npm",
-        package: "superpowers",
-        version: "5.0.7",
+        type: "github-release",
+        repository: "obra/superpowers",
+        tag: "v5.0.7",
+        tarballUrl:
+          "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
       },
     },
     installedAt: "<generated-by-init>",
@@ -262,9 +268,10 @@ export const DEFAULT_PROJECT_SKILL_DIR = ".patchmill/skills";
 export const SKILL_PACK_METADATA_FILE = "patchmill-skill-pack.json";
 
 export type SkillPackSource = {
-  type: "npm";
-  package: "superpowers";
-  version: "5.0.7";
+  type: "github-release";
+  repository: "obra/superpowers";
+  tag: "v5.0.7";
+  tarballUrl: "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz";
 };
 
 export type SkillPackSkill = {
@@ -295,9 +302,11 @@ export const PATCHMILL_RECOMMENDED_SKILL_PACK: SkillPack = {
   name: "patchmill-recommended",
   version: "2026.05",
   source: {
-    type: "npm",
-    package: "superpowers",
-    version: "5.0.7",
+    type: "github-release",
+    repository: "obra/superpowers",
+    tag: "v5.0.7",
+    tarballUrl:
+      "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
   },
   skills: [
     { name: "patchmill-issue-triage", source: "patchmill" },
@@ -1779,7 +1788,13 @@ async function writeSkillMetadata(
         pack: {
           name: "patchmill-recommended",
           version: "2026.05",
-          source: { type: "npm", package: "superpowers", version: "5.0.7" },
+          source: {
+            type: "github-release",
+            repository: "obra/superpowers",
+            tag: "v5.0.7",
+            tarballUrl:
+              "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+          },
         },
         installedAt: "2026-05-29T00:00:00.000Z",
         skillDir: ".patchmill/skills",

--- a/docs/plans/2026-05-29-project-local-default-skills.md
+++ b/docs/plans/2026-05-29-project-local-default-skills.md
@@ -1,0 +1,2453 @@
+# Project-local Default Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `patchmill init` install Patchmill's recommended skill pack into
+`.patchmill/skills/`, write config that points at those local skills, and make
+`doctor` validate the project-owned skill files.
+
+**Architecture:** Add a small pure skill-pack module for recommended project
+paths, metadata, and config mappings; add an init skill-installer module for
+filesystem copying; update init orchestration to install project-local skills by
+default while supporting `--skills project|global|none|path:<dir>`. Add shared
+skill target resolution so triage and run-once Pi invocations pass path-like
+skills through `--skill`, and extend doctor with shape, metadata, customization,
+git-ignore, and Pi skill-loading checks.
+
+**Tech Stack:** TypeScript ESM, Node 24 built-ins (`node:test`, `fs/promises`,
+`crypto`, `module`, `path`), existing Patchmill CLI command modules, existing
+`CommandRunner`, npm dependency management.
+
+---
+
+## File structure
+
+Create:
+
+- `src/workflow/skill-pack.ts` — pure manifest, project-local recommended skill
+  paths, metadata types, hash helpers, and local config builders.
+- `src/workflow/skill-pack.test.ts` — unit tests for path building, metadata
+  shape, and config mapping.
+- `src/cli/commands/init/skill-installer.ts` — install/copy recommended skill
+  directories, write metadata, validate path-mode sources, and avoid overwrites.
+- `src/cli/commands/init/skill-installer.test.ts` — filesystem tests for project
+  install, metadata, no-overwrite safety, and path-mode validation.
+
+Modify:
+
+- `package.json`, `package-lock.json`, `npm-shrinkwrap.json` — add the pinned
+  external recommended skill-pack source dependency.
+- `src/workflow/skills.ts` — add path-like skill detection and `--skill`
+  argument resolution helpers.
+- `src/workflow/skills.test.ts` — cover path-like detection and invocation
+  argument resolution.
+- `src/config/defaults.test.ts` and `src/workflow/skills.test.ts` — update
+  expectations only where default behavior intentionally changes or remains
+  global.
+- `src/cli/commands/init/args.ts` — parse `--skills` mode.
+- `src/cli/commands/init/args.test.ts` — cover `--skills` parsing and invalid
+  values.
+- `src/cli/commands/init/config-writer.ts` — write skill mappings into generated
+  config when init selects project/global/path modes.
+- `src/cli/commands/init/config-writer.test.ts` — cover generated config skill
+  mappings.
+- `src/cli/commands/init/main.ts` — run selected skill installation mode and
+  update user-facing output.
+- `src/cli/commands/init/main.test.ts` — cover default project install, `none`,
+  `global`, and `path:<dir>` init modes.
+- `src/cli/commands/doctor/checks.ts` — validate local skill shape, pack
+  metadata, git-ignore status, customized hashes, and Pi visibility for the
+  project-local skill pack.
+- `src/cli/commands/doctor/checks.test.ts` — cover fresh project-local skills,
+  missing skills, malformed skills, customized skills, missing metadata, ignored
+  skill directory, and Pi failing to load the project-local skill pack.
+- `src/cli/commands/triage/dry-run-agent.ts` — use shared skill invocation args
+  for configured triage skill paths.
+- `src/cli/commands/triage/dry-run-agent.test.ts` — cover `--skill` for
+  project-local triage paths.
+- `src/cli/commands/triage/execute-agent.ts` — use shared skill invocation args
+  for configured triage skill paths.
+- `src/cli/commands/triage/execute-agent.test.ts` — cover `--skill` for
+  project-local triage paths.
+- `src/cli/commands/run-once/pi.ts` — allow plan/implementation Pi calls to pass
+  local skill files through `--skill`.
+- `src/pi/runner.ts` — resolve local skill paths for planning and implementation
+  stages.
+- `src/pi/runner.test.ts` and `src/cli/commands/run-once/pi.test.ts` — cover
+  plan/implementation `--skill` arguments.
+- `docs/configuration.md`, `docs/skills.md`, `docs/issue-agent-workflows.md`,
+  `README.md` — document init-installed project-local skills.
+
+Do not modify:
+
+- Triage policy labels or issue-state decisions.
+- Host provider behavior.
+- Future `patchmill skills diff/update/reset` commands; this plan only creates
+  metadata that later commands can use.
+
+---
+
+## Task 1: Pin the external recommended skill-pack source
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `npm-shrinkwrap.json`
+
+- [ ] **Step 1: Add the dependency with npm**
+
+Run:
+
+```sh
+npm install superpowers@5.0.7 --save-exact
+```
+
+Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` include
+`superpowers` at exact version `5.0.7`.
+
+- [ ] **Step 2: Verify the dependency exposes skills**
+
+Run:
+
+```sh
+node -e "const {createRequire}=require('node:module'); const {join}=require('node:path'); const {readdirSync}=require('node:fs'); const requireFromHere=createRequire(process.cwd() + '/src/workflow/skill-pack.ts'); const root=require('node:path').dirname(requireFromHere.resolve('superpowers/package.json')); console.log(readdirSync(join(root, 'skills')).filter((name)=>name !== 'node_modules').sort().join('\n'))"
+```
+
+Expected output includes:
+
+```text
+subagent-driven-development
+writing-plans
+```
+
+- [ ] **Step 3: Commit dependency pin**
+
+Run:
+
+```sh
+git add package.json package-lock.json npm-shrinkwrap.json
+git commit -m "chore(skills): pin recommended skill pack source"
+```
+
+---
+
+## Task 2: Add pure recommended skill-pack manifest and metadata helpers
+
+**Files:**
+
+- Create: `src/workflow/skill-pack.ts`
+- Create: `src/workflow/skill-pack.test.ts`
+
+- [ ] **Step 1: Write failing tests for recommended project paths and metadata**
+
+Create `src/workflow/skill-pack.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_DEFAULT_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  buildRecommendedProjectSkillConfig,
+  buildSkillPackMetadata,
+  hashText,
+  projectSkillPath,
+} from "./skill-pack.ts";
+
+const unixNewline = "name: sample\n";
+
+test("recommended project skill paths are repo-relative POSIX paths", () => {
+  assert.equal(DEFAULT_PROJECT_SKILL_DIR, ".patchmill/skills");
+  assert.equal(
+    projectSkillPath("writing-plans"),
+    ".patchmill/skills/writing-plans",
+  );
+  assert.equal(
+    projectSkillPath("subagent-driven-development", "project/skills"),
+    "project/skills/subagent-driven-development",
+  );
+});
+
+test("buildRecommendedProjectSkillConfig maps required workflow stages locally", () => {
+  assert.deepEqual(buildRecommendedProjectSkillConfig(), {
+    triage: ".patchmill/skills/patchmill-issue-triage",
+    planning: ".patchmill/skills/writing-plans",
+    implementation: ".patchmill/skills/subagent-driven-development",
+  });
+});
+
+test("default pack records pinned external source", () => {
+  assert.equal(PATCHMILL_RECOMMENDED_SKILL_PACK.name, "patchmill-recommended");
+  assert.equal(PATCHMILL_RECOMMENDED_SKILL_PACK.version, "2026.05");
+  assert.deepEqual(PATCHMILL_RECOMMENDED_SKILL_PACK.source, {
+    type: "npm",
+    package: "superpowers",
+    version: "5.0.7",
+  });
+  assert.ok(
+    PATCHMILL_RECOMMENDED_SKILL_PACK.skills.some(
+      (skill) => skill.name === "patchmill-issue-triage",
+    ),
+  );
+  assert.ok(
+    PATCHMILL_RECOMMENDED_SKILL_PACK.skills.some(
+      (skill) => skill.name === "writing-plans",
+    ),
+  );
+});
+
+test("hashText returns stable sha256 hex", () => {
+  assert.equal(
+    hashText(unixNewline),
+    createHash("sha256").update(unixNewline).digest("hex"),
+  );
+});
+
+test("buildSkillPackMetadata records installed file hashes", () => {
+  const metadata = buildSkillPackMetadata([
+    {
+      path: ".patchmill/skills/writing-plans/SKILL.md",
+      sha256: hashText(unixNewline),
+    },
+  ]);
+
+  assert.deepEqual(metadata, {
+    pack: {
+      name: "patchmill-recommended",
+      version: "2026.05",
+      source: {
+        type: "npm",
+        package: "superpowers",
+        version: "5.0.7",
+      },
+    },
+    installedAt: "<generated-by-init>",
+    skillDir: ".patchmill/skills",
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files: [
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(unixNewline),
+      },
+    ],
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test to verify failure**
+
+Run:
+
+```sh
+node --test src/workflow/skill-pack.test.ts
+```
+
+Expected: FAIL because `src/workflow/skill-pack.ts` does not exist.
+
+- [ ] **Step 3: Implement the pure manifest module**
+
+Create `src/workflow/skill-pack.ts`:
+
+```ts
+import { createHash } from "node:crypto";
+import type { PatchmillSkillsConfig } from "./skills.ts";
+
+export const DEFAULT_PROJECT_SKILL_DIR = ".patchmill/skills";
+export const SKILL_PACK_METADATA_FILE = "patchmill-skill-pack.json";
+
+export type SkillPackSource = {
+  type: "npm";
+  package: "superpowers";
+  version: "5.0.7";
+};
+
+export type SkillPackSkill = {
+  name: string;
+  source: "patchmill" | "superpowers";
+};
+
+export type SkillPack = {
+  name: "patchmill-recommended";
+  version: "2026.05";
+  source: SkillPackSource;
+  skills: SkillPackSkill[];
+};
+
+export type SkillPackMetadataFile = {
+  pack: {
+    name: SkillPack["name"];
+    version: SkillPack["version"];
+    source: SkillPackSource;
+  };
+  installedAt: "<generated-by-init>" | string;
+  skillDir: string;
+  metadataFile: typeof SKILL_PACK_METADATA_FILE;
+  files: Array<{ path: string; sha256: string }>;
+};
+
+export const PATCHMILL_RECOMMENDED_SKILL_PACK: SkillPack = {
+  name: "patchmill-recommended",
+  version: "2026.05",
+  source: {
+    type: "npm",
+    package: "superpowers",
+    version: "5.0.7",
+  },
+  skills: [
+    { name: "patchmill-issue-triage", source: "patchmill" },
+    { name: "brainstorming", source: "superpowers" },
+    { name: "dispatching-parallel-agents", source: "superpowers" },
+    { name: "executing-plans", source: "superpowers" },
+    { name: "finishing-a-development-branch", source: "superpowers" },
+    { name: "receiving-code-review", source: "superpowers" },
+    { name: "requesting-code-review", source: "superpowers" },
+    { name: "subagent-driven-development", source: "superpowers" },
+    { name: "systematic-debugging", source: "superpowers" },
+    { name: "test-driven-development", source: "superpowers" },
+    { name: "using-git-worktrees", source: "superpowers" },
+    { name: "using-superpowers", source: "superpowers" },
+    { name: "verification-before-completion", source: "superpowers" },
+    { name: "writing-plans", source: "superpowers" },
+    { name: "writing-skills", source: "superpowers" },
+  ],
+};
+
+export function projectSkillPath(
+  skillName: string,
+  skillDir = DEFAULT_PROJECT_SKILL_DIR,
+): string {
+  return `${skillDir.replace(/\/+$/u, "")}/${skillName}`;
+}
+
+export function buildRecommendedProjectSkillConfig(
+  skillDir = DEFAULT_PROJECT_SKILL_DIR,
+): Pick<PatchmillSkillsConfig, "triage" | "planning" | "implementation"> {
+  return {
+    triage: projectSkillPath("patchmill-issue-triage", skillDir),
+    planning: projectSkillPath("writing-plans", skillDir),
+    implementation: projectSkillPath("subagent-driven-development", skillDir),
+  };
+}
+
+export function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function buildSkillPackMetadata(
+  files: Array<{ path: string; sha256: string }>,
+  options: { installedAt?: string; skillDir?: string } = {},
+): SkillPackMetadataFile {
+  return {
+    pack: {
+      name: PATCHMILL_RECOMMENDED_SKILL_PACK.name,
+      version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+      source: PATCHMILL_RECOMMENDED_SKILL_PACK.source,
+    },
+    installedAt: options.installedAt ?? "<generated-by-init>",
+    skillDir: options.skillDir ?? DEFAULT_PROJECT_SKILL_DIR,
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files,
+  };
+}
+```
+
+- [ ] **Step 4: Run the manifest test to verify it passes**
+
+Run:
+
+```sh
+node --test src/workflow/skill-pack.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit manifest module**
+
+Run:
+
+```sh
+git add src/workflow/skill-pack.ts src/workflow/skill-pack.test.ts
+git commit -m "feat(skills): describe recommended skill pack"
+```
+
+---
+
+## Task 3: Add project-local skill installer
+
+**Files:**
+
+- Create: `src/cli/commands/init/skill-installer.ts`
+- Create: `src/cli/commands/init/skill-installer.test.ts`
+
+- [ ] **Step 1: Write failing installer tests**
+
+Create `src/cli/commands/init/skill-installer.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { SKILL_PACK_METADATA_FILE } from "../../../workflow/skill-pack.ts";
+import {
+  installProjectSkills,
+  validateExistingSkillDirectory,
+} from "./skill-installer.ts";
+
+async function tempRoot(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function writeSkill(
+  root: string,
+  name: string,
+  body: string,
+): Promise<void> {
+  await mkdir(join(root, name), { recursive: true });
+  await writeFile(join(root, name, "SKILL.md"), body);
+}
+
+const triageSkill = `---
+name: patchmill-issue-triage
+description: Triage issues.
+---
+# Triage
+`;
+
+const planningSkill = `---
+name: writing-plans
+description: Write plans.
+---
+# Plans
+`;
+
+const implementationSkill = `---
+name: subagent-driven-development
+description: Execute plans.
+---
+# Implementation
+`;
+
+test("installProjectSkills copies skills and writes metadata", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+  await writeSkill(
+    superpowersSource,
+    "subagent-driven-development",
+    implementationSkill,
+  );
+
+  const result = await installProjectSkills({
+    repoRoot,
+    sourceRoots: {
+      patchmillSkillsDir: patchmillSource,
+      superpowersSkillsDir: superpowersSource,
+    },
+    installedAt: "2026-05-29T00:00:00.000Z",
+    packSkills: [
+      { name: "patchmill-issue-triage", source: "patchmill" },
+      { name: "writing-plans", source: "superpowers" },
+      { name: "subagent-driven-development", source: "superpowers" },
+    ],
+  });
+
+  assert.deepEqual(result.skillConfig, {
+    triage: ".patchmill/skills/patchmill-issue-triage",
+    planning: ".patchmill/skills/writing-plans",
+    implementation: ".patchmill/skills/subagent-driven-development",
+  });
+  assert.equal(result.installedSkills.length, 3);
+  assert.match(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+      "utf8",
+    ),
+    /name: writing-plans/,
+  );
+
+  const metadata = JSON.parse(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+      "utf8",
+    ),
+  ) as { installedAt: string; files: Array<{ path: string; sha256: string }> };
+  assert.equal(metadata.installedAt, "2026-05-29T00:00:00.000Z");
+  assert.ok(
+    metadata.files.some(
+      (file) => file.path === ".patchmill/skills/writing-plans/SKILL.md",
+    ),
+  );
+});
+
+test("installProjectSkills refuses to overwrite existing skill files", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+  await mkdir(join(repoRoot, ".patchmill", "skills", "writing-plans"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+    "existing\n",
+  );
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [
+        { name: "patchmill-issue-triage", source: "patchmill" },
+        { name: "writing-plans", source: "superpowers" },
+      ],
+    }),
+    /Refusing to overwrite existing skill path/,
+  );
+});
+
+test("validateExistingSkillDirectory returns local config for path mode", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  await writeSkill(
+    repoRoot,
+    "project-skills/patchmill-issue-triage",
+    triageSkill,
+  );
+  await writeSkill(repoRoot, "project-skills/writing-plans", planningSkill);
+  await writeSkill(
+    repoRoot,
+    "project-skills/subagent-driven-development",
+    implementationSkill,
+  );
+
+  assert.deepEqual(
+    await validateExistingSkillDirectory(repoRoot, "project-skills"),
+    {
+      triage: "project-skills/patchmill-issue-triage",
+      planning: "project-skills/writing-plans",
+      implementation: "project-skills/subagent-driven-development",
+    },
+  );
+});
+
+test("validateExistingSkillDirectory fails when a required skill is missing", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  await writeSkill(repoRoot, "project-skills/writing-plans", planningSkill);
+
+  await assert.rejects(
+    validateExistingSkillDirectory(repoRoot, "project-skills"),
+    /Missing required skill file: project-skills\/patchmill-issue-triage\/SKILL.md/,
+  );
+});
+```
+
+- [ ] **Step 2: Run the installer test to verify failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/skill-installer.test.ts
+```
+
+Expected: FAIL because `skill-installer.ts` does not exist.
+
+- [ ] **Step 3: Implement the installer**
+
+Create `src/cli/commands/init/skill-installer.ts`:
+
+```ts
+import { constants } from "node:fs";
+import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  buildRecommendedProjectSkillConfig,
+  buildSkillPackMetadata,
+  hashText,
+  projectSkillPath,
+  type SkillPackSkill,
+} from "../../../workflow/skill-pack.ts";
+import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
+import { bundledTriageSkillPath } from "../../../workflow/skills.ts";
+
+const require = createRequire(import.meta.url);
+
+type SourceRoots = {
+  patchmillSkillsDir: string;
+  superpowersSkillsDir: string;
+};
+
+export type ProjectSkillInstallResult = {
+  skillDir: string;
+  skillConfig: Pick<
+    PatchmillSkillsConfig,
+    "triage" | "planning" | "implementation"
+  >;
+  installedSkills: string[];
+  metadataPath: string;
+};
+
+export function defaultSkillSourceRoots(): SourceRoots {
+  const superpowersRoot = dirname(require.resolve("superpowers/package.json"));
+  return {
+    patchmillSkillsDir: resolve(dirname(bundledTriageSkillPath()), ".."),
+    superpowersSkillsDir: join(superpowersRoot, "skills"),
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sourceRootFor(skill: SkillPackSkill, roots: SourceRoots): string {
+  return skill.source === "patchmill"
+    ? roots.patchmillSkillsDir
+    : roots.superpowersSkillsDir;
+}
+
+async function assertSkillFile(
+  path: string,
+  displayPath: string,
+): Promise<void> {
+  try {
+    await access(path, constants.R_OK);
+  } catch {
+    throw new Error(`Missing required skill file: ${displayPath}`);
+  }
+}
+
+export async function installProjectSkills(options: {
+  repoRoot: string;
+  skillDir?: string;
+  sourceRoots?: SourceRoots;
+  packSkills?: SkillPackSkill[];
+  installedAt?: string;
+}): Promise<ProjectSkillInstallResult> {
+  const skillDir = options.skillDir ?? DEFAULT_PROJECT_SKILL_DIR;
+  const roots = options.sourceRoots ?? defaultSkillSourceRoots();
+  const packSkills =
+    options.packSkills ?? PATCHMILL_RECOMMENDED_SKILL_PACK.skills;
+  const absoluteSkillDir = resolve(options.repoRoot, skillDir);
+  const files: Array<{ path: string; sha256: string }> = [];
+  const installedSkills: string[] = [];
+
+  for (const skill of packSkills) {
+    const sourceDir = join(sourceRootFor(skill, roots), skill.name);
+    const targetRelativeDir = projectSkillPath(skill.name, skillDir);
+    const targetDir = resolve(options.repoRoot, targetRelativeDir);
+    const targetSkillFile = join(targetDir, "SKILL.md");
+    await assertSkillFile(
+      join(sourceDir, "SKILL.md"),
+      `${skill.name}/SKILL.md`,
+    );
+    if (await exists(targetDir)) {
+      throw new Error(
+        `Refusing to overwrite existing skill path: ${targetRelativeDir}`,
+      );
+    }
+    await mkdir(dirname(targetDir), { recursive: true });
+    await cp(sourceDir, targetDir, {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+    });
+    const text = await readFile(targetSkillFile, "utf8");
+    files.push({
+      path: `${targetRelativeDir}/SKILL.md`,
+      sha256: hashText(text),
+    });
+    installedSkills.push(targetRelativeDir);
+  }
+
+  const metadata = buildSkillPackMetadata(files, {
+    installedAt: options.installedAt ?? new Date().toISOString(),
+    skillDir,
+  });
+  const metadataPath = join(absoluteSkillDir, SKILL_PACK_METADATA_FILE);
+  await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, {
+    flag: "wx",
+  });
+
+  return {
+    skillDir,
+    skillConfig: buildRecommendedProjectSkillConfig(skillDir),
+    installedSkills,
+    metadataPath,
+  };
+}
+
+export async function validateExistingSkillDirectory(
+  repoRoot: string,
+  skillDir: string,
+): Promise<
+  Pick<PatchmillSkillsConfig, "triage" | "planning" | "implementation">
+> {
+  const skillConfig = buildRecommendedProjectSkillConfig(skillDir);
+  const required = [
+    skillConfig.triage,
+    skillConfig.planning,
+    skillConfig.implementation,
+  ];
+  for (const skillPath of required) {
+    const displayPath = `${skillPath}/SKILL.md`;
+    await assertSkillFile(resolve(repoRoot, displayPath), displayPath);
+  }
+  return skillConfig;
+}
+```
+
+- [ ] **Step 4: Run the installer test to verify it passes**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/skill-installer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit installer module**
+
+Run:
+
+```sh
+git add src/cli/commands/init/skill-installer.ts src/cli/commands/init/skill-installer.test.ts
+git commit -m "feat(init): install project-local skill pack"
+```
+
+---
+
+## Task 4: Parse init skill install modes
+
+**Files:**
+
+- Modify: `src/cli/commands/init/args.ts`
+- Modify: `src/cli/commands/init/args.test.ts`
+
+- [ ] **Step 1: Write failing arg parser tests**
+
+Replace the current assertions in `src/cli/commands/init/args.test.ts` with
+these updated expectations and new mode tests:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseArgs } from "./args.ts";
+
+test("parseArgs defaults to creating config with project skills", () => {
+  assert.deepEqual(parseArgs([], "/repo"), {
+    repoRoot: "/repo",
+    showHelp: false,
+    skills: { mode: "project" },
+  });
+});
+
+test("parseArgs recognizes help", () => {
+  assert.deepEqual(parseArgs(["--help"], "/repo"), {
+    repoRoot: "/repo",
+    showHelp: true,
+    skills: { mode: "project" },
+  });
+  assert.deepEqual(parseArgs(["-h"], "/repo"), {
+    repoRoot: "/repo",
+    showHelp: true,
+    skills: { mode: "project" },
+  });
+});
+
+test("parseArgs recognizes skills modes", () => {
+  assert.deepEqual(parseArgs(["--skills", "project"], "/repo").skills, {
+    mode: "project",
+  });
+  assert.deepEqual(parseArgs(["--skills=global"], "/repo").skills, {
+    mode: "global",
+  });
+  assert.deepEqual(parseArgs(["--skills", "none"], "/repo").skills, {
+    mode: "none",
+  });
+  assert.deepEqual(
+    parseArgs(["--skills", "path:project-skills"], "/repo").skills,
+    {
+      mode: "path",
+      path: "project-skills",
+    },
+  );
+});
+
+test("parseArgs rejects missing skills value", () => {
+  assert.throws(
+    () => parseArgs(["--skills"], "/repo"),
+    /--skills requires one of project, global, none, or path:<dir>/,
+  );
+});
+
+test("parseArgs rejects unsupported skills value", () => {
+  assert.throws(
+    () => parseArgs(["--skills", "remote"], "/repo"),
+    /--skills requires one of project, global, none, or path:<dir>/,
+  );
+});
+
+test("parseArgs rejects empty path mode", () => {
+  assert.throws(
+    () => parseArgs(["--skills=path:"], "/repo"),
+    /--skills path:<dir> requires a non-empty directory/,
+  );
+});
+
+test("parseArgs rejects force in v1", () => {
+  assert.throws(
+    () => parseArgs(["--force"], "/repo"),
+    /Unknown argument: --force/,
+  );
+});
+
+test("parseArgs rejects unknown arguments", () => {
+  assert.throws(
+    () => parseArgs(["--json"], "/repo"),
+    /Unknown argument: --json/,
+  );
+});
+```
+
+- [ ] **Step 2: Run arg parser tests to verify failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/args.test.ts
+```
+
+Expected: FAIL because `skills` parsing is not implemented.
+
+- [ ] **Step 3: Implement skills mode parsing**
+
+Update `src/cli/commands/init/args.ts`:
+
+```ts
+import { cwd } from "node:process";
+
+export type InitSkillsMode =
+  | { mode: "project" }
+  | { mode: "global" }
+  | { mode: "none" }
+  | { mode: "path"; path: string };
+
+export type InitConfig = {
+  repoRoot: string;
+  showHelp: boolean;
+  skills: InitSkillsMode;
+};
+
+function parseSkillsMode(value: string | undefined): InitSkillsMode {
+  if (!value) {
+    throw new Error(
+      "--skills requires one of project, global, none, or path:<dir>",
+    );
+  }
+  if (value === "project" || value === "global" || value === "none") {
+    return { mode: value };
+  }
+  if (value.startsWith("path:")) {
+    const path = value.slice("path:".length).trim();
+    if (path.length === 0) {
+      throw new Error("--skills path:<dir> requires a non-empty directory");
+    }
+    return { mode: "path", path };
+  }
+  throw new Error(
+    "--skills requires one of project, global, none, or path:<dir>",
+  );
+}
+
+export function parseArgs(args: string[], repoRoot = cwd()): InitConfig {
+  const config: InitConfig = {
+    repoRoot,
+    showHelp: false,
+    skills: { mode: "project" },
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === "--help" || arg === "-h") {
+      config.showHelp = true;
+    } else if (arg === "--skills") {
+      config.skills = parseSkillsMode(args[index + 1]);
+      index += 1;
+    } else if (arg.startsWith("--skills=")) {
+      config.skills = parseSkillsMode(arg.slice("--skills=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return config;
+}
+```
+
+- [ ] **Step 4: Run arg parser tests to verify pass**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/args.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit args parsing**
+
+Run:
+
+```sh
+git add src/cli/commands/init/args.ts src/cli/commands/init/args.test.ts
+git commit -m "feat(init): parse skill install modes"
+```
+
+---
+
+## Task 5: Generate config with selected skill mappings
+
+**Files:**
+
+- Modify: `src/cli/commands/init/config-writer.ts`
+- Modify: `src/cli/commands/init/config-writer.test.ts`
+
+- [ ] **Step 1: Write failing config writer tests**
+
+Add these tests to `src/cli/commands/init/config-writer.test.ts`:
+
+```ts
+test("buildInitialConfig includes explicit project-local skill mappings", () => {
+  assert.deepEqual(
+    buildInitialConfig({
+      skills: {
+        triage: ".patchmill/skills/patchmill-issue-triage",
+        planning: ".patchmill/skills/writing-plans",
+        implementation: ".patchmill/skills/subagent-driven-development",
+      },
+    }),
+    {
+      host: {
+        provider: "forgejo-tea",
+        login: "triage-agent",
+      },
+      skills: {
+        triage: ".patchmill/skills/patchmill-issue-triage",
+        planning: ".patchmill/skills/writing-plans",
+        implementation: ".patchmill/skills/subagent-driven-development",
+      },
+    },
+  );
+});
+
+test("writeInitialConfig writes selected skills", async () => {
+  const repoRoot = await tempRepo();
+  const result = await writeInitialConfig(repoRoot, {
+    skills: {
+      triage: ".patchmill/skills/patchmill-issue-triage",
+      planning: ".patchmill/skills/writing-plans",
+      implementation: ".patchmill/skills/subagent-driven-development",
+    },
+  });
+
+  assert.equal(result.status, "created");
+  assert.deepEqual(
+    JSON.parse(await readFile(join(repoRoot, CONFIG_FILE_NAME), "utf8")),
+    {
+      host: {
+        provider: "forgejo-tea",
+        login: "triage-agent",
+      },
+      skills: {
+        triage: ".patchmill/skills/patchmill-issue-triage",
+        planning: ".patchmill/skills/writing-plans",
+        implementation: ".patchmill/skills/subagent-driven-development",
+      },
+    },
+  );
+});
+```
+
+- [ ] **Step 2: Run config writer tests to verify failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/config-writer.test.ts
+```
+
+Expected: FAIL because `buildInitialConfig` and `writeInitialConfig` do not
+accept `skills`.
+
+- [ ] **Step 3: Update config writer types and builders**
+
+Modify the top of `src/cli/commands/init/config-writer.ts` so `InitialConfig`
+can include skills:
+
+```ts
+type InitialConfig = {
+  host: Pick<PatchmillConfig["host"], "provider" | "login">;
+  skills?: Pick<
+    PatchmillConfig["skills"],
+    "triage" | "planning" | "implementation"
+  >;
+};
+```
+
+Update `buildInitialConfig` signature and return value:
+
+```ts
+export function buildInitialConfig(
+  options: {
+    provider?: PatchmillConfig["host"]["provider"];
+    login?: string;
+    skills?: Pick<
+      PatchmillConfig["skills"],
+      "triage" | "planning" | "implementation"
+    >;
+  } = {},
+): InitialConfig {
+  const provider = options.provider ?? DEFAULT_PATCHMILL_CONFIG.host.provider;
+  return {
+    host: {
+      provider,
+      login:
+        options.login ??
+        (provider === "github-gh" ? "" : DEFAULT_PATCHMILL_CONFIG.host.login),
+    },
+    ...(options.skills !== undefined ? { skills: options.skills } : {}),
+  };
+}
+```
+
+Update `writeInitialConfig` options:
+
+```ts
+export async function writeInitialConfig(
+  repoRoot: string,
+  options: {
+    login?: string;
+    skills?: Pick<
+      PatchmillConfig["skills"],
+      "triage" | "planning" | "implementation"
+    >;
+  },
+): Promise<InitWriteResult> {
+  const path = join(repoRoot, CONFIG_FILE_NAME);
+  if (await fileExists(path)) return { status: "exists", path };
+
+  const provider = inferHostProviderFromRemote(await originRemoteUrl(repoRoot));
+  const config = buildInitialConfig({
+    provider,
+    login: options.login,
+    skills: options.skills,
+  });
+  await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, {
+    flag: "wx",
+  });
+  return { status: "created", path, config };
+}
+```
+
+- [ ] **Step 4: Run config writer tests to verify pass**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/config-writer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit config writer changes**
+
+Run:
+
+```sh
+git add src/cli/commands/init/config-writer.ts src/cli/commands/init/config-writer.test.ts
+git commit -m "feat(init): write selected skill mappings"
+```
+
+---
+
+## Task 6: Wire skill installation into `patchmill init`
+
+**Files:**
+
+- Modify: `src/cli/commands/init/main.ts`
+- Modify: `src/cli/commands/init/main.test.ts`
+
+- [ ] **Step 1: Write failing init orchestration tests**
+
+Add these tests to `src/cli/commands/init/main.test.ts`:
+
+```ts
+import { mkdir, readFile } from "node:fs/promises";
+```
+
+Keep the existing imports and add `readFile` to the current `fs/promises` import
+if it already exists.
+
+Add tests after `runInit creates config and prints next step`:
+
+```ts
+test("runInit installs project-local skills by default", async () => {
+  const repoRoot = await tempRepo();
+  const stdout: string[] = [];
+
+  assert.equal(
+    await runInit(
+      [],
+      repoRoot,
+      { stdout: (line) => stdout.push(line), stderr: () => undefined },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+      },
+    ),
+    0,
+  );
+
+  const config = JSON.parse(
+    await readFile(join(repoRoot, "patchmill.config.json"), "utf8"),
+  ) as { skills: Record<string, string> };
+  assert.deepEqual(config.skills, {
+    triage: ".patchmill/skills/patchmill-issue-triage",
+    planning: ".patchmill/skills/writing-plans",
+    implementation: ".patchmill/skills/subagent-driven-development",
+  });
+  assert.match(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+      "utf8",
+    ),
+    /name: writing-plans/,
+  );
+  assert.match(stdout.join("\n"), /Installed project-local skills/);
+  assert.match(stdout.join("\n"), /Commit `.patchmill\/skills\/`/);
+});
+
+test("runInit --skills none skips skill installation", async () => {
+  const repoRoot = await tempRepo();
+  const stdout: string[] = [];
+
+  assert.equal(
+    await runInit(
+      ["--skills", "none"],
+      repoRoot,
+      { stdout: (line) => stdout.push(line), stderr: () => undefined },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+      },
+    ),
+    0,
+  );
+
+  const config = JSON.parse(
+    await readFile(join(repoRoot, "patchmill.config.json"), "utf8"),
+  ) as { skills?: Record<string, string> };
+  assert.equal(config.skills, undefined);
+  assert.match(stdout.join("\n"), /Skipped default skill installation/);
+});
+
+test("runInit --skills global writes global default skill names", async () => {
+  const repoRoot = await tempRepo();
+
+  assert.equal(
+    await runInit(
+      ["--skills=global"],
+      repoRoot,
+      { stdout: () => undefined, stderr: () => undefined },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+      },
+    ),
+    0,
+  );
+
+  const config = JSON.parse(
+    await readFile(join(repoRoot, "patchmill.config.json"), "utf8"),
+  ) as { skills: Record<string, string> };
+  assert.deepEqual(config.skills, {
+    triage: "patchmill-issue-triage",
+    planning: "superpowers:writing-plans",
+    implementation: "superpowers:subagent-driven-development",
+  });
+});
+
+test("runInit --skills path validates and writes existing local skills", async () => {
+  const repoRoot = await tempRepo();
+  await mkdir(join(repoRoot, "project-skills", "patchmill-issue-triage"), {
+    recursive: true,
+  });
+  await mkdir(join(repoRoot, "project-skills", "writing-plans"), {
+    recursive: true,
+  });
+  await mkdir(join(repoRoot, "project-skills", "subagent-driven-development"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(repoRoot, "project-skills", "patchmill-issue-triage", "SKILL.md"),
+    "---\nname: patchmill-issue-triage\ndescription: Triage.\n---\n",
+  );
+  await writeFile(
+    join(repoRoot, "project-skills", "writing-plans", "SKILL.md"),
+    "---\nname: writing-plans\ndescription: Plan.\n---\n",
+  );
+  await writeFile(
+    join(repoRoot, "project-skills", "subagent-driven-development", "SKILL.md"),
+    "---\nname: subagent-driven-development\ndescription: Implement.\n---\n",
+  );
+
+  assert.equal(
+    await runInit(
+      ["--skills", "path:project-skills"],
+      repoRoot,
+      { stdout: () => undefined, stderr: () => undefined },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+      },
+    ),
+    0,
+  );
+
+  const config = JSON.parse(
+    await readFile(join(repoRoot, "patchmill.config.json"), "utf8"),
+  ) as { skills: Record<string, string> };
+  assert.deepEqual(config.skills, {
+    triage: "project-skills/patchmill-issue-triage",
+    planning: "project-skills/writing-plans",
+    implementation: "project-skills/subagent-driven-development",
+  });
+});
+```
+
+- [ ] **Step 2: Run init main tests to verify failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/main.test.ts
+```
+
+Expected: FAIL because `runInit` does not install skills or pass skill config to
+the writer.
+
+- [ ] **Step 3: Update help text**
+
+Modify `HELP_TEXT` in `src/cli/commands/init/main.ts`:
+
+```ts
+export const HELP_TEXT = `Usage:
+  patchmill init [options]
+
+Create a minimal patchmill.config.json for this repository and install the recommended project-local skill pack by default.
+
+Options:
+  --skills <mode>  Skill setup mode: project, global, none, or path:<dir>. Default: project.
+  --help, -h       Show this help and exit.
+`;
+```
+
+- [ ] **Step 4: Add skill mode resolution to main**
+
+Add imports to `src/cli/commands/init/main.ts`:
+
+```ts
+import { DEFAULT_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
+import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
+import type { InitSkillsMode } from "./args.ts";
+import {
+  installProjectSkills,
+  validateExistingSkillDirectory,
+} from "./skill-installer.ts";
+```
+
+Add this helper above `runInit`:
+
+```ts
+type SelectedSkills = {
+  configSkills?: Pick<
+    PatchmillSkillsConfig,
+    "triage" | "planning" | "implementation"
+  >;
+  message: string;
+};
+
+async function selectSkills(
+  repoRoot: string,
+  mode: InitSkillsMode,
+): Promise<SelectedSkills> {
+  if (mode.mode === "none") {
+    return {
+      message:
+        "Skipped default skill installation. Patchmill will use built-in skill defaults unless config is edited.",
+    };
+  }
+  if (mode.mode === "global") {
+    return {
+      configSkills: {
+        triage: DEFAULT_PATCHMILL_SKILLS.triage,
+        planning: DEFAULT_PATCHMILL_SKILLS.planning,
+        implementation: DEFAULT_PATCHMILL_SKILLS.implementation,
+      },
+      message:
+        "Configured global/default skill names. Ensure those skills are installed for the agent runtime.",
+    };
+  }
+  if (mode.mode === "path") {
+    return {
+      configSkills: await validateExistingSkillDirectory(repoRoot, mode.path),
+      message: `Configured existing local skills from ${mode.path}. Commit that directory if it governs this project.`,
+    };
+  }
+
+  const install = await installProjectSkills({ repoRoot });
+  return {
+    configSkills: install.skillConfig,
+    message: `Installed project-local skills in ${install.skillDir}. Commit \`${install.skillDir}/\` because these files govern implementation behavior.`,
+  };
+}
+```
+
+Update `runInit` before calling `writeInitialConfig`:
+
+```ts
+const selectedSkills = await selectSkills(config.repoRoot, config.skills);
+const result = await writeInitialConfig(config.repoRoot, {
+  skills: selectedSkills.configSkills,
+});
+```
+
+Update the existing final output block by replacing:
+
+```ts
+Using Patchmill defaults for labels, paths, skills, and git policy.
+```
+
+with:
+
+```ts
+Using Patchmill defaults for labels, paths, and git policy.
+
+Skills:
+  ${selectedSkills.message}
+```
+
+- [ ] **Step 5: Preserve existing-config no-overwrite behavior before installing
+      skills**
+
+The previous step installs project skills before `writeInitialConfig` can return
+`exists`. Fix this by exporting `configFileExists` from `config-writer.ts`:
+
+```ts
+export async function configFileExists(repoRoot: string): Promise<boolean> {
+  return fileExists(join(repoRoot, CONFIG_FILE_NAME));
+}
+```
+
+Import it in `main.ts`:
+
+```ts
+import { configFileExists, writeInitialConfig } from "./config-writer.ts";
+```
+
+Add this guard before `selectSkills`:
+
+```ts
+if (await configFileExists(config.repoRoot)) {
+  output.stdout(
+    `patchmill.config.json already exists.\n\nPatchmill did not overwrite it.\n\nNext:\n  patchmill doctor`,
+  );
+  return 1;
+}
+```
+
+Keep the existing `result.status === "exists"` branch after `writeInitialConfig`
+as a race-safety fallback.
+
+- [ ] **Step 6: Run init tests to verify pass**
+
+Run:
+
+```sh
+node --test src/cli/commands/init/*.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit init integration**
+
+Run:
+
+```sh
+git add src/cli/commands/init/args.ts src/cli/commands/init/args.test.ts src/cli/commands/init/config-writer.ts src/cli/commands/init/config-writer.test.ts src/cli/commands/init/main.ts src/cli/commands/init/main.test.ts src/cli/commands/init/skill-installer.ts src/cli/commands/init/skill-installer.test.ts
+git commit -m "feat(init): install committed project skills by default"
+```
+
+---
+
+## Task 7: Resolve path-like skills into Pi `--skill` arguments
+
+**Files:**
+
+- Modify: `src/workflow/skills.ts`
+- Modify: `src/workflow/skills.test.ts`
+- Modify: `src/cli/commands/triage/dry-run-agent.ts`
+- Modify: `src/cli/commands/triage/dry-run-agent.test.ts`
+- Modify: `src/cli/commands/triage/execute-agent.ts`
+- Modify: `src/cli/commands/triage/execute-agent.test.ts`
+- Modify: `src/cli/commands/run-once/pi.ts`
+- Modify: `src/cli/commands/run-once/pi.test.ts`
+- Modify: `src/pi/runner.ts`
+- Modify: `src/pi/runner.test.ts`
+
+- [ ] **Step 1: Write failing skill resolution tests**
+
+Add tests to `src/workflow/skills.test.ts`:
+
+```ts
+import { resolve } from "node:path";
+```
+
+Add these imports from `./skills.ts`:
+
+```ts
+  isPathLikeSkill,
+  skillInvocationArgs,
+```
+
+Add tests:
+
+```ts
+test("isPathLikeSkill detects local and absolute paths", () => {
+  assert.equal(isPathLikeSkill(".patchmill/skills/writing-plans"), true);
+  assert.equal(isPathLikeSkill("skills\\writing-plans"), true);
+  assert.equal(isPathLikeSkill("/repo/skills/writing-plans"), true);
+  assert.equal(isPathLikeSkill("C:\\repo\\skills\\writing-plans"), true);
+  assert.equal(isPathLikeSkill("superpowers:writing-plans"), false);
+  assert.equal(isPathLikeSkill("writing-plans"), false);
+});
+
+test("skillInvocationArgs resolves bundled default triage skill", () => {
+  assert.deepEqual(skillInvocationArgs("patchmill-issue-triage", "/repo"), [
+    "--skill",
+    bundledTriageSkillPath(),
+  ]);
+});
+
+test("skillInvocationArgs resolves local skill directories to SKILL.md", () => {
+  assert.deepEqual(
+    skillInvocationArgs(".patchmill/skills/writing-plans", "/repo"),
+    [
+      "--skill",
+      resolve("/repo", ".patchmill/skills/writing-plans", "SKILL.md"),
+    ],
+  );
+});
+
+test("skillInvocationArgs ignores named external skills", () => {
+  assert.deepEqual(
+    skillInvocationArgs("superpowers:writing-plans", "/repo"),
+    [],
+  );
+});
+```
+
+- [ ] **Step 2: Run skill tests to verify failure**
+
+Run:
+
+```sh
+node --test src/workflow/skills.test.ts
+```
+
+Expected: FAIL because helper functions do not exist.
+
+- [ ] **Step 3: Implement shared skill resolution helpers**
+
+Add to `src/workflow/skills.ts` before `renderConfiguredSkillLine`:
+
+```ts
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
+const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
+
+export function isNamespaceStyleSkill(skill: string): boolean {
+  return (
+    SKILL_NAMESPACE_PATTERN.test(skill) &&
+    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  );
+}
+
+export function isPathLikeSkill(skill: string): boolean {
+  if (
+    skill.startsWith(".") ||
+    skill.startsWith("/") ||
+    WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  ) {
+    return true;
+  }
+  return /[\\/]/u.test(skill) && !isNamespaceStyleSkill(skill);
+}
+
+export function skillInvocationArgs(
+  skill: string | undefined,
+  repoRoot: string,
+): string[] {
+  if (!skill) return [];
+  if (skill === DEFAULT_PATCHMILL_SKILLS.triage) {
+    return ["--skill", bundledTriageSkillPath()];
+  }
+  if (!isPathLikeSkill(skill)) return [];
+  const resolved = WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+    ? skill
+    : join(repoRoot, skill);
+  return ["--skill", join(resolved, "SKILL.md")];
+}
+
+export function skillInvocationPaths(
+  skills: Array<string | undefined>,
+  repoRoot: string,
+): string[] {
+  return skills.flatMap((skill) => {
+    const args = skillInvocationArgs(skill, repoRoot);
+    return args.length === 2 ? [args[1]!] : [];
+  });
+}
+```
+
+- [ ] **Step 4: Replace duplicated path-like helpers in doctor**
+
+Remove `WINDOWS_ABSOLUTE_PATH_PATTERN`, `SKILL_NAMESPACE_PATTERN`,
+`isNamespaceStyleSkill`, and `isPathLikeSkill` from
+`src/cli/commands/doctor/checks.ts`. Import `isPathLikeSkill` from
+`../../../workflow/skills.ts`.
+
+- [ ] **Step 5: Use helper in triage agents**
+
+In `src/cli/commands/triage/dry-run-agent.ts`, replace the current `skillArgs`
+calculation with:
+
+```ts
+const skillArgs = skillInvocationArgs(skills.triage, repoRoot);
+```
+
+Add `skillInvocationArgs` to the existing import from
+`../../../workflow/skills.ts` and remove `bundledTriageSkillPath` if it becomes
+unused.
+
+Make the same change in `src/cli/commands/triage/execute-agent.ts`.
+
+- [ ] **Step 6: Add triage tests for project-local skill paths**
+
+In `src/cli/commands/triage/dry-run-agent.test.ts`, add a test near the existing
+bundled `--skill` test:
+
+```ts
+test("runTriageDryRunAgent passes project-local triage skill through --skill", async () => {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const runner = {
+    async run(command: string, args: string[]) {
+      calls.push({ command, args });
+      return {
+        code: 0,
+        stdout: JSON.stringify({ previews: [] }),
+        stderr: "",
+      };
+    },
+  };
+
+  await runTriageDryRunAgent(runner, "/repo", {
+    issues: [],
+    labels: DEFAULT_PATCHMILL_CONFIG.labels,
+    stateMap: DEFAULT_PATCHMILL_CONFIG.triage.stateMap,
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      triage: ".patchmill/skills/patchmill-issue-triage",
+    },
+  });
+
+  const skillIndex = calls[0]!.args.indexOf("--skill");
+  assert.equal(
+    calls[0]!.args[skillIndex + 1],
+    join("/repo", ".patchmill/skills/patchmill-issue-triage", "SKILL.md"),
+  );
+});
+```
+
+In `src/cli/commands/triage/execute-agent.test.ts`, add the same assertion
+pattern around `runTriageExecuteAgent`, returning
+`{ code: 0, stdout: "", stderr: "" }` from the runner.
+
+- [ ] **Step 7: Add skill path support to run-once Pi calls**
+
+Update `src/cli/commands/run-once/pi.ts`:
+
+```ts
+function piPromptArgs(
+  promptPath: string,
+  sessionDir?: string,
+  skillPaths: string[] = [],
+): string[] {
+  const skillArgs = skillPaths.flatMap((path) => ["--skill", path]);
+  const baseArgs = ["-e", PI_SUBAGENTS_PACKAGE_ROOT, ...skillArgs, "-p"];
+  return sessionDir
+    ? [...baseArgs, "--session-dir", sessionDir, `@${promptPath}`]
+    : [...baseArgs, `@${promptPath}`];
+}
+```
+
+Add to `RunPiPromptOptions`:
+
+```ts
+  skillPaths?: string[];
+```
+
+Update the runner call:
+
+```ts
+result = await runner.run(
+  "pi",
+  piPromptArgs(promptPath, sessionDir, options?.skillPaths),
+  { cwd },
+);
+```
+
+Update `src/pi/runner.ts` imports:
+
+```ts
+import { skillInvocationPaths } from "../workflow/skills.ts";
+```
+
+Add `skillPaths` to the plan `runPiPrompt` options:
+
+```ts
+        skillPaths: skillInvocationPaths([input.skills.planning], input.repoRoot),
+```
+
+Add `skillPaths` to the implementation `runPiPrompt` options:
+
+```ts
+        skillPaths: skillInvocationPaths(
+          [
+            input.skills.toolchain,
+            input.skills.implementation,
+            input.skills.review,
+            input.skills.visualEvidence,
+            input.skills.landing,
+          ],
+          worktreeRoot,
+        ),
+```
+
+- [ ] **Step 8: Add run-once Pi tests for skill paths**
+
+In `src/cli/commands/run-once/pi.test.ts`, add a test next to the existing
+`runPiPrompt` command argument tests:
+
+```ts
+test("runPiPrompt passes configured local skill paths to pi", async () => {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const runner = {
+    async run(command: string, args: string[]) {
+      calls.push({ command, args });
+      return {
+        code: 0,
+        stdout: JSON.stringify({ status: "blocked", reason: "stop" }),
+        stderr: "",
+      };
+    },
+  };
+
+  await runPiPrompt(runner, "/repo", "prompt", {
+    stage: "pi-plan",
+    skillPaths: ["/repo/.patchmill/skills/writing-plans/SKILL.md"],
+  });
+
+  const skillIndex = calls[0]!.args.indexOf("--skill");
+  assert.equal(
+    calls[0]!.args[skillIndex + 1],
+    "/repo/.patchmill/skills/writing-plans/SKILL.md",
+  );
+});
+```
+
+In `src/pi/runner.test.ts`, add tests that instantiate `PiRunner` with a
+recording runner and verify plan and implementation calls include local skills.
+Use existing test fixtures in that file and assert the final `pi` command
+contains `--skill` followed by the expected `SKILL.md` path.
+
+- [ ] **Step 9: Run focused tests to verify pass**
+
+Run:
+
+```sh
+node --test src/workflow/skills.test.ts src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/execute-agent.test.ts src/cli/commands/run-once/pi.test.ts src/pi/runner.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit skill invocation changes**
+
+Run:
+
+```sh
+git add src/workflow/skills.ts src/workflow/skills.test.ts src/cli/commands/doctor/checks.ts src/cli/commands/triage/dry-run-agent.ts src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/execute-agent.ts src/cli/commands/triage/execute-agent.test.ts src/cli/commands/run-once/pi.ts src/cli/commands/run-once/pi.test.ts src/pi/runner.ts src/pi/runner.test.ts
+git commit -m "feat(skills): pass local skill files to pi"
+```
+
+---
+
+## Task 8: Extend doctor skill validation
+
+**Files:**
+
+- Modify: `src/cli/commands/doctor/checks.ts`
+- Modify: `src/cli/commands/doctor/checks.test.ts`
+
+- [ ] **Step 1: Write failing doctor tests for project-local skills**
+
+Add imports to `src/cli/commands/doctor/checks.test.ts`:
+
+```ts
+import { readFile } from "node:fs/promises";
+import {
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+} from "../../../workflow/skill-pack.ts";
+```
+
+Add helper functions near `writeConfig`:
+
+```ts
+async function writeLocalSkill(
+  repoRoot: string,
+  name: string,
+  body: string,
+): Promise<void> {
+  await mkdir(join(repoRoot, ".patchmill", "skills", name), {
+    recursive: true,
+  });
+  await writeFile(
+    join(repoRoot, ".patchmill", "skills", name, "SKILL.md"),
+    body,
+  );
+}
+
+async function writeSkillMetadata(
+  repoRoot: string,
+  files: Array<{ path: string; body: string }>,
+): Promise<void> {
+  await mkdir(join(repoRoot, ".patchmill", "skills"), { recursive: true });
+  await writeFile(
+    join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+    `${JSON.stringify(
+      {
+        pack: {
+          name: "patchmill-recommended",
+          version: "2026.05",
+          source: { type: "npm", package: "superpowers", version: "5.0.7" },
+        },
+        installedAt: "2026-05-29T00:00:00.000Z",
+        skillDir: ".patchmill/skills",
+        metadataFile: SKILL_PACK_METADATA_FILE,
+        files: files.map((file) => ({
+          path: file.path,
+          sha256: hashText(file.body),
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function piSkillSmokeMock(
+  repoRoot: string,
+  skills: string[],
+): Record<string, { code: number; stdout?: string; stderr?: string }> {
+  const args = skills.flatMap((skill) => [
+    "--skill",
+    join(repoRoot, ".patchmill", "skills", skill, "SKILL.md"),
+  ]);
+  return {
+    [`pi --no-session --no-context-files --no-prompt-templates ${args.join(" ")} -p Reply with PATCHMILL_SKILLS_OK and nothing else.`]:
+      {
+        code: 0,
+        stdout: "PATCHMILL_SKILLS_OK\n",
+      },
+  };
+}
+```
+
+Add tests:
+
+```ts
+test("runDoctorChecks passes freshly initialized project-local skills", async () => {
+  const repoRoot = await tempRepo();
+  const triage =
+    "---\nname: patchmill-issue-triage\ndescription: Triage.\n---\n";
+  const planning = "---\nname: writing-plans\ndescription: Plan.\n---\n";
+  const implementation =
+    "---\nname: subagent-driven-development\ndescription: Implement.\n---\n";
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      triage: ".patchmill/skills/patchmill-issue-triage",
+      planning: ".patchmill/skills/writing-plans",
+      implementation: ".patchmill/skills/subagent-driven-development",
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeLocalSkill(repoRoot, "patchmill-issue-triage", triage);
+  await writeLocalSkill(repoRoot, "writing-plans", planning);
+  await writeLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+    implementation,
+  );
+  await writeSkillMetadata(repoRoot, [
+    { path: ".patchmill/skills/patchmill-issue-triage/SKILL.md", body: triage },
+    { path: ".patchmill/skills/writing-plans/SKILL.md", body: planning },
+    {
+      path: ".patchmill/skills/subagent-driven-development/SKILL.md",
+      body: implementation,
+    },
+  ]);
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": { code: 1 },
+      ...piSkillSmokeMock(repoRoot, [
+        "patchmill-issue-triage",
+        "writing-plans",
+        "subagent-driven-development",
+      ]),
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "pass");
+  assert.match(skills?.message ?? "", /project-local metadata verified/);
+});
+
+test("runDoctorChecks fails when a local skill is malformed", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: { planning: ".patchmill/skills/writing-plans" },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await mkdir(join(repoRoot, ".patchmill"), { recursive: true });
+  await writeLocalSkill(repoRoot, "writing-plans", "# Missing frontmatter\n");
+  const runner = runnerFrom(successMocks());
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(
+    skills?.message ?? "",
+    /missing skill frontmatter with name and description/,
+  );
+});
+
+test("runDoctorChecks warns when project-local skills are customized", async () => {
+  const repoRoot = await tempRepo();
+  const original =
+    "---\nname: writing-plans\ndescription: Plan.\n---\n# Original\n";
+  const customized =
+    "---\nname: writing-plans\ndescription: Plan.\n---\n# Customized\n";
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: { planning: ".patchmill/skills/writing-plans" },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeLocalSkill(repoRoot, "writing-plans", customized);
+  await writeSkillMetadata(repoRoot, [
+    { path: ".patchmill/skills/writing-plans/SKILL.md", body: original },
+  ]);
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": { code: 1 },
+      ...piSkillSmokeMock(repoRoot, ["writing-plans"]),
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(skills?.message ?? "", /customized from installed pack/);
+});
+
+test("runDoctorChecks fails when project-local skill directory is gitignored", async () => {
+  const repoRoot = await tempRepo();
+  const planning = "---\nname: writing-plans\ndescription: Plan.\n---\n";
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: { planning: ".patchmill/skills/writing-plans" },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeLocalSkill(repoRoot, "writing-plans", planning);
+  await writeSkillMetadata(repoRoot, [
+    { path: ".patchmill/skills/writing-plans/SKILL.md", body: planning },
+  ]);
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": {
+        code: 0,
+        stdout: ".patchmill/skills",
+      },
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(skills?.message ?? "", /.patchmill\/skills is ignored by git/);
+});
+
+test("runDoctorChecks fails when Pi cannot load project-local skills", async () => {
+  const repoRoot = await tempRepo();
+  const planning = "---\nname: writing-plans\ndescription: Plan.\n---\n";
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: { planning: ".patchmill/skills/writing-plans" },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeLocalSkill(repoRoot, "writing-plans", planning);
+  await writeSkillMetadata(repoRoot, [
+    { path: ".patchmill/skills/writing-plans/SKILL.md", body: planning },
+  ]);
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": { code: 1 },
+      [`pi --no-session --no-context-files --no-prompt-templates --skill ${join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md")} -p Reply with PATCHMILL_SKILLS_OK and nothing else.`]:
+        {
+          code: 1,
+          stderr: "skill could not be loaded",
+        },
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(
+    skills?.message ?? "",
+    /Pi could not load the project-local skill pack/,
+  );
+  assert.match(skills?.message ?? "", /skill could not be loaded/);
+});
+```
+
+Remove the unused `readFile` import if your final version does not use it.
+
+- [ ] **Step 2: Run doctor tests to verify failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/doctor/checks.test.ts
+```
+
+Expected: FAIL because doctor only checks readability and named-skill warnings.
+
+- [ ] **Step 3: Add skill target shape validation**
+
+In `src/cli/commands/doctor/checks.ts`, update imports:
+
+```ts
+import { access, readFile, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "../../../workflow/skill-pack.ts";
+import { isPathLikeSkill } from "../../../workflow/skills.ts";
+```
+
+Replace `checkReadableSkillTarget` with:
+
+```ts
+type SkillTargetCheck =
+  | { ok: true; skillFile: string; text: string }
+  | { ok: false; message: string };
+
+async function resolveSkillFile(path: string): Promise<string> {
+  const pathStat = await stat(path);
+  return pathStat.isDirectory() ? join(path, "SKILL.md") : path;
+}
+
+function hasSkillFrontmatter(text: string): boolean {
+  return /^---\s*\n[\s\S]*?^name:\s*\S+[\s\S]*?^description:\s*/mu.test(text);
+}
+
+async function checkSkillTarget(path: string): Promise<SkillTargetCheck> {
+  try {
+    const skillFile = await resolveSkillFile(path);
+    const text = await readFile(skillFile, "utf8");
+    if (!hasSkillFrontmatter(text)) {
+      return {
+        ok: false,
+        message: "missing skill frontmatter with name and description",
+      };
+    }
+    return { ok: true, skillFile, text };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ok: false, message: `configured path unreadable at ${path}` };
+    }
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Add metadata and git-ignore checks**
+
+Add helpers above `checkSkills`:
+
+```ts
+function projectRelative(repoRoot: string, absolutePath: string): string {
+  return absolutePath.startsWith(repoRoot)
+    ? absolutePath.slice(repoRoot.length + 1).replace(/\\/gu, "/")
+    : absolutePath.replace(/\\/gu, "/");
+}
+
+async function readSkillPackMetadata(
+  repoRoot: string,
+): Promise<SkillPackMetadataFile | undefined> {
+  try {
+    return JSON.parse(
+      await readFile(
+        resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+        "utf8",
+      ),
+    ) as SkillPackMetadataFile;
+  } catch {
+    return undefined;
+  }
+}
+
+async function checkSkillGitIgnore(
+  runner: CommandRunner,
+  repoRoot: string,
+): Promise<"not-ignored" | "ignored" | "unknown"> {
+  const result = await runner.run(
+    "git",
+    ["check-ignore", "-q", DEFAULT_PROJECT_SKILL_DIR],
+    {
+      cwd: repoRoot,
+    },
+  );
+  if (result.code === 0) return "ignored";
+  if (result.code === 1) return "not-ignored";
+  return "unknown";
+}
+
+async function checkPiLoadsSkills(
+  runner: CommandRunner,
+  repoRoot: string,
+  skillFiles: string[],
+): Promise<DoctorCheckResult | undefined> {
+  if (skillFiles.length === 0) return undefined;
+  const result = await runner.run(
+    "pi",
+    [
+      "--no-session",
+      "--no-context-files",
+      "--no-prompt-templates",
+      ...skillFiles.flatMap((skillFile) => ["--skill", skillFile]),
+      "-p",
+      "Reply with PATCHMILL_SKILLS_OK and nothing else.",
+    ],
+    { cwd: repoRoot },
+  );
+  if (result.code === 0 && result.stdout.includes("PATCHMILL_SKILLS_OK")) {
+    return pass("pi skills", "Pi loaded the project-local skill pack");
+  }
+  return fail(
+    "pi skills",
+    `Pi could not load the project-local skill pack: ${commandOutput(result)}`,
+    [
+      "Patchmill passed the project-local skill pack files to Pi with --skill.",
+      "Fix the reported skill parse/load error, then rerun:",
+      "  patchmill doctor",
+    ],
+  );
+}
+```
+
+Change `checkSkills` signature:
+
+```ts
+async function checkSkills(
+  runner: CommandRunner,
+  config: PatchmillConfig,
+  repoRoot: string,
+): Promise<DoctorCheckResult> {
+```
+
+Within `checkSkills`, collect verified local skill files and compare them to
+metadata:
+
+```ts
+const checkedFiles: Array<{
+  relativePath: string;
+  absolutePath: string;
+  text: string;
+}> = [];
+```
+
+When a path-like skill check passes, push:
+
+```ts
+checkedFiles.push({
+  relativePath: projectRelative(repoRoot, checked.skillFile),
+  absolutePath: checked.skillFile,
+  text: checked.text,
+});
+```
+
+After building `entries`, add metadata and git-ignore entries when any checked
+file starts with `.patchmill/skills/`:
+
+```ts
+const hasProjectLocalSkills = checkedFiles.some((file) =>
+  file.relativePath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`),
+);
+if (hasProjectLocalSkills) {
+  const ignored = await checkSkillGitIgnore(runner, repoRoot);
+  if (ignored === "ignored") {
+    entries.push({
+      status: "fail" as const,
+      summary: `${DEFAULT_PROJECT_SKILL_DIR} is ignored by git`,
+    });
+  } else if (ignored === "unknown") {
+    entries.push({
+      status: "warn" as const,
+      summary: `${DEFAULT_PROJECT_SKILL_DIR} git-ignore status could not be verified`,
+    });
+  }
+
+  const metadata = await readSkillPackMetadata(repoRoot);
+  if (!metadata) {
+    entries.push({
+      status: "warn" as const,
+      summary: "project-local skill pack metadata missing",
+    });
+  } else {
+    const metadataHashes = new Map(
+      metadata.files.map((file) => [file.path, file.sha256]),
+    );
+    const customized = checkedFiles.filter((file) => {
+      const expected = metadataHashes.get(file.relativePath);
+      return expected !== undefined && expected !== hashText(file.text);
+    });
+    entries.push(
+      customized.length > 0
+        ? {
+            status: "warn" as const,
+            summary: `${customized.map((file) => file.relativePath).join(", ")} customized from installed pack`,
+          }
+        : {
+            status: "pass" as const,
+            summary: "project-local metadata verified",
+          },
+    );
+  }
+}
+```
+
+Inside the `hasProjectLocalSkills` block, ask Pi to load the project-local skill
+pack when no skill validation failure has already been found. Use metadata file
+paths when metadata exists so the smoke test covers every installed pack skill,
+not only the currently configured stages:
+
+```ts
+const projectLocalSkillFiles = metadata
+  ? metadata.files
+      .filter((file) => file.path.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`))
+      .map((file) => resolve(repoRoot, file.path))
+  : checkedFiles
+      .filter((file) =>
+        file.relativePath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`),
+      )
+      .map((file) => file.absolutePath);
+
+if (!entries.some((entry) => entry.status === "fail")) {
+  const piSkills = await checkPiLoadsSkills(
+    runner,
+    repoRoot,
+    projectLocalSkillFiles,
+  );
+  if (piSkills) {
+    entries.push({ status: piSkills.status, summary: piSkills.message });
+  }
+}
+```
+
+Update the call site in `runDoctorChecks`:
+
+```ts
+results.push(await checkSkills(runner, config, options.repoRoot));
+```
+
+- [ ] **Step 5: Run doctor tests to verify pass**
+
+Run:
+
+```sh
+node --test src/cli/commands/doctor/checks.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit doctor validation**
+
+Run:
+
+```sh
+git add src/cli/commands/doctor/checks.ts src/cli/commands/doctor/checks.test.ts
+git commit -m "feat(doctor): validate project-local skills"
+```
+
+---
+
+## Task 9: Update documentation
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/skills.md`
+- Modify: `docs/issue-agent-workflows.md`
+
+- [ ] **Step 1: Update README first-use flow**
+
+Edit the README onboarding section so it states:
+
+```md
+patchmill init
+```
+
+creates `patchmill.config.json` and installs Patchmill's recommended skills into
+`.patchmill/skills/` by default. The skill files should be committed because
+they govern how Patchmill plans and implements code changes.
+
+Document alternatives:
+
+```sh
+patchmill init --skills project
+patchmill init --skills global
+patchmill init --skills none
+patchmill init --skills path:project-skills
+```
+
+- [ ] **Step 2: Update configuration docs**
+
+In `docs/configuration.md`, update the skills default section so it explains:
+
+````md
+For new repositories, `patchmill init` writes project-local skill mappings by
+default:
+
+```json
+{
+  "skills": {
+    "triage": ".patchmill/skills/patchmill-issue-triage",
+    "planning": ".patchmill/skills/writing-plans",
+    "implementation": ".patchmill/skills/subagent-driven-development"
+  }
+}
+```
+
+If no config file overrides skills, Patchmill still has built-in defaults for
+compatibility with older repositories.
+````
+
+- [ ] **Step 3: Update skills docs**
+
+In `docs/skills.md`, add a section named `Project-local default skills` with
+this content:
+
+```md
+`patchmill init` installs the recommended skill pack into `.patchmill/skills/`
+unless a different `--skills` mode is selected. Commit this directory to git.
+Skill changes are process changes: they affect how Patchmill triages, plans,
+implements, reviews, and validates work.
+
+Patchmill treats the installed files as project-owned after init. It does not
+silently overwrite edited skills. `patchmill doctor` warns when installed skills
+differ from the recorded pack metadata and fails when configured required skill
+paths are missing or malformed.
+```
+
+- [ ] **Step 4: Update issue workflow docs**
+
+In `docs/issue-agent-workflows.md`, update the init/doctor preflight description
+so it says doctor verifies configured local skills, asks Pi to load the
+project-local skill pack, and checks that `.patchmill/skills/` is not ignored by
+git.
+
+- [ ] **Step 5: Run docs lint**
+
+Run:
+
+```sh
+npm run lint:md
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit docs**
+
+Run:
+
+```sh
+git add README.md docs/configuration.md docs/skills.md docs/issue-agent-workflows.md
+git commit -m "docs(skills): document project-local defaults"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:**
+
+- Verify all changed files.
+
+- [ ] **Step 1: Run focused test suites**
+
+Run:
+
+```sh
+node --test src/workflow/*.test.ts src/cli/commands/init/*.test.ts src/cli/commands/doctor/*.test.ts src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/execute-agent.test.ts src/cli/commands/run-once/pi.test.ts src/pi/runner.test.ts
+```
+
+Expected: all listed tests PASS.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+
+```sh
+npm test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```sh
+npm run lint
+```
+
+Expected: format check, TypeScript lint, and markdown lint all PASS.
+
+- [ ] **Step 4: Smoke-test init in a temporary git repo**
+
+Run:
+
+```sh
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+git init
+node /home/roche/projects/patchmill/bin/patchmill.ts init --skills project
+find .patchmill/skills -maxdepth 2 -name SKILL.md | sort
+node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync('patchmill.config.json','utf8')); console.log(JSON.stringify(cfg.skills, null, 2));"
+git status --short
+```
+
+Expected output includes:
+
+```text
+.patchmill/skills/patchmill-issue-triage/SKILL.md
+.patchmill/skills/subagent-driven-development/SKILL.md
+.patchmill/skills/writing-plans/SKILL.md
+```
+
+Expected config output:
+
+```json
+{
+  "triage": ".patchmill/skills/patchmill-issue-triage",
+  "planning": ".patchmill/skills/writing-plans",
+  "implementation": ".patchmill/skills/subagent-driven-development"
+}
+```
+
+Expected `git status --short` includes untracked `patchmill.config.json` and
+`.patchmill/skills/`, proving the skills are not ignored and are ready to
+commit.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```sh
+git diff --stat HEAD~10..HEAD
+git status --short
+```
+
+Expected: committed changes are grouped by the task commits above, and
+`git status --short` is empty.

--- a/docs/plans/2026-05-30-fix-project-local-skills-review-findings.md
+++ b/docs/plans/2026-05-30-fix-project-local-skills-review-findings.md
@@ -1,0 +1,1514 @@
+# Fix Project-local Skills Review Findings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the structural review findings in the project-local default skills
+branch so runtime, doctor, init, and docs share one coherent skill-resolution
+model.
+
+**Architecture:** Move project-local skill-pack resolution into one canonical
+workflow module that both runtime invocation and doctor validation consume. Make
+init installation atomic by staging the full skill pack before publishing it,
+and separate bundled fallback triage from user-global skill names so config
+strings no longer carry two meanings.
+
+**Tech Stack:** TypeScript ESM, Node built-ins (`node:test`, `fs/promises`,
+`fs`, `crypto`, `path`, `os`), existing Patchmill CLI modules, existing
+`CommandRunner`, npm lockfiles.
+
+---
+
+## File structure
+
+Create:
+
+- `src/workflow/skill-resolution.ts` — canonical configured-skill and
+  project-local pack resolver. Owns path-like skill detection, local path
+  resolution, metadata parsing, metadata path safety, hash/customization checks,
+  exact Pi invocation path calculation, and non-fatal diagnostics. This is the
+  only module allowed to parse project-local skill-pack metadata or metadata
+  file paths.
+- `src/workflow/skill-resolution.test.ts` — unit tests for runtime/doctor shared
+  resolution semantics.
+
+Modify:
+
+- `src/workflow/skills.ts` — keep skill config constants and presentation
+  helpers; delete duplicated invocation/path/metadata resolution and re-export
+  the new functions for compatibility.
+- `src/workflow/skills.test.ts` — remove or migrate resolver-specific tests to
+  `skill-resolution.test.ts`; keep config merge/render tests.
+- `src/cli/commands/doctor/checks.ts` — consume the shared resolver,
+  validate/smoke-test exact resolved paths, and gate `.patchmill/skills` checks
+  on configured project-local usage. It must not parse project-local skill-pack
+  metadata JSON, metadata file paths, or metadata hashes directly.
+- `src/cli/commands/doctor/checks.test.ts` — add regression tests for unused
+  local packs, malformed metadata, and exact smoke paths.
+- `src/cli/commands/init/main.ts` — use a distinct global skill mapping for
+  `--skills global`.
+- `src/cli/commands/init/main.test.ts` — cover that global init writes the
+  non-bundled global triage name.
+- `src/cli/commands/init/skill-installer.ts` — stage skill installation into a
+  temporary directory and publish atomically.
+- `src/cli/commands/init/skill-installer.test.ts` — cover rollback/no partial
+  target publication when copy or metadata publication fails.
+- `src/workflow/skill-pack.ts` — keep manifest/provenance source aligned with
+  actual dependency source.
+- `package.json`, `package-lock.json`, `npm-shrinkwrap.json` — ensure the
+  selected `superpowers` source is installable and lockfiles are refreshed.
+- `docs/plans/2026-05-29-project-local-default-skills.md` and
+  `docs/specs/2026-05-29-project-local-default-skills-design.md` — align the
+  historical plan/spec with the actual GitHub tarball dependency source, because
+  `npm view superpowers versions` does not include `5.0.7`.
+
+Do not modify:
+
+- Host provider behavior.
+- Triage state policy or label definitions.
+- Pi prompt contract JSON shapes.
+
+---
+
+## Task 1: Add canonical skill-resolution tests
+
+**Files:**
+
+- Create: `src/workflow/skill-resolution.test.ts`
+- Modify: `src/workflow/skills.test.ts`
+
+- [ ] **Step 1: Create the failing shared resolver test file**
+
+Create `src/workflow/skill-resolution.test.ts` with these tests:
+
+```ts
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  BUNDLED_TRIAGE_SKILL_REFERENCE,
+  GLOBAL_PATCHMILL_SKILLS,
+} from "./skills.ts";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "./skill-pack.ts";
+import {
+  resolveConfiguredSkillInvocation,
+  resolvePathLikeSkillPath,
+} from "./skill-resolution.ts";
+
+async function tempRepo(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "patchmill-skill-resolution-"));
+}
+
+function skillDocument(name: string): string {
+  return `---\nname: ${name}\ndescription: ${name} skill.\n---\n# ${name}\n`;
+}
+
+async function writeProjectLocalSkill(
+  repoRoot: string,
+  name: string,
+): Promise<string> {
+  const skillDir = join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, name);
+  await mkdir(skillDir, { recursive: true });
+  const content = skillDocument(name);
+  await writeFile(join(skillDir, "SKILL.md"), content);
+  return content;
+}
+
+async function writeMetadata(
+  repoRoot: string,
+  files: SkillPackMetadataFile["files"],
+): Promise<void> {
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  const metadata: SkillPackMetadataFile = {
+    pack: {
+      name: PATCHMILL_RECOMMENDED_SKILL_PACK.name,
+      version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+      source: PATCHMILL_RECOMMENDED_SKILL_PACK.source,
+    },
+    installedAt: "2026-05-30T00:00:00.000Z",
+    skillDir: DEFAULT_PROJECT_SKILL_DIR,
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files,
+  };
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    JSON.stringify(metadata),
+  );
+}
+
+test("resolveConfiguredSkillInvocation expands a valid project-local pack exactly once", async () => {
+  const repoRoot = await tempRepo();
+  const triage = await writeProjectLocalSkill(
+    repoRoot,
+    "patchmill-issue-triage",
+  );
+  const planning = await writeProjectLocalSkill(repoRoot, "writing-plans");
+  const implementation = await writeProjectLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+  );
+  await writeMetadata(repoRoot, [
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/patchmill-issue-triage/SKILL.md`,
+      sha256: hashText(triage),
+    },
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans/SKILL.md`,
+      sha256: hashText(planning),
+    },
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development/SKILL.md`,
+      sha256: hashText(implementation),
+    },
+  ]);
+
+  const result = resolveConfiguredSkillInvocation(
+    [
+      `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+      `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    ],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "patchmill-issue-triage",
+      "SKILL.md",
+    ),
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.deepEqual(
+    result.diagnostics.map((entry) => entry.status),
+    ["pass"],
+  );
+});
+
+test("resolveConfiguredSkillInvocation uses configured paths only when metadata is missing", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "writing-plans");
+  await writeProjectLocalSkill(repoRoot, "subagent-driven-development");
+
+  const result = resolveConfiguredSkillInvocation(
+    [
+      `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+      `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    ],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.deepEqual(result.diagnostics, [
+    {
+      status: "warn",
+      summary:
+        "project-local skill pack metadata missing; using configured project-local skill paths only",
+    },
+  ]);
+});
+
+test("resolveConfiguredSkillInvocation uses configured paths only when metadata is malformed", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "writing-plans");
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    "{ malformed json",
+  );
+
+  const result = resolveConfiguredSkillInvocation(
+    [`${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+  ]);
+  assert.equal(result.diagnostics[0]?.status, "warn");
+  assert.match(
+    result.diagnostics[0]?.summary ?? "",
+    /project-local skill pack metadata malformed; using configured project-local skill paths only/,
+  );
+});
+
+test("resolveConfiguredSkillInvocation reports customized project-local pack files", async () => {
+  const repoRoot = await tempRepo();
+  const planning = await writeProjectLocalSkill(repoRoot, "writing-plans");
+  await writeMetadata(repoRoot, [
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans/SKILL.md`,
+      sha256: hashText(planning),
+    },
+  ]);
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    skillDocument("writing-plans") + "\n# local customization\n",
+  );
+
+  const result = resolveConfiguredSkillInvocation(
+    [`${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`],
+    repoRoot,
+  );
+
+  assert.deepEqual(
+    result.diagnostics.map((entry) => entry.summary),
+    [
+      "project-local metadata verified",
+      "project-local skill pack customized from installed pack",
+    ],
+  );
+});
+
+test("resolveConfiguredSkillInvocation ignores unused project-local directories", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "stale-unused-skill");
+
+  const result = resolveConfiguredSkillInvocation(
+    ["superpowers:writing-plans", "superpowers:subagent-driven-development"],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, []);
+  assert.deepEqual(result.diagnostics, []);
+});
+
+test("resolveConfiguredSkillInvocation separates bundled fallback from global triage", async () => {
+  const repoRoot = await tempRepo();
+
+  assert.equal(
+    resolveConfiguredSkillInvocation([BUNDLED_TRIAGE_SKILL_REFERENCE], repoRoot)
+      .paths.length,
+    1,
+  );
+  assert.deepEqual(
+    resolveConfiguredSkillInvocation([GLOBAL_PATCHMILL_SKILLS.triage], repoRoot)
+      .paths,
+    [],
+  );
+});
+
+test("resolvePathLikeSkillPath preserves configured SKILL.md file paths", async () => {
+  const repoRoot = await tempRepo();
+
+  assert.equal(
+    resolvePathLikeSkillPath("project-skills/writing-plans/SKILL.md", repoRoot),
+    join(repoRoot, "project-skills", "writing-plans", "SKILL.md"),
+  );
+  assert.equal(
+    resolvePathLikeSkillPath("project-skills/writing-plans", repoRoot),
+    join(repoRoot, "project-skills", "writing-plans", "SKILL.md"),
+  );
+});
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+node --test src/workflow/skill-resolution.test.ts
+```
+
+Expected: FAIL with a module-not-found or missing-export error for
+`./skill-resolution.ts`, `BUNDLED_TRIAGE_SKILL_REFERENCE`, or
+`GLOBAL_PATCHMILL_SKILLS`.
+
+- [ ] **Step 3: Remove duplicated resolver tests from `skills.test.ts` after the
+      new module exists**
+
+Do not delete config tests. Move resolver-focused expectations from
+`src/workflow/skills.test.ts` into `src/workflow/skill-resolution.test.ts` after
+Task 2 is complete. Keep tests for:
+
+```ts
+DEFAULT_PATCHMILL_SKILLS;
+mergeSkillsConfig;
+cloneSkillsConfig;
+renderConfiguredSkillLine;
+```
+
+- [ ] **Step 4: Commit tests**
+
+```bash
+git add src/workflow/skill-resolution.test.ts src/workflow/skills.test.ts
+git commit -m "test(skills): capture shared skill resolution semantics"
+```
+
+---
+
+## Task 2: Implement the canonical shared resolver
+
+**Files:**
+
+- Create: `src/workflow/skill-resolution.ts`
+- Modify: `src/workflow/skills.ts`
+- Test: `src/workflow/skill-resolution.test.ts`
+
+- [ ] **Step 1: Add explicit resolver result types**
+
+Create `src/workflow/skill-resolution.ts` with the public result shape:
+
+```ts
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashContent,
+  type SkillPackMetadataFile,
+} from "./skill-pack.ts";
+import { BUNDLED_TRIAGE_SKILL_REFERENCE } from "./skills.ts";
+
+export type SkillResolutionStatus = "pass" | "warn" | "fail";
+
+export type SkillResolutionDiagnostic = {
+  status: SkillResolutionStatus;
+  summary: string;
+};
+
+export type SkillInvocationResolution = {
+  paths: string[];
+  diagnostics: SkillResolutionDiagnostic[];
+  configuredProjectLocalPaths: string[];
+  usedProjectLocalPack: boolean;
+};
+
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
+const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
+const SKILL_FILE_NAME = "SKILL.md";
+```
+
+- [ ] **Step 2: Move path-like helpers into the new module**
+
+Add these helpers to `skill-resolution.ts`:
+
+```ts
+export function bundledTriageSkillPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "..", "skills", "patchmill-issue-triage", "SKILL.md");
+}
+
+export function isNamespaceStyleSkill(skill: string): boolean {
+  return (
+    SKILL_NAMESPACE_PATTERN.test(skill) &&
+    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  );
+}
+
+export function isPathLikeSkill(skill: string): boolean {
+  if (
+    skill.startsWith(".") ||
+    skill.startsWith("/") ||
+    WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  ) {
+    return true;
+  }
+
+  return /[\\/]/u.test(skill) && !isNamespaceStyleSkill(skill);
+}
+
+function isSkillFilePath(skill: string): boolean {
+  const normalizedPath = skill.replaceAll("\\", "/");
+  return (
+    normalizedPath === SKILL_FILE_NAME ||
+    normalizedPath.endsWith(`/${SKILL_FILE_NAME}`)
+  );
+}
+
+export function resolvePathLikeSkillPath(
+  skill: string,
+  repoRoot: string,
+): string {
+  if (WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)) {
+    return isSkillFilePath(skill)
+      ? win32.normalize(skill)
+      : win32.join(skill, SKILL_FILE_NAME);
+  }
+
+  const normalizedPath = skill.replaceAll("\\", "/");
+  if (isSkillFilePath(normalizedPath)) {
+    return normalizedPath.startsWith("/")
+      ? resolve(normalizedPath)
+      : resolve(repoRoot, normalizedPath);
+  }
+
+  return normalizedPath.startsWith("/")
+    ? resolve(normalizedPath, SKILL_FILE_NAME)
+    : resolve(repoRoot, normalizedPath, SKILL_FILE_NAME);
+}
+```
+
+- [ ] **Step 3: Add project-local metadata parsing with non-fatal diagnostics**
+
+Add this implementation to `skill-resolution.ts`:
+
+```ts
+function pathStartsWith(path: string, prefix: string): boolean {
+  return (
+    path === prefix ||
+    path.startsWith(`${prefix}/`) ||
+    path.startsWith(`${prefix}\\`)
+  );
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const pathRelative = relative(parent, child);
+  return (
+    pathRelative === "" ||
+    (!pathRelative.startsWith("..") && !isAbsolute(pathRelative))
+  );
+}
+
+function resolveProjectLocalMetadataFilePath(
+  filePath: string,
+  repoRoot: string,
+  projectLocalRoot: string,
+): string | null {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  if (isAbsolute(normalizedPath) || win32.isAbsolute(filePath)) return null;
+  if (!normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`)) return null;
+
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  return isPathInside(projectLocalRoot, resolvedPath) ? resolvedPath : null;
+}
+
+function validMetadata(
+  value: unknown,
+  repoRoot: string,
+  projectLocalRoot: string,
+): value is SkillPackMetadataFile {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<SkillPackMetadataFile> & {
+    pack?: { source?: Record<string, unknown> };
+  };
+
+  return (
+    candidate.pack?.name === PATCHMILL_RECOMMENDED_SKILL_PACK.name &&
+    candidate.pack.version === PATCHMILL_RECOMMENDED_SKILL_PACK.version &&
+    candidate.pack.source?.type ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.type &&
+    candidate.pack.source?.repository ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.repository &&
+    candidate.pack.source?.tag ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tag &&
+    candidate.pack.source?.tarballUrl ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tarballUrl &&
+    typeof candidate.installedAt === "string" &&
+    candidate.skillDir === DEFAULT_PROJECT_SKILL_DIR &&
+    candidate.metadataFile === SKILL_PACK_METADATA_FILE &&
+    Array.isArray(candidate.files) &&
+    candidate.files.every(
+      (file) =>
+        file &&
+        typeof file.path === "string" &&
+        typeof file.sha256 === "string" &&
+        resolveProjectLocalMetadataFilePath(
+          file.path,
+          repoRoot,
+          projectLocalRoot,
+        ) !== null,
+    )
+  );
+}
+
+function metadataSkillPaths(
+  metadata: SkillPackMetadataFile,
+  repoRoot: string,
+  projectLocalRoot: string,
+): string[] {
+  return metadata.files
+    .filter((file) => isSkillFilePath(file.path))
+    .flatMap((file) => {
+      const resolvedPath = resolveProjectLocalMetadataFilePath(
+        file.path,
+        repoRoot,
+        projectLocalRoot,
+      );
+      return resolvedPath ? [resolvedPath] : [];
+    });
+}
+
+function projectLocalPackResolution(
+  repoRoot: string,
+  configuredProjectLocalPaths: string[],
+): { paths: string[]; diagnostics: SkillResolutionDiagnostic[] } {
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
+  const metadataPath = join(projectLocalRoot, SKILL_PACK_METADATA_FILE);
+
+  let metadataContent: string;
+  try {
+    metadataContent = readFileSync(metadataPath, "utf8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return {
+      paths: configuredProjectLocalPaths,
+      diagnostics: [
+        {
+          status: "warn",
+          summary:
+            code === "ENOENT"
+              ? "project-local skill pack metadata missing; using configured project-local skill paths only"
+              : `project-local skill pack metadata unreadable; using configured project-local skill paths only: ${String(error)}`,
+        },
+      ],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadataContent);
+  } catch (error) {
+    return {
+      paths: configuredProjectLocalPaths,
+      diagnostics: [
+        {
+          status: "warn",
+          summary: `project-local skill pack metadata malformed; using configured project-local skill paths only: ${String(error)}`,
+        },
+      ],
+    };
+  }
+
+  if (!validMetadata(parsed, repoRoot, projectLocalRoot)) {
+    return {
+      paths: configuredProjectLocalPaths,
+      diagnostics: [
+        {
+          status: "warn",
+          summary:
+            "project-local skill pack metadata malformed; using configured project-local skill paths only",
+        },
+      ],
+    };
+  }
+
+  return {
+    paths: metadataSkillPaths(parsed, repoRoot, projectLocalRoot),
+    diagnostics: [
+      { status: "pass", summary: "project-local metadata verified" },
+      ...projectLocalCustomizationDiagnostics(
+        parsed,
+        repoRoot,
+        projectLocalRoot,
+      ),
+    ],
+  };
+}
+
+function projectLocalCustomizationDiagnostics(
+  metadata: SkillPackMetadataFile,
+  repoRoot: string,
+  projectLocalRoot: string,
+): SkillResolutionDiagnostic[] {
+  for (const file of metadata.files) {
+    const resolvedPath = resolveProjectLocalMetadataFilePath(
+      file.path,
+      repoRoot,
+      projectLocalRoot,
+    );
+    if (!resolvedPath) {
+      return [
+        {
+          status: "warn",
+          summary: "project-local skill pack customized from installed pack",
+        },
+      ];
+    }
+
+    try {
+      if (hashContent(readFileSync(resolvedPath)) !== file.sha256) {
+        return [
+          {
+            status: "warn",
+            summary: "project-local skill pack customized from installed pack",
+          },
+        ];
+      }
+    } catch {
+      return [
+        {
+          status: "warn",
+          summary: "project-local skill pack customized from installed pack",
+        },
+      ];
+    }
+  }
+
+  return [];
+}
+```
+
+- [ ] **Step 4: Add the canonical invocation resolver**
+
+Add this public function to `skill-resolution.ts`:
+
+```ts
+function unique(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    if (seen.has(path)) return false;
+    seen.add(path);
+    return true;
+  });
+}
+
+export function resolveConfiguredSkillInvocation(
+  skills: Array<string | undefined>,
+  repoRoot: string,
+): SkillInvocationResolution {
+  const diagnostics: SkillResolutionDiagnostic[] = [];
+  const configuredPaths = skills.flatMap((skill) => {
+    if (!skill) return [];
+    if (skill === BUNDLED_TRIAGE_SKILL_REFERENCE)
+      return [bundledTriageSkillPath()];
+    if (!isPathLikeSkill(skill)) return [];
+    return [resolvePathLikeSkillPath(skill, repoRoot)];
+  });
+
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
+  const configuredProjectLocalPaths = configuredPaths.filter((path) =>
+    pathStartsWith(resolve(path), projectLocalRoot),
+  );
+
+  if (configuredProjectLocalPaths.length === 0) {
+    return {
+      paths: unique(configuredPaths),
+      diagnostics,
+      configuredProjectLocalPaths,
+      usedProjectLocalPack: false,
+    };
+  }
+
+  const pack = projectLocalPackResolution(
+    repoRoot,
+    configuredProjectLocalPaths,
+  );
+  diagnostics.push(...pack.diagnostics);
+
+  return {
+    paths: unique([...configuredPaths, ...pack.paths]),
+    diagnostics,
+    configuredProjectLocalPaths: unique(configuredProjectLocalPaths),
+    usedProjectLocalPack: true,
+  };
+}
+
+export function skillInvocationPaths(
+  skills: Array<string | undefined>,
+  repoRoot: string,
+): string[] {
+  return resolveConfiguredSkillInvocation(skills, repoRoot).paths;
+}
+
+export function skillInvocationArgs(
+  skill: string | undefined,
+  repoRoot: string,
+): string[] {
+  return skillInvocationPaths([skill], repoRoot).flatMap((path) => [
+    "--skill",
+    path,
+  ]);
+}
+```
+
+- [ ] **Step 5: Keep existing imports stable through `skills.ts` re-exports**
+
+In `src/workflow/skills.ts`, remove the duplicated resolver implementation and
+re-export resolver helpers:
+
+```ts
+export {
+  bundledTriageSkillPath,
+  isNamespaceStyleSkill,
+  isPathLikeSkill,
+  resolveConfiguredSkillInvocation,
+  resolvePathLikeSkillPath,
+  skillInvocationArgs,
+  skillInvocationPaths,
+  type SkillInvocationResolution,
+  type SkillResolutionDiagnostic,
+} from "./skill-resolution.ts";
+```
+
+- [ ] **Step 6: Add explicit bundled/global constants in `skills.ts`**
+
+In `src/workflow/skills.ts`, define the bundled fallback separately from
+user-global names:
+
+```ts
+export const BUNDLED_TRIAGE_SKILL_REFERENCE = "patchmill:bundled-issue-triage";
+
+export const DEFAULT_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
+  triage: BUNDLED_TRIAGE_SKILL_REFERENCE,
+  planning: "superpowers:writing-plans",
+  implementation: "superpowers:subagent-driven-development",
+};
+
+export const GLOBAL_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
+  triage: "patchmill-issue-triage",
+  planning: "superpowers:writing-plans",
+  implementation: "superpowers:subagent-driven-development",
+};
+```
+
+- [ ] **Step 7: Run resolver tests**
+
+Run:
+
+```bash
+node --test src/workflow/skill-resolution.test.ts src/workflow/skills.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit resolver implementation**
+
+```bash
+git add src/workflow/skill-resolution.ts src/workflow/skills.ts src/workflow/skill-resolution.test.ts src/workflow/skills.test.ts
+git commit -m "fix(skills): share runtime skill resolution semantics"
+```
+
+---
+
+## Task 3: Make doctor consume the shared resolver and ignore unused local packs
+
+**Files:**
+
+- Modify: `src/cli/commands/doctor/checks.ts`
+- Modify: `src/cli/commands/doctor/checks.test.ts`
+- Test: `src/cli/commands/doctor/checks.test.ts`
+
+- [ ] **Step 1: Add failing doctor regression tests**
+
+Add these tests to `src/cli/commands/doctor/checks.test.ts` near the existing
+project-local skill tests:
+
+```ts
+test("runDoctorChecks ignores unused .patchmill skills when config uses global skills", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      triage: "patchmill-issue-triage",
+      planning: "superpowers:writing-plans",
+      implementation: "superpowers:subagent-driven-development",
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(
+    repoRoot,
+    "stale-unused-skill",
+    "not a valid skill document\n",
+  );
+
+  const runner = runnerFrom(successMocks(REQUIRED_LABELS));
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(
+    skills?.message ?? "",
+    /triage: `patchmill-issue-triage` \(named skill configured; doctor did not verify it\)/,
+  );
+  assert.doesNotMatch(skills?.message ?? "", /stale-unused-skill/);
+  assert.doesNotMatch(
+    skills?.message ?? "",
+    /project-local skill pack metadata/,
+  );
+});
+
+test("runDoctorChecks smoke-tests the exact shared resolver paths when metadata is malformed", async () => {
+  const repoRoot = await tempRepo();
+  const planningSkill = skillDocument("writing-plans", "Write plans.");
+
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      planning: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(repoRoot, "writing-plans", planningSkill);
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    "{ malformed json",
+  );
+
+  const smokePaths = [projectLocalSkillPath(repoRoot, "writing-plans")];
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
+      [projectLocalPiSmokeCommand(smokePaths)]: {
+        code: 0,
+        stdout: "PATCHMILL_SKILLS_OK\n",
+      },
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(skills?.message ?? "", /metadata malformed/);
+  assert.match(skills?.message ?? "", /Pi loaded project-local skill pack/);
+});
+```
+
+- [ ] **Step 2: Run doctor tests and verify they fail**
+
+Run:
+
+```bash
+node --test src/cli/commands/doctor/checks.test.ts
+```
+
+Expected: FAIL because doctor still validates any readable `.patchmill/skills`
+directory and still owns metadata parsing itself.
+
+- [ ] **Step 3: Replace doctor metadata resolution with shared resolver output**
+
+In `src/cli/commands/doctor/checks.ts`, import the resolver:
+
+```ts
+import {
+  resolveConfiguredSkillInvocation,
+  resolvePathLikeSkillPath,
+  isPathLikeSkill,
+} from "../../../workflow/skills.ts";
+```
+
+Then change `checkSkills` so it computes the shared resolution once:
+
+```ts
+const configuredSkillValues = PATCHMILL_SKILL_KEYS.flatMap((key) => {
+  const skill = config.skills[key];
+  return skill ? [skill] : [];
+});
+const resolution = resolveConfiguredSkillInvocation(
+  configuredSkillValues,
+  repoRoot,
+);
+```
+
+Keep per-configured-skill shape validation for path-like skills, but remove
+doctor-owned metadata parsing as the source of smoke paths. Use:
+
+```ts
+entries.push(...resolution.diagnostics);
+
+if (resolution.usedProjectLocalPack) {
+  entries.push(await checkProjectLocalGitIgnore(runner, repoRoot));
+
+  if (
+    !entries.some((entry) => entry.status === "fail") &&
+    resolution.paths.length > 0
+  ) {
+    entries.push(
+      await smokeTestProjectLocalSkills(runner, repoRoot, resolution.paths),
+    );
+  }
+}
+```
+
+Delete these doctor-local helpers after their logic moves to
+`skill-resolution.ts`:
+
+```ts
+isValidProjectLocalMetadata;
+metadataSkillPaths;
+checkProjectLocalMetadata;
+resolveProjectLocalMetadataFilePath;
+```
+
+Do not replace them with another doctor-local metadata parser.
+`src/cli/commands/doctor/checks.ts` must not call `JSON.parse` on
+`patchmill-skill-pack.json`, must not inspect `metadata.files`, must not resolve
+metadata file paths, and must not compare metadata hashes directly.
+Customized-pack warnings must arrive through `resolution.diagnostics` from
+`resolveConfiguredSkillInvocation`.
+
+- [ ] **Step 4: Add a no-duplication guard for doctor metadata parsing**
+
+Add a targeted assertion or source scan to
+`src/cli/commands/doctor/checks.test.ts` so future edits cannot reintroduce
+metadata/path parsing into doctor. Use a test like:
+
+```ts
+test("doctor does not parse project-local skill-pack metadata directly", async () => {
+  const source = await readFile(
+    new URL("./checks.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.doesNotMatch(source, /checkProjectLocalMetadata/);
+  assert.doesNotMatch(source, /isValidProjectLocalMetadata/);
+  assert.doesNotMatch(source, /metadataSkillPaths/);
+  assert.doesNotMatch(source, /resolveProjectLocalMetadataFilePath/);
+  assert.doesNotMatch(source, /metadata\.files/);
+  assert.doesNotMatch(source, /JSON\.parse\([^\n]*patchmill-skill-pack/);
+});
+```
+
+If the exact `JSON.parse` regex is too brittle because the filename is not on
+the same line, use a simpler guard that forbids `SKILL_PACK_METADATA_FILE` and
+`JSON.parse` appearing in the same helper block. The important invariant is
+strict: doctor may read configured skill files for frontmatter and may format
+resolver diagnostics, but only `src/workflow/skill-resolution.ts` may parse
+project-local skill-pack metadata, metadata paths, or metadata hashes.
+
+- [ ] **Step 5: Run doctor tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/doctor/checks.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit doctor integration**
+
+```bash
+git add src/cli/commands/doctor/checks.ts src/cli/commands/doctor/checks.test.ts
+git commit -m "fix(doctor): validate resolved project-local skill paths"
+```
+
+---
+
+## Task 4: Separate bundled fallback triage from global init config
+
+**Files:**
+
+- Modify: `src/cli/commands/init/main.ts`
+- Modify: `src/cli/commands/init/main.test.ts`
+- Modify: `src/workflow/skills.ts`
+- Test: `src/cli/commands/init/main.test.ts`,
+  `src/workflow/skill-resolution.test.ts`
+
+- [ ] **Step 1: Update init to use global skill names for `--skills global`**
+
+In `src/cli/commands/init/main.ts`, replace `DEFAULT_GLOBAL_SKILLS` with the
+exported global mapping:
+
+```ts
+import { GLOBAL_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
+```
+
+Then set:
+
+```ts
+const DEFAULT_GLOBAL_SKILLS: InitialConfigSkills = {
+  triage: GLOBAL_PATCHMILL_SKILLS.triage,
+  planning: GLOBAL_PATCHMILL_SKILLS.planning,
+  implementation: GLOBAL_PATCHMILL_SKILLS.implementation,
+};
+```
+
+- [ ] **Step 2: Update the global init test expectation**
+
+In `src/cli/commands/init/main.test.ts`, change `GLOBAL_SKILLS` to:
+
+```ts
+const GLOBAL_SKILLS = {
+  triage: "patchmill-issue-triage",
+  planning: "superpowers:writing-plans",
+  implementation: "superpowers:subagent-driven-development",
+};
+```
+
+Keep `PROJECT_LOCAL_SKILLS` unchanged.
+
+- [ ] **Step 3: Run targeted init and resolver tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/main.test.ts src/workflow/skill-resolution.test.ts
+```
+
+Expected: PASS. The resolver test must prove `patchmill-issue-triage` no longer
+maps to `--skill <bundled path>` while `patchmill:bundled-issue-triage` does.
+
+- [ ] **Step 4: Commit global-mode fix**
+
+```bash
+git add src/cli/commands/init/main.ts src/cli/commands/init/main.test.ts src/workflow/skills.ts src/workflow/skill-resolution.test.ts
+git commit -m "fix(init): distinguish global skills from bundled fallback"
+```
+
+---
+
+## Task 5: Make project skill installation atomic
+
+**Files:**
+
+- Modify: `src/cli/commands/init/skill-installer.ts`
+- Modify: `src/cli/commands/init/skill-installer.test.ts`
+- Test: `src/cli/commands/init/skill-installer.test.ts`
+
+- [ ] **Step 1: Add failing rollback tests**
+
+Add this test to `src/cli/commands/init/skill-installer.test.ts` after the
+existing preflight tests:
+
+```ts
+test("installProjectSkills does not publish partial targets when staging fails", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+  await symlink(
+    "missing-template.md",
+    join(superpowersSource, "writing-plans", "broken-link.md"),
+  );
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [
+        { name: "patchmill-issue-triage", source: "patchmill" },
+        { name: "writing-plans", source: "superpowers" },
+      ],
+    }),
+    /Unsupported skill source entry: writing-plans\/broken-link\.md/,
+  );
+
+  await assert.rejects(access(join(repoRoot, ".patchmill", "skills")));
+});
+```
+
+Add this test to verify publication happens as a single directory publish:
+
+```ts
+test("installProjectSkills can rerun after a failed staged install", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+
+  const result = await installProjectSkills({
+    repoRoot,
+    sourceRoots: {
+      patchmillSkillsDir: patchmillSource,
+      superpowersSkillsDir: superpowersSource,
+    },
+    packSkills: [
+      { name: "patchmill-issue-triage", source: "patchmill" },
+      { name: "writing-plans", source: "superpowers" },
+    ],
+    installedAt: "2026-05-30T00:00:00.000Z",
+  });
+
+  assert.equal(result.installedSkills.length, 2);
+  await access(
+    join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+  );
+});
+```
+
+- [ ] **Step 2: Run installer tests and verify the first new test fails if
+      current copy order publishes partial data**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/skill-installer.test.ts
+```
+
+Expected before implementation: FAIL if `.patchmill/skills` is published before
+the full staging operation completes.
+
+- [ ] **Step 3: Stage the entire skill directory before publishing**
+
+In `src/cli/commands/init/skill-installer.ts`, import staging helpers:
+
+```ts
+import { tmpdir } from "node:os";
+import { basename } from "node:path";
+import { mkdtemp, rename, rm } from "node:fs/promises";
+```
+
+Then change `installProjectSkills` after preflight planning to copy into a
+temporary staging root first:
+
+```ts
+const stagingRoot = await mkdtemp(join(tmpdir(), "patchmill-skills-install-"));
+const stagedSkillDir = join(stagingRoot, "skills");
+let published = false;
+
+try {
+  for (const { sourceDir, targetRelativeDir } of installationPlan) {
+    const stagedTarget = join(
+      stagedSkillDir,
+      relative(skillDir, targetRelativeDir),
+    );
+    await mkdir(dirname(stagedTarget), { recursive: true });
+    await cp(sourceDir, stagedTarget, {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+    });
+  }
+
+  files.sort((a, b) => comparePaths(a.path, b.path));
+  const metadata = buildSkillPackMetadata(files, {
+    installedAt: options.installedAt ?? new Date().toISOString(),
+    skillDir,
+  });
+  await writeFile(
+    join(stagedSkillDir, SKILL_PACK_METADATA_FILE),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    { flag: "wx" },
+  );
+
+  await mkdir(dirname(absoluteSkillDir), { recursive: true });
+  await rename(stagedSkillDir, absoluteSkillDir);
+  published = true;
+
+  return {
+    skillDir: metadata.skillDir,
+    skillConfig: buildRecommendedProjectSkillConfig(metadata.skillDir),
+    installedSkills,
+    metadataPath,
+  };
+} finally {
+  if (!published) {
+    await rm(stagingRoot, { recursive: true, force: true });
+  } else {
+    await rm(stagingRoot, { recursive: true, force: true });
+  }
+}
+```
+
+When building staged target paths, preserve each skill directory name exactly.
+If `relative(skillDir, targetRelativeDir)` is awkward for custom `skillDir`, use
+`basename(targetRelativeDir)` because each plan entry targets one top-level
+skill directory under `skillDir`.
+
+- [ ] **Step 4: Preserve the no-overwrite preflight**
+
+Keep these checks before staging starts:
+
+```ts
+if (await pathExists(targetDir)) {
+  throw new Error(
+    `Refusing to overwrite existing skill path: ${targetRelativeDir}`,
+  );
+}
+
+if (await pathExists(metadataPath)) {
+  throw new Error(
+    `Refusing to overwrite existing skill path: ${projectSkillPath(SKILL_PACK_METADATA_FILE, skillDir)}`,
+  );
+}
+```
+
+Also add a preflight for the top-level target directory:
+
+```ts
+if (await pathExists(absoluteSkillDir)) {
+  throw new Error(`Refusing to overwrite existing skill path: ${skillDir}`);
+}
+```
+
+- [ ] **Step 5: Run installer tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/skill-installer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit atomic installer**
+
+```bash
+git add src/cli/commands/init/skill-installer.ts src/cli/commands/init/skill-installer.test.ts
+git commit -m "fix(init): stage project skill installation atomically"
+```
+
+---
+
+## Task 6: Align skill-pack dependency provenance with the installable source
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `npm-shrinkwrap.json`
+- Modify: `src/workflow/skill-pack.ts`
+- Modify: `docs/plans/2026-05-29-project-local-default-skills.md`
+- Modify: `docs/specs/2026-05-29-project-local-default-skills-design.md`
+- Test: `src/cli/commands/init/skill-installer.test.ts`,
+  `src/workflow/skill-pack.test.ts`
+
+- [ ] **Step 1: Verify the source decision**
+
+Run:
+
+```bash
+npm view superpowers version
+npm view superpowers versions --json
+```
+
+Expected: the public npm package does not expose `5.0.7`; keep the existing
+GitHub tarball dependency instead of switching to `superpowers@5.0.7`.
+
+- [ ] **Step 2: Refresh installed dependencies and lockfiles from the selected
+      tarball source**
+
+Run:
+
+```bash
+npm install
+```
+
+Expected:
+
+- `node_modules/superpowers/package.json` exists.
+- `npm ls superpowers --depth=0` shows `superpowers` installed from the GitHub
+  tarball dependency.
+- `package-lock.json` and `npm-shrinkwrap.json` are consistent with
+  `package.json`.
+
+- [ ] **Step 3: Keep manifest source typed as GitHub release**
+
+Confirm `src/workflow/skill-pack.ts` still records:
+
+```ts
+export type SkillPackSource = {
+  type: "github-release";
+  repository: "obra/superpowers";
+  tag: "v5.0.7";
+  tarballUrl: "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz";
+};
+```
+
+No code change is needed here if Task 2 still passes. If the lockfile resolved
+URL differs, update only the docs, not the metadata constants.
+
+- [ ] **Step 4: Update the old implementation plan to stop claiming npm exact
+      package install**
+
+In `docs/plans/2026-05-29-project-local-default-skills.md`, replace the Task 1
+command block that says:
+
+```sh
+npm install superpowers@5.0.7 --save-exact
+```
+
+with:
+
+```sh
+npm install https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz --save-exact
+```
+
+Also replace the expected text:
+
+```md
+Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` include
+`superpowers` at exact version `5.0.7`.
+```
+
+with:
+
+```md
+Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` include
+`superpowers` from the pinned GitHub tag tarball `v5.0.7`.
+```
+
+- [ ] **Step 5: Update the design distribution wording**
+
+In `docs/specs/2026-05-29-project-local-default-skills-design.md`, replace:
+
+```md
+The initial implementation should install a pinned external skill pack during
+`patchmill init`. This keeps Patchmill lean while giving users good defaults.
+```
+
+with:
+
+```md
+The initial implementation should depend on a pinned GitHub release tarball for
+the external skill pack and copy those installed files during `patchmill init`.
+This keeps Patchmill lean while giving users good defaults without relying on a
+mutable user-global skill installation.
+```
+
+- [ ] **Step 6: Run provenance-related tests**
+
+Run:
+
+```bash
+node --test src/workflow/skill-pack.test.ts src/cli/commands/init/skill-installer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit provenance alignment**
+
+```bash
+git add package.json package-lock.json npm-shrinkwrap.json src/workflow/skill-pack.ts docs/plans/2026-05-29-project-local-default-skills.md docs/specs/2026-05-29-project-local-default-skills-design.md
+git commit -m "docs(skills): align recommended pack provenance"
+```
+
+---
+
+## Task 7: Full verification and cleanup
+
+**Files:**
+
+- Modify only if verification exposes failures in files touched above.
+
+- [ ] **Step 1: Run TypeScript lint**
+
+Run:
+
+```bash
+npm run lint:ts
+```
+
+Expected: PASS with zero warnings.
+
+- [ ] **Step 2: Run formatting check**
+
+Run:
+
+```bash
+npm run format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run markdown lint**
+
+Run:
+
+```bash
+npm run lint:md
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: PASS. The previous failures for
+`Cannot find module 'superpowers/package.json'` must be gone after `npm install`
+or `npm ci`.
+
+- [ ] **Step 5: Check changed file sizes**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+wc -l src/cli/commands/doctor/checks.ts src/workflow/skills.ts src/workflow/skill-resolution.ts
+```
+
+Expected:
+
+- `src/workflow/skills.ts` is smaller than before because resolver logic moved
+  out.
+- `src/cli/commands/doctor/checks.ts` does not grow past 1000 lines.
+- `src/workflow/skill-resolution.ts` stays focused on resolution and
+  diagnostics.
+
+- [ ] **Step 6: Review the final diff for the original findings**
+
+Run:
+
+```bash
+git diff origin/main...HEAD -- src/workflow src/cli/commands/init src/cli/commands/doctor docs package.json package-lock.json npm-shrinkwrap.json
+```
+
+Expected, by finding:
+
+- Runtime and doctor both use `resolveConfiguredSkillInvocation`.
+- `src/workflow/skills.ts` no longer contains path-like, project-local metadata,
+  or metadata-file parsing logic; it only re-exports resolver helpers.
+- `src/cli/commands/doctor/checks.ts` no longer contains project-local metadata
+  JSON parsing, metadata path resolution, or metadata hash comparison logic.
+- Doctor does not validate unused `.patchmill/skills` directories.
+- Init stages project skills before publishing `.patchmill/skills`.
+- `--skills global` writes global skill names and does not trigger bundled
+  triage injection.
+- Docs and manifest agree on GitHub tarball provenance.
+
+- [ ] **Step 7: Commit verification fixes if needed**
+
+If Step 1-6 required code changes, commit them:
+
+```bash
+git add <changed-files>
+git commit -m "fix(skills): finish project-local skill validation cleanup"
+```
+
+If no code changes were needed, do not create an empty commit.
+
+---
+
+## Self-review checklist
+
+- Spec coverage: every review finding maps to a task.
+  - Divergent runtime/doctor resolver and duplicated metadata/path parsing
+    deletion: Tasks 1-3 and Task 7 verification.
+  - Unused `.patchmill/skills` validation: Task 3.
+  - Non-atomic install: Task 5.
+  - Bundled/global triage overload: Task 4.
+  - Dependency/provenance mismatch and failing local dependency verification:
+    Task 6.
+- Placeholder scan: no task uses open-ended implementation placeholders.
+- Type consistency: resolver types use `SkillInvocationResolution`,
+  `SkillResolutionDiagnostic`, and status strings consistently across tasks.
+- Scope check: this is one coherent refactor around project-local skill
+  resolution and init safety; no unrelated host, policy, or prompt behavior is
+  included.

--- a/docs/plans/2026-05-30-fix-project-local-skills-review-findings.md
+++ b/docs/plans/2026-05-30-fix-project-local-skills-review-findings.md
@@ -714,12 +714,14 @@ export function resolveConfiguredSkillInvocation(
   diagnostics.push(...pack.diagnostics);
 
   return {
-    paths: unique([...configuredPaths, ...pack.paths]),
+    paths: unique([...pack.paths, ...configuredPaths]),
     diagnostics,
     configuredProjectLocalPaths: unique(configuredProjectLocalPaths),
     usedProjectLocalPack: true,
   };
 }
+
+// Project-local pack metadata order stays canonical; configured paths only fill gaps.
 
 export function skillInvocationPaths(
   skills: Array<string | undefined>,

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -22,22 +22,27 @@ A few terms appear throughout this page:
 
 ## Direct skills settings
 
-Use the top-level `skills` key:
+Use the top-level `skills` key with a supported reference form (examples):
 
 ```json
 {
   "skills": {
     "triage": "patchmill-issue-triage",
-    "planning": "superpowers:writing-plans",
+    "planning": ".patchmill/skills/writing-plans",
     "implementation": "superpowers:subagent-driven-development",
     "visualEvidence": "capturing-proof-screenshots"
   }
 }
 ```
 
-Each stage accepts one skill name. If a workflow needs several skills or
-detailed instructions, create a project skill that references those skills and
-configure that project skill here.
+`patchmill init` writes `.patchmill/skills/...` references by default, and
+namespace-style references like `superpowers:writing-plans` are supported custom
+examples.
+
+Each stage accepts one skill reference (name, namespace-style, or path-like
+local skill directory/file). If a workflow needs several skills or detailed
+instructions, create a project skill that references those skills and configure
+that project skill here.
 
 The old prompt-fragment settings are removed instead of kept for compatibility.
 Move toolchain, host workflow, landing judgment, visual-evidence procedure, and
@@ -62,6 +67,23 @@ Supported keys:
 - `landing`: optional skill used for direct-land versus PR decisions. It is
   required for direct squash-land eligibility; without it, Patchmill uses PR
   fallback even when direct land is enabled.
+
+## Project-local default skills
+
+`patchmill init` installs Patchmill's recommended skill pack into
+`.patchmill/skills/` by default (mode `project`). If you choose another
+`--skills` mode, the default pack is not installed.
+
+Commit `.patchmill/skills/` to git. It is part of repository process: changes to
+those files directly alter triage, planning, implementation, review, and
+validation behavior.
+
+Patchmill treats installed files as project-owned. It will not silently
+overwrite edited skill files and will preserve repository-specific edits.
+
+`patchmill doctor` checks configured project-local skills by reading the skill
+metadata; it warns when installed skills differ from expected metadata and fails
+when required configured skill paths are missing or malformed.
 
 ## Triage
 

--- a/docs/specs/2026-05-29-project-local-default-skills-design.md
+++ b/docs/specs/2026-05-29-project-local-default-skills-design.md
@@ -1,0 +1,201 @@
+# Project-local default skills design
+
+Date: 2026-05-29
+
+## Summary
+
+Patchmill should own the default skill experience by installing a recommended
+skill set during `patchmill init`. The default installation mode is
+project-local: `init` writes the selected skills into the repository, configures
+Patchmill to use those local files, and expects them to be committed to git.
+
+This makes Patchmill effective on first use while preserving project control.
+Patchmill supplies a strong starting point; the repository owns the resulting
+implementation process.
+
+## Goals
+
+- Make Patchmill useful immediately after `patchmill init` without requiring
+  users to separately discover or install workflow skills.
+- Treat skills that govern implementation behavior as project-owned, reviewable
+  source files.
+- Allow projects to customize skills without affecting other Patchmill projects.
+- Keep the default workflow replaceable through configuration.
+- Let `patchmill doctor` validate the exact skills the project will use.
+
+## Non-goals
+
+- Build a full skill registry or marketplace in this change.
+- Automatically upgrade customized project-local skills.
+- Force all projects to use Patchmill's recommended skills.
+- Require user-global skill installation for normal Patchmill usage.
+
+## Skill ownership and installation policy
+
+`patchmill init` installs Patchmill's recommended default skill set
+project-locally and expects those skill files to be committed to git.
+
+Default behavior:
+
+- Install skills into `.patchmill/skills/`.
+- Generate config that points workflow stages at those local skills.
+- Do not add the skills directory to `.gitignore`.
+- Include pack, version, and provenance metadata in config or a lock/manifest
+  file.
+- Let `patchmill doctor` verify that committed skill files exist and have the
+  expected shape.
+- Allow users to edit, replace, or override the skills per project.
+
+Configurable alternatives:
+
+- `patchmill init --skills project`: install recommended skills project-locally.
+  This is the default.
+- `patchmill init --skills global`: reference user-global skills.
+- `patchmill init --skills none`: do not install default skills.
+- `patchmill init --skills path:<dir>`: use an existing local skill directory.
+
+## Architecture
+
+Patchmill treats default skills as first-class init artifacts, similar to
+generated configuration.
+
+### Skill pack manifest
+
+A skill pack manifest defines the recommended pack name, version, source, and
+files. For example, Patchmill may publish or reference
+`patchmill-recommended@2026.05`. The manifest is used by `init`, `doctor`, and
+future skill maintenance commands.
+
+### Project-local skill directory
+
+The default target is `.patchmill/skills/`. It contains the actual committed
+skill files. Generated Patchmill config references these local files rather than
+external package names, for example `superpowers:subagent-driven-development`.
+
+Example generated mapping:
+
+```json
+{
+  "skills": {
+    "triage": ".patchmill/skills/triage",
+    "planning": ".patchmill/skills/writing-plans",
+    "implementation": ".patchmill/skills/subagent-driven-development"
+  }
+}
+```
+
+If Pi or a downstream runtime requires skill identifiers instead of paths,
+Patchmill resolves these local paths into the runtime invocation.
+
+### Skill installation metadata
+
+Patchmill writes metadata describing what was installed and where it came from.
+The metadata can live in `.patchmill/skills/patchmill-skill-pack.json` or a
+broader `.patchmill/patchmill.lock.json`.
+
+The metadata lets `doctor` and future commands distinguish between:
+
+- missing skills
+- malformed skills
+- customized skills
+- outdated default packs
+- intentionally overridden config
+
+### Init flow
+
+```text
+patchmill init
+  -> choose skill install mode
+  -> resolve default skill pack
+  -> copy or install skills into .patchmill/skills/
+  -> write config pointing at local skills
+  -> write skill pack metadata
+  -> run or suggest doctor readiness validation
+```
+
+## Behavior, customization, and safety
+
+Patchmill distinguishes installed defaults from project-owned behavior.
+
+- `patchmill init` installs the default skills once.
+- After installation, the skill files are normal project files.
+- Users are encouraged to edit them when the project needs different behavior.
+- Patchmill does not silently overwrite modified project-local skills.
+- If a skill path already exists during init, Patchmill avoids overwriting
+  unless the user explicitly confirms.
+- `doctor` warns when committed skills differ from the original pack, because
+  customization is expected.
+- `doctor` readiness-blocks only when required configured skills are missing or
+  malformed.
+
+Future maintenance commands can build on the manifest and metadata:
+
+- `patchmill skills diff`
+- `patchmill skills update`
+- `patchmill skills reset`
+
+These commands are explicit so skill changes remain reviewable.
+
+## Distribution strategy
+
+The initial implementation should install a pinned external skill pack during
+`patchmill init`. This keeps Patchmill lean while giving users good defaults.
+
+A later hybrid model can add bundled fallback skills so init still works when
+the network or external source is unavailable. The product direction remains the
+same in both cases: Patchmill owns the default onboarding experience, while each
+repository owns the committed skill files it runs.
+
+## Validation
+
+`patchmill doctor` checks:
+
+- required configured skill paths exist
+- each required skill has the expected shape and metadata
+- generated config points to project-local skills after default init
+- the skill directory is not ignored by git
+- skill pack metadata exists for project-local default installs
+- modified skills are reported as customized, not broken
+
+Readiness should fail when required skills are missing or malformed. Readiness
+should warn, not fail, when installed default skills have been customized.
+
+## Testing
+
+Automated tests should cover:
+
+- `patchmill init` installs default skills into `.patchmill/skills/`.
+- Generated config references local skill paths.
+- Initialized skills are not added to `.gitignore`.
+- `patchmill doctor` passes for a freshly initialized repo.
+- `patchmill doctor` fails if a required local skill is missing.
+- `patchmill doctor` warns, but does not fail, if a default skill was edited.
+- `patchmill init --skills none` skips default installation.
+- `patchmill init --skills global` references user-global skills without writing
+  project-local defaults.
+- `patchmill init --skills path:<dir>` uses an existing local skill directory.
+- Existing skill files are not overwritten without explicit confirmation.
+
+## Error handling
+
+- If default skill installation fails, `init` explains whether the project is
+  still usable and what command can repair it.
+- If a network install fails, the current implementation reports the failure
+  clearly; a later hybrid implementation may fall back to bundled defaults.
+- If configured skill paths are missing, `doctor` reports the exact missing
+  paths and suggested repair.
+- If local skills are customized, `doctor` reports that state as customization
+  rather than corruption.
+
+## Open extension points
+
+This design leaves room for:
+
+- third-party skill packs
+- a future Patchmill skill catalog
+- skill pack upgrades and diffs
+- project-specific skill forks
+- bundled offline fallback defaults
+
+None of these are required for the initial project-local default skill
+installation behavior.

--- a/docs/specs/2026-05-29-project-local-default-skills-design.md
+++ b/docs/specs/2026-05-29-project-local-default-skills-design.md
@@ -69,8 +69,9 @@ future skill maintenance commands.
 ### Project-local skill directory
 
 The default target is `.patchmill/skills/`. It contains the actual committed
-skill files. Generated Patchmill config references these local files rather than
-external package names, for example `superpowers:subagent-driven-development`.
+skill files. Generated Patchmill config references local paths such as
+`.patchmill/skills/subagent-driven-development` instead of namespaced/global
+identifiers such as `superpowers:subagent-driven-development`.
 
 Example generated mapping:
 
@@ -138,8 +139,10 @@ These commands are explicit so skill changes remain reviewable.
 
 ## Distribution strategy
 
-The initial implementation should install a pinned external skill pack during
-`patchmill init`. This keeps Patchmill lean while giving users good defaults.
+The initial implementation should depend on a pinned GitHub release tarball for
+the external skill pack and, during `patchmill init`, copy the installed skill
+files into `.patchmill/skills/`. This keeps Patchmill lean while giving users
+good defaults.
 
 A later hybrid model can add bundled fallback skills so init still works when
 the network or external source is unavailable. The product direction remains the

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "pi-subagents": "^0.25.0"
+        "pi-subagents": "^0.25.0",
+        "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz"
       },
       "bin": {
         "patchmill": "bin/patchmill.ts"
@@ -2826,6 +2827,11 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/superpowers": {
+      "version": "5.0.7",
+      "resolved": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+      "integrity": "sha512-xGb/ZAZjyimxdRzR26KLzMz4IwIzsVSg9appLnbpCuZlVbtiu2YUBZiaxuB9G8oqGamkY71Zbxut2L2mf/RVNw=="
     },
     "node_modules/tinyexec": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "pi-subagents": "^0.25.0"
+        "pi-subagents": "^0.25.0",
+        "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz"
       },
       "bin": {
         "patchmill": "bin/patchmill.ts"
@@ -2826,6 +2827,11 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/superpowers": {
+      "version": "5.0.7",
+      "resolved": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+      "integrity": "sha512-xGb/ZAZjyimxdRzR26KLzMz4IwIzsVSg9appLnbpCuZlVbtiu2YUBZiaxuB9G8oqGamkY71Zbxut2L2mf/RVNw=="
     },
     "node_modules/tinyexec": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bin",
     "src",
     "docs",
+    "skills",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "typescript-eslint": "^8.59.4"
   },
   "dependencies": {
-    "pi-subagents": "^0.25.0"
+    "pi-subagents": "^0.25.0",
+    "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz"
   }
 }

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -318,6 +318,41 @@ test("runDoctorChecks fails when a configured path-like skill is missing", async
   assert.match(skills?.message ?? "", /configured path unreadable/);
 });
 
+test("runDoctorChecks resolves configured skill directories to their SKILL.md target", async () => {
+  const repoRoot = await tempRepo();
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      host: { provider: "forgejo-tea", login: "triage-agent" },
+      skills: {
+        planning: "./skills/project-planning",
+      },
+    }),
+  );
+  await mkdir(join(repoRoot, "skills", "project-planning"), {
+    recursive: true,
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await mkdir(join(repoRoot, ".patchmill"), { recursive: true });
+  const runner = runnerFrom(successMocks());
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(
+    skills?.message ?? "",
+    /planning: `\.\/skills\/project-planning`/,
+  );
+  assert.match(
+    skills?.message ?? "",
+    /configured path unreadable at .*skills\/project-planning\/SKILL\.md/,
+  );
+});
+
 test("runDoctorChecks never invokes known mutating host commands", async () => {
   const repoRoot = await tempRepo();
   await writeFile(

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -554,6 +554,129 @@ test("runDoctorChecks fails when a local skill frontmatter is malformed", async 
   assert.match(skills?.message ?? "", /missing description/);
 });
 
+test("runDoctorChecks ignores unused .patchmill skills when config uses global/named skills", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      triage: "patchmill-issue-triage",
+      planning: "superpowers:writing-plans",
+      implementation: "superpowers:subagent-driven-development",
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(
+    repoRoot,
+    "stale-unused-skill",
+    "not a valid skill document\n",
+  );
+
+  const calls: string[] = [];
+  const runner: CommandRunner = {
+    async run(command, args) {
+      const key = [command, ...args].join(" ");
+      calls.push(key);
+      return (
+        successMocks(REQUIRED_LABELS)[key] ?? {
+          code: 127,
+          stdout: "",
+          stderr: `missing mock for ${key}`,
+        }
+      );
+    },
+  };
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(
+    skills?.message ?? "",
+    /triage: `patchmill-issue-triage` \(named skill configured; doctor did not verify it\)/,
+  );
+  assert.doesNotMatch(skills?.message ?? "", /stale-unused-skill/);
+  assert.doesNotMatch(
+    skills?.message ?? "",
+    /project-local skill pack metadata/,
+  );
+  assert.equal(
+    calls.some((call) =>
+      call.includes("git check-ignore --no-index -q .patchmill/skills"),
+    ),
+    false,
+  );
+  assert.equal(
+    calls.some((call) => call.includes("PATCHMILL_SKILLS_OK")),
+    false,
+  );
+});
+
+test("runDoctorChecks smoke-tests the exact shared resolver paths when metadata is malformed", async () => {
+  const repoRoot = await tempRepo();
+  const planningSkill = skillDocument("writing-plans", "Write plans.");
+
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      triage: "patchmill-issue-triage",
+      planning: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+      implementation: "superpowers:subagent-driven-development",
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(repoRoot, "writing-plans", planningSkill);
+  await writeProjectLocalSkill(
+    repoRoot,
+    "stale-unused-skill",
+    "not a valid skill document\n",
+  );
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    "{ malformed json",
+  );
+
+  const smokePaths = [projectLocalSkillPath(repoRoot, "writing-plans")];
+  const calls: string[] = [];
+  const runner: CommandRunner = {
+    async run(command, args) {
+      const key = [command, ...args].join(" ");
+      calls.push(key);
+      return (
+        successMocks(REQUIRED_LABELS, {
+          "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
+          [projectLocalPiSmokeCommand(smokePaths)]: {
+            code: 0,
+            stdout: "PATCHMILL_SKILLS_OK\n",
+          },
+        })[key] ?? {
+          code: 127,
+          stdout: "",
+          stderr: `missing mock for ${key}`,
+        }
+      );
+    },
+  };
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(skills?.message ?? "", /metadata malformed/);
+  assert.match(skills?.message ?? "", /Pi loaded project-local skill pack/);
+  assert.ok(calls.includes(projectLocalPiSmokeCommand(smokePaths)));
+  assert.equal(
+    calls.some((call) => call.includes("stale-unused-skill")),
+    false,
+  );
+});
+
 test("runDoctorChecks rejects metadata paths outside project-local skills", async () => {
   for (const invalidPath of [
     "/tmp/outside/SKILL.md",
@@ -877,6 +1000,22 @@ test("runDoctorChecks warns when project-local metadata is missing", async () =>
     /project-local skill pack metadata missing/,
   );
   assert.match(skills?.message ?? "", /Pi loaded project-local skill pack/);
+});
+
+test("doctor does not parse project-local skill-pack metadata directly", async () => {
+  const source = await readFile(
+    new URL("./checks.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.doesNotMatch(source, /checkProjectLocalMetadata/);
+  assert.doesNotMatch(source, /isValidProjectLocalMetadata/);
+  assert.doesNotMatch(source, /metadataSkillPaths/);
+  assert.doesNotMatch(source, /resolveProjectLocalMetadataFilePath/);
+  assert.doesNotMatch(source, /metadata\.files/);
+  assert.doesNotMatch(source, /hashContent/);
+  assert.doesNotMatch(source, /SKILL_PACK_METADATA_FILE/);
+  assert.doesNotMatch(source, /patchmill-skill-pack(?:\.json)?/);
 });
 
 test("runDoctorChecks never invokes known mutating host commands", async () => {

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -489,7 +489,7 @@ test("runDoctorChecks passes for a fresh project-local skill pack", async () => 
       calls.push(key);
       return (
         successMocks(REQUIRED_LABELS, {
-          "git check-ignore -q .patchmill/skills": { code: 1 },
+          "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
           [projectLocalPiSmokeCommand(smokePaths)]: {
             code: 0,
             stdout: "PATCHMILL_SKILLS_OK\n",
@@ -604,7 +604,7 @@ test("runDoctorChecks rejects metadata paths outside project-local skills", asyn
         calls.push(key);
         return (
           successMocks(REQUIRED_LABELS, {
-            "git check-ignore -q .patchmill/skills": { code: 1 },
+            "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
             [projectLocalPiSmokeCommand(smokePaths)]: {
               code: 0,
               stdout: "PATCHMILL_SKILLS_OK\n",
@@ -685,7 +685,7 @@ test("runDoctorChecks warns when project-local skill files differ from metadata"
   ];
   const runner = runnerFrom(
     successMocks(REQUIRED_LABELS, {
-      "git check-ignore -q .patchmill/skills": { code: 1 },
+      "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
       [projectLocalPiSmokeCommand(smokePaths)]: {
         code: 0,
         stdout: "PATCHMILL_SKILLS_OK\n",
@@ -744,7 +744,7 @@ test("runDoctorChecks fails when .patchmill/skills is gitignored", async () => {
       calls.push(key);
       return (
         successMocks(REQUIRED_LABELS, {
-          "git check-ignore -q .patchmill/skills": { code: 0 },
+          "git check-ignore --no-index -q .patchmill/skills": { code: 0 },
         })[key] ?? {
           code: 127,
           stdout: "",
@@ -762,6 +762,7 @@ test("runDoctorChecks fails when .patchmill/skills is gitignored", async () => {
 
   assert.equal(skills?.status, "fail");
   assert.match(skills?.message ?? "", /\.patchmill\/skills is ignored by git/);
+  assert.ok(calls.includes("git check-ignore --no-index -q .patchmill/skills"));
   assert.equal(
     calls.some((command) => command.includes("PATCHMILL_SKILLS_OK")),
     false,
@@ -808,7 +809,7 @@ test("runDoctorChecks fails when Pi cannot load project-local skills", async () 
   ];
   const runner = runnerFrom(
     successMocks(REQUIRED_LABELS, {
-      "git check-ignore -q .patchmill/skills": { code: 1 },
+      "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
       [projectLocalPiSmokeCommand(smokePaths)]: {
         code: 1,
         stderr: "pi failed to load one or more skills",
@@ -856,7 +857,7 @@ test("runDoctorChecks warns when project-local metadata is missing", async () =>
   ];
   const runner = runnerFrom(
     successMocks(REQUIRED_LABELS, {
-      "git check-ignore -q .patchmill/skills": { code: 1 },
+      "git check-ignore --no-index -q .patchmill/skills": { code: 1 },
       [projectLocalPiSmokeCommand(smokePaths)]: {
         code: 0,
         stdout: "PATCHMILL_SKILLS_OK\n",

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -1,10 +1,18 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { runDoctorChecks } from "./checks.ts";
+import { installProjectSkills } from "../init/skill-installer.ts";
 import type { CommandRunner } from "../triage/types.ts";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "../../../workflow/skill-pack.ts";
 
 async function tempRepo(): Promise<string> {
   return mkdtemp(join(tmpdir(), "patchmill-doctor-"));
@@ -15,6 +23,99 @@ async function writeConfig(repoRoot: string, config: unknown): Promise<void> {
     join(repoRoot, "patchmill.config.json"),
     JSON.stringify(config),
   );
+}
+
+function skillDocument(name: string, description?: string): string {
+  return [
+    "---",
+    `name: ${name}`,
+    ...(description ? [`description: ${description}`] : []),
+    "---",
+    `# ${name}`,
+    "",
+  ].join("\n");
+}
+
+async function writeSkillFile(
+  rootDir: string,
+  skillDir: string,
+  content: string,
+): Promise<string> {
+  const fullSkillDir = join(rootDir, skillDir);
+  await mkdir(fullSkillDir, { recursive: true });
+  const skillPath = join(fullSkillDir, "SKILL.md");
+  await writeFile(skillPath, content);
+  return skillPath;
+}
+
+async function writeProjectLocalSkill(
+  repoRoot: string,
+  skillName: string,
+  content: string,
+): Promise<string> {
+  return writeSkillFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR),
+    skillName,
+    content,
+  );
+}
+
+function recommendedProjectLocalConfig() {
+  return {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      triage: `${DEFAULT_PROJECT_SKILL_DIR}/patchmill-issue-triage`,
+      planning: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+      implementation: `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    },
+  };
+}
+
+function recommendedProjectLocalMetadata(
+  files: Array<{ path: string; sha256: string }>,
+): SkillPackMetadataFile {
+  return {
+    pack: {
+      name: PATCHMILL_RECOMMENDED_SKILL_PACK.name,
+      version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+      source: PATCHMILL_RECOMMENDED_SKILL_PACK.source,
+    },
+    installedAt: "2026-05-29T00:00:00.000Z",
+    skillDir: DEFAULT_PROJECT_SKILL_DIR,
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files,
+  };
+}
+
+async function writeProjectLocalMetadata(
+  repoRoot: string,
+  files: Array<{ path: string; sha256: string }>,
+): Promise<void> {
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    JSON.stringify(recommendedProjectLocalMetadata(files)),
+  );
+}
+
+function projectLocalSkillPath(repoRoot: string, skillName: string): string {
+  return join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, skillName, "SKILL.md");
+}
+
+function projectLocalMetadataSkillPath(skillName: string): string {
+  return `${DEFAULT_PROJECT_SKILL_DIR}/${skillName}/SKILL.md`;
+}
+
+function projectLocalPiSmokeCommand(paths: string[]): string {
+  return [
+    "pi",
+    "--no-session",
+    "--no-context-files",
+    "--no-prompt-templates",
+    ...paths.flatMap((path) => ["--skill", path]),
+    "-p",
+    "Reply with PATCHMILL_SKILLS_OK and nothing else.",
+  ].join(" ");
 }
 
 function runnerFrom(
@@ -351,6 +452,430 @@ test("runDoctorChecks resolves configured skill directories to their SKILL.md ta
     skills?.message ?? "",
     /configured path unreadable at .*skills\/project-planning\/SKILL\.md/,
   );
+});
+
+test("runDoctorChecks passes for a fresh project-local skill pack", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, recommendedProjectLocalConfig());
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await installProjectSkills({
+    repoRoot,
+    installedAt: "2026-05-29T00:00:00.000Z",
+  });
+
+  const installedTriageSkill = await readFile(
+    projectLocalSkillPath(repoRoot, "patchmill-issue-triage"),
+    "utf8",
+  );
+  assert.match(
+    installedTriageSkill,
+    /description:\s*\n\s+Triage repository issues/u,
+  );
+
+  const metadata = JSON.parse(
+    await readFile(
+      join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+      "utf8",
+    ),
+  ) as SkillPackMetadataFile;
+  const smokePaths = metadata.files
+    .filter((file) => file.path.endsWith("/SKILL.md"))
+    .map((file) => join(repoRoot, file.path));
+
+  const calls: string[] = [];
+  const runner: CommandRunner = {
+    async run(command, args) {
+      const key = [command, ...args].join(" ");
+      calls.push(key);
+      return (
+        successMocks(REQUIRED_LABELS, {
+          "git check-ignore -q .patchmill/skills": { code: 1 },
+          [projectLocalPiSmokeCommand(smokePaths)]: {
+            code: 0,
+            stdout: "PATCHMILL_SKILLS_OK\n",
+          },
+        })[key] ?? {
+          code: 127,
+          stdout: "",
+          stderr: `missing mock for ${key}`,
+        }
+      );
+    },
+  };
+
+  const expectedSmokeCommand = projectLocalPiSmokeCommand(smokePaths);
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "pass");
+  assert.match(skills?.message ?? "", /project-local metadata verified/);
+  assert.match(skills?.message ?? "", /Pi loaded project-local skill pack/);
+  assert.doesNotMatch(skills?.message ?? "", /metadata missing|customized/);
+  assert.ok(calls.includes(expectedSmokeCommand));
+  assert.equal(
+    calls.some((call) =>
+      call.includes(
+        `${join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, DEFAULT_PROJECT_SKILL_DIR)}/`,
+      ),
+    ),
+    false,
+  );
+});
+
+test("runDoctorChecks fails when a local skill frontmatter is malformed", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      planning: "./skills/project-planning",
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await mkdir(join(repoRoot, ".patchmill"), { recursive: true });
+  await writeSkillFile(
+    join(repoRoot, "skills"),
+    "project-planning",
+    skillDocument("project-planning"),
+  );
+  const runner = runnerFrom(successMocks());
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(skills?.message ?? "", /malformed skill frontmatter/);
+  assert.match(skills?.message ?? "", /missing description/);
+});
+
+test("runDoctorChecks rejects metadata paths outside project-local skills", async () => {
+  for (const invalidPath of [
+    "/tmp/outside/SKILL.md",
+    "C:\\temp\\outside\\SKILL.md",
+    ".patchmill/skills/../../outside/SKILL.md",
+  ]) {
+    const repoRoot = await tempRepo();
+    const triageSkill = skillDocument(
+      "patchmill-issue-triage",
+      "Triage issues.",
+    );
+    const planningSkill = skillDocument("writing-plans", "Write plans.");
+    const implementationSkill = skillDocument(
+      "subagent-driven-development",
+      "Execute plans.",
+    );
+
+    await writeConfig(repoRoot, recommendedProjectLocalConfig());
+    await mkdir(join(repoRoot, "docs"), { recursive: true });
+    await writeProjectLocalSkill(
+      repoRoot,
+      "patchmill-issue-triage",
+      triageSkill,
+    );
+    await writeProjectLocalSkill(repoRoot, "writing-plans", planningSkill);
+    await writeProjectLocalSkill(
+      repoRoot,
+      "subagent-driven-development",
+      implementationSkill,
+    );
+    await writeProjectLocalMetadata(repoRoot, [
+      {
+        path: projectLocalMetadataSkillPath("patchmill-issue-triage"),
+        sha256: hashText(triageSkill),
+      },
+      { path: invalidPath, sha256: hashText("outside") },
+    ]);
+
+    const smokePaths = [
+      projectLocalSkillPath(repoRoot, "patchmill-issue-triage"),
+      projectLocalSkillPath(repoRoot, "writing-plans"),
+      projectLocalSkillPath(repoRoot, "subagent-driven-development"),
+    ];
+    const calls: string[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        const key = [command, ...args].join(" ");
+        calls.push(key);
+        return (
+          successMocks(REQUIRED_LABELS, {
+            "git check-ignore -q .patchmill/skills": { code: 1 },
+            [projectLocalPiSmokeCommand(smokePaths)]: {
+              code: 0,
+              stdout: "PATCHMILL_SKILLS_OK\n",
+            },
+          })[key] ?? {
+            code: 127,
+            stdout: "",
+            stderr: `missing mock for ${key}`,
+          }
+        );
+      },
+    };
+
+    const results = await runDoctorChecks(runner, {
+      repoRoot,
+      teaRepoRootForTests: "/repo",
+    });
+    const skills = results.find((result) => result.name === "skills");
+
+    assert.equal(skills?.status, "warn");
+    assert.match(
+      skills?.message ?? "",
+      /project-local skill pack metadata malformed/,
+    );
+    assert.ok(calls.includes(projectLocalPiSmokeCommand(smokePaths)));
+    assert.equal(
+      calls.some((call) => call.includes(invalidPath)),
+      false,
+    );
+  }
+});
+
+test("runDoctorChecks warns when project-local skill files differ from metadata", async () => {
+  const repoRoot = await tempRepo();
+  const triageSkill = skillDocument("patchmill-issue-triage", "Triage issues.");
+  const originalPlanningSkill = skillDocument("writing-plans", "Write plans.");
+  const customizedPlanningSkill = skillDocument(
+    "writing-plans",
+    "Write plans with local tweaks.",
+  );
+  const implementationSkill = skillDocument(
+    "subagent-driven-development",
+    "Execute plans.",
+  );
+
+  await writeConfig(repoRoot, recommendedProjectLocalConfig());
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(repoRoot, "patchmill-issue-triage", triageSkill);
+  await writeProjectLocalSkill(
+    repoRoot,
+    "writing-plans",
+    customizedPlanningSkill,
+  );
+  await writeProjectLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+    implementationSkill,
+  );
+  await writeProjectLocalMetadata(repoRoot, [
+    {
+      path: projectLocalMetadataSkillPath("patchmill-issue-triage"),
+      sha256: hashText(triageSkill),
+    },
+    {
+      path: projectLocalMetadataSkillPath("writing-plans"),
+      sha256: hashText(originalPlanningSkill),
+    },
+    {
+      path: projectLocalMetadataSkillPath("subagent-driven-development"),
+      sha256: hashText(implementationSkill),
+    },
+  ]);
+
+  const smokePaths = [
+    projectLocalSkillPath(repoRoot, "patchmill-issue-triage"),
+    projectLocalSkillPath(repoRoot, "writing-plans"),
+    projectLocalSkillPath(repoRoot, "subagent-driven-development"),
+  ];
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": { code: 1 },
+      [projectLocalPiSmokeCommand(smokePaths)]: {
+        code: 0,
+        stdout: "PATCHMILL_SKILLS_OK\n",
+      },
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(skills?.message ?? "", /customized from installed pack/);
+  assert.match(skills?.message ?? "", /Pi loaded project-local skill pack/);
+});
+
+test("runDoctorChecks fails when .patchmill/skills is gitignored", async () => {
+  const repoRoot = await tempRepo();
+  const triageSkill = skillDocument("patchmill-issue-triage", "Triage issues.");
+  const planningSkill = skillDocument("writing-plans", "Write plans.");
+  const implementationSkill = skillDocument(
+    "subagent-driven-development",
+    "Execute plans.",
+  );
+
+  await writeConfig(repoRoot, recommendedProjectLocalConfig());
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(repoRoot, "patchmill-issue-triage", triageSkill);
+  await writeProjectLocalSkill(repoRoot, "writing-plans", planningSkill);
+  await writeProjectLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+    implementationSkill,
+  );
+  await writeProjectLocalMetadata(repoRoot, [
+    {
+      path: projectLocalMetadataSkillPath("patchmill-issue-triage"),
+      sha256: hashText(triageSkill),
+    },
+    {
+      path: projectLocalMetadataSkillPath("writing-plans"),
+      sha256: hashText(planningSkill),
+    },
+    {
+      path: projectLocalMetadataSkillPath("subagent-driven-development"),
+      sha256: hashText(implementationSkill),
+    },
+  ]);
+
+  const calls: string[] = [];
+  const runner: CommandRunner = {
+    async run(command, args) {
+      const key = [command, ...args].join(" ");
+      calls.push(key);
+      return (
+        successMocks(REQUIRED_LABELS, {
+          "git check-ignore -q .patchmill/skills": { code: 0 },
+        })[key] ?? {
+          code: 127,
+          stdout: "",
+          stderr: `missing mock for ${key}`,
+        }
+      );
+    },
+  };
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(skills?.message ?? "", /\.patchmill\/skills is ignored by git/);
+  assert.equal(
+    calls.some((command) => command.includes("PATCHMILL_SKILLS_OK")),
+    false,
+  );
+});
+
+test("runDoctorChecks fails when Pi cannot load project-local skills", async () => {
+  const repoRoot = await tempRepo();
+  const triageSkill = skillDocument("patchmill-issue-triage", "Triage issues.");
+  const planningSkill = skillDocument("writing-plans", "Write plans.");
+  const implementationSkill = skillDocument(
+    "subagent-driven-development",
+    "Execute plans.",
+  );
+
+  await writeConfig(repoRoot, recommendedProjectLocalConfig());
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(repoRoot, "patchmill-issue-triage", triageSkill);
+  await writeProjectLocalSkill(repoRoot, "writing-plans", planningSkill);
+  await writeProjectLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+    implementationSkill,
+  );
+  await writeProjectLocalMetadata(repoRoot, [
+    {
+      path: projectLocalMetadataSkillPath("patchmill-issue-triage"),
+      sha256: hashText(triageSkill),
+    },
+    {
+      path: projectLocalMetadataSkillPath("writing-plans"),
+      sha256: hashText(planningSkill),
+    },
+    {
+      path: projectLocalMetadataSkillPath("subagent-driven-development"),
+      sha256: hashText(implementationSkill),
+    },
+  ]);
+
+  const smokePaths = [
+    projectLocalSkillPath(repoRoot, "patchmill-issue-triage"),
+    projectLocalSkillPath(repoRoot, "writing-plans"),
+    projectLocalSkillPath(repoRoot, "subagent-driven-development"),
+  ];
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": { code: 1 },
+      [projectLocalPiSmokeCommand(smokePaths)]: {
+        code: 1,
+        stderr: "pi failed to load one or more skills",
+      },
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "fail");
+  assert.match(
+    skills?.message ?? "",
+    /Pi could not load the project-local skill pack/,
+  );
+  assert.match(skills?.message ?? "", /pi failed to load one or more skills/);
+});
+
+test("runDoctorChecks warns when project-local metadata is missing", async () => {
+  const repoRoot = await tempRepo();
+  const triageSkill = skillDocument("patchmill-issue-triage", "Triage issues.");
+  const planningSkill = skillDocument("writing-plans", "Write plans.");
+  const implementationSkill = skillDocument(
+    "subagent-driven-development",
+    "Execute plans.",
+  );
+
+  await writeConfig(repoRoot, recommendedProjectLocalConfig());
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await writeProjectLocalSkill(repoRoot, "patchmill-issue-triage", triageSkill);
+  await writeProjectLocalSkill(repoRoot, "writing-plans", planningSkill);
+  await writeProjectLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+    implementationSkill,
+  );
+
+  const smokePaths = [
+    projectLocalSkillPath(repoRoot, "patchmill-issue-triage"),
+    projectLocalSkillPath(repoRoot, "writing-plans"),
+    projectLocalSkillPath(repoRoot, "subagent-driven-development"),
+  ];
+  const runner = runnerFrom(
+    successMocks(REQUIRED_LABELS, {
+      "git check-ignore -q .patchmill/skills": { code: 1 },
+      [projectLocalPiSmokeCommand(smokePaths)]: {
+        code: 0,
+        stdout: "PATCHMILL_SKILLS_OK\n",
+      },
+    }),
+  );
+
+  const results = await runDoctorChecks(runner, {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(
+    skills?.message ?? "",
+    /project-local skill pack metadata missing/,
+  );
+  assert.match(skills?.message ?? "", /Pi loaded project-local skill pack/);
 });
 
 test("runDoctorChecks never invokes known mutating host commands", async () => {

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -22,7 +22,7 @@ import {
   DEFAULT_PROJECT_SKILL_DIR,
   PATCHMILL_RECOMMENDED_SKILL_PACK,
   SKILL_PACK_METADATA_FILE,
-  hashText,
+  hashContent,
   type SkillPackMetadataFile,
 } from "../../../workflow/skill-pack.ts";
 
@@ -503,8 +503,8 @@ async function checkProjectLocalMetadata(
         break;
       }
 
-      const content = await readFile(resolvedPath, "utf8");
-      if (hashText(content) !== file.sha256) {
+      const content = await readFile(resolvedPath);
+      if (hashContent(content) !== file.sha256) {
         hasHashMismatch = true;
         break;
       }
@@ -535,7 +535,7 @@ async function checkProjectLocalGitIgnore(
 ): Promise<SkillCheckEntry> {
   const result = await runner.run(
     "git",
-    ["check-ignore", "-q", DEFAULT_PROJECT_SKILL_DIR],
+    ["check-ignore", "--no-index", "-q", DEFAULT_PROJECT_SKILL_DIR],
     { cwd: repoRoot },
   );
 

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import { access, stat } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
@@ -15,6 +15,8 @@ import {
   DEFAULT_PATCHMILL_SKILLS,
   PATCHMILL_SKILL_KEYS,
   bundledTriageSkillPath,
+  isPathLikeSkill,
+  resolvePathLikeSkillPath,
 } from "../../../workflow/skills.ts";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
@@ -182,27 +184,6 @@ async function checkPiProvider(
   ]);
 }
 
-const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
-const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
-
-function isNamespaceStyleSkill(skill: string): boolean {
-  return (
-    SKILL_NAMESPACE_PATTERN.test(skill) &&
-    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
-  );
-}
-
-function isPathLikeSkill(skill: string): boolean {
-  if (
-    skill.startsWith(".") ||
-    skill.startsWith("/") ||
-    WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
-  ) {
-    return true;
-  }
-  return /[\\/]/u.test(skill) && !isNamespaceStyleSkill(skill);
-}
-
 async function checkReadableSkillTarget(path: string): Promise<boolean> {
   try {
     const pathStat = await stat(path);
@@ -247,9 +228,7 @@ async function checkSkills(
         };
       }
 
-      const resolvedPath = WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
-        ? skill
-        : resolve(repoRoot, skill);
+      const resolvedPath = resolvePathLikeSkillPath(skill, repoRoot);
       return (await checkReadableSkillTarget(resolvedPath))
         ? {
             status: "pass" as const,

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
-import { access, stat } from "node:fs/promises";
-import { dirname } from "node:path";
+import { access, readFile, stat } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
@@ -18,6 +18,13 @@ import {
   isPathLikeSkill,
   resolvePathLikeSkillPath,
 } from "../../../workflow/skills.ts";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "../../../workflow/skill-pack.ts";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
 
@@ -33,6 +40,18 @@ type DoctorOptions = {
   env?: Record<string, string | undefined>;
   teaRepoRootForTests?: string;
 };
+
+type SkillCheckEntry = {
+  status: DoctorCheckStatus;
+  summary: string;
+};
+
+type LocalSkillValidation = SkillCheckEntry & {
+  smokePath?: string;
+};
+
+const PROJECT_LOCAL_SKILLS_PROMPT =
+  "Reply with PATCHMILL_SKILLS_OK and nothing else.";
 
 function pass(name: string, message: string): DoctorCheckResult {
   return { name, status: "pass", message };
@@ -197,16 +216,392 @@ async function checkReadableSkillTarget(path: string): Promise<boolean> {
   }
 }
 
+function parseSkillFrontmatter(
+  text: string,
+): { name: string; description: string } | { error: string } {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u);
+  if (!match) {
+    return { error: "missing frontmatter" };
+  }
+
+  const values = new Map<string, string>();
+  const continuationLines = new Map<string, string[]>();
+  let currentKey: string | undefined;
+  let currentValueAllowsContinuation = false;
+
+  for (const line of match[1].split(/\r?\n/u)) {
+    const trimmed = line.trim();
+
+    if (/^[^\s].*:/u.test(line)) {
+      const separatorIndex = line.indexOf(":");
+      if (separatorIndex === -1) {
+        currentKey = undefined;
+        currentValueAllowsContinuation = false;
+        continue;
+      }
+
+      const key = line.slice(0, separatorIndex).trim();
+      const value = line.slice(separatorIndex + 1).trim();
+      values.set(key, value);
+      continuationLines.set(key, []);
+      currentKey = key;
+      currentValueAllowsContinuation =
+        value.length === 0 || /^[>|]/u.test(value);
+      continue;
+    }
+
+    if (
+      currentKey &&
+      currentValueAllowsContinuation &&
+      (/^[ \t]/u.test(line) || trimmed.length === 0)
+    ) {
+      continuationLines.get(currentKey)?.push(trimmed);
+      continue;
+    }
+
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    currentKey = undefined;
+    currentValueAllowsContinuation = false;
+  }
+
+  for (const [key, value] of values) {
+    if (value.length > 0 && !/^[>|]/u.test(value)) continue;
+
+    const continuation = (continuationLines.get(key) ?? []).join("\n").trim();
+    values.set(key, continuation);
+  }
+
+  const missing = ["name", "description"].filter((key) => !values.get(key));
+  if (missing.length > 0) {
+    return { error: `missing ${missing.join(" and ")}` };
+  }
+
+  return {
+    name: values.get("name") ?? "",
+    description: values.get("description") ?? "",
+  };
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const pathRelative = relative(parent, child);
+  return (
+    pathRelative === "" ||
+    (!pathRelative.startsWith("..") && !isAbsolute(pathRelative))
+  );
+}
+
+function resolveProjectLocalMetadataFilePath(
+  filePath: string,
+  repoRoot: string,
+): string | null {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  if (isAbsolute(normalizedPath) || win32.isAbsolute(filePath)) {
+    return null;
+  }
+
+  if (!normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`)) {
+    return null;
+  }
+
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  return isPathInside(projectLocalRoot, resolvedPath) ? resolvedPath : null;
+}
+
+async function validateResolvedLocalSkill(
+  label: string,
+  configuredPath: string,
+  resolvedPath: string,
+  options: { projectLocalRoot: string },
+): Promise<LocalSkillValidation> {
+  try {
+    const pathStat = await stat(resolvedPath);
+    if (!pathStat.isFile()) {
+      return {
+        status: "fail",
+        summary: `${label}: \`${configuredPath}\` (configured path unreadable at ${resolvedPath})`,
+      };
+    }
+
+    await access(resolvedPath, constants.R_OK);
+    const content = await readFile(resolvedPath, "utf8");
+    const frontmatter = parseSkillFrontmatter(content);
+    if ("error" in frontmatter) {
+      return {
+        status: "fail",
+        summary: `${label}: \`${configuredPath}\` (malformed skill frontmatter: ${frontmatter.error} at ${resolvedPath})`,
+      };
+    }
+
+    return {
+      status: "pass",
+      summary: `${label}: \`${configuredPath}\` (path verified)`,
+      ...(isPathInside(options.projectLocalRoot, resolvedPath)
+        ? { smokePath: resolvedPath }
+        : {}),
+    };
+  } catch {
+    return {
+      status: "fail",
+      summary: `${label}: \`${configuredPath}\` (configured path unreadable at ${resolvedPath})`,
+    };
+  }
+}
+
+function isValidProjectLocalMetadata(
+  value: unknown,
+  repoRoot: string,
+): value is SkillPackMetadataFile {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<SkillPackMetadataFile> & {
+    pack?: { source?: Record<string, unknown> };
+  };
+
+  return (
+    candidate.pack?.name === PATCHMILL_RECOMMENDED_SKILL_PACK.name &&
+    candidate.pack.version === PATCHMILL_RECOMMENDED_SKILL_PACK.version &&
+    candidate.pack.source?.type ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.type &&
+    candidate.pack.source?.repository ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.repository &&
+    candidate.pack.source?.tag ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tag &&
+    candidate.pack.source?.tarballUrl ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tarballUrl &&
+    typeof candidate.installedAt === "string" &&
+    candidate.skillDir === DEFAULT_PROJECT_SKILL_DIR &&
+    candidate.metadataFile === SKILL_PACK_METADATA_FILE &&
+    Array.isArray(candidate.files) &&
+    candidate.files.every(
+      (file) =>
+        file &&
+        typeof file.path === "string" &&
+        typeof file.sha256 === "string" &&
+        resolveProjectLocalMetadataFilePath(file.path, repoRoot) !== null,
+    )
+  );
+}
+
+function metadataSkillPaths(
+  metadata: SkillPackMetadataFile,
+  repoRoot: string,
+): string[] {
+  return metadata.files
+    .filter(
+      (file) => file.path === "SKILL.md" || file.path.endsWith("/SKILL.md"),
+    )
+    .flatMap((file) => {
+      const resolvedPath = resolveProjectLocalMetadataFilePath(
+        file.path,
+        repoRoot,
+      );
+      return resolvedPath ? [resolvedPath] : [];
+    });
+}
+
+async function checkProjectLocalMetadata(
+  repoRoot: string,
+  configuredProjectLocalPaths: string[],
+): Promise<{ entries: SkillCheckEntry[]; smokePaths: string[] }> {
+  const metadataPath = join(
+    repoRoot,
+    DEFAULT_PROJECT_SKILL_DIR,
+    SKILL_PACK_METADATA_FILE,
+  );
+
+  let metadataContent: string;
+  try {
+    metadataContent = await readFile(metadataPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        entries: [
+          {
+            status: "warn",
+            summary: "project-local skill pack metadata missing",
+          },
+        ],
+        smokePaths: configuredProjectLocalPaths,
+      };
+    }
+    return {
+      entries: [
+        {
+          status: "warn",
+          summary: `project-local skill pack metadata unreadable: ${String(error)}`,
+        },
+      ],
+      smokePaths: configuredProjectLocalPaths,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadataContent);
+  } catch (error) {
+    return {
+      entries: [
+        {
+          status: "warn",
+          summary: `project-local skill pack metadata malformed: ${String(error)}`,
+        },
+      ],
+      smokePaths: configuredProjectLocalPaths,
+    };
+  }
+
+  if (!isValidProjectLocalMetadata(parsed, repoRoot)) {
+    return {
+      entries: [
+        {
+          status: "warn",
+          summary: "project-local skill pack metadata malformed",
+        },
+      ],
+      smokePaths: configuredProjectLocalPaths,
+    };
+  }
+
+  const metadata = parsed;
+  const entries: SkillCheckEntry[] = [];
+  const smokePaths = metadataSkillPaths(metadata, repoRoot);
+  const configuredPathSet = new Set(configuredProjectLocalPaths);
+
+  for (const skillPath of smokePaths) {
+    if (configuredPathSet.has(skillPath)) continue;
+
+    const relativeSkillPath = relative(repoRoot, skillPath).replaceAll(
+      "\\",
+      "/",
+    );
+    const validation = await validateResolvedLocalSkill(
+      "project-local",
+      `./${relativeSkillPath}`,
+      skillPath,
+      { projectLocalRoot: resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR) },
+    );
+
+    if (validation.status === "fail") {
+      entries.push({
+        status: validation.status,
+        summary: `installed pack skill validation failed (${validation.summary})`,
+      });
+    }
+  }
+
+  let hasHashMismatch = false;
+  for (const file of metadata.files) {
+    try {
+      const resolvedPath = resolveProjectLocalMetadataFilePath(
+        file.path,
+        repoRoot,
+      );
+      if (!resolvedPath) {
+        hasHashMismatch = true;
+        break;
+      }
+
+      const content = await readFile(resolvedPath, "utf8");
+      if (hashText(content) !== file.sha256) {
+        hasHashMismatch = true;
+        break;
+      }
+    } catch {
+      hasHashMismatch = true;
+      break;
+    }
+  }
+
+  entries.push(
+    hasHashMismatch
+      ? {
+          status: "warn",
+          summary: "project-local skill pack customized from installed pack",
+        }
+      : {
+          status: "pass",
+          summary: "project-local metadata verified",
+        },
+  );
+
+  return { entries, smokePaths };
+}
+
+async function checkProjectLocalGitIgnore(
+  runner: CommandRunner,
+  repoRoot: string,
+): Promise<SkillCheckEntry> {
+  const result = await runner.run(
+    "git",
+    ["check-ignore", "-q", DEFAULT_PROJECT_SKILL_DIR],
+    { cwd: repoRoot },
+  );
+
+  if (result.code === 0) {
+    return {
+      status: "fail",
+      summary: `${DEFAULT_PROJECT_SKILL_DIR} is ignored by git`,
+    };
+  }
+
+  if (result.code === 1) {
+    return {
+      status: "pass",
+      summary: `${DEFAULT_PROJECT_SKILL_DIR} is not ignored by git`,
+    };
+  }
+
+  return {
+    status: "warn",
+    summary: `git-ignore status could not be verified: ${commandOutput(result)}`,
+  };
+}
+
+async function smokeTestProjectLocalSkills(
+  runner: CommandRunner,
+  repoRoot: string,
+  skillPaths: string[],
+): Promise<SkillCheckEntry> {
+  const result = await runner.run(
+    "pi",
+    [
+      "--no-session",
+      "--no-context-files",
+      "--no-prompt-templates",
+      ...skillPaths.flatMap((path) => ["--skill", path]),
+      "-p",
+      PROJECT_LOCAL_SKILLS_PROMPT,
+    ],
+    { cwd: repoRoot },
+  );
+
+  if (result.code === 0 && result.stdout.includes("PATCHMILL_SKILLS_OK")) {
+    return {
+      status: "pass",
+      summary: "Pi loaded project-local skill pack",
+    };
+  }
+
+  return {
+    status: "fail",
+    summary: `Pi could not load the project-local skill pack: ${commandOutput(result)}`,
+  };
+}
+
 async function checkSkills(
+  runner: CommandRunner,
   config: PatchmillConfig,
   repoRoot: string,
 ): Promise<DoctorCheckResult> {
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
   const configuredSkills = PATCHMILL_SKILL_KEYS.flatMap((key) => {
     const skill = config.skills[key];
     return skill ? [{ key, skill }] : [];
   });
 
-  const entries = await Promise.all(
+  const entries: SkillCheckEntry[] = await Promise.all(
     configuredSkills.map(async ({ key, skill }) => {
       if (key === "triage" && skill === DEFAULT_PATCHMILL_SKILLS.triage) {
         const bundledPath = bundledTriageSkillPath();
@@ -229,17 +624,39 @@ async function checkSkills(
       }
 
       const resolvedPath = resolvePathLikeSkillPath(skill, repoRoot);
-      return (await checkReadableSkillTarget(resolvedPath))
-        ? {
-            status: "pass" as const,
-            summary: `${key}: \`${skill}\` (path verified)`,
-          }
-        : {
-            status: "fail" as const,
-            summary: `${key}: \`${skill}\` (configured path unreadable at ${resolvedPath})`,
-          };
+      return validateResolvedLocalSkill(key, skill, resolvedPath, {
+        projectLocalRoot,
+      });
     }),
   );
+
+  const configuredProjectLocalPaths = [
+    ...new Set(
+      entries.flatMap((entry) =>
+        entry.status === "pass" && entry.smokePath ? [entry.smokePath] : [],
+      ),
+    ),
+  ];
+
+  if (await checkReadableSkillTarget(projectLocalRoot)) {
+    const metadata = await checkProjectLocalMetadata(
+      repoRoot,
+      configuredProjectLocalPaths,
+    );
+    entries.push(...metadata.entries);
+    entries.push(await checkProjectLocalGitIgnore(runner, repoRoot));
+
+    if (
+      !entries.some((entry) => entry.status === "fail") &&
+      metadata.smokePaths.length > 0
+    ) {
+      entries.push(
+        await smokeTestProjectLocalSkills(runner, repoRoot, [
+          ...new Set(metadata.smokePaths),
+        ]),
+      );
+    }
+  }
 
   const message = entries.map((entry) => entry.summary).join("; ");
   if (entries.some((entry) => entry.status === "fail")) {
@@ -345,7 +762,7 @@ export async function runDoctorChecks(
       );
     }
 
-    results.push(await checkSkills(config, options.repoRoot));
+    results.push(await checkSkills(runner, config, options.repoRoot));
 
     const paths = [
       ["plans", config.paths.plansDir],

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import { access, readFile, stat } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
+import { dirname } from "node:path";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
@@ -16,15 +16,10 @@ import {
   PATCHMILL_SKILL_KEYS,
   bundledTriageSkillPath,
   isPathLikeSkill,
+  resolveConfiguredSkillInvocation,
   resolvePathLikeSkillPath,
 } from "../../../workflow/skills.ts";
-import {
-  DEFAULT_PROJECT_SKILL_DIR,
-  PATCHMILL_RECOMMENDED_SKILL_PACK,
-  SKILL_PACK_METADATA_FILE,
-  hashContent,
-  type SkillPackMetadataFile,
-} from "../../../workflow/skill-pack.ts";
+import { DEFAULT_PROJECT_SKILL_DIR } from "../../../workflow/skill-pack.ts";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
 
@@ -44,10 +39,6 @@ type DoctorOptions = {
 type SkillCheckEntry = {
   status: DoctorCheckStatus;
   summary: string;
-};
-
-type LocalSkillValidation = SkillCheckEntry & {
-  smokePath?: string;
 };
 
 const PROJECT_LOCAL_SKILLS_PROMPT =
@@ -283,38 +274,11 @@ function parseSkillFrontmatter(
   };
 }
 
-function isPathInside(parent: string, child: string): boolean {
-  const pathRelative = relative(parent, child);
-  return (
-    pathRelative === "" ||
-    (!pathRelative.startsWith("..") && !isAbsolute(pathRelative))
-  );
-}
-
-function resolveProjectLocalMetadataFilePath(
-  filePath: string,
-  repoRoot: string,
-): string | null {
-  const normalizedPath = filePath.replaceAll("\\", "/");
-  if (isAbsolute(normalizedPath) || win32.isAbsolute(filePath)) {
-    return null;
-  }
-
-  if (!normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`)) {
-    return null;
-  }
-
-  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
-  const resolvedPath = resolve(repoRoot, normalizedPath);
-  return isPathInside(projectLocalRoot, resolvedPath) ? resolvedPath : null;
-}
-
 async function validateResolvedLocalSkill(
   label: string,
   configuredPath: string,
   resolvedPath: string,
-  options: { projectLocalRoot: string },
-): Promise<LocalSkillValidation> {
+): Promise<SkillCheckEntry> {
   try {
     const pathStat = await stat(resolvedPath);
     if (!pathStat.isFile()) {
@@ -337,9 +301,6 @@ async function validateResolvedLocalSkill(
     return {
       status: "pass",
       summary: `${label}: \`${configuredPath}\` (path verified)`,
-      ...(isPathInside(options.projectLocalRoot, resolvedPath)
-        ? { smokePath: resolvedPath }
-        : {}),
     };
   } catch {
     return {
@@ -347,186 +308,6 @@ async function validateResolvedLocalSkill(
       summary: `${label}: \`${configuredPath}\` (configured path unreadable at ${resolvedPath})`,
     };
   }
-}
-
-function isValidProjectLocalMetadata(
-  value: unknown,
-  repoRoot: string,
-): value is SkillPackMetadataFile {
-  if (!value || typeof value !== "object") return false;
-
-  const candidate = value as Partial<SkillPackMetadataFile> & {
-    pack?: { source?: Record<string, unknown> };
-  };
-
-  return (
-    candidate.pack?.name === PATCHMILL_RECOMMENDED_SKILL_PACK.name &&
-    candidate.pack.version === PATCHMILL_RECOMMENDED_SKILL_PACK.version &&
-    candidate.pack.source?.type ===
-      PATCHMILL_RECOMMENDED_SKILL_PACK.source.type &&
-    candidate.pack.source?.repository ===
-      PATCHMILL_RECOMMENDED_SKILL_PACK.source.repository &&
-    candidate.pack.source?.tag ===
-      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tag &&
-    candidate.pack.source?.tarballUrl ===
-      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tarballUrl &&
-    typeof candidate.installedAt === "string" &&
-    candidate.skillDir === DEFAULT_PROJECT_SKILL_DIR &&
-    candidate.metadataFile === SKILL_PACK_METADATA_FILE &&
-    Array.isArray(candidate.files) &&
-    candidate.files.every(
-      (file) =>
-        file &&
-        typeof file.path === "string" &&
-        typeof file.sha256 === "string" &&
-        resolveProjectLocalMetadataFilePath(file.path, repoRoot) !== null,
-    )
-  );
-}
-
-function metadataSkillPaths(
-  metadata: SkillPackMetadataFile,
-  repoRoot: string,
-): string[] {
-  return metadata.files
-    .filter(
-      (file) => file.path === "SKILL.md" || file.path.endsWith("/SKILL.md"),
-    )
-    .flatMap((file) => {
-      const resolvedPath = resolveProjectLocalMetadataFilePath(
-        file.path,
-        repoRoot,
-      );
-      return resolvedPath ? [resolvedPath] : [];
-    });
-}
-
-async function checkProjectLocalMetadata(
-  repoRoot: string,
-  configuredProjectLocalPaths: string[],
-): Promise<{ entries: SkillCheckEntry[]; smokePaths: string[] }> {
-  const metadataPath = join(
-    repoRoot,
-    DEFAULT_PROJECT_SKILL_DIR,
-    SKILL_PACK_METADATA_FILE,
-  );
-
-  let metadataContent: string;
-  try {
-    metadataContent = await readFile(metadataPath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return {
-        entries: [
-          {
-            status: "warn",
-            summary: "project-local skill pack metadata missing",
-          },
-        ],
-        smokePaths: configuredProjectLocalPaths,
-      };
-    }
-    return {
-      entries: [
-        {
-          status: "warn",
-          summary: `project-local skill pack metadata unreadable: ${String(error)}`,
-        },
-      ],
-      smokePaths: configuredProjectLocalPaths,
-    };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(metadataContent);
-  } catch (error) {
-    return {
-      entries: [
-        {
-          status: "warn",
-          summary: `project-local skill pack metadata malformed: ${String(error)}`,
-        },
-      ],
-      smokePaths: configuredProjectLocalPaths,
-    };
-  }
-
-  if (!isValidProjectLocalMetadata(parsed, repoRoot)) {
-    return {
-      entries: [
-        {
-          status: "warn",
-          summary: "project-local skill pack metadata malformed",
-        },
-      ],
-      smokePaths: configuredProjectLocalPaths,
-    };
-  }
-
-  const metadata = parsed;
-  const entries: SkillCheckEntry[] = [];
-  const smokePaths = metadataSkillPaths(metadata, repoRoot);
-  const configuredPathSet = new Set(configuredProjectLocalPaths);
-
-  for (const skillPath of smokePaths) {
-    if (configuredPathSet.has(skillPath)) continue;
-
-    const relativeSkillPath = relative(repoRoot, skillPath).replaceAll(
-      "\\",
-      "/",
-    );
-    const validation = await validateResolvedLocalSkill(
-      "project-local",
-      `./${relativeSkillPath}`,
-      skillPath,
-      { projectLocalRoot: resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR) },
-    );
-
-    if (validation.status === "fail") {
-      entries.push({
-        status: validation.status,
-        summary: `installed pack skill validation failed (${validation.summary})`,
-      });
-    }
-  }
-
-  let hasHashMismatch = false;
-  for (const file of metadata.files) {
-    try {
-      const resolvedPath = resolveProjectLocalMetadataFilePath(
-        file.path,
-        repoRoot,
-      );
-      if (!resolvedPath) {
-        hasHashMismatch = true;
-        break;
-      }
-
-      const content = await readFile(resolvedPath);
-      if (hashContent(content) !== file.sha256) {
-        hasHashMismatch = true;
-        break;
-      }
-    } catch {
-      hasHashMismatch = true;
-      break;
-    }
-  }
-
-  entries.push(
-    hasHashMismatch
-      ? {
-          status: "warn",
-          summary: "project-local skill pack customized from installed pack",
-        }
-      : {
-          status: "pass",
-          summary: "project-local metadata verified",
-        },
-  );
-
-  return { entries, smokePaths };
 }
 
 async function checkProjectLocalGitIgnore(
@@ -595,11 +376,18 @@ async function checkSkills(
   config: PatchmillConfig,
   repoRoot: string,
 ): Promise<DoctorCheckResult> {
-  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
   const configuredSkills = PATCHMILL_SKILL_KEYS.flatMap((key) => {
     const skill = config.skills[key];
     return skill ? [{ key, skill }] : [];
   });
+  const configuredSkillValues = PATCHMILL_SKILL_KEYS.flatMap((key) => {
+    const skill = config.skills[key];
+    return skill ? [skill] : [];
+  });
+  const resolution = resolveConfiguredSkillInvocation(
+    configuredSkillValues,
+    repoRoot,
+  );
 
   const entries: SkillCheckEntry[] = await Promise.all(
     configuredSkills.map(async ({ key, skill }) => {
@@ -624,36 +412,21 @@ async function checkSkills(
       }
 
       const resolvedPath = resolvePathLikeSkillPath(skill, repoRoot);
-      return validateResolvedLocalSkill(key, skill, resolvedPath, {
-        projectLocalRoot,
-      });
+      return validateResolvedLocalSkill(key, skill, resolvedPath);
     }),
   );
 
-  const configuredProjectLocalPaths = [
-    ...new Set(
-      entries.flatMap((entry) =>
-        entry.status === "pass" && entry.smokePath ? [entry.smokePath] : [],
-      ),
-    ),
-  ];
+  entries.push(...resolution.diagnostics);
 
-  if (await checkReadableSkillTarget(projectLocalRoot)) {
-    const metadata = await checkProjectLocalMetadata(
-      repoRoot,
-      configuredProjectLocalPaths,
-    );
-    entries.push(...metadata.entries);
+  if (resolution.usedProjectLocalPack) {
     entries.push(await checkProjectLocalGitIgnore(runner, repoRoot));
 
     if (
       !entries.some((entry) => entry.status === "fail") &&
-      metadata.smokePaths.length > 0
+      resolution.paths.length > 0
     ) {
       entries.push(
-        await smokeTestProjectLocalSkills(runner, repoRoot, [
-          ...new Set(metadata.smokePaths),
-        ]),
+        await smokeTestProjectLocalSkills(runner, repoRoot, resolution.paths),
       );
     }
   }

--- a/src/cli/commands/init/args.test.ts
+++ b/src/cli/commands/init/args.test.ts
@@ -2,22 +2,81 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { parseArgs } from "./args.ts";
 
+const expectedDefault = {
+  repoRoot: "/repo",
+  showHelp: false,
+  skills: { mode: "project" },
+};
+
 test("parseArgs defaults to creating config", () => {
-  assert.deepEqual(parseArgs([], "/repo"), {
-    repoRoot: "/repo",
-    showHelp: false,
-  });
+  assert.deepEqual(parseArgs([], "/repo"), expectedDefault);
 });
 
 test("parseArgs recognizes help", () => {
   assert.deepEqual(parseArgs(["--help"], "/repo"), {
-    repoRoot: "/repo",
+    ...expectedDefault,
     showHelp: true,
   });
   assert.deepEqual(parseArgs(["-h"], "/repo"), {
-    repoRoot: "/repo",
+    ...expectedDefault,
     showHelp: true,
   });
+});
+
+test("parseArgs supports project skills mode", () => {
+  assert.deepEqual(parseArgs(["--skills", "project"], "/repo"), {
+    ...expectedDefault,
+    skills: { mode: "project" },
+  });
+});
+
+test("parseArgs supports global skills mode", () => {
+  assert.deepEqual(parseArgs(["--skills=global"], "/repo"), {
+    ...expectedDefault,
+    skills: { mode: "global" },
+  });
+});
+
+test("parseArgs supports none skills mode", () => {
+  assert.deepEqual(parseArgs(["--skills", "none"], "/repo"), {
+    ...expectedDefault,
+    skills: { mode: "none" },
+  });
+});
+
+test("parseArgs supports path skills mode", () => {
+  assert.deepEqual(parseArgs(["--skills", "path:foo"], "/repo"), {
+    ...expectedDefault,
+    skills: { mode: "path", path: "foo" },
+  });
+});
+
+test("parseArgs rejects missing skills value", () => {
+  assert.throws(
+    () => parseArgs(["--skills"], "/repo"),
+    /--skills requires one of project, global, none, or path:<dir>/,
+  );
+});
+
+test("parseArgs rejects unsupported skills values", () => {
+  assert.throws(
+    () => parseArgs(["--skills", "unknown"], "/repo"),
+    /--skills requires one of project, global, none, or path:<dir>/,
+  );
+});
+
+test("parseArgs rejects empty path skills value", () => {
+  assert.throws(
+    () => parseArgs(["--skills=path:"], "/repo"),
+    /--skills path:<dir> requires a non-empty directory/,
+  );
+});
+
+test("parseArgs rejects whitespace-only path skills value", () => {
+  assert.throws(
+    () => parseArgs(["--skills=path:   "], "/repo"),
+    /--skills path:<dir> requires a non-empty directory/,
+  );
 });
 
 test("parseArgs rejects force in v1", () => {

--- a/src/cli/commands/init/args.ts
+++ b/src/cli/commands/init/args.ts
@@ -1,19 +1,69 @@
 import { cwd } from "node:process";
 
+export type InitSkillsMode =
+  | { mode: "project" }
+  | { mode: "global" }
+  | { mode: "none" }
+  | { mode: "path"; path: string };
+
 export type InitConfig = {
   repoRoot: string;
   showHelp: boolean;
+  skills: InitSkillsMode;
 };
+
+const SKILLS_VALUE_ERROR =
+  "--skills requires one of project, global, none, or path:<dir>";
+const SKILLS_PATH_ERROR = "--skills path:<dir> requires a non-empty directory";
+
+function parseSkillsMode(value: string): InitSkillsMode {
+  if (value === "project") {
+    return { mode: "project" };
+  }
+  if (value === "global") {
+    return { mode: "global" };
+  }
+  if (value === "none") {
+    return { mode: "none" };
+  }
+  if (value.startsWith("path:")) {
+    const path = value.slice("path:".length).trim();
+    if (!path) {
+      throw new Error(SKILLS_PATH_ERROR);
+    }
+    return { mode: "path", path };
+  }
+  throw new Error(SKILLS_VALUE_ERROR);
+}
+
+function requireSkillsValue(args: string[], index: number): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(SKILLS_VALUE_ERROR);
+  }
+  return value;
+}
 
 export function parseArgs(args: string[], repoRoot = cwd()): InitConfig {
   const config: InitConfig = {
     repoRoot,
     showHelp: false,
+    skills: { mode: "project" },
   };
 
-  for (const arg of args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
     if (arg === "--help" || arg === "-h") {
       config.showHelp = true;
+    } else if (arg === "--skills") {
+      config.skills = parseSkillsMode(requireSkillsValue(args, index));
+      index += 1;
+    } else if (arg.startsWith("--skills=")) {
+      const value = arg.slice("--skills=".length);
+      if (value === "") {
+        throw new Error(SKILLS_VALUE_ERROR);
+      }
+      config.skills = parseSkillsMode(value);
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }

--- a/src/cli/commands/init/config-writer.test.ts
+++ b/src/cli/commands/init/config-writer.test.ts
@@ -10,6 +10,12 @@ import {
   writeInitialConfig,
 } from "./config-writer.ts";
 
+const PROJECT_LOCAL_SKILLS = {
+  triage: ".patchmill/skills/patchmill-issue-triage",
+  planning: ".patchmill/skills/writing-plans",
+  implementation: ".patchmill/skills/subagent-driven-development",
+};
+
 async function tempRepo(): Promise<string> {
   return mkdtemp(join(tmpdir(), "patchmill-init-"));
 }
@@ -29,6 +35,16 @@ test("buildInitialConfig defaults GitHub host login to empty", () => {
       provider: "github-gh",
       login: "",
     },
+  });
+});
+
+test("buildInitialConfig includes provided skills", () => {
+  assert.deepEqual(buildInitialConfig({ skills: PROJECT_LOCAL_SKILLS }), {
+    host: {
+      provider: "forgejo-tea",
+      login: "triage-agent",
+    },
+    skills: PROJECT_LOCAL_SKILLS,
   });
 });
 
@@ -85,6 +101,25 @@ test("writeInitialConfig writes pretty minimal JSON", async () => {
   assert.equal(
     await readFile(join(repoRoot, CONFIG_FILE_NAME), "utf8"),
     `${JSON.stringify(buildInitialConfig(), null, 2)}\n`,
+  );
+});
+
+test("writeInitialConfig writes selected skills", async () => {
+  const repoRoot = await tempRepo();
+  const result = await writeInitialConfig(repoRoot, {
+    skills: PROJECT_LOCAL_SKILLS,
+  });
+
+  const expectedConfig = buildInitialConfig({ skills: PROJECT_LOCAL_SKILLS });
+
+  assert.deepEqual(result, {
+    status: "created",
+    path: join(repoRoot, CONFIG_FILE_NAME),
+    config: expectedConfig,
+  });
+  assert.equal(
+    await readFile(join(repoRoot, CONFIG_FILE_NAME), "utf8"),
+    `${JSON.stringify(expectedConfig, null, 2)}\n`,
   );
 });
 

--- a/src/cli/commands/init/config-writer.test.ts
+++ b/src/cli/commands/init/config-writer.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
   CONFIG_FILE_NAME,
   buildInitialConfig,
+  configFileExists,
   inferHostProviderFromRemote,
   writeInitialConfig,
 } from "./config-writer.ts";
@@ -137,6 +138,16 @@ test("writeInitialConfig refuses to overwrite existing config", async () => {
     await readFile(join(repoRoot, CONFIG_FILE_NAME), "utf8"),
     "{}\n",
   );
+});
+
+test("configFileExists reports whether patchmill config is present", async () => {
+  const repoRoot = await tempRepo();
+
+  assert.equal(await configFileExists(repoRoot), false);
+
+  await writeFile(join(repoRoot, CONFIG_FILE_NAME), "{}\n");
+
+  assert.equal(await configFileExists(repoRoot), true);
 });
 
 test("writeInitialConfig reads origin remote from git config when present", async () => {

--- a/src/cli/commands/init/config-writer.ts
+++ b/src/cli/commands/init/config-writer.ts
@@ -6,7 +6,7 @@ import type { PatchmillConfig } from "../../../config/types.ts";
 
 export const CONFIG_FILE_NAME = "patchmill.config.json";
 
-type InitialConfigSkills = Pick<
+export type InitialConfigSkills = Pick<
   PatchmillConfig["skills"],
   "triage" | "planning" | "implementation"
 >;
@@ -71,6 +71,10 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+export async function configFileExists(repoRoot: string): Promise<boolean> {
+  return fileExists(join(repoRoot, CONFIG_FILE_NAME));
+}
+
 async function originRemoteUrl(repoRoot: string): Promise<string | undefined> {
   try {
     const config = await readFile(join(repoRoot, ".git", "config"), "utf8");
@@ -100,7 +104,7 @@ export async function writeInitialConfig(
   },
 ): Promise<InitWriteResult> {
   const path = join(repoRoot, CONFIG_FILE_NAME);
-  if (await fileExists(path)) return { status: "exists", path };
+  if (await configFileExists(repoRoot)) return { status: "exists", path };
 
   const provider = inferHostProviderFromRemote(await originRemoteUrl(repoRoot));
   const config = buildInitialConfig({

--- a/src/cli/commands/init/config-writer.ts
+++ b/src/cli/commands/init/config-writer.ts
@@ -6,8 +6,14 @@ import type { PatchmillConfig } from "../../../config/types.ts";
 
 export const CONFIG_FILE_NAME = "patchmill.config.json";
 
+type InitialConfigSkills = Pick<
+  PatchmillConfig["skills"],
+  "triage" | "planning" | "implementation"
+>;
+
 type InitialConfig = {
   host: Pick<PatchmillConfig["host"], "provider" | "login">;
+  skills?: InitialConfigSkills;
 };
 
 export type InitWriteResult =
@@ -36,10 +42,11 @@ export function buildInitialConfig(
   options: {
     provider?: PatchmillConfig["host"]["provider"];
     login?: string;
+    skills?: InitialConfigSkills;
   } = {},
 ): InitialConfig {
   const provider = options.provider ?? DEFAULT_PATCHMILL_CONFIG.host.provider;
-  return {
+  const config: InitialConfig = {
     host: {
       provider,
       login:
@@ -47,6 +54,12 @@ export function buildInitialConfig(
         (provider === "github-gh" ? "" : DEFAULT_PATCHMILL_CONFIG.host.login),
     },
   };
+
+  if (options.skills) {
+    config.skills = options.skills;
+  }
+
+  return config;
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -81,13 +94,20 @@ async function originRemoteUrl(repoRoot: string): Promise<string | undefined> {
 
 export async function writeInitialConfig(
   repoRoot: string,
-  options: { login?: string },
+  options: {
+    login?: string;
+    skills?: InitialConfigSkills;
+  },
 ): Promise<InitWriteResult> {
   const path = join(repoRoot, CONFIG_FILE_NAME);
   if (await fileExists(path)) return { status: "exists", path };
 
   const provider = inferHostProviderFromRemote(await originRemoteUrl(repoRoot));
-  const config = buildInitialConfig({ provider, login: options.login });
+  const config = buildInitialConfig({
+    provider,
+    login: options.login,
+    skills: options.skills,
+  });
   await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, {
     flag: "wx",
   });

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -92,6 +92,10 @@ test("runInit installs project-local skills by default", async () => {
   );
   assert.match(stdout.join("\n"), /Installed project-local skills/);
   assert.match(stdout.join("\n"), /Commit \.patchmill\/skills\//);
+  assert.match(
+    stdout.join("\n"),
+    /Commit `patchmill\.config\.json` and `\.patchmill\/skills\/` before running `patchmill doctor`/,
+  );
 });
 
 test("runInit --skills none skips skill installation and omits skills config", async () => {
@@ -226,6 +230,10 @@ test("runInit creates config and prints next step", async () => {
   assert.match(stdout.join("\n"), /Created patchmill\.config\.json/);
   assert.match(stdout.join("\n"), /provider: forgejo-tea/);
   assert.match(stdout.join("\n"), /PATCHMILL_HOST_LOGIN/);
+  assert.match(
+    stdout.join("\n"),
+    /Commit `patchmill\.config\.json` before running `patchmill doctor`/,
+  );
   assert.match(stdout.join("\n"), /patchmill doctor/);
 });
 

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -1,12 +1,30 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { HELP_TEXT, runInit } from "./main.ts";
 
+const PROJECT_LOCAL_SKILLS = {
+  triage: ".patchmill/skills/patchmill-issue-triage",
+  planning: ".patchmill/skills/writing-plans",
+  implementation: ".patchmill/skills/subagent-driven-development",
+};
+
+const GLOBAL_SKILLS = {
+  triage: "patchmill-issue-triage",
+  planning: "superpowers:writing-plans",
+  implementation: "superpowers:subagent-driven-development",
+};
+
 async function tempRepo(): Promise<string> {
   return mkdtemp(join(tmpdir(), "patchmill-init-main-"));
+}
+
+async function readConfig(repoRoot: string): Promise<Record<string, unknown>> {
+  return JSON.parse(
+    await readFile(join(repoRoot, "patchmill.config.json"), "utf8"),
+  );
 }
 
 test("runInit prints help", async () => {
@@ -24,7 +42,7 @@ test("runInit prints help", async () => {
   assert.deepEqual(stderr, []);
 });
 
-test("runInit creates config and prints next step", async () => {
+test("runInit installs project-local skills by default", async () => {
   const repoRoot = await tempRepo();
   const stdout: string[] = [];
 
@@ -46,24 +64,191 @@ test("runInit creates config and prints next step", async () => {
     0,
   );
 
+  assert.deepEqual((await readConfig(repoRoot)).skills, PROJECT_LOCAL_SKILLS);
+  await access(
+    join(
+      repoRoot,
+      ".patchmill",
+      "skills",
+      "patchmill-issue-triage",
+      "SKILL.md",
+    ),
+  );
+  await access(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+  );
+  await access(
+    join(
+      repoRoot,
+      ".patchmill",
+      "skills",
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  );
+  assert.match(stdout.join("\n"), /Installed project-local skills/);
+  assert.match(stdout.join("\n"), /Commit \.patchmill\/skills\//);
+});
+
+test("runInit --skills none skips skill installation and omits skills config", async () => {
+  const repoRoot = await tempRepo();
+  const stdout: string[] = [];
+  let installCalled = false;
+
+  assert.equal(
+    await runInit(
+      ["--skills", "none"],
+      repoRoot,
+      {
+        stdout: (line) => stdout.push(line),
+        stderr: () => undefined,
+      },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+        installProjectSkills: async () => {
+          installCalled = true;
+          throw new Error("should not install skills");
+        },
+      },
+    ),
+    0,
+  );
+
+  assert.equal(installCalled, false);
+  assert.equal(Object.hasOwn(await readConfig(repoRoot), "skills"), false);
+  assert.match(
+    stdout.join("\n"),
+    /Skipped default project-local skill installation/,
+  );
+});
+
+test("runInit --skills global writes default global skill names", async () => {
+  const repoRoot = await tempRepo();
+  let installCalled = false;
+
+  assert.equal(
+    await runInit(
+      ["--skills", "global"],
+      repoRoot,
+      {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+        installProjectSkills: async () => {
+          installCalled = true;
+          throw new Error("should not install skills");
+        },
+      },
+    ),
+    0,
+  );
+
+  assert.equal(installCalled, false);
+  assert.deepEqual((await readConfig(repoRoot)).skills, GLOBAL_SKILLS);
+});
+
+test("runInit --skills path validates existing local skill directory", async () => {
+  const repoRoot = await tempRepo();
+  let validatedPath: string | undefined;
+  let installCalled = false;
+  const localSkills = {
+    triage: "vendor/skills/patchmill-issue-triage",
+    planning: "vendor/skills/writing-plans",
+    implementation: "vendor/skills/subagent-driven-development",
+  };
+
+  assert.equal(
+    await runInit(
+      ["--skills", "path:vendor/skills"],
+      repoRoot,
+      {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+        installProjectSkills: async () => {
+          installCalled = true;
+          throw new Error("should not install skills");
+        },
+        validateExistingSkillDirectory: async (validateRepoRoot, skillDir) => {
+          assert.equal(validateRepoRoot, repoRoot);
+          validatedPath = skillDir;
+          return localSkills;
+        },
+      },
+    ),
+    0,
+  );
+
+  assert.equal(installCalled, false);
+  assert.equal(validatedPath, "vendor/skills");
+  assert.deepEqual((await readConfig(repoRoot)).skills, localSkills);
+});
+
+test("runInit creates config and prints next step", async () => {
+  const repoRoot = await tempRepo();
+  const stdout: string[] = [];
+
+  assert.equal(
+    await runInit(
+      ["--skills", "none"],
+      repoRoot,
+      {
+        stdout: (line) => stdout.push(line),
+        stderr: () => undefined,
+      },
+      {
+        env: {},
+        homeDir: await tempRepo(),
+        isInteractive: false,
+        checkPiAvailable: async () => false,
+      },
+    ),
+    0,
+  );
+
   assert.match(stdout.join("\n"), /Created patchmill\.config\.json/);
   assert.match(stdout.join("\n"), /provider: forgejo-tea/);
   assert.match(stdout.join("\n"), /PATCHMILL_HOST_LOGIN/);
   assert.match(stdout.join("\n"), /patchmill doctor/);
 });
 
-test("runInit refuses existing config", async () => {
+test("runInit refuses existing config without installing skills", async () => {
   const repoRoot = await tempRepo();
   await writeFile(join(repoRoot, "patchmill.config.json"), "{}\n");
   const stdout: string[] = [];
+  let installCalled = false;
 
   assert.equal(
-    await runInit([], repoRoot, {
-      stdout: (line) => stdout.push(line),
-      stderr: () => undefined,
-    }),
+    await runInit(
+      [],
+      repoRoot,
+      {
+        stdout: (line) => stdout.push(line),
+        stderr: () => undefined,
+      },
+      {
+        installProjectSkills: async () => {
+          installCalled = true;
+          throw new Error("should not install skills");
+        },
+      },
+    ),
     1,
   );
+  assert.equal(installCalled, false);
   assert.match(stdout.join("\n"), /already exists/);
   assert.match(stdout.join("\n"), /did not overwrite/);
 });
@@ -75,7 +260,7 @@ test("runInit does not offer Pi handoff when provider config is apparent", async
 
   assert.equal(
     await runInit(
-      [],
+      ["--skills", "none"],
       repoRoot,
       { stdout: (line) => stdout.push(line), stderr: () => undefined },
       {
@@ -102,7 +287,7 @@ test("runInit offers Pi handoff when provider config is not apparent", async () 
 
   assert.equal(
     await runInit(
-      [],
+      ["--skills", "none"],
       repoRoot,
       { stdout: (line) => stdout.push(line), stderr: () => undefined },
       {
@@ -141,7 +326,7 @@ test("runInit gives manual Pi setup guidance when Pi exits non-zero", async () =
 
   assert.equal(
     await runInit(
-      [],
+      ["--skills", "none"],
       repoRoot,
       { stdout: (line) => stdout.push(line), stderr: () => undefined },
       {
@@ -178,7 +363,7 @@ test("runInit skips Pi handoff prompt when Pi is unavailable", async () => {
 
   assert.equal(
     await runInit(
-      [],
+      ["--skills", "none"],
       repoRoot,
       { stdout: (line) => stdout.push(line), stderr: () => undefined },
       {
@@ -210,7 +395,7 @@ test("runInit handles declined Pi handoff without error", async () => {
 
   assert.equal(
     await runInit(
-      [],
+      ["--skills", "none"],
       repoRoot,
       { stdout: (line) => stdout.push(line), stderr: () => undefined },
       {

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -42,6 +42,10 @@ test("runInit prints help", async () => {
   assert.deepEqual(stderr, []);
 });
 
+test("HELP_TEXT documents project as the default --skills mode", () => {
+  assert.match(HELP_TEXT, /--skills <mode>[\s\S]*Default: project\./);
+});
+
 test("runInit installs project-local skills by default", async () => {
   const repoRoot = await tempRepo();
   const stdout: string[] = [];

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -8,7 +8,7 @@ import {
 import { createInterface } from "node:readline/promises";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "./args.ts";
-import { DEFAULT_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
+import { GLOBAL_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
 import {
   installProjectSkills,
   validateExistingSkillDirectory,
@@ -88,9 +88,9 @@ function isYes(value: string): boolean {
 }
 
 const DEFAULT_GLOBAL_SKILLS: InitialConfigSkills = {
-  triage: DEFAULT_PATCHMILL_SKILLS.triage,
-  planning: DEFAULT_PATCHMILL_SKILLS.planning,
-  implementation: DEFAULT_PATCHMILL_SKILLS.implementation,
+  triage: GLOBAL_PATCHMILL_SKILLS.triage,
+  planning: GLOBAL_PATCHMILL_SKILLS.planning,
+  implementation: GLOBAL_PATCHMILL_SKILLS.implementation,
 };
 
 const EXISTING_CONFIG_MESSAGE =

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -8,15 +8,27 @@ import {
 import { createInterface } from "node:readline/promises";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "./args.ts";
-import { writeInitialConfig } from "./config-writer.ts";
+import { DEFAULT_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
+import {
+  installProjectSkills,
+  validateExistingSkillDirectory,
+  type ProjectSkillInstallResult,
+} from "./skill-installer.ts";
+import {
+  configFileExists,
+  writeInitialConfig,
+  type InitialConfigSkills,
+} from "./config-writer.ts";
 import { hasApparentPiProviderConfig } from "./pi-preflight.ts";
 
 export const HELP_TEXT = `Usage:
   patchmill init [options]
 
 Create a minimal patchmill.config.json for this repository.
+Installs the recommended project-local skill pack by default.
 
 Options:
+  --skills <mode>  Skill installation mode: project, global, none, or path:<dir>.
   --help, -h  Show this help and exit.
 `;
 
@@ -28,6 +40,13 @@ export type InitOutput = {
 export type PiLauncher = () => Promise<number>;
 export type PiAvailabilityCheck = () => Promise<boolean>;
 export type InitPrompt = (question: string) => Promise<string>;
+export type ProjectSkillInstaller = (options: {
+  repoRoot: string;
+}) => Promise<ProjectSkillInstallResult>;
+export type ExistingSkillDirectoryValidator = (
+  repoRoot: string,
+  skillDir: string,
+) => Promise<InitialConfigSkills>;
 
 const DEFAULT_OUTPUT: InitOutput = {
   stdout: (line) => console.log(line),
@@ -68,6 +87,15 @@ function isYes(value: string): boolean {
   return /^(y|yes)$/iu.test(value.trim());
 }
 
+const DEFAULT_GLOBAL_SKILLS: InitialConfigSkills = {
+  triage: DEFAULT_PATCHMILL_SKILLS.triage,
+  planning: DEFAULT_PATCHMILL_SKILLS.planning,
+  implementation: DEFAULT_PATCHMILL_SKILLS.implementation,
+};
+
+const EXISTING_CONFIG_MESSAGE =
+  "patchmill.config.json already exists.\n\nPatchmill did not overwrite it.\n\nNext:\n  patchmill doctor";
+
 export async function runInit(
   args: string[],
   repoRoot = cwd(),
@@ -79,6 +107,8 @@ export async function runInit(
     launchPi?: PiLauncher;
     checkPiAvailable?: PiAvailabilityCheck;
     isInteractive?: boolean;
+    installProjectSkills?: ProjectSkillInstaller;
+    validateExistingSkillDirectory?: ExistingSkillDirectoryValidator;
   } = {},
 ): Promise<number> {
   const config = parseArgs(args, repoRoot);
@@ -87,11 +117,37 @@ export async function runInit(
     return 0;
   }
 
-  const result = await writeInitialConfig(config.repoRoot, {});
+  if (await configFileExists(config.repoRoot)) {
+    output.stdout(EXISTING_CONFIG_MESSAGE);
+    return 1;
+  }
+
+  let skills: InitialConfigSkills | undefined;
+  let skillsMessage: string;
+
+  if (config.skills.mode === "project") {
+    const installResult = await (
+      options.installProjectSkills ?? installProjectSkills
+    )({ repoRoot: config.repoRoot });
+    skills = installResult.skillConfig;
+    skillsMessage = `Installed project-local skills:\n  ${installResult.installedSkills.join("\n  ")}\n\nCommit ${installResult.skillDir}/ to share the recommended skill pack with this repository.\n\nUsing Patchmill defaults for labels, paths, and git policy.`;
+  } else if (config.skills.mode === "global") {
+    skills = DEFAULT_GLOBAL_SKILLS;
+    skillsMessage =
+      "Using Patchmill default global skill names.\nNo project-local skills were installed.\n\nUsing Patchmill defaults for labels, paths, and git policy.";
+  } else if (config.skills.mode === "none") {
+    skillsMessage =
+      "Skipped default project-local skill installation (--skills none).\nNo skills mapping was written to patchmill.config.json.\n\nUsing Patchmill defaults for labels, paths, and git policy.";
+  } else {
+    skills = await (
+      options.validateExistingSkillDirectory ?? validateExistingSkillDirectory
+    )(config.repoRoot, config.skills.path);
+    skillsMessage = `Validated existing local skills from ${config.skills.path}.\nNo project-local skills were installed.\n\nUsing Patchmill defaults for labels, paths, and git policy.`;
+  }
+
+  const result = await writeInitialConfig(config.repoRoot, { skills });
   if (result.status === "exists") {
-    output.stdout(
-      `patchmill.config.json already exists.\n\nPatchmill did not overwrite it.\n\nNext:\n  patchmill doctor`,
-    );
+    output.stdout(EXISTING_CONFIG_MESSAGE);
     return 1;
   }
 
@@ -131,7 +187,7 @@ export async function runInit(
   }
 
   output.stdout(
-    `Created patchmill.config.json\n\nHost:\n  provider: ${result.config.host.provider}\n  login: ${result.config.host.login}\n\n${HOST_LOGIN_GUIDANCE}\n\nUsing Patchmill defaults for labels, paths, skills, and git policy.\n\n${piMessage}\n\nNext:\n  patchmill doctor`,
+    `Created patchmill.config.json\n\nHost:\n  provider: ${result.config.host.provider}\n  login: ${result.config.host.login}\n\n${HOST_LOGIN_GUIDANCE}\n\n${skillsMessage}\n\n${piMessage}\n\nNext:\n  patchmill doctor`,
   );
   return 0;
 }

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -28,7 +28,7 @@ Create a minimal patchmill.config.json for this repository.
 Installs the recommended project-local skill pack by default.
 
 Options:
-  --skills <mode>  Skill installation mode: project, global, none, or path:<dir>.
+  --skills <mode>  Skill installation mode: project, global, none, or path:<dir>. Default: project.
   --help, -h  Show this help and exit.
 `;
 

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -96,6 +96,15 @@ const DEFAULT_GLOBAL_SKILLS: InitialConfigSkills = {
 const EXISTING_CONFIG_MESSAGE =
   "patchmill.config.json already exists.\n\nPatchmill did not overwrite it.\n\nNext:\n  patchmill doctor";
 
+function successNextSteps(skillsMode: "project" | "global" | "none" | "path") {
+  const commitTargets =
+    skillsMode === "project"
+      ? "`patchmill.config.json` and `.patchmill/skills/`"
+      : "`patchmill.config.json`";
+
+  return `Commit ${commitTargets} before running \`patchmill doctor\`. Doctor expects a clean worktree.\n\nNext:\n  patchmill doctor`;
+}
+
 export async function runInit(
   args: string[],
   repoRoot = cwd(),
@@ -187,7 +196,7 @@ export async function runInit(
   }
 
   output.stdout(
-    `Created patchmill.config.json\n\nHost:\n  provider: ${result.config.host.provider}\n  login: ${result.config.host.login}\n\n${HOST_LOGIN_GUIDANCE}\n\n${skillsMessage}\n\n${piMessage}\n\nNext:\n  patchmill doctor`,
+    `Created patchmill.config.json\n\nHost:\n  provider: ${result.config.host.provider}\n  login: ${result.config.host.login}\n\n${HOST_LOGIN_GUIDANCE}\n\n${skillsMessage}\n\n${piMessage}\n\n${successNextSteps(config.skills.mode)}`,
   );
   return 0;
 }

--- a/src/cli/commands/init/skill-installer.test.ts
+++ b/src/cli/commands/init/skill-installer.test.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
 import {
   access,
+  cp,
   mkdtemp,
   mkdir,
   readFile,
+  readdir,
+  rename,
+  rm,
   symlink,
+  unlink,
   writeFile,
+  stat,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,8 +25,22 @@ import {
 import {
   defaultSkillSourceRoots,
   installProjectSkills,
+  type SkillInstallerDependencies,
   validateExistingSkillDirectory,
 } from "./skill-installer.ts";
+
+const skillInstallerDependencies: SkillInstallerDependencies = {
+  access,
+  cp,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+};
 
 async function tempRoot(prefix: string): Promise<string> {
   return mkdtemp(join(tmpdir(), prefix));
@@ -269,6 +289,142 @@ test("installProjectSkills preflights later source trees before copying any skil
 
   await assert.rejects(
     access(join(repoRoot, ".patchmill", "skills", "patchmill-issue-triage")),
+  );
+});
+
+test("installProjectSkills does not publish partial targets when staging fails", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill, {
+    "triage-notes.md": "take notes\n",
+  });
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+
+  const secondSkillDir = join(superpowersSource, "writing-plans");
+  const secondSkillPath = join(secondSkillDir, "SKILL.md");
+  let copyCalls = 0;
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [
+        { name: "patchmill-issue-triage", source: "patchmill" },
+        { name: "writing-plans", source: "superpowers" },
+      ],
+      dependencies: {
+        ...skillInstallerDependencies,
+        async cp(source, destination, options) {
+          copyCalls += 1;
+          if (copyCalls === 1) {
+            await unlink(secondSkillPath);
+            await symlink("missing-skill.md", secondSkillPath);
+          }
+          if (source === secondSkillDir) {
+            throw new Error(
+              `ENOENT: no such file or directory, copyfile '${secondSkillPath}'`,
+            );
+          }
+
+          return cp(source, destination, options);
+        },
+      },
+    }),
+    /ENOENT: no such file or directory, copyfile .*writing-plans\/SKILL\.md/,
+  );
+
+  await assert.rejects(access(join(repoRoot, ".patchmill", "skills")));
+});
+
+test("installProjectSkills can install two skills and publish metadata in one directory publish", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill, {
+    "plan-template.md": "template\n",
+  });
+
+  const publishedSkillDir = join(repoRoot, ".patchmill", "skills");
+  let renameCalls = 0;
+
+  const result = await installProjectSkills({
+    repoRoot,
+    sourceRoots: {
+      patchmillSkillsDir: patchmillSource,
+      superpowersSkillsDir: superpowersSource,
+    },
+    installedAt: "2026-05-29T00:00:00.000Z",
+    packSkills: [
+      { name: "patchmill-issue-triage", source: "patchmill" },
+      { name: "writing-plans", source: "superpowers" },
+    ],
+    dependencies: {
+      ...skillInstallerDependencies,
+      async rename(from, to) {
+        renameCalls += 1;
+        assert.equal(to, publishedSkillDir);
+        await assert.rejects(access(publishedSkillDir));
+        assert.equal(
+          await readFile(
+            join(from, "patchmill-issue-triage", "SKILL.md"),
+            "utf8",
+          ),
+          triageSkill,
+        );
+        assert.equal(
+          await readFile(join(from, "writing-plans", "SKILL.md"), "utf8"),
+          planningSkill,
+        );
+
+        const metadata = JSON.parse(
+          await readFile(join(from, SKILL_PACK_METADATA_FILE), "utf8"),
+        ) as ReturnType<typeof buildSkillPackMetadata>;
+        assert.deepEqual(
+          metadata.files.map((file) => file.path),
+          [
+            ".patchmill/skills/patchmill-issue-triage/SKILL.md",
+            ".patchmill/skills/writing-plans/SKILL.md",
+            ".patchmill/skills/writing-plans/plan-template.md",
+          ],
+        );
+
+        return rename(from, to);
+      },
+    },
+  });
+
+  assert.equal(renameCalls, 1);
+  assert.deepEqual(result.installedSkills, [
+    ".patchmill/skills/patchmill-issue-triage",
+    ".patchmill/skills/writing-plans",
+  ]);
+  assert.equal(
+    await readFile(join(publishedSkillDir, SKILL_PACK_METADATA_FILE), "utf8"),
+    await readFile(result.metadataPath, "utf8"),
+  );
+});
+
+test("installProjectSkills refuses to overwrite existing skill root", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await mkdir(join(repoRoot, ".patchmill", "skills"), { recursive: true });
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: await tempRoot("patchmill-install-superpowers-"),
+      },
+      packSkills: [{ name: "patchmill-issue-triage", source: "patchmill" }],
+    }),
+    /Refusing to overwrite existing skill path: \.patchmill\/skills/,
   );
 });
 

--- a/src/cli/commands/init/skill-installer.test.ts
+++ b/src/cli/commands/init/skill-installer.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import {
+  access,
+  mkdtemp,
+  mkdir,
+  readFile,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  SKILL_PACK_METADATA_FILE,
+  buildRecommendedProjectSkillConfig,
+  buildSkillPackMetadata,
+  hashText,
+} from "../../../workflow/skill-pack.ts";
+import {
+  defaultSkillSourceRoots,
+  installProjectSkills,
+  validateExistingSkillDirectory,
+} from "./skill-installer.ts";
+
+async function tempRoot(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function writeSkill(
+  root: string,
+  skillPath: string,
+  skillBody: string,
+  extraFiles: Record<string, string> = {},
+): Promise<void> {
+  const skillDir = join(root, skillPath);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(join(skillDir, "SKILL.md"), skillBody);
+  for (const [relativePath, content] of Object.entries(extraFiles)) {
+    const fullPath = join(skillDir, relativePath);
+    await mkdir(join(fullPath, ".."), { recursive: true });
+    await writeFile(fullPath, content);
+  }
+}
+
+const triageSkill = `---
+name: patchmill-issue-triage
+description: Triage issues.
+---
+# Triage
+`;
+
+const planningSkill = `---
+name: writing-plans
+description: Write plans.
+---
+# Planning
+`;
+
+const implementationSkill = `---
+name: subagent-driven-development
+description: Execute plans.
+---
+# Implementation
+`;
+
+test("installProjectSkills copies skills and writes metadata", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill, {
+    "plan-document-reviewer-prompt.md": "review plans carefully\n",
+  });
+  await writeSkill(
+    superpowersSource,
+    "subagent-driven-development",
+    implementationSkill,
+  );
+
+  const result = await installProjectSkills({
+    repoRoot,
+    sourceRoots: {
+      patchmillSkillsDir: patchmillSource,
+      superpowersSkillsDir: superpowersSource,
+    },
+    installedAt: "2026-05-29T00:00:00.000Z",
+    packSkills: [
+      { name: "patchmill-issue-triage", source: "patchmill" },
+      { name: "writing-plans", source: "superpowers" },
+      { name: "subagent-driven-development", source: "superpowers" },
+    ],
+  });
+
+  assert.equal(result.skillDir, ".patchmill/skills");
+  assert.deepEqual(result.skillConfig, buildRecommendedProjectSkillConfig());
+  assert.deepEqual(result.installedSkills, [
+    ".patchmill/skills/patchmill-issue-triage",
+    ".patchmill/skills/writing-plans",
+    ".patchmill/skills/subagent-driven-development",
+  ]);
+  assert.equal(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+      "utf8",
+    ),
+    planningSkill,
+  );
+  assert.equal(
+    await readFile(
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "writing-plans",
+        "plan-document-reviewer-prompt.md",
+      ),
+      "utf8",
+    ),
+    "review plans carefully\n",
+  );
+
+  const metadata = JSON.parse(
+    await readFile(result.metadataPath, "utf8"),
+  ) as ReturnType<typeof buildSkillPackMetadata>;
+  const expectedMetadata = buildSkillPackMetadata(
+    [
+      {
+        path: ".patchmill/skills/patchmill-issue-triage/SKILL.md",
+        sha256: hashText(triageSkill),
+      },
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(planningSkill),
+      },
+      {
+        path: ".patchmill/skills/writing-plans/plan-document-reviewer-prompt.md",
+        sha256: hashText("review plans carefully\n"),
+      },
+      {
+        path: ".patchmill/skills/subagent-driven-development/SKILL.md",
+        sha256: hashText(implementationSkill),
+      },
+    ],
+    {
+      installedAt: "2026-05-29T00:00:00.000Z",
+      skillDir: ".patchmill/skills",
+    },
+  );
+
+  assert.equal(
+    result.metadataPath,
+    join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+  );
+  assert.deepEqual(
+    metadata.files,
+    expectedMetadata.files.toSorted((a, b) =>
+      a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+    ),
+  );
+  assert.deepEqual(
+    { ...metadata, files: undefined },
+    { ...expectedMetadata, files: undefined },
+  );
+});
+
+test("installProjectSkills refuses to overwrite existing skill files/directories", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await mkdir(
+    join(repoRoot, ".patchmill", "skills", "patchmill-issue-triage"),
+    {
+      recursive: true,
+    },
+  );
+  await writeFile(
+    join(
+      repoRoot,
+      ".patchmill",
+      "skills",
+      "patchmill-issue-triage",
+      "SKILL.md",
+    ),
+    "existing\n",
+  );
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [{ name: "patchmill-issue-triage", source: "patchmill" }],
+    }),
+    /Refusing to overwrite existing skill path: \.patchmill\/skills\/patchmill-issue-triage/,
+  );
+  assert.equal(
+    await readFile(
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "patchmill-issue-triage",
+        "SKILL.md",
+      ),
+      "utf8",
+    ),
+    "existing\n",
+  );
+});
+
+test("installProjectSkills preflights all targets before copying any skill", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+  await mkdir(join(repoRoot, ".patchmill", "skills", "writing-plans"), {
+    recursive: true,
+  });
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [
+        { name: "patchmill-issue-triage", source: "patchmill" },
+        { name: "writing-plans", source: "superpowers" },
+      ],
+    }),
+    /Refusing to overwrite existing skill path: \.patchmill\/skills\/writing-plans/,
+  );
+
+  await assert.rejects(
+    access(join(repoRoot, ".patchmill", "skills", "patchmill-issue-triage")),
+  );
+});
+
+test("installProjectSkills preflights later source trees before copying any skill", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  const patchmillSource = await tempRoot("patchmill-install-patchmill-");
+  const superpowersSource = await tempRoot("patchmill-install-superpowers-");
+  await writeSkill(patchmillSource, "patchmill-issue-triage", triageSkill);
+  await writeSkill(superpowersSource, "writing-plans", planningSkill);
+  await symlink(
+    "missing-plan-template.md",
+    join(superpowersSource, "writing-plans", "broken-link.md"),
+  );
+
+  await assert.rejects(
+    installProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: patchmillSource,
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [
+        { name: "patchmill-issue-triage", source: "patchmill" },
+        { name: "writing-plans", source: "superpowers" },
+      ],
+    }),
+    /Unsupported skill source entry: writing-plans\/broken-link\.md/,
+  );
+
+  await assert.rejects(
+    access(join(repoRoot, ".patchmill", "skills", "patchmill-issue-triage")),
+  );
+});
+
+test("validateExistingSkillDirectory returns local config for path mode", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  await writeSkill(
+    repoRoot,
+    "project-skills/patchmill-issue-triage",
+    triageSkill,
+  );
+  await writeSkill(repoRoot, "project-skills/writing-plans", planningSkill);
+  await writeSkill(
+    repoRoot,
+    "project-skills/subagent-driven-development",
+    implementationSkill,
+  );
+
+  assert.deepEqual(
+    await validateExistingSkillDirectory(repoRoot, "project-skills"),
+    buildRecommendedProjectSkillConfig("project-skills"),
+  );
+});
+
+test("validateExistingSkillDirectory fails when a required skill is missing", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  await writeSkill(repoRoot, "project-skills/writing-plans", planningSkill);
+
+  await assert.rejects(
+    validateExistingSkillDirectory(repoRoot, "project-skills"),
+    /Missing required skill file: project-skills\/patchmill-issue-triage\/SKILL\.md/,
+  );
+});
+
+test("validateExistingSkillDirectory fails when SKILL.md is a directory", async () => {
+  const repoRoot = await tempRoot("patchmill-install-repo-");
+  await mkdir(
+    join(repoRoot, "project-skills", "patchmill-issue-triage", "SKILL.md"),
+    {
+      recursive: true,
+    },
+  );
+  await writeSkill(repoRoot, "project-skills/writing-plans", planningSkill);
+  await writeSkill(
+    repoRoot,
+    "project-skills/subagent-driven-development",
+    implementationSkill,
+  );
+
+  await assert.rejects(
+    validateExistingSkillDirectory(repoRoot, "project-skills"),
+    /Missing required skill file: project-skills\/patchmill-issue-triage\/SKILL\.md/,
+  );
+});
+
+test("defaultSkillSourceRoots resolves bundled and dependency skill roots", async () => {
+  const roots = defaultSkillSourceRoots();
+
+  await access(
+    join(roots.patchmillSkillsDir, "patchmill-issue-triage", "SKILL.md"),
+  );
+  await access(join(roots.superpowersSkillsDir, "writing-plans", "SKILL.md"));
+});

--- a/src/cli/commands/init/skill-installer.ts
+++ b/src/cli/commands/init/skill-installer.ts
@@ -3,14 +3,17 @@ import { constants } from "node:fs";
 import {
   access,
   cp,
+  mkdtemp,
   mkdir,
   readdir,
   readFile,
+  rename,
+  rm,
   stat,
   writeFile,
 } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import {
   DEFAULT_PROJECT_SKILL_DIR,
   PATCHMILL_RECOMMENDED_SKILL_PACK,
@@ -40,6 +43,32 @@ export type ProjectSkillInstallResult = {
   metadataPath: string;
 };
 
+export type SkillInstallerDependencies = {
+  access: typeof access;
+  cp: typeof cp;
+  mkdtemp: typeof mkdtemp;
+  mkdir: typeof mkdir;
+  readdir: typeof readdir;
+  readFile: typeof readFile;
+  rename: typeof rename;
+  rm: typeof rm;
+  stat: typeof stat;
+  writeFile: typeof writeFile;
+};
+
+const defaultDependencies: SkillInstallerDependencies = {
+  access,
+  cp,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+};
+
 export function defaultSkillSourceRoots(): SourceRoots {
   const superpowersRoot = dirname(require.resolve("superpowers/package.json"));
   return {
@@ -48,9 +77,12 @@ export function defaultSkillSourceRoots(): SourceRoots {
   };
 }
 
-async function pathExists(path: string): Promise<boolean> {
+async function pathExists(
+  path: string,
+  dependencies: SkillInstallerDependencies = defaultDependencies,
+): Promise<boolean> {
   try {
-    await access(path, constants.F_OK);
+    await dependencies.access(path, constants.F_OK);
     return true;
   } catch {
     return false;
@@ -66,13 +98,14 @@ function sourceRootFor(skill: SkillPackSkill, roots: SourceRoots): string {
 async function assertSkillFile(
   path: string,
   displayPath: string,
+  dependencies: SkillInstallerDependencies = defaultDependencies,
 ): Promise<void> {
   try {
-    const skillFile = await stat(path);
+    const skillFile = await dependencies.stat(path);
     if (!skillFile.isFile()) {
       throw new Error("Skill path is not a file");
     }
-    await access(path, constants.R_OK);
+    await dependencies.access(path, constants.R_OK);
   } catch {
     throw new Error(`Missing required skill file: ${displayPath}`);
   }
@@ -84,9 +117,12 @@ function comparePaths(a: string, b: string): number {
   return 0;
 }
 
-async function hashFile(path: string): Promise<string> {
+async function hashFile(
+  path: string,
+  dependencies: SkillInstallerDependencies = defaultDependencies,
+): Promise<string> {
   return createHash("sha256")
-    .update(await readFile(path))
+    .update(await dependencies.readFile(path))
     .digest("hex");
 }
 
@@ -95,9 +131,12 @@ async function collectSourceFiles(
   currentDir: string,
   targetRelativeDir: string,
   displayRoot: string,
+  dependencies: SkillInstallerDependencies = defaultDependencies,
 ): Promise<Array<{ path: string; sha256: string }>> {
   const files: Array<{ path: string; sha256: string }> = [];
-  const entries = await readdir(currentDir, { withFileTypes: true });
+  const entries = await dependencies.readdir(currentDir, {
+    withFileTypes: true,
+  });
   entries.sort((a, b) => comparePaths(a.name, b.name));
 
   for (const entry of entries) {
@@ -113,6 +152,7 @@ async function collectSourceFiles(
           entryPath,
           targetRelativeDir,
           displayRoot,
+          dependencies,
         )),
       );
       continue;
@@ -123,7 +163,7 @@ async function collectSourceFiles(
 
     files.push({
       path: metadataPath,
-      sha256: await hashFile(entryPath),
+      sha256: await hashFile(entryPath, dependencies),
     });
   }
 
@@ -136,11 +176,13 @@ export async function installProjectSkills(options: {
   sourceRoots?: SourceRoots;
   packSkills?: SkillPackSkill[];
   installedAt?: string;
+  dependencies?: SkillInstallerDependencies;
 }): Promise<ProjectSkillInstallResult> {
   const skillDir = options.skillDir ?? DEFAULT_PROJECT_SKILL_DIR;
   const sourceRoots = options.sourceRoots ?? defaultSkillSourceRoots();
   const packSkills =
     options.packSkills ?? PATCHMILL_RECOMMENDED_SKILL_PACK.skills;
+  const dependencies = options.dependencies ?? defaultDependencies;
   const absoluteSkillDir = resolve(options.repoRoot, skillDir);
   const metadataPath = join(absoluteSkillDir, SKILL_PACK_METADATA_FILE);
   const installedSkills: string[] = [];
@@ -157,11 +199,12 @@ export async function installProjectSkills(options: {
     await assertSkillFile(
       join(sourceDir, "SKILL.md"),
       `${skill.name}/SKILL.md`,
+      dependencies,
     );
 
     const targetRelativeDir = projectSkillPath(skill.name, skillDir);
     const targetDir = resolve(options.repoRoot, targetRelativeDir);
-    if (await pathExists(targetDir)) {
+    if (await pathExists(targetDir, dependencies)) {
       throw new Error(
         `Refusing to overwrite existing skill path: ${targetRelativeDir}`,
       );
@@ -172,6 +215,7 @@ export async function installProjectSkills(options: {
       sourceDir,
       targetRelativeDir,
       skill.name,
+      dependencies,
     );
 
     installationPlan.push({
@@ -182,25 +226,18 @@ export async function installProjectSkills(options: {
     });
   }
 
-  if (await pathExists(metadataPath)) {
+  if (await pathExists(metadataPath, dependencies)) {
     throw new Error(
       `Refusing to overwrite existing skill path: ${projectSkillPath(SKILL_PACK_METADATA_FILE, skillDir)}`,
     );
   }
 
-  for (const plan of installationPlan) {
-    files.push(...plan.files);
+  if (await pathExists(absoluteSkillDir, dependencies)) {
+    throw new Error(`Refusing to overwrite existing skill path: ${skillDir}`);
   }
 
-  for (const { sourceDir, targetDir, targetRelativeDir } of installationPlan) {
-    await mkdir(dirname(targetDir), { recursive: true });
-    await cp(sourceDir, targetDir, {
-      recursive: true,
-      errorOnExist: true,
-      force: false,
-    });
-
-    installedSkills.push(targetRelativeDir);
+  for (const plan of installationPlan) {
+    files.push(...plan.files);
   }
 
   files.sort((a, b) => comparePaths(a.path, b.path));
@@ -209,10 +246,47 @@ export async function installProjectSkills(options: {
     installedAt: options.installedAt ?? new Date().toISOString(),
     skillDir,
   });
-  await mkdir(absoluteSkillDir, { recursive: true });
-  await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, {
-    flag: "wx",
-  });
+
+  let stagingSkillDir: string | undefined;
+
+  try {
+    await dependencies.mkdir(dirname(absoluteSkillDir), { recursive: true });
+    stagingSkillDir = await dependencies.mkdtemp(
+      join(dirname(absoluteSkillDir), `${basename(absoluteSkillDir)}-staging-`),
+    );
+
+    for (const {
+      sourceDir,
+      targetDir,
+      targetRelativeDir,
+    } of installationPlan) {
+      await dependencies.cp(
+        sourceDir,
+        join(stagingSkillDir, relative(absoluteSkillDir, targetDir)),
+        {
+          recursive: true,
+          errorOnExist: true,
+          force: false,
+        },
+      );
+
+      installedSkills.push(targetRelativeDir);
+    }
+
+    await dependencies.writeFile(
+      join(stagingSkillDir, SKILL_PACK_METADATA_FILE),
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      {
+        flag: "wx",
+      },
+    );
+
+    await dependencies.rename(stagingSkillDir, absoluteSkillDir);
+  } finally {
+    if (stagingSkillDir !== undefined) {
+      await dependencies.rm(stagingSkillDir, { recursive: true, force: true });
+    }
+  }
 
   return {
     skillDir: metadata.skillDir,

--- a/src/cli/commands/init/skill-installer.ts
+++ b/src/cli/commands/init/skill-installer.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  access,
+  cp,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  buildRecommendedProjectSkillConfig,
+  buildSkillPackMetadata,
+  projectSkillPath,
+  type SkillPackSkill,
+} from "../../../workflow/skill-pack.ts";
+import { bundledTriageSkillPath } from "../../../workflow/skills.ts";
+import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
+
+const require = createRequire(import.meta.url);
+
+export type SourceRoots = {
+  patchmillSkillsDir: string;
+  superpowersSkillsDir: string;
+};
+
+export type ProjectSkillInstallResult = {
+  skillDir: string;
+  skillConfig: Pick<
+    PatchmillSkillsConfig,
+    "triage" | "planning" | "implementation"
+  >;
+  installedSkills: string[];
+  metadataPath: string;
+};
+
+export function defaultSkillSourceRoots(): SourceRoots {
+  const superpowersRoot = dirname(require.resolve("superpowers/package.json"));
+  return {
+    patchmillSkillsDir: resolve(dirname(bundledTriageSkillPath()), ".."),
+    superpowersSkillsDir: join(superpowersRoot, "skills"),
+  };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sourceRootFor(skill: SkillPackSkill, roots: SourceRoots): string {
+  return skill.source === "patchmill"
+    ? roots.patchmillSkillsDir
+    : roots.superpowersSkillsDir;
+}
+
+async function assertSkillFile(
+  path: string,
+  displayPath: string,
+): Promise<void> {
+  try {
+    const skillFile = await stat(path);
+    if (!skillFile.isFile()) {
+      throw new Error("Skill path is not a file");
+    }
+    await access(path, constants.R_OK);
+  } catch {
+    throw new Error(`Missing required skill file: ${displayPath}`);
+  }
+}
+
+function comparePaths(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+async function hashFile(path: string): Promise<string> {
+  return createHash("sha256")
+    .update(await readFile(path))
+    .digest("hex");
+}
+
+async function collectSourceFiles(
+  skillRoot: string,
+  currentDir: string,
+  targetRelativeDir: string,
+  displayRoot: string,
+): Promise<Array<{ path: string; sha256: string }>> {
+  const files: Array<{ path: string; sha256: string }> = [];
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  entries.sort((a, b) => comparePaths(a.name, b.name));
+
+  for (const entry of entries) {
+    const entryPath = join(currentDir, entry.name);
+    const relativePath = relative(skillRoot, entryPath).split(sep).join("/");
+    const metadataPath = `${targetRelativeDir}/${relativePath}`;
+    const displayPath = `${displayRoot}/${relativePath}`;
+
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await collectSourceFiles(
+          skillRoot,
+          entryPath,
+          targetRelativeDir,
+          displayRoot,
+        )),
+      );
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(`Unsupported skill source entry: ${displayPath}`);
+    }
+
+    files.push({
+      path: metadataPath,
+      sha256: await hashFile(entryPath),
+    });
+  }
+
+  return files;
+}
+
+export async function installProjectSkills(options: {
+  repoRoot: string;
+  skillDir?: string;
+  sourceRoots?: SourceRoots;
+  packSkills?: SkillPackSkill[];
+  installedAt?: string;
+}): Promise<ProjectSkillInstallResult> {
+  const skillDir = options.skillDir ?? DEFAULT_PROJECT_SKILL_DIR;
+  const sourceRoots = options.sourceRoots ?? defaultSkillSourceRoots();
+  const packSkills =
+    options.packSkills ?? PATCHMILL_RECOMMENDED_SKILL_PACK.skills;
+  const absoluteSkillDir = resolve(options.repoRoot, skillDir);
+  const metadataPath = join(absoluteSkillDir, SKILL_PACK_METADATA_FILE);
+  const installedSkills: string[] = [];
+  const files: Array<{ path: string; sha256: string }> = [];
+  const installationPlan: Array<{
+    sourceDir: string;
+    targetDir: string;
+    targetRelativeDir: string;
+    files: Array<{ path: string; sha256: string }>;
+  }> = [];
+
+  for (const skill of packSkills) {
+    const sourceDir = join(sourceRootFor(skill, sourceRoots), skill.name);
+    await assertSkillFile(
+      join(sourceDir, "SKILL.md"),
+      `${skill.name}/SKILL.md`,
+    );
+
+    const targetRelativeDir = projectSkillPath(skill.name, skillDir);
+    const targetDir = resolve(options.repoRoot, targetRelativeDir);
+    if (await pathExists(targetDir)) {
+      throw new Error(
+        `Refusing to overwrite existing skill path: ${targetRelativeDir}`,
+      );
+    }
+
+    const sourceFiles = await collectSourceFiles(
+      sourceDir,
+      sourceDir,
+      targetRelativeDir,
+      skill.name,
+    );
+
+    installationPlan.push({
+      sourceDir,
+      targetDir,
+      targetRelativeDir,
+      files: sourceFiles,
+    });
+  }
+
+  if (await pathExists(metadataPath)) {
+    throw new Error(
+      `Refusing to overwrite existing skill path: ${projectSkillPath(SKILL_PACK_METADATA_FILE, skillDir)}`,
+    );
+  }
+
+  for (const plan of installationPlan) {
+    files.push(...plan.files);
+  }
+
+  for (const { sourceDir, targetDir, targetRelativeDir } of installationPlan) {
+    await mkdir(dirname(targetDir), { recursive: true });
+    await cp(sourceDir, targetDir, {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+    });
+
+    installedSkills.push(targetRelativeDir);
+  }
+
+  files.sort((a, b) => comparePaths(a.path, b.path));
+
+  const metadata = buildSkillPackMetadata(files, {
+    installedAt: options.installedAt ?? new Date().toISOString(),
+    skillDir,
+  });
+  await mkdir(absoluteSkillDir, { recursive: true });
+  await writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, {
+    flag: "wx",
+  });
+
+  return {
+    skillDir: metadata.skillDir,
+    skillConfig: buildRecommendedProjectSkillConfig(metadata.skillDir),
+    installedSkills,
+    metadataPath,
+  };
+}
+
+export async function validateExistingSkillDirectory(
+  repoRoot: string,
+  skillDir: string,
+): Promise<
+  Pick<PatchmillSkillsConfig, "triage" | "planning" | "implementation">
+> {
+  const skillConfig = buildRecommendedProjectSkillConfig(skillDir);
+  for (const skillPath of [
+    skillConfig.triage,
+    skillConfig.planning,
+    skillConfig.implementation,
+  ]) {
+    const displayPath = `${skillPath}/SKILL.md`;
+    await assertSkillFile(resolve(repoRoot, displayPath), displayPath);
+  }
+
+  return skillConfig;
+}

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -156,6 +156,36 @@ test("runPiPrompt writes the prompt to a temp file and surfaces nonzero pi failu
   );
 });
 
+test("runPiPrompt passes configured skill files before the prompt argument", async () => {
+  const runner = createMockRunner(async (call) => {
+    assert.equal(call.command, "pi");
+    assert.deepEqual(call.args.slice(0, 7), [
+      "-e",
+      call.args[1],
+      "--skill",
+      "/repo/.patchmill/skills/writing-plans/SKILL.md",
+      "--skill",
+      "/repo/.patchmill/skills/review/SKILL.md",
+      "-p",
+    ]);
+    assert.match(call.args[1] ?? "", /node_modules\/pi-subagents$/);
+    assert.equal(call.args[7]?.startsWith("@"), true);
+    return {
+      code: 0,
+      stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+      stderr: "",
+    };
+  });
+
+  await runPiPrompt(runner, "/repo", "prompt", {
+    stage: "pi-plan",
+    skillPaths: [
+      "/repo/.patchmill/skills/writing-plans/SKILL.md",
+      "/repo/.patchmill/skills/review/SKILL.md",
+    ],
+  });
+});
+
 test("runPiPrompt logs pi stdout and stderr chunks", async () => {
   const events: AgentIssueProgressEvent[] = [];
   const runner = createStaticCommandRunner([

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -26,8 +26,13 @@ const PI_SUBAGENTS_PACKAGE_ROOT = dirname(
   require.resolve("pi-subagents/package.json"),
 );
 
-function piPromptArgs(promptPath: string, sessionDir?: string): string[] {
-  const baseArgs = ["-e", PI_SUBAGENTS_PACKAGE_ROOT, "-p"];
+function piPromptArgs(
+  promptPath: string,
+  sessionDir?: string,
+  skillPaths: string[] = [],
+): string[] {
+  const skillArgs = skillPaths.flatMap((path) => ["--skill", path]);
+  const baseArgs = ["-e", PI_SUBAGENTS_PACKAGE_ROOT, ...skillArgs, "-p"];
   return sessionDir
     ? [...baseArgs, "--session-dir", sessionDir, `@${promptPath}`]
     : [...baseArgs, `@${promptPath}`];
@@ -176,6 +181,7 @@ export type PiTaskProgress = {
 export type RunPiPromptOptions = {
   progress?: ProgressReporter;
   stage: "pi-plan" | "pi-implementation";
+  skillPaths?: string[];
   heartbeatMs?: number;
   streamOutput?: (chunk: string) => void;
   issueNumber?: number;
@@ -347,9 +353,13 @@ export async function runPiPrompt(
     sessionStreamer?.start();
     let result: CommandResult;
     try {
-      result = await runner.run("pi", piPromptArgs(promptPath, sessionDir), {
-        cwd,
-      });
+      result = await runner.run(
+        "pi",
+        piPromptArgs(promptPath, sessionDir, options?.skillPaths),
+        {
+          cwd,
+        },
+      );
     } finally {
       await sessionStreamer?.stop();
       await Promise.all(pendingObservations);

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -12,6 +12,10 @@ import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import {
+  buildSkillPackMetadata,
+  hashText,
+} from "../../../workflow/skill-pack.ts";
 import { runStatePath, writeRunState } from "./run-state.ts";
 import { runOneIssue } from "./pipeline.ts";
 import { JsonlProgressReporter } from "./progress.ts";
@@ -3591,6 +3595,8 @@ test("runOneIssue resolves implementation skills from the worktree root and expa
         join(worktreeRoot, ".patchmill", "skills", "requesting-code-review"),
         { recursive: true },
       );
+      const implementationSkill = "# implementation\n";
+      const reviewSkill = "# review\n";
       await writeFile(
         join(
           worktreeRoot,
@@ -3599,7 +3605,7 @@ test("runOneIssue resolves implementation skills from the worktree root and expa
           "subagent-driven-development",
           "SKILL.md",
         ),
-        "# implementation\n",
+        implementationSkill,
         "utf8",
       );
       await writeFile(
@@ -3610,23 +3616,23 @@ test("runOneIssue resolves implementation skills from the worktree root and expa
           "requesting-code-review",
           "SKILL.md",
         ),
-        "# review\n",
+        reviewSkill,
         "utf8",
       );
       await writeFile(
         join(worktreeRoot, ".patchmill", "skills", "patchmill-skill-pack.json"),
-        JSON.stringify({
-          files: [
+        JSON.stringify(
+          buildSkillPackMetadata([
             {
               path: ".patchmill/skills/subagent-driven-development/SKILL.md",
-              sha256: "implementation",
+              sha256: hashText(implementationSkill),
             },
             {
               path: ".patchmill/skills/requesting-code-review/SKILL.md",
-              sha256: "review",
+              sha256: hashText(reviewSkill),
             },
-          ],
-        }),
+          ]),
+        ),
         "utf8",
       );
       return { code: 0, stdout: "", stderr: "" };

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -3524,6 +3524,105 @@ test("runOneIssue creates a missing plan, then creates a worktree and runs Pi fr
   assert.equal(runState.implementingAt, NOW.toISOString());
 });
 
+test("runOneIssue passes configured local planning and implementation skills to pi commands", async () => {
+  const baseConfig = await makeConfig({ dryRun: false, execute: true });
+  const config = {
+    ...baseConfig,
+    skills: {
+      ...baseConfig.skills,
+      planning: ".patchmill/skills/local-planning/SKILL.md",
+      implementation: join(
+        baseConfig.repoRoot,
+        "skills",
+        "local-implementation",
+        "SKILL.md",
+      ),
+    },
+  };
+  const selected = issue(16, ["agent-ready", "bug"], "Use local skills");
+  const expectedPlanPath = "docs/plans/2026-05-09-issue-16-use-local-skills.md";
+  let piCalls = 0;
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    ) {
+      return { code: 0, stdout: labelListPayload(), stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "show-ref")
+      return { code: 1, stdout: "", stderr: "" };
+    if (call.command === "git" && call.args[0] === "worktree")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "tea" &&
+      (call.args[0] === "issues" || call.args[0] === "comment")
+    ) {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (call.command === "pi") {
+      piCalls += 1;
+      const skillPaths = call.args.flatMap((arg, index) =>
+        arg === "--skill" ? [call.args[index + 1] ?? ""] : [],
+      );
+
+      if (piCalls === 1) {
+        assert.deepEqual(skillPaths, [
+          join(
+            config.repoRoot,
+            ".patchmill",
+            "skills",
+            "local-planning",
+            "SKILL.md",
+          ),
+        ]);
+        return {
+          code: 0,
+          stdout: `{"status":"plan-created","planPath":"${expectedPlanPath}","commit":"abc123"}`,
+          stderr: "",
+        };
+      }
+
+      assert.deepEqual(skillPaths, [
+        join(config.repoRoot, "skills", "local-implementation", "SKILL.md"),
+      ]);
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          status: "pr-created",
+          prUrl: "https://forgejo.example/pr/16",
+          branch: "agent/issue-16-use-local-skills",
+          commits: ["def456"],
+          validation: ["node --test ok"],
+        }),
+        stderr: "",
+      };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created");
+  assert.equal(piCalls, 2);
+});
+
 test("runOneIssue renders configured project policy visual evidence fields in the implementation prompt", async () => {
   const baseConfig = await makeConfig({ dryRun: false, execute: true });
   const config = {

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -3524,23 +3524,23 @@ test("runOneIssue creates a missing plan, then creates a worktree and runs Pi fr
   assert.equal(runState.implementingAt, NOW.toISOString());
 });
 
-test("runOneIssue passes configured local planning and implementation skills to pi commands", async () => {
+test("runOneIssue resolves implementation skills from the worktree root and expands the local skill pack", async () => {
   const baseConfig = await makeConfig({ dryRun: false, execute: true });
   const config = {
     ...baseConfig,
     skills: {
       ...baseConfig.skills,
-      planning: ".patchmill/skills/local-planning/SKILL.md",
-      implementation: join(
-        baseConfig.repoRoot,
-        "skills",
-        "local-implementation",
-        "SKILL.md",
-      ),
+      planning: "skills/local-planning/SKILL.md",
+      implementation: ".patchmill/skills/subagent-driven-development",
     },
   };
   const selected = issue(16, ["agent-ready", "bug"], "Use local skills");
   const expectedPlanPath = "docs/plans/2026-05-09-issue-16-use-local-skills.md";
+  const worktreeRoot = join(
+    config.repoRoot,
+    ".worktrees",
+    "patchmill-issue-16-use-local-skills",
+  );
   let piCalls = 0;
   const runner = createMockRunner(async (call) => {
     if (
@@ -3566,8 +3566,71 @@ test("runOneIssue passes configured local planning and implementation skills to 
     }
     if (call.command === "git" && call.args[0] === "show-ref")
       return { code: 1, stdout: "", stderr: "" };
-    if (call.command === "git" && call.args[0] === "worktree")
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "list"
+    ) {
       return { code: 0, stdout: "", stderr: "" };
+    }
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "add"
+    ) {
+      await mkdir(
+        join(
+          worktreeRoot,
+          ".patchmill",
+          "skills",
+          "subagent-driven-development",
+        ),
+        { recursive: true },
+      );
+      await mkdir(
+        join(worktreeRoot, ".patchmill", "skills", "requesting-code-review"),
+        { recursive: true },
+      );
+      await writeFile(
+        join(
+          worktreeRoot,
+          ".patchmill",
+          "skills",
+          "subagent-driven-development",
+          "SKILL.md",
+        ),
+        "# implementation\n",
+        "utf8",
+      );
+      await writeFile(
+        join(
+          worktreeRoot,
+          ".patchmill",
+          "skills",
+          "requesting-code-review",
+          "SKILL.md",
+        ),
+        "# review\n",
+        "utf8",
+      );
+      await writeFile(
+        join(worktreeRoot, ".patchmill", "skills", "patchmill-skill-pack.json"),
+        JSON.stringify({
+          files: [
+            {
+              path: ".patchmill/skills/subagent-driven-development/SKILL.md",
+              sha256: "implementation",
+            },
+            {
+              path: ".patchmill/skills/requesting-code-review/SKILL.md",
+              sha256: "review",
+            },
+          ],
+        }),
+        "utf8",
+      );
+      return { code: 0, stdout: "", stderr: "" };
+    }
     if (
       call.command === "tea" &&
       (call.args[0] === "issues" || call.args[0] === "comment")
@@ -3582,13 +3645,7 @@ test("runOneIssue passes configured local planning and implementation skills to 
 
       if (piCalls === 1) {
         assert.deepEqual(skillPaths, [
-          join(
-            config.repoRoot,
-            ".patchmill",
-            "skills",
-            "local-planning",
-            "SKILL.md",
-          ),
+          join(config.repoRoot, "skills", "local-planning", "SKILL.md"),
         ]);
         return {
           code: 0,
@@ -3598,7 +3655,20 @@ test("runOneIssue passes configured local planning and implementation skills to 
       }
 
       assert.deepEqual(skillPaths, [
-        join(config.repoRoot, "skills", "local-implementation", "SKILL.md"),
+        join(
+          worktreeRoot,
+          ".patchmill",
+          "skills",
+          "subagent-driven-development",
+          "SKILL.md",
+        ),
+        join(
+          worktreeRoot,
+          ".patchmill",
+          "skills",
+          "requesting-code-review",
+          "SKILL.md",
+        ),
       ]);
       return {
         code: 0,

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -1359,7 +1359,7 @@ export async function runOneIssue(
                 config.skills.visualEvidence,
                 config.skills.landing,
               ],
-              config.repoRoot,
+              worktreeRoot,
             ),
             streamOutput: options.streamPiOutput,
             issueNumber: issue.number,

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -9,6 +9,7 @@ import type { GitWorktreeStrategyConfig } from "../../../git/types.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import type { IssueHostProvider } from "../../../host/types.ts";
 import type { PatchmillTriagePolicy } from "../../../policy/triage.ts";
+import { skillInvocationPaths } from "../../../workflow/skills.ts";
 import {
   DEFAULT_TRIAGE_POLICY,
   missingLabelDefinitions,
@@ -963,6 +964,10 @@ export async function runOneIssue(
           {
             progress: options.progress,
             stage: "pi-plan",
+            skillPaths: skillInvocationPaths(
+              [config.skills.planning],
+              config.repoRoot,
+            ),
             streamOutput: options.streamPiOutput,
             issueNumber: issue.number,
             repoRoot: config.repoRoot,
@@ -1346,6 +1351,16 @@ export async function runOneIssue(
           {
             progress: options.progress,
             stage: "pi-implementation",
+            skillPaths: skillInvocationPaths(
+              [
+                config.skills.toolchain,
+                config.skills.implementation,
+                config.skills.review,
+                config.skills.visualEvidence,
+                config.skills.landing,
+              ],
+              config.repoRoot,
+            ),
             streamOutput: options.streamPiOutput,
             issueNumber: issue.number,
             repoRoot: worktreeRoot,

--- a/src/cli/commands/triage/dry-run-agent.test.ts
+++ b/src/cli/commands/triage/dry-run-agent.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import {
@@ -32,6 +34,43 @@ const stateMap = {
   "needs-info": "needs-info",
   "ready-for-human": "agent-unsuitable",
 } as const;
+
+async function createProjectLocalTriageRepo(): Promise<{
+  repoRoot: string;
+  triageSkillPath: string;
+  supportSkillPath: string;
+}> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-triage-dry-run-"));
+  const skillsRoot = join(repoRoot, ".patchmill", "skills");
+  const triageSkillPath = join(
+    skillsRoot,
+    "patchmill-issue-triage",
+    "SKILL.md",
+  );
+  const supportSkillPath = join(skillsRoot, "triage-support", "SKILL.md");
+
+  await mkdir(join(skillsRoot, "patchmill-issue-triage"), { recursive: true });
+  await mkdir(join(skillsRoot, "triage-support"), { recursive: true });
+  await writeFile(triageSkillPath, "# triage\n");
+  await writeFile(supportSkillPath, "# support\n");
+  await writeFile(
+    join(skillsRoot, "patchmill-skill-pack.json"),
+    JSON.stringify({
+      files: [
+        {
+          path: ".patchmill/skills/patchmill-issue-triage/SKILL.md",
+          sha256: "triage",
+        },
+        {
+          path: ".patchmill/skills/triage-support/SKILL.md",
+          sha256: "support",
+        },
+      ],
+    }),
+  );
+
+  return { repoRoot, triageSkillPath, supportSkillPath };
+}
 
 class RecordingRunner implements CommandRunner {
   readonly calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
@@ -294,4 +333,26 @@ test("runTriageDryRunAgent resolves configured local triage skill paths", async 
     call.args[skillIndex + 1],
     "/repo/.patchmill/skills/triage-local/SKILL.md",
   );
+});
+
+test("runTriageDryRunAgent expands project-local triage skill packs from metadata", async () => {
+  const runner = new RecordingRunner();
+  const { repoRoot, triageSkillPath, supportSkillPath } =
+    await createProjectLocalTriageRepo();
+
+  await runTriageDryRunAgent(runner, repoRoot, {
+    issues,
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      triage: ".patchmill/skills/patchmill-issue-triage",
+    },
+    stateMap,
+  });
+
+  const call = runner.calls[0]!;
+  const skillPaths = call.args.flatMap((arg, index) =>
+    arg === "--skill" ? [call.args[index + 1] ?? ""] : [],
+  );
+  assert.deepEqual(skillPaths, [triageSkillPath, supportSkillPath]);
 });

--- a/src/cli/commands/triage/dry-run-agent.test.ts
+++ b/src/cli/commands/triage/dry-run-agent.test.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_PATCHMILL_SKILLS,
 } from "../../../workflow/skills.ts";
 import {
+  buildSkillPackMetadata,
+  hashText,
+} from "../../../workflow/skill-pack.ts";
+import {
   buildTriageDryRunPrompt,
   parseTriagePreviewJson,
   runTriageDryRunAgent,
@@ -51,22 +55,24 @@ async function createProjectLocalTriageRepo(): Promise<{
 
   await mkdir(join(skillsRoot, "patchmill-issue-triage"), { recursive: true });
   await mkdir(join(skillsRoot, "triage-support"), { recursive: true });
-  await writeFile(triageSkillPath, "# triage\n");
-  await writeFile(supportSkillPath, "# support\n");
+  const triageSkill = "# triage\n";
+  const supportSkill = "# support\n";
+  await writeFile(triageSkillPath, triageSkill);
+  await writeFile(supportSkillPath, supportSkill);
   await writeFile(
     join(skillsRoot, "patchmill-skill-pack.json"),
-    JSON.stringify({
-      files: [
+    JSON.stringify(
+      buildSkillPackMetadata([
         {
           path: ".patchmill/skills/patchmill-issue-triage/SKILL.md",
-          sha256: "triage",
+          sha256: hashText(triageSkill),
         },
         {
           path: ".patchmill/skills/triage-support/SKILL.md",
-          sha256: "support",
+          sha256: hashText(supportSkill),
         },
-      ],
-    }),
+      ]),
+    ),
   );
 
   return { repoRoot, triageSkillPath, supportSkillPath };

--- a/src/cli/commands/triage/dry-run-agent.test.ts
+++ b/src/cli/commands/triage/dry-run-agent.test.ts
@@ -273,3 +273,25 @@ test("runTriageDryRunAgent does not add bundled triage skill for custom skills",
   const call = runner.calls[0]!;
   assert.equal(call.args.includes("--skill"), false);
 });
+
+test("runTriageDryRunAgent resolves configured local triage skill paths", async () => {
+  const runner = new RecordingRunner();
+
+  await runTriageDryRunAgent(runner, "/repo", {
+    issues,
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      triage: ".patchmill/skills/triage-local",
+    },
+    stateMap,
+  });
+
+  const call = runner.calls[0]!;
+  const skillIndex = call.args.indexOf("--skill");
+  assert.notEqual(skillIndex, -1);
+  assert.equal(
+    call.args[skillIndex + 1],
+    "/repo/.patchmill/skills/triage-local/SKILL.md",
+  );
+});

--- a/src/cli/commands/triage/dry-run-agent.ts
+++ b/src/cli/commands/triage/dry-run-agent.ts
@@ -4,7 +4,7 @@ import { TRIAGE_CANONICAL_BUCKETS } from "../../../policy/triage-state.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import {
   DEFAULT_PATCHMILL_SKILLS,
-  skillInvocationArgs,
+  skillInvocationPaths,
   type PatchmillSkillsConfig,
 } from "../../../workflow/skills.ts";
 import type {
@@ -226,7 +226,9 @@ export async function runTriageDryRunAgent(
 ): Promise<TriagePreview[]> {
   const prompt = buildTriageDryRunPrompt(input);
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
-  const skillArgs = skillInvocationArgs(skills.triage, repoRoot);
+  const skillArgs = skillInvocationPaths([skills.triage], repoRoot).flatMap(
+    (path) => ["--skill", path],
+  );
   const thinking = input.thinking ?? "high";
   return withPromptFile("agent-triage-dry-run-", prompt, async (promptPath) => {
     const result = await runner.run(

--- a/src/cli/commands/triage/dry-run-agent.ts
+++ b/src/cli/commands/triage/dry-run-agent.ts
@@ -3,8 +3,8 @@ import type { PatchmillTriageStateMap } from "../../../policy/triage-state.ts";
 import { TRIAGE_CANONICAL_BUCKETS } from "../../../policy/triage-state.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import {
-  bundledTriageSkillPath,
   DEFAULT_PATCHMILL_SKILLS,
+  skillInvocationArgs,
   type PatchmillSkillsConfig,
 } from "../../../workflow/skills.ts";
 import type {
@@ -226,10 +226,7 @@ export async function runTriageDryRunAgent(
 ): Promise<TriagePreview[]> {
   const prompt = buildTriageDryRunPrompt(input);
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
-  const skillArgs =
-    skills.triage === DEFAULT_PATCHMILL_SKILLS.triage
-      ? ["--skill", bundledTriageSkillPath()]
-      : [];
+  const skillArgs = skillInvocationArgs(skills.triage, repoRoot);
   const thinking = input.thinking ?? "high";
   return withPromptFile("agent-triage-dry-run-", prompt, async (promptPath) => {
     const result = await runner.run(

--- a/src/cli/commands/triage/execute-agent.test.ts
+++ b/src/cli/commands/triage/execute-agent.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import {
@@ -30,6 +32,43 @@ const stateMap = {
   "awaiting-reporter": "needs-info",
   "manual-only": "agent-unsuitable",
 } as const;
+
+async function createProjectLocalTriageRepo(): Promise<{
+  repoRoot: string;
+  triageSkillPath: string;
+  supportSkillPath: string;
+}> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-triage-execute-"));
+  const skillsRoot = join(repoRoot, ".patchmill", "skills");
+  const triageSkillPath = join(
+    skillsRoot,
+    "patchmill-issue-triage",
+    "SKILL.md",
+  );
+  const supportSkillPath = join(skillsRoot, "triage-support", "SKILL.md");
+
+  await mkdir(join(skillsRoot, "patchmill-issue-triage"), { recursive: true });
+  await mkdir(join(skillsRoot, "triage-support"), { recursive: true });
+  await writeFile(triageSkillPath, "# triage\n");
+  await writeFile(supportSkillPath, "# support\n");
+  await writeFile(
+    join(skillsRoot, "patchmill-skill-pack.json"),
+    JSON.stringify({
+      files: [
+        {
+          path: ".patchmill/skills/patchmill-issue-triage/SKILL.md",
+          sha256: "triage",
+        },
+        {
+          path: ".patchmill/skills/triage-support/SKILL.md",
+          sha256: "support",
+        },
+      ],
+    }),
+  );
+
+  return { repoRoot, triageSkillPath, supportSkillPath };
+}
 
 class RecordingRunner implements CommandRunner {
   readonly calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
@@ -195,4 +234,27 @@ test("runTriageExecuteAgent resolves configured local triage skill paths", async
     call.args[skillIndex + 1],
     "/repo/.patchmill/skills/triage-local/SKILL.md",
   );
+});
+
+test("runTriageExecuteAgent expands project-local triage skill packs from metadata", async () => {
+  const runner = new RecordingRunner();
+  const { repoRoot, triageSkillPath, supportSkillPath } =
+    await createProjectLocalTriageRepo();
+
+  await runTriageExecuteAgent(runner, repoRoot, {
+    issues,
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    host: { provider: "forgejo-tea", login: "" },
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      triage: ".patchmill/skills/patchmill-issue-triage",
+    },
+    stateMap,
+  });
+
+  const call = runner.calls[0]!;
+  const skillPaths = call.args.flatMap((arg, index) =>
+    arg === "--skill" ? [call.args[index + 1] ?? ""] : [],
+  );
+  assert.deepEqual(skillPaths, [triageSkillPath, supportSkillPath]);
 });

--- a/src/cli/commands/triage/execute-agent.test.ts
+++ b/src/cli/commands/triage/execute-agent.test.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_PATCHMILL_SKILLS,
 } from "../../../workflow/skills.ts";
 import {
+  buildSkillPackMetadata,
+  hashText,
+} from "../../../workflow/skill-pack.ts";
+import {
   buildTriageExecutePrompt,
   runTriageExecuteAgent,
 } from "./execute-agent.ts";
@@ -49,22 +53,24 @@ async function createProjectLocalTriageRepo(): Promise<{
 
   await mkdir(join(skillsRoot, "patchmill-issue-triage"), { recursive: true });
   await mkdir(join(skillsRoot, "triage-support"), { recursive: true });
-  await writeFile(triageSkillPath, "# triage\n");
-  await writeFile(supportSkillPath, "# support\n");
+  const triageSkill = "# triage\n";
+  const supportSkill = "# support\n";
+  await writeFile(triageSkillPath, triageSkill);
+  await writeFile(supportSkillPath, supportSkill);
   await writeFile(
     join(skillsRoot, "patchmill-skill-pack.json"),
-    JSON.stringify({
-      files: [
+    JSON.stringify(
+      buildSkillPackMetadata([
         {
           path: ".patchmill/skills/patchmill-issue-triage/SKILL.md",
-          sha256: "triage",
+          sha256: hashText(triageSkill),
         },
         {
           path: ".patchmill/skills/triage-support/SKILL.md",
-          sha256: "support",
+          sha256: hashText(supportSkill),
         },
-      ],
-    }),
+      ]),
+    ),
   );
 
   return { repoRoot, triageSkillPath, supportSkillPath };

--- a/src/cli/commands/triage/execute-agent.test.ts
+++ b/src/cli/commands/triage/execute-agent.test.ts
@@ -173,3 +173,26 @@ test("runTriageExecuteAgent does not add bundled triage skill for custom skills"
   const call = runner.calls[0]!;
   assert.equal(call.args.includes("--skill"), false);
 });
+
+test("runTriageExecuteAgent resolves configured local triage skill paths", async () => {
+  const runner = new RecordingRunner();
+
+  await runTriageExecuteAgent(runner, "/repo", {
+    issues,
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    host: { provider: "forgejo-tea", login: "" },
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      triage: ".patchmill/skills/triage-local",
+    },
+    stateMap,
+  });
+
+  const call = runner.calls[0]!;
+  const skillIndex = call.args.indexOf("--skill");
+  assert.notEqual(skillIndex, -1);
+  assert.equal(
+    call.args[skillIndex + 1],
+    "/repo/.patchmill/skills/triage-local/SKILL.md",
+  );
+});

--- a/src/cli/commands/triage/execute-agent.ts
+++ b/src/cli/commands/triage/execute-agent.ts
@@ -3,8 +3,8 @@ import type { PatchmillHostConfig } from "../../../config/types.ts";
 import type { PatchmillTriageStateMap } from "../../../policy/triage-state.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import {
-  bundledTriageSkillPath,
   DEFAULT_PATCHMILL_SKILLS,
+  skillInvocationArgs,
   type PatchmillSkillsConfig,
 } from "../../../workflow/skills.ts";
 import type { CommandRunner, IssueSummary } from "./types.ts";
@@ -96,10 +96,7 @@ export async function runTriageExecuteAgent(
 ): Promise<void> {
   const prompt = buildTriageExecutePrompt(input);
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
-  const skillArgs =
-    skills.triage === DEFAULT_PATCHMILL_SKILLS.triage
-      ? ["--skill", bundledTriageSkillPath()]
-      : [];
+  const skillArgs = skillInvocationArgs(skills.triage, repoRoot);
   const thinking = input.thinking ?? "high";
   await withPromptFile("agent-triage-execute-", prompt, async (promptPath) => {
     const result = await runner.run(

--- a/src/cli/commands/triage/execute-agent.ts
+++ b/src/cli/commands/triage/execute-agent.ts
@@ -4,7 +4,7 @@ import type { PatchmillTriageStateMap } from "../../../policy/triage-state.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import {
   DEFAULT_PATCHMILL_SKILLS,
-  skillInvocationArgs,
+  skillInvocationPaths,
   type PatchmillSkillsConfig,
 } from "../../../workflow/skills.ts";
 import type { CommandRunner, IssueSummary } from "./types.ts";
@@ -96,7 +96,9 @@ export async function runTriageExecuteAgent(
 ): Promise<void> {
   const prompt = buildTriageExecutePrompt(input);
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
-  const skillArgs = skillInvocationArgs(skills.triage, repoRoot);
+  const skillArgs = skillInvocationPaths([skills.triage], repoRoot).flatMap(
+    (path) => ["--skill", path],
+  );
   const thinking = input.thinking ?? "high";
   await withPromptFile("agent-triage-execute-", prompt, async (promptPath) => {
     const result = await runner.run(

--- a/src/pi/runner.test.ts
+++ b/src/pi/runner.test.ts
@@ -207,6 +207,44 @@ test("PiRunner plan passes configured ready and needs-info labels into the promp
   });
 });
 
+test("PiRunner plan resolves configured local planning skills into pi --skill args", async () => {
+  const repoRoot = "/repo";
+  const planPath = "docs/plans/2026-05-23-pi-runner-local-skill.md";
+  const runner = createFakeRunner((call) => {
+    const skillIndex = call.args.indexOf("--skill");
+    assert.notEqual(skillIndex, -1);
+    assert.equal(
+      call.args[skillIndex + 1],
+      "/repo/.patchmill/skills/writing-plans/SKILL.md",
+    );
+    return {
+      code: 0,
+      stdout: JSON.stringify({
+        status: "plan-created",
+        planPath,
+        commit: "ghi789",
+      }),
+      stderr: "",
+    };
+  });
+
+  const result = await new PiRunner(runner).plan({
+    repoRoot,
+    issue,
+    planPath,
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      planning: ".patchmill/skills/writing-plans",
+    },
+  });
+
+  assert.deepEqual(result, {
+    status: "plan-created",
+    planPath,
+    commit: "ghi789",
+  });
+});
+
 test("PiRunner implementation uses the worktree root, derives the default landing branch from git.baseBranch, preserves resume context, and keeps runner metadata authoritative", async () => {
   const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-pi-runner-"));
   const worktreePath = "worktrees/issue-42-fix";
@@ -309,4 +347,78 @@ test("PiRunner implementation uses the worktree root, derives the default landin
         event.message.includes("task 1/1"),
     ),
   );
+});
+
+test("PiRunner implementation resolves configured local skill paths against the repo root", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-pi-runner-local-"));
+  const worktreePath = "worktrees/issue-42-local-skills";
+  const worktreeRoot = join(repoRoot, worktreePath);
+  const planPath = "docs/plans/2026-05-23-pi-runner-local-skills.md";
+  await mkdir(join(worktreeRoot, ".pi", "todos"), { recursive: true });
+  await writeFile(
+    join(
+      worktreeRoot,
+      ".pi",
+      "todos",
+      "issue-42-task-01-check-local-skills.md",
+    ),
+    `${JSON.stringify({ title: "issue-42-task-01-check-local-skills", status: "open" })}\nTask body`,
+    "utf8",
+  );
+
+  const runner = createFakeRunner((call) => {
+    const skillPaths = call.args.flatMap((arg, index, args) =>
+      arg === "--skill" ? [args[index + 1] ?? ""] : [],
+    );
+    assert.deepEqual(skillPaths, [
+      join(repoRoot, ".patchmill", "skills", "toolchain", "SKILL.md"),
+      join(repoRoot, ".patchmill", "skills", "implementation", "SKILL.md"),
+      join(repoRoot, ".patchmill", "skills", "review", "SKILL.md"),
+      join(repoRoot, ".patchmill", "skills", "visual-evidence", "SKILL.md"),
+      join(repoRoot, ".patchmill", "skills", "landing", "SKILL.md"),
+    ]);
+    assert.equal(call.cwd, worktreeRoot);
+    return {
+      code: 0,
+      stdout: JSON.stringify({
+        status: "merged",
+        branch: "agent/issue-42-local-skills",
+        mergeCommit: "merge456",
+        commits: ["commit456"],
+        validation: ["npm test"],
+      }),
+      stderr: "",
+    };
+  });
+
+  const result = await new PiRunner(runner).implementation({
+    repoRoot,
+    issue,
+    planPath,
+    branch: "agent/issue-42-local-skills",
+    worktreePath,
+    git: {
+      baseBranch: "main",
+      remote: "origin",
+      allowDirectLand: true,
+    },
+    skills: {
+      ...DEFAULT_PATCHMILL_SKILLS,
+      toolchain: ".patchmill/skills/toolchain",
+      implementation: ".patchmill/skills/implementation",
+      review: ".patchmill/skills/review",
+      visualEvidence: ".patchmill/skills/visual-evidence",
+      landing: ".patchmill/skills/landing",
+    },
+  });
+
+  assert.deepEqual(result, {
+    status: "merged",
+    branch: "agent/issue-42-local-skills",
+    mergeCommit: "merge456",
+    commits: ["commit456"],
+    validation: ["npm test"],
+    reviewSummary: undefined,
+    landingDecision: undefined,
+  });
 });

--- a/src/pi/runner.test.ts
+++ b/src/pi/runner.test.ts
@@ -349,12 +349,64 @@ test("PiRunner implementation uses the worktree root, derives the default landin
   );
 });
 
-test("PiRunner implementation resolves configured local skill paths against the repo root", async () => {
+test("PiRunner implementation resolves local skills from the worktree root and expands the local skill pack", async () => {
   const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-pi-runner-local-"));
   const worktreePath = "worktrees/issue-42-local-skills";
   const worktreeRoot = join(repoRoot, worktreePath);
   const planPath = "docs/plans/2026-05-23-pi-runner-local-skills.md";
   await mkdir(join(worktreeRoot, ".pi", "todos"), { recursive: true });
+  await mkdir(
+    join(worktreeRoot, ".patchmill", "skills", "subagent-driven-development"),
+    {
+      recursive: true,
+    },
+  );
+  await mkdir(
+    join(worktreeRoot, ".patchmill", "skills", "requesting-code-review"),
+    {
+      recursive: true,
+    },
+  );
+  await mkdir(join(worktreeRoot, "skills", "toolchain"), { recursive: true });
+  await writeFile(
+    join(
+      worktreeRoot,
+      ".patchmill",
+      "skills",
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+    "# implementation\n",
+  );
+  await writeFile(
+    join(
+      worktreeRoot,
+      ".patchmill",
+      "skills",
+      "requesting-code-review",
+      "SKILL.md",
+    ),
+    "# review\n",
+  );
+  await writeFile(
+    join(worktreeRoot, "skills", "toolchain", "SKILL.md"),
+    "# toolchain\n",
+  );
+  await writeFile(
+    join(worktreeRoot, ".patchmill", "skills", "patchmill-skill-pack.json"),
+    JSON.stringify({
+      files: [
+        {
+          path: ".patchmill/skills/subagent-driven-development/SKILL.md",
+          sha256: "implementation",
+        },
+        {
+          path: ".patchmill/skills/requesting-code-review/SKILL.md",
+          sha256: "review",
+        },
+      ],
+    }),
+  );
   await writeFile(
     join(
       worktreeRoot,
@@ -371,11 +423,21 @@ test("PiRunner implementation resolves configured local skill paths against the 
       arg === "--skill" ? [args[index + 1] ?? ""] : [],
     );
     assert.deepEqual(skillPaths, [
-      join(repoRoot, ".patchmill", "skills", "toolchain", "SKILL.md"),
-      join(repoRoot, ".patchmill", "skills", "implementation", "SKILL.md"),
-      join(repoRoot, ".patchmill", "skills", "review", "SKILL.md"),
-      join(repoRoot, ".patchmill", "skills", "visual-evidence", "SKILL.md"),
-      join(repoRoot, ".patchmill", "skills", "landing", "SKILL.md"),
+      join(worktreeRoot, "skills", "toolchain", "SKILL.md"),
+      join(
+        worktreeRoot,
+        ".patchmill",
+        "skills",
+        "subagent-driven-development",
+        "SKILL.md",
+      ),
+      join(
+        worktreeRoot,
+        ".patchmill",
+        "skills",
+        "requesting-code-review",
+        "SKILL.md",
+      ),
     ]);
     assert.equal(call.cwd, worktreeRoot);
     return {
@@ -404,11 +466,8 @@ test("PiRunner implementation resolves configured local skill paths against the 
     },
     skills: {
       ...DEFAULT_PATCHMILL_SKILLS,
-      toolchain: ".patchmill/skills/toolchain",
-      implementation: ".patchmill/skills/implementation",
-      review: ".patchmill/skills/review",
-      visualEvidence: ".patchmill/skills/visual-evidence",
-      landing: ".patchmill/skills/landing",
+      toolchain: "skills/toolchain",
+      implementation: ".patchmill/skills/subagent-driven-development",
     },
   });
 

--- a/src/pi/runner.test.ts
+++ b/src/pi/runner.test.ts
@@ -16,6 +16,7 @@ import type {
   IssueSummary,
 } from "../cli/commands/triage/types.ts";
 import { DEFAULT_PATCHMILL_SKILLS } from "../workflow/skills.ts";
+import { buildSkillPackMetadata, hashText } from "../workflow/skill-pack.ts";
 import type { ImplementationPiInput } from "./types.ts";
 
 type RecordedCall = {
@@ -368,6 +369,8 @@ test("PiRunner implementation resolves local skills from the worktree root and e
     },
   );
   await mkdir(join(worktreeRoot, "skills", "toolchain"), { recursive: true });
+  const implementationSkill = "# implementation\n";
+  const reviewSkill = "# review\n";
   await writeFile(
     join(
       worktreeRoot,
@@ -376,7 +379,7 @@ test("PiRunner implementation resolves local skills from the worktree root and e
       "subagent-driven-development",
       "SKILL.md",
     ),
-    "# implementation\n",
+    implementationSkill,
   );
   await writeFile(
     join(
@@ -386,7 +389,7 @@ test("PiRunner implementation resolves local skills from the worktree root and e
       "requesting-code-review",
       "SKILL.md",
     ),
-    "# review\n",
+    reviewSkill,
   );
   await writeFile(
     join(worktreeRoot, "skills", "toolchain", "SKILL.md"),
@@ -394,18 +397,18 @@ test("PiRunner implementation resolves local skills from the worktree root and e
   );
   await writeFile(
     join(worktreeRoot, ".patchmill", "skills", "patchmill-skill-pack.json"),
-    JSON.stringify({
-      files: [
+    JSON.stringify(
+      buildSkillPackMetadata([
         {
           path: ".patchmill/skills/subagent-driven-development/SKILL.md",
-          sha256: "implementation",
+          sha256: hashText(implementationSkill),
         },
         {
           path: ".patchmill/skills/requesting-code-review/SKILL.md",
-          sha256: "review",
+          sha256: hashText(reviewSkill),
         },
-      ],
-    }),
+      ]),
+    ),
   );
   await writeFile(
     join(
@@ -423,7 +426,6 @@ test("PiRunner implementation resolves local skills from the worktree root and e
       arg === "--skill" ? [args[index + 1] ?? ""] : [],
     );
     assert.deepEqual(skillPaths, [
-      join(worktreeRoot, "skills", "toolchain", "SKILL.md"),
       join(
         worktreeRoot,
         ".patchmill",
@@ -438,6 +440,7 @@ test("PiRunner implementation resolves local skills from the worktree root and e
         "requesting-code-review",
         "SKILL.md",
       ),
+      join(worktreeRoot, "skills", "toolchain", "SKILL.md"),
     ]);
     assert.equal(call.cwd, worktreeRoot);
     return {

--- a/src/pi/runner.ts
+++ b/src/pi/runner.ts
@@ -88,7 +88,7 @@ export class PiRunner implements PiPromptContracts {
             input.skills?.visualEvidence,
             input.skills?.landing,
           ],
-          input.repoRoot,
+          worktreeRoot,
         ),
         issueNumber: input.issue.number,
         repoRoot: worktreeRoot,

--- a/src/pi/runner.ts
+++ b/src/pi/runner.ts
@@ -12,6 +12,7 @@ import type {
   PiPromptContracts,
   PlanPiInput,
 } from "./types.ts";
+import { skillInvocationPaths } from "../workflow/skills.ts";
 
 function defaultImplementationPolicy(
   baseBranch: string,
@@ -47,6 +48,10 @@ export class PiRunner implements PiPromptContracts {
       {
         ...input.runOptions,
         stage: "pi-plan",
+        skillPaths: skillInvocationPaths(
+          [input.skills?.planning],
+          input.repoRoot,
+        ),
         issueNumber: input.issue.number,
         repoRoot: input.repoRoot,
         taskContract: projectPolicy.pi.taskContract,
@@ -75,6 +80,16 @@ export class PiRunner implements PiPromptContracts {
       {
         ...input.runOptions,
         stage: "pi-implementation",
+        skillPaths: skillInvocationPaths(
+          [
+            input.skills?.toolchain,
+            input.skills?.implementation,
+            input.skills?.review,
+            input.skills?.visualEvidence,
+            input.skills?.landing,
+          ],
+          input.repoRoot,
+        ),
         issueNumber: input.issue.number,
         repoRoot: worktreeRoot,
         taskContract: projectPolicy.pi.taskContract,

--- a/src/workflow/skill-pack.test.ts
+++ b/src/workflow/skill-pack.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  buildRecommendedProjectSkillConfig,
+  buildSkillPackMetadata,
+  hashText,
+  projectSkillPath,
+} from "./skill-pack.ts";
+
+const unixNewline = "name: sample\n";
+
+test("recommended project skill paths are repo-relative POSIX paths", () => {
+  assert.equal(DEFAULT_PROJECT_SKILL_DIR, ".patchmill/skills");
+  assert.equal(
+    projectSkillPath("writing-plans"),
+    ".patchmill/skills/writing-plans",
+  );
+  assert.equal(
+    projectSkillPath("subagent-driven-development", "project/skills/"),
+    "project/skills/subagent-driven-development",
+  );
+});
+
+test("buildRecommendedProjectSkillConfig maps required workflow stages locally", () => {
+  assert.deepEqual(buildRecommendedProjectSkillConfig(), {
+    triage: ".patchmill/skills/patchmill-issue-triage",
+    planning: ".patchmill/skills/writing-plans",
+    implementation: ".patchmill/skills/subagent-driven-development",
+  });
+});
+
+test("default pack records pinned external source", () => {
+  assert.equal(PATCHMILL_RECOMMENDED_SKILL_PACK.name, "patchmill-recommended");
+  assert.equal(PATCHMILL_RECOMMENDED_SKILL_PACK.version, "2026.05");
+  assert.deepEqual(PATCHMILL_RECOMMENDED_SKILL_PACK.source, {
+    type: "github-release",
+    repository: "obra/superpowers",
+    tag: "v5.0.7",
+    tarballUrl:
+      "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+  });
+  assert.deepEqual(PATCHMILL_RECOMMENDED_SKILL_PACK.skills, [
+    { name: "patchmill-issue-triage", source: "patchmill" },
+    { name: "brainstorming", source: "superpowers" },
+    { name: "dispatching-parallel-agents", source: "superpowers" },
+    { name: "executing-plans", source: "superpowers" },
+    { name: "finishing-a-development-branch", source: "superpowers" },
+    { name: "receiving-code-review", source: "superpowers" },
+    { name: "requesting-code-review", source: "superpowers" },
+    { name: "subagent-driven-development", source: "superpowers" },
+    { name: "systematic-debugging", source: "superpowers" },
+    { name: "test-driven-development", source: "superpowers" },
+    { name: "using-git-worktrees", source: "superpowers" },
+    { name: "using-superpowers", source: "superpowers" },
+    { name: "verification-before-completion", source: "superpowers" },
+    { name: "writing-plans", source: "superpowers" },
+    { name: "writing-skills", source: "superpowers" },
+  ]);
+  assert.equal(
+    new Set(PATCHMILL_RECOMMENDED_SKILL_PACK.skills.map((skill) => skill.name))
+      .size,
+    PATCHMILL_RECOMMENDED_SKILL_PACK.skills.length,
+  );
+});
+
+test("hashText returns stable sha256 hex", () => {
+  assert.equal(
+    hashText(unixNewline),
+    createHash("sha256").update(unixNewline).digest("hex"),
+  );
+});
+
+test("buildSkillPackMetadata records installed file hashes", () => {
+  const files = [
+    {
+      path: ".patchmill/skills/writing-plans/SKILL.md",
+      sha256: hashText(unixNewline),
+    },
+  ];
+  const metadata = buildSkillPackMetadata(files, {
+    skillDir: "custom/skills/",
+  });
+
+  assert.deepEqual(metadata, {
+    pack: {
+      name: "patchmill-recommended",
+      version: "2026.05",
+      source: {
+        type: "github-release",
+        repository: "obra/superpowers",
+        tag: "v5.0.7",
+        tarballUrl:
+          "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+      },
+    },
+    installedAt: "<generated-by-init>",
+    skillDir: "custom/skills",
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files: [
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(unixNewline),
+      },
+    ],
+  });
+
+  files[0].path = "changed/path.md";
+  assert.equal(
+    metadata.files[0]?.path,
+    ".patchmill/skills/writing-plans/SKILL.md",
+  );
+  assert.notEqual(metadata.files[0]?.path, files[0]?.path);
+});

--- a/src/workflow/skill-pack.test.ts
+++ b/src/workflow/skill-pack.test.ts
@@ -7,6 +7,7 @@ import {
   SKILL_PACK_METADATA_FILE,
   buildRecommendedProjectSkillConfig,
   buildSkillPackMetadata,
+  hashContent,
   hashText,
   projectSkillPath,
 } from "./skill-pack.ts";
@@ -71,6 +72,15 @@ test("hashText returns stable sha256 hex", () => {
   assert.equal(
     hashText(unixNewline),
     createHash("sha256").update(unixNewline).digest("hex"),
+  );
+});
+
+test("hashContent hashes raw bytes without text decoding", () => {
+  const content = Buffer.from([0x66, 0x6f, 0x80, 0x6f]);
+
+  assert.equal(
+    hashContent(content),
+    createHash("sha256").update(content).digest("hex"),
   );
 });
 

--- a/src/workflow/skill-pack.ts
+++ b/src/workflow/skill-pack.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, type BinaryLike } from "node:crypto";
 import type { PatchmillSkillsConfig } from "./skills.ts";
 
 export const DEFAULT_PROJECT_SKILL_DIR = ".patchmill/skills";
@@ -85,8 +85,12 @@ export function buildRecommendedProjectSkillConfig(
   };
 }
 
+export function hashContent(content: BinaryLike): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
 export function hashText(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
+  return hashContent(text);
 }
 
 export function buildSkillPackMetadata(

--- a/src/workflow/skill-pack.ts
+++ b/src/workflow/skill-pack.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import type { PatchmillSkillsConfig } from "./skills.ts";
+
+export const DEFAULT_PROJECT_SKILL_DIR = ".patchmill/skills";
+export const SKILL_PACK_METADATA_FILE = "patchmill-skill-pack.json";
+
+export type SkillPackSource = {
+  type: "github-release";
+  repository: "obra/superpowers";
+  tag: "v5.0.7";
+  tarballUrl: "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz";
+};
+
+export type SkillPackSkill = {
+  name: string;
+  source: "patchmill" | "superpowers";
+};
+
+export type SkillPack = {
+  name: "patchmill-recommended";
+  version: "2026.05";
+  source: SkillPackSource;
+  skills: SkillPackSkill[];
+};
+
+export type SkillPackMetadataFile = {
+  pack: {
+    name: SkillPack["name"];
+    version: SkillPack["version"];
+    source: SkillPackSource;
+  };
+  installedAt: "<generated-by-init>" | string;
+  skillDir: string;
+  metadataFile: typeof SKILL_PACK_METADATA_FILE;
+  files: Array<{ path: string; sha256: string }>;
+};
+
+export const PATCHMILL_RECOMMENDED_SKILL_PACK: SkillPack = {
+  name: "patchmill-recommended",
+  version: "2026.05",
+  source: {
+    type: "github-release",
+    repository: "obra/superpowers",
+    tag: "v5.0.7",
+    tarballUrl:
+      "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+  },
+  skills: [
+    { name: "patchmill-issue-triage", source: "patchmill" },
+    { name: "brainstorming", source: "superpowers" },
+    { name: "dispatching-parallel-agents", source: "superpowers" },
+    { name: "executing-plans", source: "superpowers" },
+    { name: "finishing-a-development-branch", source: "superpowers" },
+    { name: "receiving-code-review", source: "superpowers" },
+    { name: "requesting-code-review", source: "superpowers" },
+    { name: "subagent-driven-development", source: "superpowers" },
+    { name: "systematic-debugging", source: "superpowers" },
+    { name: "test-driven-development", source: "superpowers" },
+    { name: "using-git-worktrees", source: "superpowers" },
+    { name: "using-superpowers", source: "superpowers" },
+    { name: "verification-before-completion", source: "superpowers" },
+    { name: "writing-plans", source: "superpowers" },
+    { name: "writing-skills", source: "superpowers" },
+  ],
+};
+
+function trimTrailingSkillDirSlashes(skillDir: string): string {
+  return skillDir.replace(/\/+$/u, "");
+}
+
+export function projectSkillPath(
+  skillName: string,
+  skillDir = DEFAULT_PROJECT_SKILL_DIR,
+): string {
+  return `${trimTrailingSkillDirSlashes(skillDir)}/${skillName}`;
+}
+
+export function buildRecommendedProjectSkillConfig(
+  skillDir = DEFAULT_PROJECT_SKILL_DIR,
+): Pick<PatchmillSkillsConfig, "triage" | "planning" | "implementation"> {
+  return {
+    triage: projectSkillPath("patchmill-issue-triage", skillDir),
+    planning: projectSkillPath("writing-plans", skillDir),
+    implementation: projectSkillPath("subagent-driven-development", skillDir),
+  };
+}
+
+export function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function buildSkillPackMetadata(
+  files: Array<{ path: string; sha256: string }>,
+  options: { installedAt?: string; skillDir?: string } = {},
+): SkillPackMetadataFile {
+  return {
+    pack: {
+      name: PATCHMILL_RECOMMENDED_SKILL_PACK.name,
+      version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+      source: PATCHMILL_RECOMMENDED_SKILL_PACK.source,
+    },
+    installedAt: options.installedAt ?? "<generated-by-init>",
+    skillDir: trimTrailingSkillDirSlashes(
+      options.skillDir ?? DEFAULT_PROJECT_SKILL_DIR,
+    ),
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files: files.map((file) => ({ ...file })),
+  };
+}

--- a/src/workflow/skill-resolution.test.ts
+++ b/src/workflow/skill-resolution.test.ts
@@ -1,0 +1,468 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  BUNDLED_TRIAGE_SKILL_REFERENCE,
+  GLOBAL_PATCHMILL_SKILLS,
+} from "./skills.ts";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "./skill-pack.ts";
+import {
+  bundledTriageSkillPath,
+  isNamespaceStyleSkill,
+  isPathLikeSkill,
+  resolveConfiguredSkillInvocation,
+  resolvePathLikeSkillPath,
+  skillInvocationArgs,
+  skillInvocationPaths,
+} from "./skill-resolution.ts";
+
+async function tempRepo(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "patchmill-skill-resolution-"));
+}
+
+function skillDocument(name: string): string {
+  return `---\nname: ${name}\ndescription: ${name} skill.\n---\n# ${name}\n`;
+}
+
+async function writeProjectLocalSkill(
+  repoRoot: string,
+  name: string,
+): Promise<string> {
+  const skillDir = join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, name);
+  await mkdir(skillDir, { recursive: true });
+  const content = skillDocument(name);
+  await writeFile(join(skillDir, "SKILL.md"), content);
+  return content;
+}
+
+async function writeMetadata(
+  repoRoot: string,
+  files: SkillPackMetadataFile["files"],
+): Promise<void> {
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  const metadata: SkillPackMetadataFile = {
+    pack: {
+      name: PATCHMILL_RECOMMENDED_SKILL_PACK.name,
+      version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+      source: PATCHMILL_RECOMMENDED_SKILL_PACK.source,
+    },
+    installedAt: "2026-05-30T00:00:00.000Z",
+    skillDir: DEFAULT_PROJECT_SKILL_DIR,
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files,
+  };
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    JSON.stringify(metadata),
+  );
+}
+
+test("bundledTriageSkillPath points at the bundled SKILL.md file", () => {
+  assert.ok(
+    bundledTriageSkillPath().endsWith(
+      join("skills", "patchmill-issue-triage", "SKILL.md"),
+    ),
+  );
+});
+
+test("isNamespaceStyleSkill recognizes namespace-style skills only", () => {
+  assert.equal(isNamespaceStyleSkill("superpowers:writing-plans"), true);
+  assert.equal(isNamespaceStyleSkill("writing-plans"), false);
+  assert.equal(isNamespaceStyleSkill("C:\\repo\\skills\\writing-plans"), false);
+});
+
+test("isPathLikeSkill recognizes relative and absolute local skill paths", () => {
+  assert.equal(isPathLikeSkill(".patchmill/skills/writing-plans"), true);
+  assert.equal(isPathLikeSkill("skills\\writing-plans"), true);
+  assert.equal(isPathLikeSkill("/repo/skills/writing-plans"), true);
+  assert.equal(isPathLikeSkill("C:\\repo\\skills\\writing-plans"), true);
+  assert.equal(isPathLikeSkill("superpowers:writing-plans"), false);
+  assert.equal(isPathLikeSkill("writing-plans"), false);
+});
+
+test("skillInvocationArgs resolves bundled, local, and named skills", () => {
+  assert.deepEqual(skillInvocationArgs(undefined, "/repo"), []);
+  assert.deepEqual(skillInvocationArgs("writing-plans", "/repo"), []);
+  assert.deepEqual(
+    skillInvocationArgs(GLOBAL_PATCHMILL_SKILLS.triage, "/repo"),
+    [],
+  );
+  assert.deepEqual(
+    skillInvocationArgs(BUNDLED_TRIAGE_SKILL_REFERENCE, "/repo"),
+    ["--skill", bundledTriageSkillPath()],
+  );
+  assert.deepEqual(
+    skillInvocationArgs(".patchmill/skills/writing-plans", "/repo"),
+    ["--skill", "/repo/.patchmill/skills/writing-plans/SKILL.md"],
+  );
+  assert.deepEqual(skillInvocationArgs("skills\\writing-plans", "/repo"), [
+    "--skill",
+    "/repo/skills/writing-plans/SKILL.md",
+  ]);
+  assert.deepEqual(skillInvocationArgs("/repo/skills/writing-plans", "/repo"), [
+    "--skill",
+    "/repo/skills/writing-plans/SKILL.md",
+  ]);
+  assert.deepEqual(
+    skillInvocationArgs("C:\\repo\\skills\\writing-plans", "/repo"),
+    ["--skill", "C:\\repo\\skills\\writing-plans\\SKILL.md"],
+  );
+  assert.deepEqual(
+    skillInvocationArgs("./skills/writing-plans/SKILL.md", "/repo"),
+    ["--skill", "/repo/skills/writing-plans/SKILL.md"],
+  );
+  assert.deepEqual(
+    skillInvocationArgs("/repo/skills/writing-plans/SKILL.md", "/repo"),
+    ["--skill", "/repo/skills/writing-plans/SKILL.md"],
+  );
+  assert.deepEqual(
+    skillInvocationArgs("C:\\repo\\skills\\writing-plans\\SKILL.md", "/repo"),
+    ["--skill", "C:\\repo\\skills\\writing-plans\\SKILL.md"],
+  );
+});
+
+test("resolvePathLikeSkillPath preserves configured SKILL.md file paths", async () => {
+  const repoRoot = await tempRepo();
+
+  assert.equal(
+    resolvePathLikeSkillPath("project-skills/writing-plans/SKILL.md", repoRoot),
+    join(repoRoot, "project-skills", "writing-plans", "SKILL.md"),
+  );
+  assert.equal(
+    resolvePathLikeSkillPath("project-skills/writing-plans", repoRoot),
+    join(repoRoot, "project-skills", "writing-plans", "SKILL.md"),
+  );
+  assert.equal(
+    resolvePathLikeSkillPath(
+      "C:\\repo\\skills\\writing-plans\\SKILL.md",
+      repoRoot,
+    ),
+    "C:\\repo\\skills\\writing-plans\\SKILL.md",
+  );
+});
+
+test("skillInvocationPaths keeps only invokable skill paths in order", () => {
+  assert.deepEqual(
+    skillInvocationPaths(
+      [
+        ".patchmill/skills/writing-plans",
+        "superpowers:writing-plans",
+        undefined,
+        BUNDLED_TRIAGE_SKILL_REFERENCE,
+        "skills\\implementation",
+      ],
+      "/repo",
+    ),
+    [
+      "/repo/.patchmill/skills/writing-plans/SKILL.md",
+      bundledTriageSkillPath(),
+      "/repo/skills/implementation/SKILL.md",
+    ],
+  );
+});
+
+test("resolveConfiguredSkillInvocation expands a valid project-local pack exactly once", async () => {
+  const repoRoot = await tempRepo();
+  const triage = await writeProjectLocalSkill(
+    repoRoot,
+    "patchmill-issue-triage",
+  );
+  const planning = await writeProjectLocalSkill(repoRoot, "writing-plans");
+  const implementation = await writeProjectLocalSkill(
+    repoRoot,
+    "subagent-driven-development",
+  );
+  await writeMetadata(repoRoot, [
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/patchmill-issue-triage/SKILL.md`,
+      sha256: hashText(triage),
+    },
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans/SKILL.md`,
+      sha256: hashText(planning),
+    },
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development/SKILL.md`,
+      sha256: hashText(implementation),
+    },
+  ]);
+
+  const result = resolveConfiguredSkillInvocation(
+    [
+      `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+      `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    ],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "patchmill-issue-triage",
+      "SKILL.md",
+    ),
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.equal(result.usedProjectLocalPack, true);
+  assert.deepEqual(result.configuredProjectLocalPaths, [
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.deepEqual(
+    result.diagnostics.map((entry) => entry.status),
+    ["pass"],
+  );
+});
+
+test("resolveConfiguredSkillInvocation uses configured paths only when metadata is missing", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "writing-plans");
+  await writeProjectLocalSkill(repoRoot, "subagent-driven-development");
+
+  const result = resolveConfiguredSkillInvocation(
+    [
+      `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`,
+      `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    ],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.deepEqual(result.diagnostics, [
+    {
+      status: "warn",
+      summary:
+        "project-local skill pack metadata missing; using configured project-local skill paths only",
+    },
+  ]);
+});
+
+test("resolveConfiguredSkillInvocation preserves mixed configured ordering when metadata is missing", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "subagent-driven-development");
+
+  const result = resolveConfiguredSkillInvocation(
+    [
+      "skills/toolchain",
+      `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    ],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(repoRoot, "skills", "toolchain", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.deepEqual(result.diagnostics, [
+    {
+      status: "warn",
+      summary:
+        "project-local skill pack metadata missing; using configured project-local skill paths only",
+    },
+  ]);
+  assert.equal(result.usedProjectLocalPack, true);
+});
+
+test("resolveConfiguredSkillInvocation treats unsafe metadata paths as malformed", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "subagent-driven-development");
+  await writeProjectLocalSkill(repoRoot, "requesting-code-review");
+  await writeMetadata(repoRoot, [
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/../other/SKILL.md`,
+      sha256: "escaped",
+    },
+  ]);
+
+  const result = resolveConfiguredSkillInvocation(
+    [`${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.deepEqual(result.diagnostics, [
+    {
+      status: "warn",
+      summary:
+        "project-local skill pack metadata malformed; using configured project-local skill paths only",
+    },
+  ]);
+});
+
+test("resolveConfiguredSkillInvocation uses configured paths only when metadata is malformed", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "writing-plans");
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    "{ malformed json",
+  );
+
+  const result = resolveConfiguredSkillInvocation(
+    [`${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+  ]);
+  assert.equal(result.diagnostics[0]?.status, "warn");
+  assert.match(
+    result.diagnostics[0]?.summary ?? "",
+    /project-local skill pack metadata malformed; using configured project-local skill paths only/,
+  );
+});
+
+test("resolveConfiguredSkillInvocation preserves mixed configured ordering when metadata is malformed", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "subagent-driven-development");
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    "{ malformed json",
+  );
+
+  const result = resolveConfiguredSkillInvocation(
+    [
+      "skills/toolchain",
+      `${DEFAULT_PROJECT_SKILL_DIR}/subagent-driven-development`,
+    ],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, [
+    join(repoRoot, "skills", "toolchain", "SKILL.md"),
+    join(
+      repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      "subagent-driven-development",
+      "SKILL.md",
+    ),
+  ]);
+  assert.equal(result.diagnostics[0]?.status, "warn");
+  assert.match(
+    result.diagnostics[0]?.summary ?? "",
+    /project-local skill pack metadata malformed; using configured project-local skill paths only/,
+  );
+  assert.equal(result.usedProjectLocalPack, true);
+});
+
+test("resolveConfiguredSkillInvocation reports customized project-local pack files", async () => {
+  const repoRoot = await tempRepo();
+  const planning = await writeProjectLocalSkill(repoRoot, "writing-plans");
+  await writeMetadata(repoRoot, [
+    {
+      path: `${DEFAULT_PROJECT_SKILL_DIR}/writing-plans/SKILL.md`,
+      sha256: hashText(planning),
+    },
+  ]);
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, "writing-plans", "SKILL.md"),
+    skillDocument("writing-plans") + "\n# local customization\n",
+  );
+
+  const result = resolveConfiguredSkillInvocation(
+    [`${DEFAULT_PROJECT_SKILL_DIR}/writing-plans`],
+    repoRoot,
+  );
+
+  assert.deepEqual(
+    result.diagnostics.map((entry) => entry.status),
+    ["pass", "warn"],
+  );
+  assert.equal(
+    result.diagnostics[0]?.summary,
+    "project-local metadata verified",
+  );
+  assert.match(
+    result.diagnostics[1]?.summary ?? "",
+    /project-local skill pack customized from installed pack/,
+  );
+});
+
+test("resolveConfiguredSkillInvocation ignores unused project-local directories and metadata", async () => {
+  const repoRoot = await tempRepo();
+  await writeProjectLocalSkill(repoRoot, "stale-unused-skill");
+  await mkdir(join(repoRoot, DEFAULT_PROJECT_SKILL_DIR), { recursive: true });
+  await writeFile(
+    join(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE),
+    "{ malformed json",
+  );
+
+  const result = resolveConfiguredSkillInvocation(
+    ["superpowers:writing-plans", "superpowers:subagent-driven-development"],
+    repoRoot,
+  );
+
+  assert.deepEqual(result.paths, []);
+  assert.deepEqual(result.diagnostics, []);
+  assert.equal(result.usedProjectLocalPack, false);
+  assert.deepEqual(result.configuredProjectLocalPaths, []);
+});
+
+test("resolveConfiguredSkillInvocation separates bundled fallback from global triage", async () => {
+  const repoRoot = await tempRepo();
+
+  assert.equal(
+    resolveConfiguredSkillInvocation([BUNDLED_TRIAGE_SKILL_REFERENCE], repoRoot)
+      .paths.length,
+    1,
+  );
+  assert.deepEqual(
+    resolveConfiguredSkillInvocation([GLOBAL_PATCHMILL_SKILLS.triage], repoRoot)
+      .paths,
+    [],
+  );
+});
+
+test("bundled triage skill matches dry-run previews and execute mutations", async () => {
+  const skill = await readFile(bundledTriageSkillPath(), "utf8");
+
+  assert.doesNotMatch(skill, /required JSON decision document/);
+  assert.doesNotMatch(skill, /Do not mutate repository-hosting state\./);
+  assert.match(skill, /dry-run\/preview mode[\s\S]*read-only JSON preview/i);
+  assert.match(
+    skill,
+    /execute mode[\s\S]*apply[\s\S]*labels, comments, closures[\s\S]*(host tools|configured workflow)/i,
+  );
+});

--- a/src/workflow/skill-resolution.ts
+++ b/src/workflow/skill-resolution.ts
@@ -1,0 +1,359 @@
+import { readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashContent,
+  type SkillPackMetadataFile,
+} from "./skill-pack.ts";
+
+export type SkillResolutionStatus = "pass" | "warn" | "fail";
+
+export type SkillResolutionDiagnostic = {
+  status: SkillResolutionStatus;
+  summary: string;
+};
+
+export type SkillInvocationResolution = {
+  paths: string[];
+  diagnostics: SkillResolutionDiagnostic[];
+  configuredProjectLocalPaths: string[];
+  usedProjectLocalPack: boolean;
+};
+
+export const BUNDLED_TRIAGE_SKILL_REFERENCE = "patchmill:bundled-issue-triage";
+
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
+const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
+const SKILL_FILE_NAME = "SKILL.md";
+const PROJECT_LOCAL_CUSTOMIZED_SUMMARY =
+  "project-local skill pack customized from installed pack";
+
+export function bundledTriageSkillPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "..", "skills", "patchmill-issue-triage", "SKILL.md");
+}
+
+export function isNamespaceStyleSkill(skill: string): boolean {
+  return (
+    SKILL_NAMESPACE_PATTERN.test(skill) &&
+    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  );
+}
+
+export function isPathLikeSkill(skill: string): boolean {
+  if (
+    skill.startsWith(".") ||
+    skill.startsWith("/") ||
+    WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  ) {
+    return true;
+  }
+
+  return /[\\/]/u.test(skill) && !isNamespaceStyleSkill(skill);
+}
+
+function isSkillFilePath(skill: string): boolean {
+  const normalizedPath = skill.replaceAll("\\", "/");
+  return (
+    normalizedPath === SKILL_FILE_NAME ||
+    normalizedPath.endsWith(`/${SKILL_FILE_NAME}`)
+  );
+}
+
+export function resolvePathLikeSkillPath(
+  skill: string,
+  repoRoot: string,
+): string {
+  if (WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)) {
+    return isSkillFilePath(skill)
+      ? win32.normalize(skill)
+      : win32.join(skill, SKILL_FILE_NAME);
+  }
+
+  const normalizedPath = skill.replaceAll("\\", "/");
+  if (isSkillFilePath(normalizedPath)) {
+    return normalizedPath.startsWith("/")
+      ? resolve(normalizedPath)
+      : resolve(repoRoot, normalizedPath);
+  }
+
+  return normalizedPath.startsWith("/")
+    ? resolve(normalizedPath, SKILL_FILE_NAME)
+    : resolve(repoRoot, normalizedPath, SKILL_FILE_NAME);
+}
+
+function pathStartsWith(path: string, prefix: string): boolean {
+  return (
+    path === prefix ||
+    path.startsWith(`${prefix}/`) ||
+    path.startsWith(`${prefix}\\`)
+  );
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const pathRelative = relative(parent, child);
+  return (
+    pathRelative === "" ||
+    (!pathRelative.startsWith("..") && !isAbsolute(pathRelative))
+  );
+}
+
+function resolveProjectLocalMetadataFilePath(
+  filePath: string,
+  repoRoot: string,
+  projectLocalRoot: string,
+): string | null {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  if (isAbsolute(normalizedPath) || win32.isAbsolute(filePath)) return null;
+  if (!normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`)) return null;
+
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  return isPathInside(projectLocalRoot, resolvedPath) ? resolvedPath : null;
+}
+
+function validMetadata(
+  value: unknown,
+  repoRoot: string,
+  projectLocalRoot: string,
+): value is SkillPackMetadataFile {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<SkillPackMetadataFile> & {
+    pack?: { source?: Record<string, unknown> };
+  };
+
+  return (
+    candidate.pack?.name === PATCHMILL_RECOMMENDED_SKILL_PACK.name &&
+    candidate.pack.version === PATCHMILL_RECOMMENDED_SKILL_PACK.version &&
+    candidate.pack.source?.type ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.type &&
+    candidate.pack.source?.repository ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.repository &&
+    candidate.pack.source?.tag ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tag &&
+    candidate.pack.source?.tarballUrl ===
+      PATCHMILL_RECOMMENDED_SKILL_PACK.source.tarballUrl &&
+    typeof candidate.installedAt === "string" &&
+    candidate.skillDir === DEFAULT_PROJECT_SKILL_DIR &&
+    candidate.metadataFile === SKILL_PACK_METADATA_FILE &&
+    Array.isArray(candidate.files) &&
+    candidate.files.every(
+      (file) =>
+        file &&
+        typeof file.path === "string" &&
+        typeof file.sha256 === "string" &&
+        resolveProjectLocalMetadataFilePath(
+          file.path,
+          repoRoot,
+          projectLocalRoot,
+        ) !== null,
+    )
+  );
+}
+
+function metadataSkillPaths(
+  metadata: SkillPackMetadataFile,
+  repoRoot: string,
+  projectLocalRoot: string,
+): string[] {
+  return metadata.files
+    .filter((file) => isSkillFilePath(file.path))
+    .flatMap((file) => {
+      const resolvedPath = resolveProjectLocalMetadataFilePath(
+        file.path,
+        repoRoot,
+        projectLocalRoot,
+      );
+      return resolvedPath ? [resolvedPath] : [];
+    });
+}
+
+function projectLocalCustomizationDiagnostics(
+  metadata: SkillPackMetadataFile,
+  repoRoot: string,
+  projectLocalRoot: string,
+): SkillResolutionDiagnostic[] {
+  for (const file of metadata.files) {
+    const resolvedPath = resolveProjectLocalMetadataFilePath(
+      file.path,
+      repoRoot,
+      projectLocalRoot,
+    );
+    if (!resolvedPath) {
+      return [
+        {
+          status: "warn",
+          summary: PROJECT_LOCAL_CUSTOMIZED_SUMMARY,
+        },
+      ];
+    }
+
+    try {
+      if (hashContent(readFileSync(resolvedPath)) !== file.sha256) {
+        return [
+          {
+            status: "warn",
+            summary: PROJECT_LOCAL_CUSTOMIZED_SUMMARY,
+          },
+        ];
+      }
+    } catch {
+      return [
+        {
+          status: "warn",
+          summary: PROJECT_LOCAL_CUSTOMIZED_SUMMARY,
+        },
+      ];
+    }
+  }
+
+  return [];
+}
+
+function projectLocalPackResolution(
+  repoRoot: string,
+  configuredProjectLocalPaths: string[],
+): {
+  paths: string[];
+  diagnostics: SkillResolutionDiagnostic[];
+  usedMetadata: boolean;
+} {
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
+  const metadataPath = join(projectLocalRoot, SKILL_PACK_METADATA_FILE);
+
+  let metadataContent: string;
+  try {
+    metadataContent = readFileSync(metadataPath, "utf8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return {
+      paths: configuredProjectLocalPaths,
+      diagnostics: [
+        {
+          status: "warn",
+          summary:
+            code === "ENOENT"
+              ? "project-local skill pack metadata missing; using configured project-local skill paths only"
+              : `project-local skill pack metadata unreadable; using configured project-local skill paths only: ${String(error)}`,
+        },
+      ],
+      usedMetadata: false,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadataContent);
+  } catch (error) {
+    return {
+      paths: configuredProjectLocalPaths,
+      diagnostics: [
+        {
+          status: "warn",
+          summary: `project-local skill pack metadata malformed; using configured project-local skill paths only: ${String(error)}`,
+        },
+      ],
+      usedMetadata: false,
+    };
+  }
+
+  if (!validMetadata(parsed, repoRoot, projectLocalRoot)) {
+    return {
+      paths: configuredProjectLocalPaths,
+      diagnostics: [
+        {
+          status: "warn",
+          summary:
+            "project-local skill pack metadata malformed; using configured project-local skill paths only",
+        },
+      ],
+      usedMetadata: false,
+    };
+  }
+
+  return {
+    paths: metadataSkillPaths(parsed, repoRoot, projectLocalRoot),
+    diagnostics: [
+      { status: "pass", summary: "project-local metadata verified" },
+      ...projectLocalCustomizationDiagnostics(
+        parsed,
+        repoRoot,
+        projectLocalRoot,
+      ),
+    ],
+    usedMetadata: true,
+  };
+}
+
+function unique(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    if (seen.has(path)) return false;
+    seen.add(path);
+    return true;
+  });
+}
+
+export function resolveConfiguredSkillInvocation(
+  skills: Array<string | undefined>,
+  repoRoot: string,
+): SkillInvocationResolution {
+  const diagnostics: SkillResolutionDiagnostic[] = [];
+  const configuredPaths = skills.flatMap((skill) => {
+    if (!skill) return [];
+    if (skill === BUNDLED_TRIAGE_SKILL_REFERENCE) {
+      return [bundledTriageSkillPath()];
+    }
+    if (!isPathLikeSkill(skill)) return [];
+    return [resolvePathLikeSkillPath(skill, repoRoot)];
+  });
+
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
+  const configuredProjectLocalPaths = configuredPaths.filter((path) =>
+    pathStartsWith(resolve(path), projectLocalRoot),
+  );
+
+  if (configuredProjectLocalPaths.length === 0) {
+    return {
+      paths: unique(configuredPaths),
+      diagnostics,
+      configuredProjectLocalPaths,
+      usedProjectLocalPack: false,
+    };
+  }
+
+  const pack = projectLocalPackResolution(
+    repoRoot,
+    configuredProjectLocalPaths,
+  );
+  diagnostics.push(...pack.diagnostics);
+
+  return {
+    paths: pack.usedMetadata
+      ? unique([...pack.paths, ...configuredPaths])
+      : unique(configuredPaths),
+    diagnostics,
+    configuredProjectLocalPaths: unique(configuredProjectLocalPaths),
+    usedProjectLocalPack: true,
+  };
+}
+
+export function skillInvocationPaths(
+  skills: Array<string | undefined>,
+  repoRoot: string,
+): string[] {
+  return resolveConfiguredSkillInvocation(skills, repoRoot).paths;
+}
+
+export function skillInvocationArgs(
+  skill: string | undefined,
+  repoRoot: string,
+): string[] {
+  return skillInvocationPaths([skill], repoRoot).flatMap((path) => [
+    "--skill",
+    path,
+  ]);
+}

--- a/src/workflow/skills.test.ts
+++ b/src/workflow/skills.test.ts
@@ -223,6 +223,85 @@ test("skillInvocationPaths expands project-local pack skills from metadata", asy
   );
 });
 
+test("skillInvocationPaths rejects metadata skill paths outside project-local skills", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-skills-metadata-traversal-"),
+  );
+  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
+  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
+    recursive: true,
+  });
+  await mkdir(join(projectSkillsRoot, "requesting-code-review"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
+    "# implementation\n",
+  );
+  await writeFile(
+    join(projectSkillsRoot, "requesting-code-review", "SKILL.md"),
+    "# review\n",
+  );
+  await writeFile(
+    join(projectSkillsRoot, "patchmill-skill-pack.json"),
+    JSON.stringify({
+      files: [
+        {
+          path: ".patchmill/skills/../other/SKILL.md",
+          sha256: "escaped",
+        },
+      ],
+    }),
+  );
+
+  assert.deepEqual(
+    skillInvocationPaths(
+      [".patchmill/skills/subagent-driven-development"],
+      repoRoot,
+    ),
+    [
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "subagent-driven-development",
+        "SKILL.md",
+      ),
+    ],
+  );
+});
+
+test("skillInvocationPaths fails fast when project-local metadata is malformed", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-skills-malformed-metadata-"),
+  );
+  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
+  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
+    recursive: true,
+  });
+  await mkdir(join(projectSkillsRoot, "test-driven-development"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
+    "# implementation\n",
+  );
+  await writeFile(
+    join(projectSkillsRoot, "test-driven-development", "SKILL.md"),
+    "# tests\n",
+  );
+  await writeFile(join(projectSkillsRoot, "patchmill-skill-pack.json"), "{");
+
+  assert.throws(
+    () =>
+      skillInvocationPaths(
+        [".patchmill/skills/subagent-driven-development"],
+        repoRoot,
+      ),
+    /project-local skill pack metadata malformed/u,
+  );
+});
+
 test("skillInvocationPaths discovers project-local pack skills when metadata is missing", async () => {
   const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-skills-discovery-"));
   const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");

--- a/src/workflow/skills.test.ts
+++ b/src/workflow/skills.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   DEFAULT_PATCHMILL_SKILLS,
@@ -157,6 +158,109 @@ test("skillInvocationPaths keeps only invokable skill paths in order", () => {
       "/repo/.patchmill/skills/writing-plans/SKILL.md",
       bundledTriageSkillPath(),
       "/repo/skills/implementation/SKILL.md",
+    ],
+  );
+});
+
+test("skillInvocationPaths expands project-local pack skills from metadata", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-skills-metadata-"));
+  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
+  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
+    recursive: true,
+  });
+  await mkdir(join(projectSkillsRoot, "requesting-code-review"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
+    "# implementation\n",
+  );
+  await writeFile(
+    join(projectSkillsRoot, "requesting-code-review", "SKILL.md"),
+    "# review\n",
+  );
+  await writeFile(
+    join(projectSkillsRoot, "patchmill-skill-pack.json"),
+    JSON.stringify({
+      files: [
+        {
+          path: ".patchmill/skills/subagent-driven-development/SKILL.md",
+          sha256: "impl",
+        },
+        {
+          path: ".patchmill/skills/requesting-code-review/SKILL.md",
+          sha256: "review",
+        },
+        {
+          path: ".patchmill/skills/subagent-driven-development/README.md",
+          sha256: "docs",
+        },
+      ],
+    }),
+  );
+
+  assert.deepEqual(
+    skillInvocationPaths(
+      [".patchmill/skills/subagent-driven-development"],
+      repoRoot,
+    ),
+    [
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "subagent-driven-development",
+        "SKILL.md",
+      ),
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "requesting-code-review",
+        "SKILL.md",
+      ),
+    ],
+  );
+});
+
+test("skillInvocationPaths discovers project-local pack skills when metadata is missing", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-skills-discovery-"));
+  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
+  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
+    recursive: true,
+  });
+  await mkdir(join(projectSkillsRoot, "test-driven-development"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
+    "# implementation\n",
+  );
+  await writeFile(
+    join(projectSkillsRoot, "test-driven-development", "SKILL.md"),
+    "# tests\n",
+  );
+
+  assert.deepEqual(
+    skillInvocationPaths(
+      [".patchmill/skills/subagent-driven-development"],
+      repoRoot,
+    ),
+    [
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "subagent-driven-development",
+        "SKILL.md",
+      ),
+      join(
+        repoRoot,
+        ".patchmill",
+        "skills",
+        "test-driven-development",
+        "SKILL.md",
+      ),
     ],
   );
 });

--- a/src/workflow/skills.test.ts
+++ b/src/workflow/skills.test.ts
@@ -8,6 +8,11 @@ import {
   mergeSkillsConfig,
   renderConfiguredSkillLine,
   bundledTriageSkillPath,
+  isNamespaceStyleSkill,
+  isPathLikeSkill,
+  resolvePathLikeSkillPath,
+  skillInvocationArgs,
+  skillInvocationPaths,
 } from "./skills.ts";
 import type { PartialPatchmillSkillsConfig } from "./skills.ts";
 
@@ -63,6 +68,96 @@ test("bundledTriageSkillPath points at the bundled SKILL.md file", () => {
     bundledTriageSkillPath().endsWith(
       join("skills", "patchmill-issue-triage", "SKILL.md"),
     ),
+  );
+});
+
+test("isNamespaceStyleSkill recognizes namespace-style skills only", () => {
+  assert.equal(isNamespaceStyleSkill("superpowers:writing-plans"), true);
+  assert.equal(isNamespaceStyleSkill("writing-plans"), false);
+  assert.equal(isNamespaceStyleSkill("C:\\repo\\skills\\writing-plans"), false);
+});
+
+test("isPathLikeSkill recognizes relative and absolute local skill paths", () => {
+  assert.equal(isPathLikeSkill(".patchmill/skills/writing-plans"), true);
+  assert.equal(isPathLikeSkill("skills\\writing-plans"), true);
+  assert.equal(isPathLikeSkill("/repo/skills/writing-plans"), true);
+  assert.equal(isPathLikeSkill("C:\\repo\\skills\\writing-plans"), true);
+  assert.equal(isPathLikeSkill("superpowers:writing-plans"), false);
+  assert.equal(isPathLikeSkill("writing-plans"), false);
+});
+
+test("skillInvocationArgs resolves bundled, local, and named skills", () => {
+  assert.deepEqual(skillInvocationArgs(undefined, "/repo"), []);
+  assert.deepEqual(skillInvocationArgs("writing-plans", "/repo"), []);
+  assert.deepEqual(skillInvocationArgs("patchmill-issue-triage", "/repo"), [
+    "--skill",
+    bundledTriageSkillPath(),
+  ]);
+  assert.deepEqual(
+    skillInvocationArgs(".patchmill/skills/writing-plans", "/repo"),
+    ["--skill", "/repo/.patchmill/skills/writing-plans/SKILL.md"],
+  );
+  assert.deepEqual(skillInvocationArgs("skills\\writing-plans", "/repo"), [
+    "--skill",
+    "/repo/skills/writing-plans/SKILL.md",
+  ]);
+  assert.deepEqual(skillInvocationArgs("/repo/skills/writing-plans", "/repo"), [
+    "--skill",
+    "/repo/skills/writing-plans/SKILL.md",
+  ]);
+  assert.deepEqual(
+    skillInvocationArgs("C:\\repo\\skills\\writing-plans", "/repo"),
+    ["--skill", "C:\\repo\\skills\\writing-plans\\SKILL.md"],
+  );
+  assert.deepEqual(
+    skillInvocationArgs("./skills/writing-plans/SKILL.md", "/repo"),
+    ["--skill", "/repo/skills/writing-plans/SKILL.md"],
+  );
+  assert.deepEqual(
+    skillInvocationArgs("/repo/skills/writing-plans/SKILL.md", "/repo"),
+    ["--skill", "/repo/skills/writing-plans/SKILL.md"],
+  );
+  assert.deepEqual(
+    skillInvocationArgs("C:\\repo\\skills\\writing-plans\\SKILL.md", "/repo"),
+    ["--skill", "C:\\repo\\skills\\writing-plans\\SKILL.md"],
+  );
+});
+
+test("resolvePathLikeSkillPath preserves configured SKILL.md file paths", () => {
+  assert.equal(
+    resolvePathLikeSkillPath("./skills/writing-plans/SKILL.md", "/repo"),
+    "/repo/skills/writing-plans/SKILL.md",
+  );
+  assert.equal(
+    resolvePathLikeSkillPath("/repo/skills/writing-plans/SKILL.md", "/repo"),
+    "/repo/skills/writing-plans/SKILL.md",
+  );
+  assert.equal(
+    resolvePathLikeSkillPath(
+      "C:\\repo\\skills\\writing-plans\\SKILL.md",
+      "/repo",
+    ),
+    "C:\\repo\\skills\\writing-plans\\SKILL.md",
+  );
+});
+
+test("skillInvocationPaths keeps only invokable skill paths in order", () => {
+  assert.deepEqual(
+    skillInvocationPaths(
+      [
+        ".patchmill/skills/writing-plans",
+        "superpowers:writing-plans",
+        undefined,
+        "patchmill-issue-triage",
+        "skills\\implementation",
+      ],
+      "/repo",
+    ),
+    [
+      "/repo/.patchmill/skills/writing-plans/SKILL.md",
+      bundledTriageSkillPath(),
+      "/repo/skills/implementation/SKILL.md",
+    ],
   );
 });
 

--- a/src/workflow/skills.test.ts
+++ b/src/workflow/skills.test.ts
@@ -1,24 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import {
+  BUNDLED_TRIAGE_SKILL_REFERENCE,
   DEFAULT_PATCHMILL_SKILLS,
+  GLOBAL_PATCHMILL_SKILLS,
   cloneSkillsConfig,
   mergeSkillsConfig,
   renderConfiguredSkillLine,
-  bundledTriageSkillPath,
-  isNamespaceStyleSkill,
-  isPathLikeSkill,
-  resolvePathLikeSkillPath,
-  skillInvocationArgs,
-  skillInvocationPaths,
 } from "./skills.ts";
 import type { PartialPatchmillSkillsConfig } from "./skills.ts";
 
-test("DEFAULT_PATCHMILL_SKILLS keeps current default workflow skills", () => {
+test("DEFAULT_PATCHMILL_SKILLS uses the bundled fallback triage reference", () => {
   assert.deepEqual(DEFAULT_PATCHMILL_SKILLS, {
+    triage: BUNDLED_TRIAGE_SKILL_REFERENCE,
+    planning: "superpowers:writing-plans",
+    implementation: "superpowers:subagent-driven-development",
+  });
+});
+
+test("GLOBAL_PATCHMILL_SKILLS keeps the global named triage skill", () => {
+  assert.deepEqual(GLOBAL_PATCHMILL_SKILLS, {
     triage: "patchmill-issue-triage",
     planning: "superpowers:writing-plans",
     implementation: "superpowers:subagent-driven-development",
@@ -32,7 +33,7 @@ test("mergeSkillsConfig replaces only configured stages", () => {
   });
 
   assert.deepEqual(merged, {
-    triage: "patchmill-issue-triage",
+    triage: BUNDLED_TRIAGE_SKILL_REFERENCE,
     planning: "superpowers:writing-plans",
     implementation: "project-implementation",
     visualEvidence: "capturing-proof-screenshots",
@@ -44,7 +45,7 @@ test("mergeSkillsConfig preserves defaults when update contains explicit undefin
     triage: undefined,
   } as PartialPatchmillSkillsConfig);
 
-  assert.equal(merged.triage, "patchmill-issue-triage");
+  assert.equal(merged.triage, BUNDLED_TRIAGE_SKILL_REFERENCE);
 });
 
 test("cloneSkillsConfig returns an independent object", () => {
@@ -61,297 +62,5 @@ test("renderConfiguredSkillLine renders direct stage-to-skill wording", () => {
       "superpowers:writing-plans",
     ),
     "Use the configured planning skill: `superpowers:writing-plans`.",
-  );
-});
-
-test("bundledTriageSkillPath points at the bundled SKILL.md file", () => {
-  assert.ok(
-    bundledTriageSkillPath().endsWith(
-      join("skills", "patchmill-issue-triage", "SKILL.md"),
-    ),
-  );
-});
-
-test("isNamespaceStyleSkill recognizes namespace-style skills only", () => {
-  assert.equal(isNamespaceStyleSkill("superpowers:writing-plans"), true);
-  assert.equal(isNamespaceStyleSkill("writing-plans"), false);
-  assert.equal(isNamespaceStyleSkill("C:\\repo\\skills\\writing-plans"), false);
-});
-
-test("isPathLikeSkill recognizes relative and absolute local skill paths", () => {
-  assert.equal(isPathLikeSkill(".patchmill/skills/writing-plans"), true);
-  assert.equal(isPathLikeSkill("skills\\writing-plans"), true);
-  assert.equal(isPathLikeSkill("/repo/skills/writing-plans"), true);
-  assert.equal(isPathLikeSkill("C:\\repo\\skills\\writing-plans"), true);
-  assert.equal(isPathLikeSkill("superpowers:writing-plans"), false);
-  assert.equal(isPathLikeSkill("writing-plans"), false);
-});
-
-test("skillInvocationArgs resolves bundled, local, and named skills", () => {
-  assert.deepEqual(skillInvocationArgs(undefined, "/repo"), []);
-  assert.deepEqual(skillInvocationArgs("writing-plans", "/repo"), []);
-  assert.deepEqual(skillInvocationArgs("patchmill-issue-triage", "/repo"), [
-    "--skill",
-    bundledTriageSkillPath(),
-  ]);
-  assert.deepEqual(
-    skillInvocationArgs(".patchmill/skills/writing-plans", "/repo"),
-    ["--skill", "/repo/.patchmill/skills/writing-plans/SKILL.md"],
-  );
-  assert.deepEqual(skillInvocationArgs("skills\\writing-plans", "/repo"), [
-    "--skill",
-    "/repo/skills/writing-plans/SKILL.md",
-  ]);
-  assert.deepEqual(skillInvocationArgs("/repo/skills/writing-plans", "/repo"), [
-    "--skill",
-    "/repo/skills/writing-plans/SKILL.md",
-  ]);
-  assert.deepEqual(
-    skillInvocationArgs("C:\\repo\\skills\\writing-plans", "/repo"),
-    ["--skill", "C:\\repo\\skills\\writing-plans\\SKILL.md"],
-  );
-  assert.deepEqual(
-    skillInvocationArgs("./skills/writing-plans/SKILL.md", "/repo"),
-    ["--skill", "/repo/skills/writing-plans/SKILL.md"],
-  );
-  assert.deepEqual(
-    skillInvocationArgs("/repo/skills/writing-plans/SKILL.md", "/repo"),
-    ["--skill", "/repo/skills/writing-plans/SKILL.md"],
-  );
-  assert.deepEqual(
-    skillInvocationArgs("C:\\repo\\skills\\writing-plans\\SKILL.md", "/repo"),
-    ["--skill", "C:\\repo\\skills\\writing-plans\\SKILL.md"],
-  );
-});
-
-test("resolvePathLikeSkillPath preserves configured SKILL.md file paths", () => {
-  assert.equal(
-    resolvePathLikeSkillPath("./skills/writing-plans/SKILL.md", "/repo"),
-    "/repo/skills/writing-plans/SKILL.md",
-  );
-  assert.equal(
-    resolvePathLikeSkillPath("/repo/skills/writing-plans/SKILL.md", "/repo"),
-    "/repo/skills/writing-plans/SKILL.md",
-  );
-  assert.equal(
-    resolvePathLikeSkillPath(
-      "C:\\repo\\skills\\writing-plans\\SKILL.md",
-      "/repo",
-    ),
-    "C:\\repo\\skills\\writing-plans\\SKILL.md",
-  );
-});
-
-test("skillInvocationPaths keeps only invokable skill paths in order", () => {
-  assert.deepEqual(
-    skillInvocationPaths(
-      [
-        ".patchmill/skills/writing-plans",
-        "superpowers:writing-plans",
-        undefined,
-        "patchmill-issue-triage",
-        "skills\\implementation",
-      ],
-      "/repo",
-    ),
-    [
-      "/repo/.patchmill/skills/writing-plans/SKILL.md",
-      bundledTriageSkillPath(),
-      "/repo/skills/implementation/SKILL.md",
-    ],
-  );
-});
-
-test("skillInvocationPaths expands project-local pack skills from metadata", async () => {
-  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-skills-metadata-"));
-  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
-  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
-    recursive: true,
-  });
-  await mkdir(join(projectSkillsRoot, "requesting-code-review"), {
-    recursive: true,
-  });
-  await writeFile(
-    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
-    "# implementation\n",
-  );
-  await writeFile(
-    join(projectSkillsRoot, "requesting-code-review", "SKILL.md"),
-    "# review\n",
-  );
-  await writeFile(
-    join(projectSkillsRoot, "patchmill-skill-pack.json"),
-    JSON.stringify({
-      files: [
-        {
-          path: ".patchmill/skills/subagent-driven-development/SKILL.md",
-          sha256: "impl",
-        },
-        {
-          path: ".patchmill/skills/requesting-code-review/SKILL.md",
-          sha256: "review",
-        },
-        {
-          path: ".patchmill/skills/subagent-driven-development/README.md",
-          sha256: "docs",
-        },
-      ],
-    }),
-  );
-
-  assert.deepEqual(
-    skillInvocationPaths(
-      [".patchmill/skills/subagent-driven-development"],
-      repoRoot,
-    ),
-    [
-      join(
-        repoRoot,
-        ".patchmill",
-        "skills",
-        "subagent-driven-development",
-        "SKILL.md",
-      ),
-      join(
-        repoRoot,
-        ".patchmill",
-        "skills",
-        "requesting-code-review",
-        "SKILL.md",
-      ),
-    ],
-  );
-});
-
-test("skillInvocationPaths rejects metadata skill paths outside project-local skills", async () => {
-  const repoRoot = await mkdtemp(
-    join(tmpdir(), "patchmill-skills-metadata-traversal-"),
-  );
-  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
-  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
-    recursive: true,
-  });
-  await mkdir(join(projectSkillsRoot, "requesting-code-review"), {
-    recursive: true,
-  });
-  await writeFile(
-    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
-    "# implementation\n",
-  );
-  await writeFile(
-    join(projectSkillsRoot, "requesting-code-review", "SKILL.md"),
-    "# review\n",
-  );
-  await writeFile(
-    join(projectSkillsRoot, "patchmill-skill-pack.json"),
-    JSON.stringify({
-      files: [
-        {
-          path: ".patchmill/skills/../other/SKILL.md",
-          sha256: "escaped",
-        },
-      ],
-    }),
-  );
-
-  assert.deepEqual(
-    skillInvocationPaths(
-      [".patchmill/skills/subagent-driven-development"],
-      repoRoot,
-    ),
-    [
-      join(
-        repoRoot,
-        ".patchmill",
-        "skills",
-        "subagent-driven-development",
-        "SKILL.md",
-      ),
-    ],
-  );
-});
-
-test("skillInvocationPaths fails fast when project-local metadata is malformed", async () => {
-  const repoRoot = await mkdtemp(
-    join(tmpdir(), "patchmill-skills-malformed-metadata-"),
-  );
-  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
-  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
-    recursive: true,
-  });
-  await mkdir(join(projectSkillsRoot, "test-driven-development"), {
-    recursive: true,
-  });
-  await writeFile(
-    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
-    "# implementation\n",
-  );
-  await writeFile(
-    join(projectSkillsRoot, "test-driven-development", "SKILL.md"),
-    "# tests\n",
-  );
-  await writeFile(join(projectSkillsRoot, "patchmill-skill-pack.json"), "{");
-
-  assert.throws(
-    () =>
-      skillInvocationPaths(
-        [".patchmill/skills/subagent-driven-development"],
-        repoRoot,
-      ),
-    /project-local skill pack metadata malformed/u,
-  );
-});
-
-test("skillInvocationPaths discovers project-local pack skills when metadata is missing", async () => {
-  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-skills-discovery-"));
-  const projectSkillsRoot = join(repoRoot, ".patchmill", "skills");
-  await mkdir(join(projectSkillsRoot, "subagent-driven-development"), {
-    recursive: true,
-  });
-  await mkdir(join(projectSkillsRoot, "test-driven-development"), {
-    recursive: true,
-  });
-  await writeFile(
-    join(projectSkillsRoot, "subagent-driven-development", "SKILL.md"),
-    "# implementation\n",
-  );
-  await writeFile(
-    join(projectSkillsRoot, "test-driven-development", "SKILL.md"),
-    "# tests\n",
-  );
-
-  assert.deepEqual(
-    skillInvocationPaths(
-      [".patchmill/skills/subagent-driven-development"],
-      repoRoot,
-    ),
-    [
-      join(
-        repoRoot,
-        ".patchmill",
-        "skills",
-        "subagent-driven-development",
-        "SKILL.md",
-      ),
-      join(
-        repoRoot,
-        ".patchmill",
-        "skills",
-        "test-driven-development",
-        "SKILL.md",
-      ),
-    ],
-  );
-});
-
-test("bundled triage skill matches dry-run previews and execute mutations", async () => {
-  const skill = await readFile(bundledTriageSkillPath(), "utf8");
-
-  assert.doesNotMatch(skill, /required JSON decision document/);
-  assert.doesNotMatch(skill, /Do not mutate repository-hosting state\./);
-  assert.match(skill, /dry-run\/preview mode[\s\S]*read-only JSON preview/i);
-  assert.match(
-    skill,
-    /execute mode[\s\S]*apply[\s\S]*labels, comments, closures[\s\S]*(host tools|configured workflow)/i,
   );
 });

--- a/src/workflow/skills.ts
+++ b/src/workflow/skills.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { dirname, join, resolve, win32 } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   DEFAULT_PROJECT_SKILL_DIR,
@@ -176,40 +176,100 @@ function pathStartsWith(path: string, prefix: string): boolean {
   );
 }
 
+function isPathInside(parent: string, child: string): boolean {
+  const pathRelative = relative(parent, child);
+  return (
+    pathRelative === "" ||
+    (!pathRelative.startsWith("..") && !isAbsolute(pathRelative))
+  );
+}
+
+function resolveProjectLocalMetadataFilePath(
+  filePath: string,
+  repoRoot: string,
+  projectLocalRoot: string,
+): string | null {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  if (isAbsolute(normalizedPath) || win32.isAbsolute(filePath)) {
+    return null;
+  }
+
+  if (!normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`)) {
+    return null;
+  }
+
+  const resolvedPath = resolve(repoRoot, normalizedPath);
+  return isPathInside(projectLocalRoot, resolvedPath) ? resolvedPath : null;
+}
+
 function projectLocalPackSkillPaths(repoRoot: string): string[] {
   const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
   const metadataSkillPaths = projectLocalMetadataSkillPaths(
     repoRoot,
     projectLocalRoot,
   );
-  return metadataSkillPaths.length > 0
-    ? metadataSkillPaths
-    : discoveredProjectLocalSkillPaths(projectLocalRoot);
+  return (
+    metadataSkillPaths ?? discoveredProjectLocalSkillPaths(projectLocalRoot)
+  );
 }
 
 function projectLocalMetadataSkillPaths(
   repoRoot: string,
   projectLocalRoot: string,
-): string[] {
+): string[] | null {
+  const metadataPath = join(projectLocalRoot, SKILL_PACK_METADATA_FILE);
+
+  let metadataContent: string;
   try {
-    const metadataPath = join(projectLocalRoot, SKILL_PACK_METADATA_FILE);
-    const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
-      files?: Array<{ path?: unknown }>;
-    };
-    if (!Array.isArray(metadata.files)) return [];
-
-    return metadata.files.flatMap((file) => {
-      if (typeof file.path !== "string") return [];
-
-      const normalizedPath = file.path.replaceAll("\\", "/");
-      return normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`) &&
-        normalizedPath.endsWith(`/${SKILL_FILE_NAME}`)
-        ? [resolve(repoRoot, normalizedPath)]
-        : [];
-    });
-  } catch {
-    return [];
+    metadataContent = readFileSync(metadataPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw new Error(
+      `project-local skill pack metadata unreadable: ${metadataPath}`,
+      { cause: error },
+    );
   }
+
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(metadataContent);
+  } catch (error) {
+    throw new Error(
+      `project-local skill pack metadata malformed: ${metadataPath}`,
+      { cause: error },
+    );
+  }
+
+  if (!metadata || typeof metadata !== "object") {
+    throw new Error(
+      `project-local skill pack metadata malformed: ${metadataPath}`,
+    );
+  }
+
+  const files = (metadata as { files?: unknown }).files;
+  if (!Array.isArray(files)) {
+    throw new Error(
+      `project-local skill pack metadata malformed: ${metadataPath}`,
+    );
+  }
+
+  return files.flatMap((file) => {
+    if (!file || typeof file !== "object") return [];
+
+    const filePath = (file as { path?: unknown }).path;
+    if (typeof filePath !== "string") return [];
+
+    if (!isSkillFilePath(filePath)) return [];
+
+    const resolvedPath = resolveProjectLocalMetadataFilePath(
+      filePath,
+      repoRoot,
+      projectLocalRoot,
+    );
+    return resolvedPath ? [resolvedPath] : [];
+  });
 }
 
 function discoveredProjectLocalSkillPaths(projectLocalRoot: string): string[] {

--- a/src/workflow/skills.ts
+++ b/src/workflow/skills.ts
@@ -1,10 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  DEFAULT_PROJECT_SKILL_DIR,
-  SKILL_PACK_METADATA_FILE,
-} from "./skill-pack.ts";
+import { BUNDLED_TRIAGE_SKILL_REFERENCE } from "./skill-resolution.ts";
 
 export type PatchmillSkillsConfig = {
   triage: string;
@@ -30,11 +24,15 @@ export type PatchmillSkillKey = (typeof PATCHMILL_SKILL_KEYS)[number];
 
 export type PartialPatchmillSkillsConfig = Partial<PatchmillSkillsConfig>;
 
-const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
-const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
-const SKILL_FILE_NAME = "SKILL.md";
+export { BUNDLED_TRIAGE_SKILL_REFERENCE };
 
 export const DEFAULT_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
+  triage: BUNDLED_TRIAGE_SKILL_REFERENCE,
+  planning: "superpowers:writing-plans",
+  implementation: "superpowers:subagent-driven-development",
+};
+
+export const GLOBAL_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
   triage: "patchmill-issue-triage",
   planning: "superpowers:writing-plans",
   implementation: "superpowers:subagent-driven-development",
@@ -71,227 +69,15 @@ export function renderConfiguredSkillLine(
   return `${prefix}: \`${skill}\`.`;
 }
 
-export function isNamespaceStyleSkill(skill: string): boolean {
-  return (
-    SKILL_NAMESPACE_PATTERN.test(skill) &&
-    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
-  );
-}
-
-export function isPathLikeSkill(skill: string): boolean {
-  if (
-    skill.startsWith(".") ||
-    skill.startsWith("/") ||
-    WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
-  ) {
-    return true;
-  }
-
-  return /[\\/]/u.test(skill) && !isNamespaceStyleSkill(skill);
-}
-
-function isSkillFilePath(skill: string): boolean {
-  const normalizedPath = skill.replaceAll("\\", "/");
-  return (
-    normalizedPath === SKILL_FILE_NAME ||
-    normalizedPath.endsWith(`/${SKILL_FILE_NAME}`)
-  );
-}
-
-export function resolvePathLikeSkillPath(
-  skill: string,
-  repoRoot: string,
-): string {
-  if (WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)) {
-    return isSkillFilePath(skill)
-      ? win32.normalize(skill)
-      : win32.join(skill, SKILL_FILE_NAME);
-  }
-
-  const normalizedPath = skill.replaceAll("\\", "/");
-  if (isSkillFilePath(normalizedPath)) {
-    return normalizedPath.startsWith("/")
-      ? resolve(normalizedPath)
-      : resolve(repoRoot, normalizedPath);
-  }
-
-  return normalizedPath.startsWith("/")
-    ? resolve(normalizedPath, SKILL_FILE_NAME)
-    : resolve(repoRoot, normalizedPath, SKILL_FILE_NAME);
-}
-
-export function skillInvocationArgs(
-  skill: string | undefined,
-  repoRoot: string,
-): string[] {
-  if (!skill) return [];
-  if (skill === DEFAULT_PATCHMILL_SKILLS.triage) {
-    return ["--skill", bundledTriageSkillPath()];
-  }
-  if (!isPathLikeSkill(skill)) return [];
-
-  return ["--skill", resolvePathLikeSkillPath(skill, repoRoot)];
-}
-
-export function skillInvocationPaths(
-  skills: Array<string | undefined>,
-  repoRoot: string,
-): string[] {
-  const configuredPaths = skills.flatMap((skill) => {
-    const [flag, path] = skillInvocationArgs(skill, repoRoot);
-    return flag === "--skill" && path ? [path] : [];
-  });
-
-  if (
-    !configuredPaths.some((path) =>
-      pathStartsWith(
-        resolve(path),
-        resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR),
-      ),
-    )
-  ) {
-    return configuredPaths;
-  }
-
-  return uniqueSkillPaths([
-    ...configuredPaths,
-    ...projectLocalPackSkillPaths(repoRoot),
-  ]);
-}
-
-function uniqueSkillPaths(paths: string[]): string[] {
-  const seen = new Set<string>();
-  return paths.filter((path) => {
-    if (seen.has(path)) return false;
-    seen.add(path);
-    return true;
-  });
-}
-
-function pathStartsWith(path: string, prefix: string): boolean {
-  return (
-    path === prefix ||
-    path.startsWith(`${prefix}/`) ||
-    path.startsWith(`${prefix}\\`)
-  );
-}
-
-function isPathInside(parent: string, child: string): boolean {
-  const pathRelative = relative(parent, child);
-  return (
-    pathRelative === "" ||
-    (!pathRelative.startsWith("..") && !isAbsolute(pathRelative))
-  );
-}
-
-function resolveProjectLocalMetadataFilePath(
-  filePath: string,
-  repoRoot: string,
-  projectLocalRoot: string,
-): string | null {
-  const normalizedPath = filePath.replaceAll("\\", "/");
-  if (isAbsolute(normalizedPath) || win32.isAbsolute(filePath)) {
-    return null;
-  }
-
-  if (!normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`)) {
-    return null;
-  }
-
-  const resolvedPath = resolve(repoRoot, normalizedPath);
-  return isPathInside(projectLocalRoot, resolvedPath) ? resolvedPath : null;
-}
-
-function projectLocalPackSkillPaths(repoRoot: string): string[] {
-  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
-  const metadataSkillPaths = projectLocalMetadataSkillPaths(
-    repoRoot,
-    projectLocalRoot,
-  );
-  return (
-    metadataSkillPaths ?? discoveredProjectLocalSkillPaths(projectLocalRoot)
-  );
-}
-
-function projectLocalMetadataSkillPaths(
-  repoRoot: string,
-  projectLocalRoot: string,
-): string[] | null {
-  const metadataPath = join(projectLocalRoot, SKILL_PACK_METADATA_FILE);
-
-  let metadataContent: string;
-  try {
-    metadataContent = readFileSync(metadataPath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw new Error(
-      `project-local skill pack metadata unreadable: ${metadataPath}`,
-      { cause: error },
-    );
-  }
-
-  let metadata: unknown;
-  try {
-    metadata = JSON.parse(metadataContent);
-  } catch (error) {
-    throw new Error(
-      `project-local skill pack metadata malformed: ${metadataPath}`,
-      { cause: error },
-    );
-  }
-
-  if (!metadata || typeof metadata !== "object") {
-    throw new Error(
-      `project-local skill pack metadata malformed: ${metadataPath}`,
-    );
-  }
-
-  const files = (metadata as { files?: unknown }).files;
-  if (!Array.isArray(files)) {
-    throw new Error(
-      `project-local skill pack metadata malformed: ${metadataPath}`,
-    );
-  }
-
-  return files.flatMap((file) => {
-    if (!file || typeof file !== "object") return [];
-
-    const filePath = (file as { path?: unknown }).path;
-    if (typeof filePath !== "string") return [];
-
-    if (!isSkillFilePath(filePath)) return [];
-
-    const resolvedPath = resolveProjectLocalMetadataFilePath(
-      filePath,
-      repoRoot,
-      projectLocalRoot,
-    );
-    return resolvedPath ? [resolvedPath] : [];
-  });
-}
-
-function discoveredProjectLocalSkillPaths(projectLocalRoot: string): string[] {
-  try {
-    const entries = readdirSync(projectLocalRoot, { withFileTypes: true });
-    entries.sort((a, b) => a.name.localeCompare(b.name));
-
-    return entries.flatMap((entry) => {
-      const entryPath = join(projectLocalRoot, entry.name);
-      if (entry.isDirectory()) {
-        return discoveredProjectLocalSkillPaths(entryPath);
-      }
-      return entry.isFile() && entry.name === SKILL_FILE_NAME
-        ? [entryPath]
-        : [];
-    });
-  } catch {
-    return [];
-  }
-}
-
-export function bundledTriageSkillPath(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  return join(here, "..", "..", "skills", "patchmill-issue-triage", "SKILL.md");
-}
+export {
+  bundledTriageSkillPath,
+  isNamespaceStyleSkill,
+  isPathLikeSkill,
+  resolveConfiguredSkillInvocation,
+  resolvePathLikeSkillPath,
+  skillInvocationArgs,
+  skillInvocationPaths,
+  type SkillInvocationResolution,
+  type SkillResolutionDiagnostic,
+  type SkillResolutionStatus,
+} from "./skill-resolution.ts";

--- a/src/workflow/skills.ts
+++ b/src/workflow/skills.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export type PatchmillSkillsConfig = {
@@ -24,6 +24,10 @@ export const PATCHMILL_SKILL_KEYS = [
 export type PatchmillSkillKey = (typeof PATCHMILL_SKILL_KEYS)[number];
 
 export type PartialPatchmillSkillsConfig = Partial<PatchmillSkillsConfig>;
+
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
+const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
+const SKILL_FILE_NAME = "SKILL.md";
 
 export const DEFAULT_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
   triage: "patchmill-issue-triage",
@@ -60,6 +64,78 @@ export function renderConfiguredSkillLine(
 ): string {
   if (!skill) return "";
   return `${prefix}: \`${skill}\`.`;
+}
+
+export function isNamespaceStyleSkill(skill: string): boolean {
+  return (
+    SKILL_NAMESPACE_PATTERN.test(skill) &&
+    !WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  );
+}
+
+export function isPathLikeSkill(skill: string): boolean {
+  if (
+    skill.startsWith(".") ||
+    skill.startsWith("/") ||
+    WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)
+  ) {
+    return true;
+  }
+
+  return /[\\/]/u.test(skill) && !isNamespaceStyleSkill(skill);
+}
+
+function isSkillFilePath(skill: string): boolean {
+  const normalizedPath = skill.replaceAll("\\", "/");
+  return (
+    normalizedPath === SKILL_FILE_NAME ||
+    normalizedPath.endsWith(`/${SKILL_FILE_NAME}`)
+  );
+}
+
+export function resolvePathLikeSkillPath(
+  skill: string,
+  repoRoot: string,
+): string {
+  if (WINDOWS_ABSOLUTE_PATH_PATTERN.test(skill)) {
+    return isSkillFilePath(skill)
+      ? win32.normalize(skill)
+      : win32.join(skill, SKILL_FILE_NAME);
+  }
+
+  const normalizedPath = skill.replaceAll("\\", "/");
+  if (isSkillFilePath(normalizedPath)) {
+    return normalizedPath.startsWith("/")
+      ? resolve(normalizedPath)
+      : resolve(repoRoot, normalizedPath);
+  }
+
+  return normalizedPath.startsWith("/")
+    ? resolve(normalizedPath, SKILL_FILE_NAME)
+    : resolve(repoRoot, normalizedPath, SKILL_FILE_NAME);
+}
+
+export function skillInvocationArgs(
+  skill: string | undefined,
+  repoRoot: string,
+): string[] {
+  if (!skill) return [];
+  if (skill === DEFAULT_PATCHMILL_SKILLS.triage) {
+    return ["--skill", bundledTriageSkillPath()];
+  }
+  if (!isPathLikeSkill(skill)) return [];
+
+  return ["--skill", resolvePathLikeSkillPath(skill, repoRoot)];
+}
+
+export function skillInvocationPaths(
+  skills: Array<string | undefined>,
+  repoRoot: string,
+): string[] {
+  return skills.flatMap((skill) => {
+    const [flag, path] = skillInvocationArgs(skill, repoRoot);
+    return flag === "--skill" && path ? [path] : [];
+  });
 }
 
 export function bundledTriageSkillPath(): string {

--- a/src/workflow/skills.ts
+++ b/src/workflow/skills.ts
@@ -1,5 +1,10 @@
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  SKILL_PACK_METADATA_FILE,
+} from "./skill-pack.ts";
 
 export type PatchmillSkillsConfig = {
   triage: string;
@@ -132,10 +137,98 @@ export function skillInvocationPaths(
   skills: Array<string | undefined>,
   repoRoot: string,
 ): string[] {
-  return skills.flatMap((skill) => {
+  const configuredPaths = skills.flatMap((skill) => {
     const [flag, path] = skillInvocationArgs(skill, repoRoot);
     return flag === "--skill" && path ? [path] : [];
   });
+
+  if (
+    !configuredPaths.some((path) =>
+      pathStartsWith(
+        resolve(path),
+        resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR),
+      ),
+    )
+  ) {
+    return configuredPaths;
+  }
+
+  return uniqueSkillPaths([
+    ...configuredPaths,
+    ...projectLocalPackSkillPaths(repoRoot),
+  ]);
+}
+
+function uniqueSkillPaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    if (seen.has(path)) return false;
+    seen.add(path);
+    return true;
+  });
+}
+
+function pathStartsWith(path: string, prefix: string): boolean {
+  return (
+    path === prefix ||
+    path.startsWith(`${prefix}/`) ||
+    path.startsWith(`${prefix}\\`)
+  );
+}
+
+function projectLocalPackSkillPaths(repoRoot: string): string[] {
+  const projectLocalRoot = resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR);
+  const metadataSkillPaths = projectLocalMetadataSkillPaths(
+    repoRoot,
+    projectLocalRoot,
+  );
+  return metadataSkillPaths.length > 0
+    ? metadataSkillPaths
+    : discoveredProjectLocalSkillPaths(projectLocalRoot);
+}
+
+function projectLocalMetadataSkillPaths(
+  repoRoot: string,
+  projectLocalRoot: string,
+): string[] {
+  try {
+    const metadataPath = join(projectLocalRoot, SKILL_PACK_METADATA_FILE);
+    const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+      files?: Array<{ path?: unknown }>;
+    };
+    if (!Array.isArray(metadata.files)) return [];
+
+    return metadata.files.flatMap((file) => {
+      if (typeof file.path !== "string") return [];
+
+      const normalizedPath = file.path.replaceAll("\\", "/");
+      return normalizedPath.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`) &&
+        normalizedPath.endsWith(`/${SKILL_FILE_NAME}`)
+        ? [resolve(repoRoot, normalizedPath)]
+        : [];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function discoveredProjectLocalSkillPaths(projectLocalRoot: string): string[] {
+  try {
+    const entries = readdirSync(projectLocalRoot, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    return entries.flatMap((entry) => {
+      const entryPath = join(projectLocalRoot, entry.name);
+      if (entry.isDirectory()) {
+        return discoveredProjectLocalSkillPaths(entryPath);
+      }
+      return entry.isFile() && entry.name === SKILL_FILE_NAME
+        ? [entryPath]
+        : [];
+    });
+  } catch {
+    return [];
+  }
 }
 
 export function bundledTriageSkillPath(): string {


### PR DESCRIPTION
## Summary
- Make `patchmill init` install the recommended skill pack into `.patchmill/skills/` by default and write project-local skill mappings.
- Pin `superpowers` from the GitHub v5.0.7 release tarball and include bundled Patchmill skills in package output.
- Pass project-local skill files to Pi invocations and extend `doctor` validation for local skill metadata, git-ignore status, and Pi loading.

## Test Plan
- [x] `npm test` (502/502 pass)
- [x] `npm run lint`
- [x] `npm pack --dry-run --json` includes `skills/patchmill-issue-triage/SKILL.md`
- [x] Smoke `patchmill init --skills project` in a temporary git repo