### PR TITLE
Run triage by default without flags

### DIFF
--- a/docs/plans/2026-06-01-triage-bare-command.md
+++ b/docs/plans/2026-06-01-triage-bare-command.md
@@ -1,0 +1,100 @@
+# Bare `patchmill triage` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `patchmill triage` execute the safe default triage run and
+reserve help display for `--help`/`-h`.
+
+**Architecture:** The command already separates argument parsing, CLI entrypoint
+behavior, and triage issue selection. This change only updates the argument/help
+defaults and tests; the existing safe issue selector remains unchanged.
+
+**Tech Stack:** TypeScript, Node test runner, Patchmill CLI command modules.
+
+---
+
+## Files
+
+- Modify: `src/cli/commands/triage/args.test.ts` to assert empty args execute by
+  default.
+- Modify: `src/cli/commands/triage/pipeline.test.ts` to assert updated help
+  text.
+- Modify: `src/cli/commands/triage/main.ts` to update help-only handling and
+  help copy.
+- Modify: `src/cli/commands/triage/args.ts` to stop treating empty args as help.
+
+## Task 1: Empty args execute by default
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/cli/commands/triage/args.test.ts`, change the empty-args test to expect
+`showHelp` false while keeping execution enabled.
+
+```ts
+test("parseArgs executes safe default triage when no args are provided", () => {
+  const config = parseArgs([], "/repo");
+
+  assert.equal(config.showHelp, false);
+  assert.equal(config.dryRun, false);
+  assert.equal(config.execute, true);
+  assert.equal(config.repoRoot, "/repo");
+  assert.equal(config.issueNumber, undefined);
+  assert.equal(config.limit, undefined);
+  assert.equal(config.teaLogin, "triage-agent");
+  assert.equal(config.triageThinking, "high");
+  assert.equal(config.logDir, "/repo/.patchmill/triage-runs");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test src/cli/commands/triage/args.test.ts` Expected: FAIL because
+`config.showHelp` is still `true` for empty args.
+
+- [ ] **Step 3: Update production code**
+
+In `src/cli/commands/triage/args.ts`, initialize `showHelp` to `false` instead
+of `args.length === 0`.
+
+In `src/cli/commands/triage/main.ts`, update `isHelpOnlyInvocation` so it
+returns true only for `--help` or `-h`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test src/cli/commands/triage/args.test.ts` Expected: PASS.
+
+## Task 2: Help copy documents the new default
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/cli/commands/triage/pipeline.test.ts`, update the help text test to
+match copy that says bare `patchmill triage` runs the configured triage skill
+for eligible untriaged open issues.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test src/cli/commands/triage/pipeline.test.ts` Expected: FAIL
+because the current help text still says no-arg invocations show help.
+
+- [ ] **Step 3: Update help text**
+
+In `src/cli/commands/triage/main.ts`, replace the no-arg help sentence with
+explicit default-run wording and clarify `--all` as an include/re-triage option.
+
+- [ ] **Step 4: Run focused triage tests**
+
+Run: `npm run test:triage` Expected: PASS.
+
+## Task 3: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test` Expected: PASS.
+
+- [ ] **Step 2: Check working tree**
+
+Run: `git status --short` Expected: only the intended docs and triage
+command/test files are modified.

--- a/docs/specs/2026-06-01-triage-bare-command-design.md
+++ b/docs/specs/2026-06-01-triage-bare-command-design.md
@@ -1,0 +1,43 @@
+# Bare `patchmill triage` Command Design
+
+## Goal
+
+Make `patchmill triage` perform a real first-time triage run, while moving help
+display exclusively to `patchmill triage --help` and `patchmill triage -h`.
+
+## Current behavior
+
+- `patchmill triage` shows help because empty args are treated as help-only.
+- `patchmill triage --dry-run` previews the default triage selection.
+- The default triage selection already skips open issues with active
+  triage/protection labels.
+- `--all` includes issues that already have triage/protection labels such as
+  `in-progress`, `needs-info`, or `blocked`.
+
+## Desired behavior
+
+- `patchmill triage` executes the configured triage skill against all eligible
+  open issues that do not have active triage/protection labels.
+- `patchmill triage --dry-run` previews the same eligible issue set without
+  mutating the issue host.
+- `patchmill triage --help` and `patchmill triage -h` show help.
+- `--all` keeps its existing recovery/re-triage semantics and includes issues
+  that would normally be skipped.
+
+## CLI copy
+
+The help text should explain the default behavior directly:
+
+- Bare `patchmill triage` runs triage for eligible untriaged open issues.
+- `--dry-run` previews that run.
+- `--all` includes already-triaged/protected issues and should be described as a
+  re-triage/recovery option.
+
+## Implementation notes
+
+- Change argument parsing so an empty arg list does not set `showHelp`.
+- Change the main command help-only check so only `--help` and `-h` skip config
+  loading and execution.
+- Update tests for empty-arg parsing, help text, and CLI config loading.
+- Keep issue selection logic unchanged because it already implements the desired
+  safe default.

--- a/src/cli/commands/triage/args.test.ts
+++ b/src/cli/commands/triage/args.test.ts
@@ -12,10 +12,10 @@ import {
 import { HELP_TEXT, loadCliConfig } from "./main.ts";
 import { parseArgs } from "./args.ts";
 
-test("parseArgs shows help when no args are provided", () => {
+test("parseArgs executes safe default triage when no args are provided", () => {
   const config = parseArgs([], "/repo");
 
-  assert.equal(config.showHelp, true);
+  assert.equal(config.showHelp, false);
   assert.equal(config.dryRun, false);
   assert.equal(config.execute, true);
   assert.equal(config.repoRoot, "/repo");
@@ -276,7 +276,7 @@ test("loadCliConfig lets triage login flags override patchmill config", async ()
   assert.equal(teaLogin.teaLogin, "tea-bot");
 });
 
-test("loadCliConfig shows help without reading malformed patchmill config", async () => {
+test("loadCliConfig shows help without reading malformed patchmill config for help flags", async () => {
   const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-triage-config-"));
   await writeFile(
     join(repoRoot, "patchmill.config.json"),
@@ -284,11 +284,9 @@ test("loadCliConfig shows help without reading malformed patchmill config", asyn
     "utf8",
   );
 
-  const noArgs = await loadCliConfig([], repoRoot, {});
   const helpLong = await loadCliConfig(["--help"], repoRoot, {});
   const helpShort = await loadCliConfig(["-h"], repoRoot, {});
 
-  assert.equal(noArgs.showHelp, true);
   assert.equal(helpLong.showHelp, true);
   assert.equal(helpShort.showHelp, true);
 });

--- a/src/cli/commands/triage/args.ts
+++ b/src/cli/commands/triage/args.ts
@@ -46,7 +46,7 @@ export function parseArgs(
     dryRun: false,
     execute: true,
     triageThinking: patchmillConfig.pi.triageThinking,
-    showHelp: args.length === 0,
+    showHelp: false,
     host,
     teaLogin: host.login,
     logDir: normalizedConfig

--- a/src/cli/commands/triage/main.ts
+++ b/src/cli/commands/triage/main.ts
@@ -12,15 +12,15 @@ export const HELP_TEXT = `Usage:
   patchmill triage [options]
   npm run triage -- [options]
 
-Automated issue triage. Defaults to showing this help when no options are provided.
-With arguments, patchmill triage executes the configured triage skill by default.
+Automated issue triage. Runs the configured triage skill against eligible untriaged open issues by default.
 By default, only open issues without active triage or protection labels are selected.
+Use --dry-run to preview decisions before mutating the configured issue host.
 
 Options:
   --help, -h          Show this help and exit.
   --dry-run, --dryrun Preview configured triage skill decisions without mutating the configured issue host.
   --issue <number>    Triage one open issue by number.
-  --all               Re-triage all selected open issues, including issues already carrying triage or protection labels such as in-progress or blocked.
+  --all               Re-triage selected open issues and include issues already carrying triage or protection labels such as in-progress or blocked.
   --limit <number>    Triage only the first N selected open issues.
   --log-dir <path>    Write triage logs to a custom directory.
   --host-login <name> Use a named host login when the provider supports named logins.
@@ -33,7 +33,7 @@ Environment:
 type Env = Record<string, string | undefined>;
 
 function isHelpOnlyInvocation(args: string[]): boolean {
-  return args.length === 0 || args.includes("--help") || args.includes("-h");
+  return args.includes("--help") || args.includes("-h");
 }
 
 function formatLabels(labels: string[]): string {

--- a/src/cli/commands/triage/pipeline.test.ts
+++ b/src/cli/commands/triage/pipeline.test.ts
@@ -218,7 +218,11 @@ test("HELP_TEXT documents usage and active triage protection wording", () => {
   assert.doesNotMatch(HELP_TEXT, /--execute/);
   assert.match(HELP_TEXT, /Automated issue triage/);
   assert.doesNotMatch(HELP_TEXT, /Automated Forgejo issue triage/);
-  assert.match(HELP_TEXT, /executes the configured triage skill by default/);
+  assert.match(
+    HELP_TEXT,
+    /Runs the configured triage skill against eligible untriaged open issues by default/,
+  );
+  assert.doesNotMatch(HELP_TEXT, /Defaults to showing this help/);
   assert.match(
     HELP_TEXT,
     /Preview configured triage skill decisions without mutating the configured issue host/,
@@ -230,7 +234,7 @@ test("HELP_TEXT documents usage and active triage protection wording", () => {
   assert.match(HELP_TEXT, /without active triage or protection labels/);
   assert.match(
     HELP_TEXT,
-    /including issues already carrying triage or protection labels such as in-progress or blocked/,
+    /include issues already carrying triage or protection labels such as in-progress or blocked/,
   );
 });
 


### PR DESCRIPTION
## Summary
- Make bare `patchmill triage` execute the safe default triage selection instead of showing help
- Keep `--help`/`-h` as help-only paths and clarify `--all` re-triage wording
- Add design and implementation plan docs for the CLI behavior change

## Test Plan
- [x] npm test
- [x] npm run lint