### PR TITLE
fix(init): add Patchmill-owned Pi auth setup

### DIFF
--- a/docs/plans/2026-06-03-patchmill-owned-pi-auth-selector.md
+++ b/docs/plans/2026-06-03-patchmill-owned-pi-auth-selector.md
@@ -1,0 +1,113 @@
+# Patchmill-Owned Pi Auth Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the production `patchmill init` provider-auth selector so
+interactive init configures repo-local Pi auth, refreshes models, selects a
+model, and smoke-tests it.
+
+**Architecture:** Keep `main.ts` as a coordinator and move provider auth into
+focused init modules. Split pure provider-list state from TUI selectors and auth
+execution so tests can cover behavior without terminal I/O. Use Pi's public
+`AuthStorage` and `ModelRegistry` APIs against `.patchmill/pi-agent/auth.json`
+and `.patchmill/pi-agent/models.json`.
+
+**Tech Stack:** TypeScript, Node test runner, `@earendil-works/pi-coding-agent`
+AuthStorage/ModelRegistry, `@earendil-works/pi-tui` TUI primitives.
+
+---
+
+## File Structure
+
+- Create `src/cli/commands/init/pi-auth-provider-state.ts`: pure
+  auth-mode/provider-choice construction, filtering, visible-window, and status
+  label helpers.
+- Create `src/cli/commands/init/pi-auth-selector.ts`: auth-method and provider
+  selector TUI runners.
+- Create `src/cli/commands/init/pi-auth-dialog.ts`: API-key prompt, Bedrock
+  info, and OAuth callback dialogs.
+- Create `src/cli/commands/init/pi-auth-flow.ts`: repo-local
+  AuthStorage/ModelRegistry orchestration and `setupPiInteractively`
+  implementation.
+- Modify `src/cli/commands/init/pi-init-setup.ts`: delegate its default
+  `setupPiInteractively` to `pi-auth-flow.ts`.
+- Add focused tests beside each new module and extend
+  `pi-init-setup.test.ts`/`pi-init-flow.test.ts` for the production path.
+
+## Tasks
+
+### Task 1: Provider State
+
+**Files:**
+
+- Create: `src/cli/commands/init/pi-auth-provider-state.ts`
+- Test: `src/cli/commands/init/pi-auth-provider-state.test.ts`
+
+- [ ] Write failing tests for auth method labels, subscription provider choices,
+      API-key provider choices, cross-mode configured labels, search, and
+      eight-row visible window.
+- [ ] Run `node --test src/cli/commands/init/pi-auth-provider-state.test.ts` and
+      verify failures mention missing exports.
+- [ ] Implement pure state helpers with narrow interfaces for auth storage and
+      registry.
+- [ ] Run the focused test until it passes.
+
+### Task 2: Auth Flow Core
+
+**Files:**
+
+- Create: `src/cli/commands/init/pi-auth-flow.ts`
+- Modify: `src/cli/commands/init/pi-init-setup.ts`
+- Test: `src/cli/commands/init/pi-auth-flow.test.ts`
+- Test: `src/cli/commands/init/pi-init-setup.test.ts`
+
+- [ ] Write failing tests proving API-key setup stores
+      `{ type: "api_key", key }`, OAuth setup calls `authStorage.login`, Bedrock
+      stores no key, registry refresh happens after setup, no models returns
+      `not-ready`, and model selection receives refreshed models.
+- [ ] Run focused tests and verify failures are behavioral, not syntax errors.
+- [ ] Implement auth orchestration with injected prompt/selector functions for
+      tests and production defaults for real init.
+- [ ] Wire `pi-init-setup.ts` default `setupPiInteractively` to the real flow.
+- [ ] Run focused tests until green.
+
+### Task 3: TUI Selectors and Dialogs
+
+**Files:**
+
+- Create: `src/cli/commands/init/pi-auth-selector.ts`
+- Create: `src/cli/commands/init/pi-auth-dialog.ts`
+- Test: `src/cli/commands/init/pi-auth-selector.test.ts`
+- Test: `src/cli/commands/init/pi-auth-dialog.test.ts`
+
+- [ ] Write failing tests around component behavior using rendered rows and fake
+      terminal input where practical.
+- [ ] Implement auth method selector, searchable provider selector, API-key
+      prompt, Bedrock info panel, and OAuth callback dialogs with cancellation.
+- [ ] Run focused tests until green.
+
+### Task 4: Init Integration
+
+**Files:**
+
+- Modify: `src/cli/commands/init/pi-init-flow.test.ts`
+- Modify: `src/cli/commands/init/main.ts` only if dependency injection requires
+  it.
+
+- [ ] Add a failing integration test proving interactive init with missing
+      readiness uses the production `setupPiInteractively` path rather than
+      returning the stub.
+- [ ] Implement any final wiring required.
+- [ ] Run
+      `node --test src/cli/commands/init/pi-auth-provider-state.test.ts src/cli/commands/init/pi-auth-flow.test.ts src/cli/commands/init/pi-auth-selector.test.ts src/cli/commands/init/pi-auth-dialog.test.ts src/cli/commands/init/pi-init-setup.test.ts src/cli/commands/init/pi-init-flow.test.ts`.
+
+### Task 5: Verification
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run lint:ts`.
+- [ ] Run `npm run build`.
+- [ ] Confirm `patchmill init` no longer prints only the incomplete guidance in
+      an interactive missing-readiness flow; it opens auth selection first.

--- a/src/cli/commands/init/pi-auth-dialog.test.ts
+++ b/src/cli/commands/init/pi-auth-dialog.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Terminal } from "@earendil-works/pi-tui";
+import {
+  createOAuthCallbacks,
+  promptApiKeyInteractively,
+  showBedrockInfoInteractively,
+} from "./pi-auth-dialog.ts";
+
+class FakeTerminal implements Terminal {
+  private onInput: ((data: string) => void) | undefined;
+  writes: string[] = [];
+  stopCalls = 0;
+  drainCalls = 0;
+
+  start(onInput: (data: string) => void, _onResize: () => void): void {
+    this.onInput = onInput;
+  }
+  stop(): void {
+    this.stopCalls += 1;
+  }
+  async drainInput(): Promise<void> {
+    this.drainCalls += 1;
+  }
+  write(data: string): void {
+    this.writes.push(data);
+  }
+  get columns(): number {
+    return 80;
+  }
+  get rows(): number {
+    return 24;
+  }
+  get kittyProtocolActive(): boolean {
+    return false;
+  }
+  moveBy(_lines: number): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(_title: string): void {}
+  setProgress(_active: boolean): void {}
+  sendInput(data: string): void {
+    this.onInput?.(data);
+  }
+}
+
+test("promptApiKeyInteractively keeps prompting after empty input", async () => {
+  const terminal = new FakeTerminal();
+  const prompt = promptApiKeyInteractively({
+    providerName: "Anthropic",
+    terminal,
+  });
+
+  terminal.sendInput("\n");
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(terminal.stopCalls, 0);
+  assert.match(terminal.writes.join(""), /API key cannot be empty/);
+
+  for (const char of "sk-test") terminal.sendInput(char);
+  terminal.sendInput("\n");
+
+  assert.equal(await prompt, "sk-test");
+  assert.equal(terminal.stopCalls, 1);
+});
+
+test("promptApiKeyInteractively cancels on escape", async () => {
+  const terminal = new FakeTerminal();
+  const prompt = promptApiKeyInteractively({
+    providerName: "Anthropic",
+    terminal,
+  });
+
+  terminal.sendInput("\u001b");
+
+  assert.equal(await prompt, undefined);
+});
+
+test("showBedrockInfoInteractively resolves when escape closes the panel", async () => {
+  const terminal = new FakeTerminal();
+  const panel = showBedrockInfoInteractively({ terminal });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.match(terminal.writes.join(""), /Amazon Bedrock setup/);
+
+  terminal.sendInput("\u001b");
+  await panel;
+
+  assert.equal(terminal.stopCalls, 1);
+});
+
+test("createOAuthCallbacks prompts for provider text input", async () => {
+  const terminal = new FakeTerminal();
+  const callbacks = createOAuthCallbacks({ terminal });
+  const answer = callbacks.onPrompt({ message: "GitHub Enterprise domain:" });
+
+  for (const char of "github.example.com") terminal.sendInput(char);
+  terminal.sendInput("\n");
+
+  assert.equal(await answer, "github.example.com");
+});
+
+test("createOAuthCallbacks selects OAuth prompt options", async () => {
+  const terminal = new FakeTerminal();
+  const callbacks = createOAuthCallbacks({ terminal });
+  const answer = callbacks.onSelect({
+    message: "Choose account:",
+    options: [
+      { id: "first", label: "First" },
+      { id: "second", label: "Second" },
+    ],
+  });
+
+  terminal.sendInput("\u001b[B");
+  terminal.sendInput("\n");
+
+  assert.equal(await answer, "second");
+});

--- a/src/cli/commands/init/pi-auth-dialog.test.ts
+++ b/src/cli/commands/init/pi-auth-dialog.test.ts
@@ -91,6 +91,31 @@ test("showBedrockInfoInteractively resolves when escape closes the panel", async
   assert.equal(terminal.stopCalls, 1);
 });
 
+test("createOAuthCallbacks opens browser URLs for auth callbacks", () => {
+  const terminal = new FakeTerminal();
+  const opened: string[] = [];
+  const callbacks = createOAuthCallbacks({
+    terminal,
+    openUrl: (url) => opened.push(url),
+  });
+
+  callbacks.onAuth({
+    url: "https://login.example.test/oauth",
+    instructions: "Complete login.",
+  });
+  callbacks.onDeviceCode({
+    verificationUri: "https://device.example.test",
+    userCode: "ABCD-EFGH",
+  });
+
+  assert.deepEqual(opened, [
+    "https://login.example.test/oauth",
+    "https://device.example.test",
+  ]);
+  assert.match(terminal.writes.join(""), /Complete login/);
+  assert.match(terminal.writes.join(""), /ABCD-EFGH/);
+});
+
 test("createOAuthCallbacks prompts for provider text input", async () => {
   const terminal = new FakeTerminal();
   const callbacks = createOAuthCallbacks({ terminal });
@@ -117,4 +142,16 @@ test("createOAuthCallbacks selects OAuth prompt options", async () => {
   terminal.sendInput("\n");
 
   assert.equal(await answer, "second");
+});
+
+test("createOAuthCallbacks dispose closes pending manual code input", async () => {
+  const terminal = new FakeTerminal();
+  const callbacks = createOAuthCallbacks({ terminal });
+  const manualInput = callbacks.onManualCodeInput?.();
+
+  await new Promise((resolve) => setImmediate(resolve));
+  callbacks.dispose?.();
+
+  assert.equal(await manualInput, "");
+  assert.equal(terminal.stopCalls, 1);
 });

--- a/src/cli/commands/init/pi-auth-dialog.ts
+++ b/src/cli/commands/init/pi-auth-dialog.ts
@@ -1,3 +1,4 @@
+import { exec } from "node:child_process";
 import {
   Container,
   Input,
@@ -143,6 +144,7 @@ async function promptText(options: {
   prompt: string;
   allowEmpty?: boolean;
   terminal?: Terminal;
+  signal?: AbortSignal;
 }): Promise<string | undefined> {
   const terminal = options.terminal ?? new ProcessTerminal();
   const tui = new TUI(terminal, true);
@@ -152,8 +154,11 @@ async function promptText(options: {
     const finish = (value: string | undefined): void => {
       if (finished) return;
       finished = true;
+      options.signal?.removeEventListener("abort", abortPrompt);
       void stopTui(tui, terminal).finally(() => resolve(value));
     };
+    const abortPrompt = (): void => finish(undefined);
+    options.signal?.addEventListener("abort", abortPrompt, { once: true });
 
     const component = new PromptComponent(
       options.title,
@@ -244,38 +249,76 @@ async function selectOption(options: {
   });
 }
 
+export type OpenUrl = (url: string) => void;
+
+function defaultOpenUrl(url: string): void {
+  const openCmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  try {
+    exec(`${openCmd} "${url}"`, () => undefined);
+  } catch {
+    // Ignore browser launch failures. The URL remains visible.
+  }
+}
+
 export function createOAuthCallbacks(
   options: {
     terminal?: Terminal;
+    openUrl?: OpenUrl;
   } = {},
 ): OAuthLoginCallbacksLike {
   const terminal = options.terminal ?? new ProcessTerminal();
+  const openUrl = options.openUrl ?? defaultOpenUrl;
+  const abortController = new AbortController();
+  let disposed = false;
   return {
+    signal: abortController.signal,
+    dispose: () => {
+      disposed = true;
+      abortController.abort();
+    },
     onAuth: (info) => {
       terminal.write(`\nOpen this URL to authenticate:\n${info.url}\n`);
       if (info.instructions) terminal.write(`${info.instructions}\n`);
+      openUrl(info.url);
     },
     onDeviceCode: (info) => {
       terminal.write(
         `\nOpen ${info.verificationUri} and enter code ${info.userCode}.\n`,
       );
+      openUrl(info.verificationUri);
     },
     onProgress: (message) => {
       terminal.write(`${message}\n`);
     },
-    onPrompt: (prompt) =>
-      promptText({
+    onPrompt: async (prompt) => {
+      const value = await promptText({
         title: prompt.message,
         prompt: prompt.placeholder ?? prompt.message,
         allowEmpty: prompt.allowEmpty,
         terminal,
-      }).then((value) => value ?? ""),
-    onManualCodeInput: () =>
-      promptText({
+        signal: abortController.signal,
+      });
+      if (value === undefined) throw new Error("Login cancelled");
+      return value;
+    },
+    onManualCodeInput: async () => {
+      const value = await promptText({
         title: "Paste redirect URL or code:",
         prompt: "Redirect URL or code:",
         terminal,
-      }).then((value) => value ?? ""),
+        signal: abortController.signal,
+      });
+      if (value === undefined) {
+        if (disposed) return "";
+        throw new Error("Login cancelled");
+      }
+      return value;
+    },
     onSelect: (prompt) =>
       selectOption({
         title: prompt.message,

--- a/src/cli/commands/init/pi-auth-dialog.ts
+++ b/src/cli/commands/init/pi-auth-dialog.ts
@@ -1,0 +1,286 @@
+import {
+  Container,
+  Input,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  Text,
+  TUI,
+  type Focusable,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+import type { OAuthLoginCallbacksLike } from "./pi-auth-flow.ts";
+
+async function stopTui(tui: TUI, terminal: Terminal): Promise<void> {
+  try {
+    tui.stop();
+  } catch {
+    // Best-effort terminal cleanup.
+  }
+  try {
+    await terminal.drainInput();
+  } catch {
+    // Best-effort terminal cleanup.
+  }
+}
+
+class PromptComponent extends Container implements Focusable {
+  private readonly input = new Input();
+  private readonly error = new Text("", 0, 0);
+  private isFocused = false;
+
+  constructor(
+    title: string,
+    prompt: string,
+    allowEmpty: boolean,
+    onSubmit: (value: string) => void,
+    onCancel: () => void,
+  ) {
+    super();
+    this.input.onEscape = onCancel;
+    this.input.onSubmit = (value) => {
+      if (!allowEmpty && value.trim().length === 0) {
+        this.error.setText("API key cannot be empty.");
+        return;
+      }
+      onSubmit(value);
+    };
+
+    this.addChild(new Text(title, 0, 0));
+    this.addChild(new Text("", 0, 0));
+    this.addChild(new Text(prompt, 0, 0));
+    this.addChild(this.input);
+    this.addChild(this.error);
+  }
+
+  get focused(): boolean {
+    return this.isFocused;
+  }
+
+  set focused(value: boolean) {
+    this.isFocused = value;
+    this.input.focused = value;
+  }
+
+  handleInput(data: string): void {
+    this.input.handleInput(data);
+  }
+}
+
+class InfoComponent extends Container {
+  private readonly onClose: () => void;
+
+  constructor(lines: string[], onClose: () => void) {
+    super();
+    this.onClose = onClose;
+    for (const line of lines) this.addChild(new Text(line, 0, 0));
+  }
+
+  handleInput(data: string): void {
+    if (
+      matchesKey(data, Key.escape) ||
+      matchesKey(data, Key.ctrl("c")) ||
+      matchesKey(data, Key.enter)
+    ) {
+      this.onClose();
+    }
+  }
+}
+
+class OptionComponent extends Container {
+  private selectedIndex = 0;
+  private readonly title: string;
+  private readonly options: Array<{ id: string; label: string }>;
+  private readonly onSelect: (id: string) => void;
+  private readonly onCancel: () => void;
+
+  constructor(
+    title: string,
+    options: Array<{ id: string; label: string }>,
+    onSelect: (id: string) => void,
+    onCancel: () => void,
+  ) {
+    super();
+    this.title = title;
+    this.options = options;
+    this.onSelect = onSelect;
+    this.onCancel = onCancel;
+    this.renderRows();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+      const delta = matchesKey(data, Key.up) ? -1 : 1;
+      this.selectedIndex =
+        (this.selectedIndex + delta + this.options.length) %
+        this.options.length;
+      this.renderRows();
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      const option = this.options[this.selectedIndex];
+      if (option) this.onSelect(option.id);
+    }
+  }
+
+  private renderRows(): void {
+    this.clear();
+    this.addChild(new Text(this.title, 0, 0));
+    this.addChild(new Text("", 0, 0));
+    this.options.forEach((option, index) => {
+      const prefix = index === this.selectedIndex ? "→" : " ";
+      this.addChild(new Text(`${prefix} ${option.label}`, 0, 0));
+    });
+  }
+}
+
+async function promptText(options: {
+  title: string;
+  prompt: string;
+  allowEmpty?: boolean;
+  terminal?: Terminal;
+}): Promise<string | undefined> {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  const tui = new TUI(terminal, true);
+
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (value: string | undefined): void => {
+      if (finished) return;
+      finished = true;
+      void stopTui(tui, terminal).finally(() => resolve(value));
+    };
+
+    const component = new PromptComponent(
+      options.title,
+      options.prompt,
+      options.allowEmpty ?? false,
+      (value) => finish(value),
+      () => finish(undefined),
+    );
+    tui.addChild(component);
+    tui.setFocus(component);
+    tui.start();
+    tui.requestRender(true);
+  });
+}
+
+export function promptApiKeyInteractively(options: {
+  providerName: string;
+  terminal?: Terminal;
+}): Promise<string | undefined> {
+  return promptText({
+    title: options.providerName,
+    prompt: "Enter API key:",
+    terminal: options.terminal,
+  });
+}
+
+export async function showBedrockInfoInteractively(
+  options: {
+    terminal?: Terminal;
+  } = {},
+): Promise<void> {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  const tui = new TUI(terminal, false);
+
+  await new Promise<void>((resolve) => {
+    let finished = false;
+    const finish = (): void => {
+      if (finished) return;
+      finished = true;
+      void stopTui(tui, terminal).finally(() => resolve());
+    };
+
+    const component = new InfoComponent(
+      [
+        "Amazon Bedrock setup",
+        "",
+        "Amazon Bedrock uses AWS credentials instead of a single API key.",
+        "Configure an AWS profile, IAM keys, bearer token, or role-based credentials.",
+        "See Pi providers.md for details.",
+        "",
+        "(escape/ctrl+c/enter to close)",
+      ],
+      finish,
+    );
+    tui.addChild(component);
+    tui.setFocus(component);
+    tui.start();
+    tui.requestRender(true);
+  });
+}
+
+async function selectOption(options: {
+  title: string;
+  choices: Array<{ id: string; label: string }>;
+  terminal?: Terminal;
+}): Promise<string | undefined> {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  const tui = new TUI(terminal, false);
+
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (value: string | undefined): void => {
+      if (finished) return;
+      finished = true;
+      void stopTui(tui, terminal).finally(() => resolve(value));
+    };
+
+    const component = new OptionComponent(
+      options.title,
+      options.choices,
+      (id) => finish(id),
+      () => finish(undefined),
+    );
+    tui.addChild(component);
+    tui.setFocus(component);
+    tui.start();
+    tui.requestRender(true);
+  });
+}
+
+export function createOAuthCallbacks(
+  options: {
+    terminal?: Terminal;
+  } = {},
+): OAuthLoginCallbacksLike {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  return {
+    onAuth: (info) => {
+      terminal.write(`\nOpen this URL to authenticate:\n${info.url}\n`);
+      if (info.instructions) terminal.write(`${info.instructions}\n`);
+    },
+    onDeviceCode: (info) => {
+      terminal.write(
+        `\nOpen ${info.verificationUri} and enter code ${info.userCode}.\n`,
+      );
+    },
+    onProgress: (message) => {
+      terminal.write(`${message}\n`);
+    },
+    onPrompt: (prompt) =>
+      promptText({
+        title: prompt.message,
+        prompt: prompt.placeholder ?? prompt.message,
+        allowEmpty: prompt.allowEmpty,
+        terminal,
+      }).then((value) => value ?? ""),
+    onManualCodeInput: () =>
+      promptText({
+        title: "Paste redirect URL or code:",
+        prompt: "Redirect URL or code:",
+        terminal,
+      }).then((value) => value ?? ""),
+    onSelect: (prompt) =>
+      selectOption({
+        title: prompt.message,
+        choices: prompt.options,
+        terminal,
+      }),
+  };
+}

--- a/src/cli/commands/init/pi-auth-flow.test.ts
+++ b/src/cli/commands/init/pi-auth-flow.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  runInteractivePiAuthSetup,
+  type PiAuthFlowRegistry,
+  type PiAuthFlowStorage,
+} from "./pi-auth-flow.ts";
+import type {
+  AuthCredential,
+  AuthStatus,
+} from "@earendil-works/pi-coding-agent";
+import type { PiModelChoice, PiReadiness } from "./pi-preflight.ts";
+
+function missingReadiness(): PiReadiness {
+  return {
+    status: "missing",
+    message: "Pi did not report any provider/model with configured auth.",
+    models: [],
+  };
+}
+
+function model(provider = "anthropic", id = "claude-sonnet-4-5") {
+  return {
+    provider,
+    id,
+    name: id,
+    reasoning: true,
+    input: ["text"],
+  };
+}
+
+function choice(
+  provider = "anthropic",
+  id = "claude-sonnet-4-5",
+): PiModelChoice {
+  return {
+    provider,
+    providerName: provider,
+    id,
+    label: `${provider} / ${id}`,
+    value: `${provider}/${id}`,
+    authSource: "stored",
+    reasoning: true,
+    input: ["text"],
+  };
+}
+
+function fakeStorage(
+  options: {
+    oauthProviders?: Array<{ id: string; name: string }>;
+    credentials?: Record<string, AuthCredential>;
+    statuses?: Record<string, AuthStatus>;
+  } = {},
+) {
+  const credentials = { ...(options.credentials ?? {}) };
+  const setCalls: Array<[string, AuthCredential]> = [];
+  const loginCalls: string[] = [];
+  const storage: PiAuthFlowStorage & {
+    setCalls: Array<[string, AuthCredential]>;
+    loginCalls: string[];
+  } = {
+    setCalls,
+    loginCalls,
+    getOAuthProviders: () => options.oauthProviders ?? [],
+    get: (provider) => credentials[provider],
+    getAuthStatus: (provider) =>
+      options.statuses?.[provider] ?? {
+        configured: Boolean(credentials[provider]),
+        source: credentials[provider] ? "stored" : undefined,
+      },
+    set: (provider, credential) => {
+      credentials[provider] = credential;
+      setCalls.push([provider, credential]);
+    },
+    login: async (provider) => {
+      credentials[provider] = {
+        type: "oauth",
+        refresh: "refresh",
+        access: "access",
+        expires: 1,
+      };
+      loginCalls.push(provider);
+    },
+  };
+  return storage;
+}
+
+function fakeRegistry(
+  options: {
+    allModels?: ReturnType<typeof model>[];
+    availableModels?: ReturnType<typeof model>[];
+    names?: Record<string, string>;
+    statuses?: Record<string, AuthStatus>;
+  } = {},
+) {
+  let refreshed = 0;
+  const registry: PiAuthFlowRegistry & { refreshCount: () => number } = {
+    refreshCount: () => refreshed,
+    refresh: () => {
+      refreshed += 1;
+    },
+    getAll: () => options.allModels ?? [],
+    getAvailable: () => options.availableModels ?? [],
+    getError: () => undefined,
+    getProviderAuthStatus: (provider) =>
+      options.statuses?.[provider] ?? { configured: false },
+    getProviderDisplayName: (provider) => options.names?.[provider] ?? provider,
+  };
+  return registry;
+}
+
+test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and selects a refreshed model", async () => {
+  const storage = fakeStorage();
+  const registry = fakeRegistry({
+    allModels: [model("anthropic")],
+    availableModels: [model("anthropic")],
+    names: { anthropic: "Anthropic" },
+  });
+  let selectorModels: PiModelChoice[] = [];
+
+  const result = await runInteractivePiAuthSetup({
+    repoRoot: "/repo",
+    agentDir: "/repo/.patchmill/pi-agent",
+    currentDefault: undefined,
+    initialReadiness: missingReadiness(),
+    authStorage: storage,
+    registry,
+    selectAuthMethod: async () => "api_key",
+    selectProvider: async ({ choices }) => choices[0],
+    promptApiKey: async () => "sk-ant-test",
+    showBedrockInfo: async () => undefined,
+    selectModelInteractively: async ({ models }) => {
+      selectorModels = models;
+      return choice("anthropic");
+    },
+  });
+
+  assert.deepEqual(storage.setCalls, [
+    ["anthropic", { type: "api_key", key: "sk-ant-test" }],
+  ]);
+  assert.equal(registry.refreshCount(), 1);
+  assert.deepEqual(
+    selectorModels.map((selected) => selected.value),
+    ["anthropic/claude-sonnet-4-5"],
+  );
+  assert.equal(result.selection.status, "selected");
+  assert.equal(
+    result.selection.status === "selected" && result.selection.model,
+    "anthropic/claude-sonnet-4-5",
+  );
+});
+
+test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async () => {
+  const storage = fakeStorage({
+    oauthProviders: [{ id: "openai-codex", name: "ChatGPT Plus/Pro" }],
+  });
+  const registry = fakeRegistry({
+    availableModels: [model("openai-codex", "gpt-5.5")],
+  });
+
+  const result = await runInteractivePiAuthSetup({
+    repoRoot: "/repo",
+    agentDir: "/repo/.patchmill/pi-agent",
+    currentDefault: undefined,
+    initialReadiness: missingReadiness(),
+    authStorage: storage,
+    registry,
+    selectAuthMethod: async () => "oauth",
+    selectProvider: async ({ choices }) => choices[0],
+    promptApiKey: async () => "unused",
+    showBedrockInfo: async () => undefined,
+    selectModelInteractively: async ({ models }) =>
+      choice(models[0]?.provider, models[0]?.id),
+  });
+
+  assert.deepEqual(storage.loginCalls, ["openai-codex"]);
+  assert.equal(registry.refreshCount(), 1);
+  assert.equal(result.selection.status, "selected");
+});
+
+test("runInteractivePiAuthSetup shows Bedrock guidance without storing a key", async () => {
+  const storage = fakeStorage();
+  const registry = fakeRegistry({
+    allModels: [model("amazon-bedrock", "us.anthropic.claude")],
+    availableModels: [],
+    names: { "amazon-bedrock": "Amazon Bedrock" },
+  });
+  let bedrockShown = false;
+
+  const result = await runInteractivePiAuthSetup({
+    repoRoot: "/repo",
+    agentDir: "/repo/.patchmill/pi-agent",
+    currentDefault: undefined,
+    initialReadiness: missingReadiness(),
+    authStorage: storage,
+    registry,
+    selectAuthMethod: async () => "api_key",
+    selectProvider: async ({ choices }) => choices[0],
+    promptApiKey: async () => "unused",
+    showBedrockInfo: async () => {
+      bedrockShown = true;
+    },
+    selectModelInteractively: async () => undefined,
+  });
+
+  assert.equal(bedrockShown, true);
+  assert.deepEqual(storage.setCalls, []);
+  assert.equal(registry.refreshCount(), 1);
+  assert.equal(result.selection.status, "unavailable");
+  assert.equal(
+    result.selection.status === "unavailable" && result.selection.reason,
+    "not-ready",
+  );
+});
+
+test("runInteractivePiAuthSetup treats cancelled auth method as cancelled selection", async () => {
+  const result = await runInteractivePiAuthSetup({
+    repoRoot: "/repo",
+    agentDir: "/repo/.patchmill/pi-agent",
+    currentDefault: undefined,
+    initialReadiness: missingReadiness(),
+    authStorage: fakeStorage(),
+    registry: fakeRegistry(),
+    selectAuthMethod: async () => undefined,
+    selectProvider: async () => undefined,
+    promptApiKey: async () => undefined,
+    showBedrockInfo: async () => undefined,
+    selectModelInteractively: async () => undefined,
+  });
+
+  assert.equal(result.selection.status, "unavailable");
+  assert.equal(
+    result.selection.status === "unavailable" && result.selection.reason,
+    "cancelled",
+  );
+});
+
+test("runInteractivePiAuthSetup rejects an empty API key", async () => {
+  const storage = fakeStorage();
+  const result = await runInteractivePiAuthSetup({
+    repoRoot: "/repo",
+    agentDir: "/repo/.patchmill/pi-agent",
+    currentDefault: undefined,
+    initialReadiness: missingReadiness(),
+    authStorage: storage,
+    registry: fakeRegistry({ allModels: [model("anthropic")] }),
+    selectAuthMethod: async () => "api_key",
+    selectProvider: async ({ choices }) => choices[0],
+    promptApiKey: async () => "   ",
+    showBedrockInfo: async () => undefined,
+    selectModelInteractively: async () => undefined,
+  });
+
+  assert.deepEqual(storage.setCalls, []);
+  assert.equal(result.selection.status, "unavailable");
+  assert.equal(
+    result.selection.status === "unavailable" && result.selection.reason,
+    "invalid-selection",
+  );
+  assert.match(result.selection.message, /API key cannot be empty/);
+});

--- a/src/cli/commands/init/pi-auth-flow.ts
+++ b/src/cli/commands/init/pi-auth-flow.ts
@@ -1,0 +1,227 @@
+import { join } from "node:path";
+import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { AuthCredential } from "@earendil-works/pi-coding-agent";
+import type { LocalPiDefaultModel } from "./pi-agent-settings.ts";
+import {
+  createOAuthCallbacks,
+  promptApiKeyInteractively,
+  showBedrockInfoInteractively,
+} from "./pi-auth-dialog.ts";
+import {
+  createAuthProviderChoices,
+  type AuthMode,
+  type AuthProviderChoice,
+  type AuthRegistryLike,
+  type AuthStorageLike,
+} from "./pi-auth-provider-state.ts";
+import {
+  selectPiModel,
+  type PersistDefaultModel,
+  type PiModelSelection,
+  type SelectInteractiveModel,
+} from "./pi-model-selection.ts";
+import {
+  selectAuthMethodInteractively,
+  selectProviderInteractively,
+} from "./pi-auth-selector.ts";
+import { selectModelInteractively as defaultSelectModelInteractively } from "./pi-model-selector.ts";
+import { detectPiReadiness, type PiReadiness } from "./pi-preflight.ts";
+
+export type OAuthLoginCallbacksLike = {
+  onAuth: (info: { url: string; instructions?: string }) => void;
+  onDeviceCode: (info: {
+    userCode: string;
+    verificationUri: string;
+    intervalSeconds?: number;
+    expiresInSeconds?: number;
+  }) => void;
+  onPrompt: (prompt: {
+    message: string;
+    placeholder?: string;
+    allowEmpty?: boolean;
+  }) => Promise<string>;
+  onProgress?: (message: string) => void;
+  onManualCodeInput?: () => Promise<string>;
+  onSelect: (prompt: {
+    message: string;
+    options: Array<{ id: string; label: string }>;
+  }) => Promise<string | undefined>;
+  signal?: AbortSignal;
+};
+
+export type PiAuthFlowStorage = AuthStorageLike & {
+  set(provider: string, credential: AuthCredential): void;
+  login(provider: string, callbacks: OAuthLoginCallbacksLike): Promise<void>;
+};
+
+export type PiAuthFlowRegistry = AuthRegistryLike & {
+  refresh(): void;
+  getAvailable(): Array<{
+    provider: string;
+    id: string;
+    name?: string;
+    reasoning?: boolean;
+    input?: string[];
+  }>;
+  getError(): string | undefined;
+};
+
+export type SelectAuthMethod = () => Promise<AuthMode | undefined>;
+export type SelectAuthProvider = (options: {
+  mode: AuthMode;
+  choices: AuthProviderChoice[];
+}) => Promise<AuthProviderChoice | undefined>;
+export type PromptApiKey = (
+  provider: AuthProviderChoice,
+) => Promise<string | undefined>;
+export type ShowBedrockInfo = () => Promise<void>;
+export type OAuthCallbacksFactory = (
+  provider: AuthProviderChoice,
+) => OAuthLoginCallbacksLike;
+
+export type InteractivePiAuthSetupOptions = {
+  repoRoot: string;
+  agentDir: string;
+  currentDefault: LocalPiDefaultModel | undefined;
+  initialReadiness: PiReadiness;
+  authStorage: PiAuthFlowStorage;
+  registry: PiAuthFlowRegistry;
+  selectAuthMethod: SelectAuthMethod;
+  selectProvider: SelectAuthProvider;
+  promptApiKey: PromptApiKey;
+  showBedrockInfo: ShowBedrockInfo;
+  selectModelInteractively: SelectInteractiveModel;
+  persistDefaultModel?: PersistDefaultModel;
+  oauthCallbacks?: OAuthCallbacksFactory;
+};
+
+type InteractivePiAuthSetupResult = {
+  readiness: PiReadiness;
+  selection: PiModelSelection;
+};
+
+function unavailable(
+  readiness: PiReadiness,
+  reason: Extract<PiModelSelection, { status: "unavailable" }>["reason"],
+  message: string,
+): InteractivePiAuthSetupResult {
+  return {
+    readiness,
+    selection: {
+      status: "unavailable",
+      reason,
+      message,
+    },
+  };
+}
+
+export function createRepoLocalPiAuth(options: { agentDir: string }): {
+  authStorage: PiAuthFlowStorage;
+  registry: PiAuthFlowRegistry;
+} {
+  const authStorage = AuthStorage.create(join(options.agentDir, "auth.json"));
+  const registry = ModelRegistry.create(
+    authStorage,
+    join(options.agentDir, "models.json"),
+  );
+  registry.refresh();
+  return { authStorage, registry };
+}
+
+export async function runInteractivePiAuthSetup(
+  options: InteractivePiAuthSetupOptions,
+): Promise<InteractivePiAuthSetupResult> {
+  const mode = await options.selectAuthMethod();
+  if (!mode) {
+    return unavailable(
+      options.initialReadiness,
+      "cancelled",
+      "Pi provider authentication was cancelled.",
+    );
+  }
+
+  const choices = createAuthProviderChoices({
+    mode,
+    authStorage: options.authStorage,
+    registry: options.registry,
+  });
+  const provider = await options.selectProvider({ mode, choices });
+  if (!provider) {
+    return unavailable(
+      options.initialReadiness,
+      "cancelled",
+      "Pi provider authentication was cancelled.",
+    );
+  }
+
+  if (mode === "api_key") {
+    if (provider.id === "amazon-bedrock") {
+      await options.showBedrockInfo();
+    } else {
+      const apiKey = await options.promptApiKey(provider);
+      if (apiKey === undefined) {
+        return unavailable(
+          options.initialReadiness,
+          "cancelled",
+          "Pi provider authentication was cancelled.",
+        );
+      }
+      const trimmed = apiKey.trim();
+      if (!trimmed) {
+        return unavailable(
+          options.initialReadiness,
+          "invalid-selection",
+          "API key cannot be empty.",
+        );
+      }
+      options.authStorage.set(provider.id, { type: "api_key", key: trimmed });
+    }
+  } else {
+    await options.authStorage.login(
+      provider.id,
+      options.oauthCallbacks?.(provider) ?? createOAuthCallbacks(),
+    );
+  }
+
+  options.registry.refresh();
+  const readiness = detectPiReadiness({ registry: options.registry });
+  const selection = await selectPiModel({
+    readiness,
+    isInteractive: true,
+    currentDefault: options.currentDefault,
+    selectModelInteractively: options.selectModelInteractively,
+    persistDefaultModel: options.persistDefaultModel,
+  });
+  return { readiness, selection };
+}
+
+export async function setupPiInteractively(options: {
+  repoRoot: string;
+  agentDir: string;
+  currentDefault: LocalPiDefaultModel | undefined;
+  initialReadiness: PiReadiness;
+  selectModelInteractively?: SelectInteractiveModel;
+  persistDefaultModel?: PersistDefaultModel;
+}): Promise<InteractivePiAuthSetupResult> {
+  const { authStorage, registry } = createRepoLocalPiAuth({
+    agentDir: options.agentDir,
+  });
+  return runInteractivePiAuthSetup({
+    repoRoot: options.repoRoot,
+    agentDir: options.agentDir,
+    currentDefault: options.currentDefault,
+    initialReadiness: options.initialReadiness,
+    authStorage,
+    registry,
+    selectAuthMethod: () => selectAuthMethodInteractively(),
+    selectProvider: ({ mode, choices }) =>
+      selectProviderInteractively({ mode, choices }),
+    promptApiKey: (provider) =>
+      promptApiKeyInteractively({ providerName: provider.name }),
+    showBedrockInfo: () => showBedrockInfoInteractively(),
+    selectModelInteractively:
+      options.selectModelInteractively ?? defaultSelectModelInteractively,
+    persistDefaultModel: options.persistDefaultModel,
+    oauthCallbacks: () => createOAuthCallbacks(),
+  });
+}

--- a/src/cli/commands/init/pi-auth-flow.ts
+++ b/src/cli/commands/init/pi-auth-flow.ts
@@ -47,6 +47,7 @@ export type OAuthLoginCallbacksLike = {
     options: Array<{ id: string; label: string }>;
   }) => Promise<string | undefined>;
   signal?: AbortSignal;
+  dispose?: () => void;
 };
 
 export type PiAuthFlowStorage = AuthStorageLike & {
@@ -177,10 +178,13 @@ export async function runInteractivePiAuthSetup(
       options.authStorage.set(provider.id, { type: "api_key", key: trimmed });
     }
   } else {
-    await options.authStorage.login(
-      provider.id,
-      options.oauthCallbacks?.(provider) ?? createOAuthCallbacks(),
-    );
+    const callbacks =
+      options.oauthCallbacks?.(provider) ?? createOAuthCallbacks();
+    try {
+      await options.authStorage.login(provider.id, callbacks);
+    } finally {
+      callbacks.dispose?.();
+    }
   }
 
   options.registry.refresh();

--- a/src/cli/commands/init/pi-auth-provider-state.test.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  AUTH_METHOD_CHOICES,
+  authProviderChoiceRows,
+  createAuthProviderChoices,
+  createProviderSelectorState,
+  searchProviderSelector,
+  visibleProviderRows,
+  type AuthProviderChoice,
+} from "./pi-auth-provider-state.ts";
+import type {
+  AuthCredential,
+  AuthStatus,
+} from "@earendil-works/pi-coding-agent";
+
+type FakeModel = { provider: string; id: string; name?: string };
+
+function storage(
+  options: {
+    oauth?: Array<{ id: string; name: string }>;
+    credentials?: Record<string, AuthCredential>;
+    statuses?: Record<string, AuthStatus>;
+  } = {},
+) {
+  const credentials = options.credentials ?? {};
+  const statuses = options.statuses ?? {};
+  return {
+    getOAuthProviders: () => options.oauth ?? [],
+    get: (provider: string) => credentials[provider],
+    getAuthStatus: (provider: string) =>
+      statuses[provider] ?? {
+        configured: Boolean(credentials[provider]),
+        source: credentials[provider] ? "stored" : undefined,
+      },
+  };
+}
+
+function registry(
+  options: {
+    models?: FakeModel[];
+    names?: Record<string, string>;
+    statuses?: Record<string, AuthStatus>;
+  } = {},
+) {
+  const statuses = options.statuses ?? {};
+  return {
+    getAll: () => options.models ?? [],
+    getProviderDisplayName: (provider: string) =>
+      options.names?.[provider] ?? provider,
+    getProviderAuthStatus: (provider: string) =>
+      statuses[provider] ?? { configured: false },
+  };
+}
+
+function labels(choices: AuthProviderChoice[]): string[] {
+  return choices.map((choice) => choice.label);
+}
+
+test("auth method choices match Patchmill init prompt order", () => {
+  assert.deepEqual(AUTH_METHOD_CHOICES, [
+    { mode: "oauth", label: "Use a subscription" },
+    { mode: "api_key", label: "Use an API key" },
+  ]);
+});
+
+test("createAuthProviderChoices lists subscription providers with configured status", () => {
+  const choices = createAuthProviderChoices({
+    mode: "oauth",
+    authStorage: storage({
+      oauth: [
+        { id: "anthropic", name: "Anthropic (Claude Pro/Max)" },
+        { id: "openai-codex", name: "ChatGPT Plus/Pro" },
+      ],
+      credentials: {
+        anthropic: {
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: 1,
+        },
+      },
+    }),
+    registry: registry(),
+  });
+
+  assert.deepEqual(labels(choices), [
+    "Anthropic (Claude Pro/Max) ✓ configured",
+    "ChatGPT Plus/Pro • unconfigured",
+  ]);
+  assert.deepEqual(
+    choices.map((choice) => choice.id),
+    ["anthropic", "openai-codex"],
+  );
+});
+
+test("createAuthProviderChoices lists unique API-key providers from all registry models", () => {
+  const choices = createAuthProviderChoices({
+    mode: "api_key",
+    authStorage: storage(),
+    registry: registry({
+      models: [
+        { provider: "anthropic", id: "claude-sonnet-4-5" },
+        { provider: "anthropic", id: "claude-opus-4-1" },
+        { provider: "amazon-bedrock", id: "us.anthropic.claude" },
+        { provider: "custom-proxy", id: "llama" },
+      ],
+      names: {
+        anthropic: "Anthropic",
+        "amazon-bedrock": "Amazon Bedrock",
+        "custom-proxy": "Custom Proxy",
+      },
+    }),
+  });
+
+  assert.deepEqual(labels(choices), [
+    "Amazon Bedrock • unconfigured",
+    "Anthropic • unconfigured",
+    "Custom Proxy • unconfigured",
+  ]);
+});
+
+test("createAuthProviderChoices renders cross-mode and external auth status labels", () => {
+  const choices = createAuthProviderChoices({
+    mode: "api_key",
+    authStorage: storage({
+      credentials: {
+        anthropic: {
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: 1,
+        },
+        openai: { type: "api_key", key: "sk-test" },
+      },
+    }),
+    registry: registry({
+      models: [
+        { provider: "anthropic", id: "claude" },
+        { provider: "openai", id: "gpt" },
+        { provider: "google", id: "gemini" },
+        { provider: "custom", id: "local" },
+        { provider: "commanded", id: "cmd" },
+      ],
+      names: {
+        anthropic: "Anthropic",
+        openai: "OpenAI",
+        google: "Google Gemini",
+        custom: "Custom",
+        commanded: "Commanded",
+      },
+      statuses: {
+        google: {
+          configured: true,
+          source: "environment",
+          label: "GEMINI_API_KEY",
+        },
+        custom: { configured: true, source: "models_json_key" },
+        commanded: { configured: true, source: "models_json_command" },
+      },
+    }),
+  });
+
+  assert.deepEqual(labels(choices), [
+    "Anthropic • subscription configured",
+    "Commanded ✓ command in models.json",
+    "Custom ✓ key in models.json",
+    "Google Gemini ✓ env: GEMINI_API_KEY",
+    "OpenAI ✓ configured",
+  ]);
+});
+
+test("provider selector search matches id, name, and status", () => {
+  const state = createProviderSelectorState([
+    {
+      id: "anthropic",
+      name: "Anthropic",
+      mode: "api_key",
+      label: "Anthropic • subscription configured",
+      statusLabel: "• subscription configured",
+    },
+    {
+      id: "google",
+      name: "Google Gemini",
+      mode: "api_key",
+      label: "Google Gemini ✓ env: GEMINI_API_KEY",
+      statusLabel: "✓ env: GEMINI_API_KEY",
+    },
+  ]);
+
+  assert.deepEqual(
+    visibleProviderRows(searchProviderSelector(state, "gemini")).map(
+      (row) => row.choice.id,
+    ),
+    ["google"],
+  );
+  assert.deepEqual(
+    visibleProviderRows(searchProviderSelector(state, "subscription")).map(
+      (row) => row.choice.id,
+    ),
+    ["anthropic"],
+  );
+});
+
+test("visibleProviderRows limits to eight rows and reports row labels", () => {
+  const choices = Array.from({ length: 10 }, (_, index) => ({
+    id: `provider-${index + 1}`,
+    name: `Provider ${index + 1}`,
+    mode: "api_key" as const,
+    label: `Provider ${index + 1} • unconfigured`,
+    statusLabel: "• unconfigured",
+  }));
+  const rows = visibleProviderRows(createProviderSelectorState(choices));
+
+  assert.equal(rows.length, 8);
+  assert.equal(rows[0]?.selected, true);
+  assert.deepEqual(authProviderChoiceRows(rows).slice(0, 2), [
+    "→ Provider 1 • unconfigured",
+    "  Provider 2 • unconfigured",
+  ]);
+});

--- a/src/cli/commands/init/pi-auth-provider-state.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.ts
@@ -1,0 +1,218 @@
+import type {
+  AuthCredential,
+  AuthStatus,
+} from "@earendil-works/pi-coding-agent";
+
+export type AuthMode = "oauth" | "api_key";
+
+export type AuthMethodChoice = {
+  mode: AuthMode;
+  label: string;
+};
+
+export const AUTH_METHOD_CHOICES: AuthMethodChoice[] = [
+  { mode: "oauth", label: "Use a subscription" },
+  { mode: "api_key", label: "Use an API key" },
+];
+
+export type OAuthProviderLike = {
+  id: string;
+  name: string;
+};
+
+export type AuthStorageLike = {
+  getOAuthProviders(): OAuthProviderLike[];
+  get(provider: string): AuthCredential | undefined;
+  getAuthStatus(provider: string): AuthStatus;
+};
+
+export type RegistryModelLike = {
+  provider: string;
+};
+
+export type AuthRegistryLike = {
+  getAll(): RegistryModelLike[];
+  getProviderDisplayName(provider: string): string;
+  getProviderAuthStatus(provider: string): AuthStatus;
+};
+
+export type AuthProviderChoice = {
+  id: string;
+  name: string;
+  mode: AuthMode;
+  label: string;
+  statusLabel: string;
+};
+
+export type ProviderSelectorState = {
+  choices: AuthProviderChoice[];
+  filtered: AuthProviderChoice[];
+  query: string;
+  selectedIndex: number;
+};
+
+export type VisibleProviderRow = {
+  choice: AuthProviderChoice;
+  selected: boolean;
+};
+
+const MAX_VISIBLE_PROVIDER_ROWS = 8;
+
+function statusLabel(options: {
+  mode: AuthMode;
+  credential: AuthCredential | undefined;
+  status: AuthStatus;
+}): string {
+  const { credential, mode, status } = options;
+
+  if (credential?.type === "oauth") {
+    return mode === "oauth" ? "✓ configured" : "• subscription configured";
+  }
+
+  if (credential?.type === "api_key") {
+    return mode === "api_key" ? "✓ configured" : "• API key configured";
+  }
+
+  if (!status.configured) return "• unconfigured";
+
+  if (status.source === "environment") {
+    return `✓ env: ${status.label ?? "environment"}`;
+  }
+  if (status.source === "runtime") return "✓ runtime API key";
+  if (status.source === "fallback") return "✓ custom API key";
+  if (status.source === "models_json_key") return "✓ key in models.json";
+  if (status.source === "models_json_command") {
+    return "✓ command in models.json";
+  }
+  if (status.source === "stored") return "✓ configured";
+
+  return "✓ configured";
+}
+
+function choice(options: {
+  id: string;
+  name: string;
+  mode: AuthMode;
+  credential: AuthCredential | undefined;
+  status: AuthStatus;
+}): AuthProviderChoice {
+  const suffix = statusLabel(options);
+  return {
+    id: options.id,
+    name: options.name,
+    mode: options.mode,
+    label: `${options.name} ${suffix}`,
+    statusLabel: suffix,
+  };
+}
+
+function apiProviderIds(registry: AuthRegistryLike): string[] {
+  return Array.from(new Set(registry.getAll().map((model) => model.provider)))
+    .filter((provider) => provider.length > 0)
+    .sort((left, right) =>
+      registry
+        .getProviderDisplayName(left)
+        .localeCompare(registry.getProviderDisplayName(right)),
+    );
+}
+
+export function createAuthProviderChoices(options: {
+  mode: AuthMode;
+  authStorage: AuthStorageLike;
+  registry: AuthRegistryLike;
+}): AuthProviderChoice[] {
+  if (options.mode === "oauth") {
+    return options.authStorage.getOAuthProviders().map((provider) =>
+      choice({
+        id: provider.id,
+        name: provider.name,
+        mode: options.mode,
+        credential: options.authStorage.get(provider.id),
+        status: options.authStorage.getAuthStatus(provider.id),
+      }),
+    );
+  }
+
+  return apiProviderIds(options.registry).map((provider) =>
+    choice({
+      id: provider,
+      name: options.registry.getProviderDisplayName(provider),
+      mode: options.mode,
+      credential: options.authStorage.get(provider),
+      status: options.registry.getProviderAuthStatus(provider),
+    }),
+  );
+}
+
+function matches(choice: AuthProviderChoice, query: string): boolean {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized) return true;
+  const haystack = [choice.id, choice.name, choice.statusLabel, choice.label]
+    .join(" ")
+    .toLocaleLowerCase();
+  return haystack.includes(normalized);
+}
+
+export function createProviderSelectorState(
+  choices: AuthProviderChoice[],
+): ProviderSelectorState {
+  return {
+    choices,
+    filtered: choices,
+    query: "",
+    selectedIndex: 0,
+  };
+}
+
+export function searchProviderSelector(
+  state: ProviderSelectorState,
+  query: string,
+): ProviderSelectorState {
+  const filtered = state.choices.filter((choice) => matches(choice, query));
+  return {
+    ...state,
+    query,
+    filtered,
+    selectedIndex: 0,
+  };
+}
+
+export function moveProviderSelection(
+  state: ProviderSelectorState,
+  delta: number,
+): ProviderSelectorState {
+  if (state.filtered.length === 0) return state;
+  return {
+    ...state,
+    selectedIndex:
+      (state.selectedIndex + delta + state.filtered.length) %
+      state.filtered.length,
+  };
+}
+
+export function selectedProvider(
+  state: ProviderSelectorState,
+): AuthProviderChoice | undefined {
+  return state.filtered[state.selectedIndex];
+}
+
+export function visibleProviderRows(
+  state: ProviderSelectorState,
+): VisibleProviderRow[] {
+  const visible = state.filtered.slice(0, MAX_VISIBLE_PROVIDER_ROWS);
+  return visible.map((choice, index) => ({
+    choice,
+    selected: index === state.selectedIndex,
+  }));
+}
+
+export function authProviderChoiceRows(rows: VisibleProviderRow[]): string[] {
+  return rows.map((row) => `${row.selected ? "→" : " "} ${row.choice.label}`);
+}
+
+export function formatProviderSelectorCount(
+  state: ProviderSelectorState,
+): string {
+  if (state.filtered.length <= MAX_VISIBLE_PROVIDER_ROWS) return "";
+  return `(${state.selectedIndex + 1}/${state.filtered.length})`;
+}

--- a/src/cli/commands/init/pi-auth-selector.test.ts
+++ b/src/cli/commands/init/pi-auth-selector.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Terminal } from "@earendil-works/pi-tui";
+import {
+  selectAuthMethodInteractively,
+  selectProviderInteractively,
+} from "./pi-auth-selector.ts";
+import type { AuthProviderChoice } from "./pi-auth-provider-state.ts";
+
+class FakeTerminal implements Terminal {
+  private onInput: ((data: string) => void) | undefined;
+  writes: string[] = [];
+  stopCalls = 0;
+  drainCalls = 0;
+
+  start(onInput: (data: string) => void, _onResize: () => void): void {
+    this.onInput = onInput;
+  }
+  stop(): void {
+    this.stopCalls += 1;
+  }
+  async drainInput(): Promise<void> {
+    this.drainCalls += 1;
+  }
+  write(data: string): void {
+    this.writes.push(data);
+  }
+  get columns(): number {
+    return 80;
+  }
+  get rows(): number {
+    return 24;
+  }
+  get kittyProtocolActive(): boolean {
+    return false;
+  }
+  moveBy(_lines: number): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(_title: string): void {}
+  setProgress(_active: boolean): void {}
+  sendInput(data: string): void {
+    this.onInput?.(data);
+  }
+}
+
+function provider(id: string, name: string): AuthProviderChoice {
+  return {
+    id,
+    name,
+    mode: "api_key",
+    label: `${name} • unconfigured`,
+    statusLabel: "• unconfigured",
+  };
+}
+
+test("selectAuthMethodInteractively returns API key after moving down", async () => {
+  const terminal = new FakeTerminal();
+  const selection = selectAuthMethodInteractively({ terminal });
+
+  terminal.sendInput("\u001b[B");
+  terminal.sendInput("\n");
+
+  assert.equal(await selection, "api_key");
+  assert.equal(terminal.stopCalls, 1);
+  assert.equal(terminal.drainCalls, 1);
+});
+
+test("selectAuthMethodInteractively cancels on escape", async () => {
+  const terminal = new FakeTerminal();
+  const selection = selectAuthMethodInteractively({ terminal });
+
+  terminal.sendInput("\u001b");
+
+  assert.equal(await selection, undefined);
+  assert.equal(terminal.stopCalls, 1);
+});
+
+test("selectProviderInteractively filters by typed search and selects matching provider", async () => {
+  const terminal = new FakeTerminal();
+  const selection = selectProviderInteractively({
+    mode: "api_key",
+    choices: [
+      provider("anthropic", "Anthropic"),
+      provider("google", "Google Gemini"),
+    ],
+    terminal,
+  });
+
+  for (const char of "google") terminal.sendInput(char);
+  terminal.sendInput("\n");
+
+  assert.equal((await selection)?.id, "google");
+});
+
+test("selectProviderInteractively renders one count for long lists", async () => {
+  const terminal = new FakeTerminal();
+  const choices = Array.from({ length: 10 }, (_entry, index) =>
+    provider(`provider-${index + 1}`, `Provider ${index + 1}`),
+  );
+  const selection = selectProviderInteractively({
+    mode: "api_key",
+    choices,
+    terminal,
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(terminal.writes.join("").match(/\(1\/10\)/gu)?.length, 1);
+
+  terminal.sendInput("\n");
+  await selection;
+});

--- a/src/cli/commands/init/pi-auth-selector.ts
+++ b/src/cli/commands/init/pi-auth-selector.ts
@@ -1,0 +1,215 @@
+import {
+  Container,
+  Input,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  Text,
+  TruncatedText,
+  TUI,
+  type Focusable,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+import {
+  AUTH_METHOD_CHOICES,
+  authProviderChoiceRows,
+  createProviderSelectorState,
+  formatProviderSelectorCount,
+  moveProviderSelection,
+  searchProviderSelector,
+  selectedProvider,
+  visibleProviderRows,
+  type AuthMode,
+  type AuthProviderChoice,
+  type ProviderSelectorState,
+} from "./pi-auth-provider-state.ts";
+
+async function stopTui(tui: TUI, terminal: Terminal): Promise<void> {
+  try {
+    tui.stop();
+  } catch {
+    // Best-effort terminal cleanup.
+  }
+  try {
+    await terminal.drainInput();
+  } catch {
+    // Best-effort terminal cleanup.
+  }
+}
+
+class AuthMethodComponent extends Container {
+  private selectedIndex = 0;
+  private readonly onSelect: (mode: AuthMode) => void;
+  private readonly onCancel: () => void;
+
+  constructor(onSelect: (mode: AuthMode) => void, onCancel: () => void) {
+    super();
+    this.onSelect = onSelect;
+    this.onCancel = onCancel;
+    this.renderRows();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+      const delta = matchesKey(data, Key.up) ? -1 : 1;
+      this.selectedIndex =
+        (this.selectedIndex + delta + AUTH_METHOD_CHOICES.length) %
+        AUTH_METHOD_CHOICES.length;
+      this.renderRows();
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      this.onSelect(AUTH_METHOD_CHOICES[this.selectedIndex]?.mode ?? "oauth");
+    }
+  }
+
+  private renderRows(): void {
+    this.clear();
+    this.addChild(new Text("Select authentication method:", 0, 0));
+    this.addChild(new Text("", 0, 0));
+    AUTH_METHOD_CHOICES.forEach((choice, index) => {
+      const prefix = index === this.selectedIndex ? "→" : " ";
+      this.addChild(new Text(`${prefix} ${choice.label}`, 0, 0));
+    });
+  }
+}
+
+class ProviderSelectorComponent extends Container implements Focusable {
+  private readonly searchInput = new Input();
+  private readonly listContainer = new Container();
+  private readonly count = new Text("", 0, 0);
+  private readonly onSelect: (provider: AuthProviderChoice) => void;
+  private readonly onCancel: () => void;
+  private state: ProviderSelectorState;
+  private isFocused = false;
+
+  constructor(
+    title: string,
+    choices: AuthProviderChoice[],
+    onSelect: (provider: AuthProviderChoice) => void,
+    onCancel: () => void,
+  ) {
+    super();
+    this.onSelect = onSelect;
+    this.onCancel = onCancel;
+    this.state = createProviderSelectorState(choices);
+
+    this.searchInput.onEscape = onCancel;
+    this.searchInput.onSubmit = () => {
+      const provider = selectedProvider(this.state);
+      if (provider) this.onSelect(provider);
+    };
+
+    this.addChild(new Text(title, 0, 0));
+    this.addChild(new Text("", 0, 0));
+    this.addChild(this.searchInput);
+    this.addChild(new Text("", 0, 0));
+    this.addChild(this.listContainer);
+    this.addChild(this.count);
+    this.renderRows();
+  }
+
+  get focused(): boolean {
+    return this.isFocused;
+  }
+
+  set focused(value: boolean) {
+    this.isFocused = value;
+    this.searchInput.focused = value;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+      this.state = moveProviderSelection(
+        this.state,
+        matchesKey(data, Key.up) ? -1 : 1,
+      );
+      this.renderRows();
+      return;
+    }
+
+    this.searchInput.handleInput(data);
+    this.state = searchProviderSelector(
+      this.state,
+      this.searchInput.getValue(),
+    );
+    this.renderRows();
+  }
+
+  private renderRows(): void {
+    this.listContainer.clear();
+    const rows = visibleProviderRows(this.state);
+    if (rows.length === 0) {
+      this.listContainer.addChild(new Text("  No matching providers", 0, 0));
+    } else {
+      for (const row of authProviderChoiceRows(rows)) {
+        this.listContainer.addChild(new TruncatedText(row));
+      }
+    }
+    this.count.setText(formatProviderSelectorCount(this.state));
+  }
+}
+
+export async function selectAuthMethodInteractively(
+  options: {
+    terminal?: Terminal;
+  } = {},
+): Promise<AuthMode | undefined> {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  const tui = new TUI(terminal, false);
+
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (mode: AuthMode | undefined): void => {
+      if (finished) return;
+      finished = true;
+      void stopTui(tui, terminal).finally(() => resolve(mode));
+    };
+
+    const component = new AuthMethodComponent(
+      (mode) => finish(mode),
+      () => finish(undefined),
+    );
+    tui.addChild(component);
+    tui.setFocus(component);
+    tui.start();
+    tui.requestRender(true);
+  });
+}
+
+export async function selectProviderInteractively(options: {
+  mode: AuthMode;
+  choices: AuthProviderChoice[];
+  terminal?: Terminal;
+}): Promise<AuthProviderChoice | undefined> {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  const tui = new TUI(terminal, true);
+  const title =
+    options.mode === "oauth"
+      ? "Select subscription provider to configure:"
+      : "Select API-key provider to configure:";
+
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (provider: AuthProviderChoice | undefined): void => {
+      if (finished) return;
+      finished = true;
+      void stopTui(tui, terminal).finally(() => resolve(provider));
+    };
+
+    const component = new ProviderSelectorComponent(
+      title,
+      options.choices,
+      (provider) => finish(provider),
+      () => finish(undefined),
+    );
+    tui.addChild(component);
+    tui.setFocus(component);
+    tui.start();
+    tui.requestRender(true);
+  });
+}

--- a/src/cli/commands/init/pi-init-flow.test.ts
+++ b/src/cli/commands/init/pi-init-flow.test.ts
@@ -190,7 +190,7 @@ test("runInit reports Patchmill setup guidance when Pi readiness remains missing
       repoRoot,
       { stdout: (line) => stdout.push(line), stderr: () => undefined },
       {
-        isInteractive: true,
+        isInteractive: false,
         detectPiReadiness: missingPiReadiness,
         runPiSmokeTest: failingPiSmokeTest,
         prompt: async () => "no",
@@ -389,6 +389,19 @@ test("runInit skips model selector and local settings when no models are availab
       {
         isInteractive: true,
         detectPiReadiness: missingPiReadiness,
+        resolvePiInitSetup: (setupOptions) =>
+          resolvePiInitSetup({
+            ...setupOptions,
+            setupPiInteractively: async () => ({
+              readiness: missingPiReadiness(),
+              selection: {
+                status: "unavailable",
+                reason: "not-ready",
+                message:
+                  "Pi did not report any provider/model with configured auth.",
+              },
+            }),
+          }),
         selectModelInteractively: async () => {
           selectorCalled = true;
           return undefined;

--- a/src/cli/commands/init/pi-init-setup.ts
+++ b/src/cli/commands/init/pi-init-setup.ts
@@ -1,5 +1,6 @@
 import { createCommandRunner } from "../triage/command.ts";
 import type { LocalPiDefaultModel } from "./pi-agent-settings.ts";
+import { setupPiInteractively as defaultSetupPiInteractively } from "./pi-auth-flow.ts";
 import {
   selectPiModel,
   type PersistDefaultModel,
@@ -14,6 +15,8 @@ export type InteractivePiSetup = (options: {
   agentDir: string;
   currentDefault: LocalPiDefaultModel | undefined;
   initialReadiness: PiReadiness;
+  selectModelInteractively?: SelectInteractiveModel;
+  persistDefaultModel?: PersistDefaultModel;
 }) => Promise<{
   readiness: PiReadiness;
   selection: PiModelSelection;
@@ -60,21 +63,8 @@ function abortingSelectionStatus(
   return undefined;
 }
 
-export async function setupPiInteractively(options: {
-  initialReadiness: PiReadiness;
-}): Promise<{
-  readiness: PiReadiness;
-  selection: PiModelSelection;
-}> {
-  return {
-    readiness: options.initialReadiness,
-    selection: {
-      status: "unavailable",
-      reason: "not-ready",
-      message: options.initialReadiness.message,
-    },
-  };
-}
+export const setupPiInteractively: InteractivePiSetup =
+  defaultSetupPiInteractively;
 
 export async function resolvePiInitSetup(options: {
   repoRoot: string;
@@ -97,6 +87,8 @@ export async function resolvePiInitSetup(options: {
       agentDir: options.piAgentDir,
       currentDefault: options.currentDefault,
       initialReadiness: readiness,
+      selectModelInteractively: options.selectModelInteractively,
+      persistDefaultModel: options.persistDefaultModel,
     });
     readiness = setup.readiness;
     selection = setup.selection;

--- a/src/cli/commands/init/pi-model-selector.test.ts
+++ b/src/cli/commands/init/pi-model-selector.test.ts
@@ -105,6 +105,21 @@ test("selectModelInteractively resolves selected model even when drainInput fail
   assert.equal(terminal.drainCalls, 1);
 });
 
+test("selectModelInteractively renders a main orchestration model instruction", async () => {
+  const terminal = new FakeTerminal();
+  const selection = selectModelInteractively({ models, terminal });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.match(
+    terminal.writes.join(""),
+    /Select Patchmill orchestration model:/,
+  );
+
+  terminal.sendInput("\n");
+
+  await selection;
+});
+
 test("selectModelInteractively renders a single selector count for the visible model list", async () => {
   const terminal = new FakeTerminal();
   const selection = selectModelInteractively({ models: manyModels, terminal });

--- a/src/cli/commands/init/pi-model-selector.ts
+++ b/src/cli/commands/init/pi-model-selector.ts
@@ -60,6 +60,8 @@ class ModelSelectorComponent extends Container implements Focusable {
       if (model) this.onSelect(model);
     };
 
+    this.addChild(new Text("Select Patchmill orchestration model:"));
+    this.addChild(new Text(""));
     this.addChild(this.searchInput);
     this.addChild(new Text(""));
     this.addChild(this.listContainer);


### PR DESCRIPTION
## Summary
- Add Patchmill-owned interactive Pi auth method/provider selectors for `patchmill init`
- Store repo-local API key/OAuth credentials, refresh Pi models, select a model, and run the smoke test
- Cover provider state, TUI selectors/dialogs, auth flow, and init integration with tests
