### PR TITLE
feat: add setup test repo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,42 @@ patchmill doctor
 patchmill triage --dry-run
 ```
 
+### Try Patchmill on a disposable demo repository
+
+Before pointing Patchmill at a production repository, create a disposable Team
+Lunch Poll demo repository and let Patchmill triage its seeded issues.
+
+For GitHub:
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+gh repo clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+```
+
+For Forgejo or Gitea with a named `tea` login:
+
+```bash
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
+tea clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+```
+
+Use an explicit disposable public repository for `OWNER/REPO`. The reset form
+deletes and recreates that repository:
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
+```
+
+The reusable demo prompts live in the Patchmill package under
+`fixtures/patchmill-test-repo/`. See `docs/setup-test-repo.md` for details.
+
 `patchmill run-once` and `patchmill run` are still in progress; treat any
 experiments with them as development testing rather than supported usage.
 

--- a/docs/plans/2026-06-06-setup-test-repo-command.md
+++ b/docs/plans/2026-06-06-setup-test-repo-command.md
@@ -10,10 +10,12 @@ Lunch Poll repository on GitHub or Forgejo/Gitea and seed it with reusable demo
 files, labels, and issues.
 
 **Architecture:** Keep provider-specific `gh` and `tea` commands in the existing
-host provider modules. Keep Team Lunch Poll fixture parsing, copying, and setup
-orchestration in `src/cli/commands/setup-test-repo`. Use small modules for args,
-fixture discovery, issue parsing, labels, and command orchestration so no setup
-file becomes a provider integration duplicate.
+host provider modules, but expose setup through a dedicated target-explicit
+`RepositorySetupHostProvider` instead of widening the triage
+`IssueHostProvider`. Keep Team Lunch Poll fixture parsing, copying, and setup
+orchestration in `src/cli/commands/setup-test-repo`. Validate fixtures and
+create the local seed commit before mutating the host, then roll back the newly
+created remote repository on post-create seeding failures.
 
 **Tech Stack:** TypeScript, Node.js built-in test runner, `gh`, `tea`, `git`,
 npm package `files` allowlist.
@@ -24,6 +26,30 @@ npm package `files` allowlist.
 
 Implement against `docs/specs/2026-06-05-patchmill-test-repo-design.md` in this
 worktree.
+
+## Review remediation update
+
+The original plan below was amended after code-quality review findings about the
+host boundary and seeding atomicity. When executing or auditing this plan, apply
+these corrections over the older Task 4-6 snippets:
+
+- Do **not** add repository setup methods to `IssueHostProvider` and do **not**
+  introduce `GitHostProvider` as `IssueHostProvider & lifecycle methods`.
+  Instead add `RepositorySetupHostProvider` with target-explicit setup methods.
+- Use `getRepository(target): Promise<RepositoryInfo | undefined>` instead of
+  `repoExists(target): Promise<boolean>`. Return `undefined` only for verified
+  not-found responses; throw for auth, rate limit, network, and malformed
+  provider responses.
+- Setup label and issue methods must carry the explicit target:
+  `listLabels(target)`, `createLabel(target, label)`, and
+  `createIssue(target, issue)`. Do not rely on temporary git remotes, cwd,
+  `GH_REPO`, or `tea --repo` inference for setup seeding.
+- The factory entry point for setup is `createRepositorySetupHostProvider()`.
+  `createIssueHostProvider()` stays narrow for triage callers.
+- The setup orchestration validates/copies fixtures and creates the local seed
+  commit before `createPublicRepo()`. If any subsequent push, label, or issue
+  step fails after this run created/recreated the remote, best-effort delete the
+  newly created repository and include the rollback result in the error.
 
 ## File map
 
@@ -36,18 +62,20 @@ worktree.
 - Modify: `package.json`
   - Add `fixtures` to the npm package `files` allowlist.
 - Modify: `src/host/types.ts`
-  - Add generic repository target, issue creation, and repository lifecycle
-    provider types.
+  - Add `RepositoryTarget`, `RepositoryInfo`, `HostIssueCreateInput`, and a
+    target-explicit `RepositorySetupHostProvider` separate from
+    `IssueHostProvider`.
 - Modify: `src/host/factory.ts`
-  - Add `createGitHostProvider()` returning the expanded generic provider type.
+  - Add `createRepositorySetupHostProvider()` returning the setup provider type.
   - Keep `createIssueHostProvider()` for existing callers.
 - Modify: `src/host/factory.test.ts`
-  - Assert factory-created providers expose generic lifecycle methods.
+  - Assert factory-created setup providers expose target-explicit setup methods.
 - Modify: `src/host/github-gh.ts`
-  - Add generic repository lifecycle and issue creation methods to
-    `GitHubGhHostProvider`.
+  - Add setup repository lookup, lifecycle, target-explicit label creation, and
+    target-explicit issue creation methods to `GitHubGhHostProvider`.
 - Modify: `src/host/github-gh.test.ts`
-  - Cover GitHub lifecycle, URL, clone command, and issue creation commands.
+  - Cover GitHub repository lookup error handling, lifecycle, clone command, and
+    target-explicit label/issue commands.
 - Create: `src/host/forgejo-tea-context.ts`
   - Generic Forgejo/Gitea `tea` repo/login argument helper shared by the
     existing triage functions and the provider class.
@@ -57,11 +85,11 @@ worktree.
   - Import the shared `withTeaContext()` helper instead of owning duplicate
     context logic.
 - Modify: `src/host/forgejo-tea.ts`
-  - Add generic repository lifecycle and issue creation methods to
-    `ForgejoTeaHostProvider`.
+  - Add setup repository lookup, lifecycle, target-explicit label creation, and
+    target-explicit issue creation methods to `ForgejoTeaHostProvider`.
 - Modify: `src/host/forgejo-tea.test.ts`
-  - Cover Forgejo/Gitea lifecycle, URL lookup, clone command, login propagation,
-    and issue creation commands.
+  - Cover Forgejo/Gitea repository lookup, lifecycle, clone command, login
+    propagation, and target-explicit label/issue commands.
 - Create: `src/cli/commands/setup-test-repo/args.ts`
   - Parse `--provider`, `--repo OWNER/REPO`, `--login`, `--reset`, and help.
 - Create: `src/cli/commands/setup-test-repo/args.test.ts`
@@ -940,7 +968,15 @@ git add src/host/types.ts src/cli/commands/setup-test-repo/args.ts src/cli/comma
 git commit -m "feat: parse setup test repo arguments"
 ```
 
-## Task 4: Add generic GitHub host capabilities
+## Task 4: Add setup-specific GitHub host capabilities
+
+> **Review remediation:** The original snippets in this task used
+> `GitHostProvider`, `repoExists()`, `gitRemoteUrl()`, `publicRepoUrl()`, and
+> non-target `createIssue(issue)`. Those details are superseded. Implement the
+> GitHub setup boundary as `RepositorySetupHostProvider` with
+> `getRepository(target)`, `listLabels(target)`, `createLabel(target, label)`,
+> and `createIssue(target, issue)`. Keep configured-repo triage behavior on the
+> existing no-target `IssueHostProvider` methods.
 
 **Files:**
 
@@ -1240,7 +1276,12 @@ git add src/host/types.ts src/host/factory.ts src/host/factory.test.ts src/host/
 git commit -m "feat: add generic github host repository commands"
 ```
 
-## Task 5: Add generic Forgejo/Gitea host capabilities
+## Task 5: Add setup-specific Forgejo/Gitea host capabilities
+
+> **Review remediation:** The setup Forgejo/Gitea path must not reuse inferred
+> `withTeaContext()` repository selection for seeding labels or issues. Use the
+> explicit `RepositoryTarget` passed by `setup-test-repo` when building
+> `tea labels list`, `tea labels create`, and `tea issues create` commands.
 
 **Files:**
 
@@ -1705,6 +1746,14 @@ git commit -m "feat: add generic forgejo host repository commands"
 ```
 
 ## Task 6: Add setup command orchestration
+
+> **Review remediation:** The orchestration snippets in this task are superseded
+> where they call `repoExists()`, `gitRemoteUrl()`, `publicRepoUrl()`,
+> `createLabel(label)`, or `createIssue(issue)`. The current flow
+> validates/copies fixtures and creates the local seed commit before
+> `createPublicRepo()`, uses `getRepository(target)` for repository info, passes
+> `target` to label/issue setup calls, and rolls back the newly created remote
+> after post-create seeding failures.
 
 **Files:**
 
@@ -2584,8 +2633,9 @@ Expected: no output.
   - Package inclusion and live verification: Task 9.
 - Placeholder scan: no placeholder markers remain in this plan.
 - Type consistency:
-  - `RepositoryTarget`, `HostIssueCreateInput`, and `GitHostProvider` are
-    defined in Task 3 and Task 4 before orchestration uses them in Task 6.
+  - `RepositoryTarget`, `RepositoryInfo`, `HostIssueCreateInput`, and
+    `RepositorySetupHostProvider` are defined before orchestration uses them.
   - Provider lifecycle method names match across `src/host/types.ts`, provider
     classes, and setup orchestration.
-  - `createGitHostProvider()` is introduced before `main.ts` imports it.
+  - `createRepositorySetupHostProvider()` is introduced before `main.ts` imports
+    it.

--- a/docs/plans/2026-06-06-setup-test-repo-command.md
+++ b/docs/plans/2026-06-06-setup-test-repo-command.md
@@ -1,0 +1,2591 @@
+# Setup Test Repo Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `patchmill setup-test-repo` to create or reset a disposable Team
+Lunch Poll repository on GitHub or Forgejo/Gitea and seed it with reusable demo
+files, labels, and issues.
+
+**Architecture:** Keep provider-specific `gh` and `tea` commands in the existing
+host provider modules. Keep Team Lunch Poll fixture parsing, copying, and setup
+orchestration in `src/cli/commands/setup-test-repo`. Use small modules for args,
+fixture discovery, issue parsing, labels, and command orchestration so no setup
+file becomes a provider integration duplicate.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, `gh`, `tea`, `git`,
+npm package `files` allowlist.
+
+---
+
+## Source spec
+
+Implement against `docs/specs/2026-06-05-patchmill-test-repo-design.md` in this
+worktree.
+
+## File map
+
+- Create: `fixtures/patchmill-test-repo/README.md`
+  - Human-facing README copied into every disposable demo repository.
+- Create: `fixtures/patchmill-test-repo/PROJECT_BRIEF.md`
+  - Reusable Team Lunch Poll product brief copied into every demo repository.
+- Create: `fixtures/patchmill-test-repo/issues/*.md`
+  - Twelve reusable issue prompts with simple frontmatter.
+- Modify: `package.json`
+  - Add `fixtures` to the npm package `files` allowlist.
+- Modify: `src/host/types.ts`
+  - Add generic repository target, issue creation, and repository lifecycle
+    provider types.
+- Modify: `src/host/factory.ts`
+  - Add `createGitHostProvider()` returning the expanded generic provider type.
+  - Keep `createIssueHostProvider()` for existing callers.
+- Modify: `src/host/factory.test.ts`
+  - Assert factory-created providers expose generic lifecycle methods.
+- Modify: `src/host/github-gh.ts`
+  - Add generic repository lifecycle and issue creation methods to
+    `GitHubGhHostProvider`.
+- Modify: `src/host/github-gh.test.ts`
+  - Cover GitHub lifecycle, URL, clone command, and issue creation commands.
+- Create: `src/host/forgejo-tea-context.ts`
+  - Generic Forgejo/Gitea `tea` repo/login argument helper shared by the
+    existing triage functions and the provider class.
+- Create: `src/host/forgejo-tea-context.test.ts`
+  - Cover `--repo` and `--login` placement, including commands with `--`.
+- Modify: `src/cli/commands/triage/forgejo.ts`
+  - Import the shared `withTeaContext()` helper instead of owning duplicate
+    context logic.
+- Modify: `src/host/forgejo-tea.ts`
+  - Add generic repository lifecycle and issue creation methods to
+    `ForgejoTeaHostProvider`.
+- Modify: `src/host/forgejo-tea.test.ts`
+  - Cover Forgejo/Gitea lifecycle, URL lookup, clone command, login propagation,
+    and issue creation commands.
+- Create: `src/cli/commands/setup-test-repo/args.ts`
+  - Parse `--provider`, `--repo OWNER/REPO`, `--login`, `--reset`, and help.
+- Create: `src/cli/commands/setup-test-repo/args.test.ts`
+  - Cover required args, malformed args, provider values, login, reset, and
+    help.
+- Create: `src/cli/commands/setup-test-repo/issue-parser.ts`
+  - Parse issue markdown frontmatter without adding a YAML dependency.
+- Create: `src/cli/commands/setup-test-repo/issue-parser.test.ts`
+  - Cover valid issues, missing titles, missing labels, invalid labels, and body
+    extraction.
+- Create: `src/cli/commands/setup-test-repo/fixtures.ts`
+  - Resolve package root, validate fixture layout, load issue files, and copy
+    fixture files to a temporary repository.
+- Create: `src/cli/commands/setup-test-repo/fixtures.test.ts`
+  - Cover package-root resolution, missing files, sorted issue loading, and copy
+    behavior.
+- Create: `src/cli/commands/setup-test-repo/labels.ts`
+  - Hold setup-specific label definitions for `feature`, `bug`, `docs`, and
+    `polish`.
+- Create: `src/cli/commands/setup-test-repo/main.ts`
+  - Orchestrate validation, reset/create, fixture copy, git push, label
+    creation, issue creation, and final instructions.
+- Create: `src/cli/commands/setup-test-repo/main.test.ts`
+  - Cover create-only, existing-without-reset, reset, provider failures, git
+    failures, and final output with mocked providers and runner.
+- Create: `src/cli/commands/setup-test-repo/host-boundary.test.ts`
+  - Enforce that the setup command does not run `gh` or `tea` directly.
+- Modify: `src/cli/main.ts`
+  - Register the public `setup-test-repo` command and top-level help entry.
+- Modify: `src/cli/main.test.ts`
+  - Assert command resolution, help text, and dispatch for `setup-test-repo`.
+- Modify: `README.md`
+  - Promote the disposable setup command near the first-use workflow.
+- Create: `docs/setup-test-repo.md`
+  - Add detailed usage, reset, provider, fixture location, and manual testing
+    documentation.
+
+## Task 1: Add the reusable Team Lunch Poll fixture
+
+**Files:**
+
+- Create: `fixtures/patchmill-test-repo/README.md`
+- Create: `fixtures/patchmill-test-repo/PROJECT_BRIEF.md`
+- Create: `fixtures/patchmill-test-repo/issues/01-project-scaffold.md`
+- Create: `fixtures/patchmill-test-repo/issues/02-domain-model.md`
+- Create: `fixtures/patchmill-test-repo/issues/03-create-poll-form.md`
+- Create: `fixtures/patchmill-test-repo/issues/04-voting-flow.md`
+- Create: `fixtures/patchmill-test-repo/issues/05-results-view.md`
+- Create: `fixtures/patchmill-test-repo/issues/06-local-persistence.md`
+- Create: `fixtures/patchmill-test-repo/issues/07-validation-empty-states.md`
+- Create: `fixtures/patchmill-test-repo/issues/08-responsive-polish.md`
+- Create: `fixtures/patchmill-test-repo/issues/09-automated-tests.md`
+- Create: `fixtures/patchmill-test-repo/issues/10-readme-docs.md`
+- Create: `fixtures/patchmill-test-repo/issues/11-make-it-social.md`
+- Create: `fixtures/patchmill-test-repo/issues/12-votes-disappear.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the fixture README**
+
+Create `fixtures/patchmill-test-repo/README.md` with this content.
+
+````markdown
+# Team Lunch Poll
+
+Team Lunch Poll is a small greenfield demo app for trying Patchmill on a safe,
+disposable repository.
+
+The app should let a team create a lunch poll, add meal or restaurant options,
+vote on those options, and see the current winner. The repository intentionally
+starts with documentation and issue prompts only. Patchmill agents should build
+the application from the seeded issues.
+
+## Demo workflow
+
+After this repository is seeded, try Patchmill manually:
+
+```bash
+patchmill init
+patchmill triage --dry-run
+patchmill triage
+```
+
+## Source of truth
+
+This repository is disposable. The reusable project brief and issue prompts live
+in the Patchmill package under `fixtures/patchmill-test-repo/`.
+````
+
+- [ ] **Step 2: Add the project brief**
+
+Create `fixtures/patchmill-test-repo/PROJECT_BRIEF.md` with this content.
+
+```markdown
+# Team Lunch Poll Project Brief
+
+Team Lunch Poll is a lightweight web app for teams that need to decide where or
+what to eat together.
+
+## Product goals
+
+- Create a poll with a lunch question and a short list of options.
+- Let teammates vote for one option.
+- Show results clearly enough for the team to pick a winner.
+- Keep the first version simple, local, and easy to run.
+
+## Suggested implementation shape
+
+A good first implementation can be a small TypeScript web app using local state
+and browser storage. A full backend, authentication system, and deployment setup
+are outside the first demo scope unless an issue explicitly asks for them.
+
+## User experience principles
+
+- The app should feel friendly and low-friction.
+- Empty states should explain what to do next.
+- Validation messages should help the user fix input quickly.
+- The interface should work on desktop and mobile screens.
+```
+
+- [ ] **Step 3: Add the twelve issue files**
+
+Create the issue files with the exact frontmatter titles and labels shown here.
+The bodies can use the paragraphs below verbatim.
+
+`fixtures/patchmill-test-repo/issues/01-project-scaffold.md`
+
+```markdown
+---
+title: Create the Team Lunch Poll app scaffold
+labels: [feature]
+---
+
+Set up the initial Team Lunch Poll web app so contributors have a working place
+to build from.
+
+Please include a minimal app shell with a heading, a short description of the
+product, and a placeholder area where poll creation and results will appear.
+Choose a simple TypeScript-friendly setup and document the commands needed to
+install dependencies, run the app locally, and run checks.
+```
+
+`fixtures/patchmill-test-repo/issues/02-domain-model.md`
+
+```markdown
+---
+title: Define the poll, option, and vote data model
+labels: [feature]
+---
+
+Define the core data structures for Team Lunch Poll.
+
+The app needs a poll with a question, a collection of lunch options, and votes
+that can be counted per option. Keep the model small enough for local browser
+state, but make the names clear so future issues can build forms, voting, and
+results on top of it.
+```
+
+`fixtures/patchmill-test-repo/issues/03-create-poll-form.md`
+
+```markdown
+---
+title: Build the create-poll form
+labels: [feature]
+---
+
+Add a form that lets someone create a lunch poll.
+
+The form should collect a poll question and at least two options. A user should
+be able to add another option before saving the poll. After saving, the app
+should show the poll instead of the empty placeholder.
+```
+
+`fixtures/patchmill-test-repo/issues/04-voting-flow.md`
+
+```markdown
+---
+title: Add the option voting flow
+labels: [feature]
+---
+
+Let a teammate vote for one lunch option in the current poll.
+
+Each option should have an obvious vote action. After a vote is cast, the UI
+should make it clear which option received the vote and prevent accidental
+double-voting in the same browser session.
+```
+
+`fixtures/patchmill-test-repo/issues/05-results-view.md`
+
+```markdown
+---
+title: Show live results and winner state
+labels: [feature]
+---
+
+Display vote totals for the current poll.
+
+The results view should update after each vote, show counts for every option,
+and highlight the current winner. If there is a tie, show that the poll is tied
+instead of pretending there is a single winner.
+```
+
+`fixtures/patchmill-test-repo/issues/06-local-persistence.md`
+
+```markdown
+---
+title: Persist polls locally
+labels: [feature]
+---
+
+Persist the current poll and votes in browser storage so a refresh does not wipe
+out the demo.
+
+Use a simple local persistence approach. The app should load saved poll data on
+startup and provide a clear way to reset the current poll when someone wants to
+start over.
+```
+
+`fixtures/patchmill-test-repo/issues/07-validation-empty-states.md`
+
+```markdown
+---
+title: Add validation, empty states, and error states
+labels: [feature]
+---
+
+Make the app resilient when users enter incomplete poll information.
+
+The create-poll form should explain what is missing when the question is blank,
+when an option is blank, or when fewer than two usable options are provided. The
+empty state should guide a new user toward creating their first lunch poll.
+```
+
+`fixtures/patchmill-test-repo/issues/08-responsive-polish.md`
+
+```markdown
+---
+title: Improve responsive visual polish
+labels: [polish]
+---
+
+Give Team Lunch Poll a friendly responsive layout.
+
+The app should be comfortable to use on a phone and on a laptop. Improve
+spacing, typography, button states, and result presentation without adding a
+large design system or unrelated UI features.
+```
+
+`fixtures/patchmill-test-repo/issues/09-automated-tests.md`
+
+```markdown
+---
+title: Add automated tests for core poll flows
+labels: [feature]
+---
+
+Add automated tests for the most important Team Lunch Poll behavior.
+
+Cover creating a poll, voting for an option, showing results, and preserving the
+poll through the chosen local persistence layer. Keep the test setup easy for a
+new contributor to run.
+```
+
+`fixtures/patchmill-test-repo/issues/10-readme-docs.md`
+
+```markdown
+---
+title: Document setup and usage
+labels: [docs]
+---
+
+Improve the repository README for people trying the Team Lunch Poll demo.
+
+Document the project purpose, local setup commands, test commands, and a short
+walkthrough of creating a poll and voting. Include notes about the current local
+persistence behavior so users know where their demo data lives.
+```
+
+`fixtures/patchmill-test-repo/issues/11-make-it-social.md`
+
+```markdown
+---
+title: Make lunch polls more social
+---
+
+The poll should feel more social and fun for a team.
+
+Maybe people should be able to react to options, add comments, invite teammates,
+or see who voted. I am not sure which of these matters most for the first
+version. Please figure out a good direction.
+```
+
+`fixtures/patchmill-test-repo/issues/12-votes-disappear.md`
+
+```markdown
+---
+title: Votes sometimes disappear when I refresh
+---
+
+I heard that votes can disappear after refreshing the page.
+
+There is not much detail yet. Please look into what could cause vote data to be
+lost and propose or make the smallest useful fix for the demo app.
+```
+
+- [ ] **Step 4: Add fixtures to the package allowlist**
+
+In `package.json`, add `"fixtures"` to the top-level `files` array immediately
+after `"dist"`.
+
+```json
+"files": [
+  "bin",
+  "src",
+  "dist",
+  "fixtures",
+  "docs",
+  "skills",
+  "extensions",
+  "README.md",
+  "CHANGELOG.md",
+  "LICENSE",
+  "THIRD_PARTY_NOTICES.md",
+  "tsconfig.build.json"
+]
+```
+
+- [ ] **Step 5: Verify fixture shape without adding a text-only test**
+
+Run:
+
+```bash
+find fixtures/patchmill-test-repo -type f | sort
+node -e "const p=require('./package.json'); if(!p.files.includes('fixtures')) process.exit(1); console.log('fixtures packaged')"
+```
+
+Expected: the `find` output lists `README.md`, `PROJECT_BRIEF.md`, and exactly
+12 files under `issues/`; the Node command prints `fixtures packaged`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json fixtures/patchmill-test-repo
+git commit -m "feat: add setup test repo fixtures"
+```
+
+## Task 2: Add issue parsing and fixture loading
+
+**Files:**
+
+- Create: `src/cli/commands/setup-test-repo/issue-parser.ts`
+- Create: `src/cli/commands/setup-test-repo/issue-parser.test.ts`
+- Create: `src/cli/commands/setup-test-repo/fixtures.ts`
+- Create: `src/cli/commands/setup-test-repo/fixtures.test.ts`
+
+- [ ] **Step 1: Write failing issue parser tests**
+
+Create `src/cli/commands/setup-test-repo/issue-parser.test.ts`.
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseIssueFile } from "./issue-parser.ts";
+
+test("parseIssueFile parses title, labels, and body", () => {
+  const issue = parseIssueFile(
+    "01-example.md",
+    [
+      "---",
+      "title: Build the form",
+      "labels: [feature, polish]",
+      "---",
+      "",
+      "Create a useful form.",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(issue, {
+    fileName: "01-example.md",
+    title: "Build the form",
+    labels: ["feature", "polish"],
+    body: "Create a useful form.\n",
+  });
+});
+
+test("parseIssueFile allows missing labels", () => {
+  const issue = parseIssueFile(
+    "11-vague.md",
+    ["---", "title: Make it social", "---", "", "Needs discovery."].join("\n"),
+  );
+
+  assert.deepEqual(issue.labels, []);
+  assert.equal(issue.body, "Needs discovery.\n");
+});
+
+test("parseIssueFile rejects missing title", () => {
+  assert.throws(
+    () => parseIssueFile("bad.md", "---\nlabels: [feature]\n---\nBody"),
+    /bad\.md is missing required frontmatter field: title/,
+  );
+});
+
+test("parseIssueFile rejects invalid label syntax", () => {
+  assert.throws(
+    () =>
+      parseIssueFile("bad.md", "---\ntitle: Bad\nlabels: feature\n---\nBody"),
+    /bad\.md labels must use \[label, other-label\] syntax/,
+  );
+});
+
+test("parseIssueFile rejects empty labels", () => {
+  assert.throws(
+    () =>
+      parseIssueFile(
+        "bad.md",
+        "---\ntitle: Bad\nlabels: [feature, ]\n---\nBody",
+      ),
+    /bad\.md labels include an empty value/,
+  );
+});
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/issue-parser.test.ts`
+
+Expected: FAIL because `issue-parser.ts` does not exist.
+
+- [ ] **Step 2: Implement the issue parser**
+
+Create `src/cli/commands/setup-test-repo/issue-parser.ts`.
+
+```ts
+export type SetupIssue = {
+  fileName: string;
+  title: string;
+  labels: string[];
+  body: string;
+};
+
+function frontmatterValue(
+  fields: Map<string, string>,
+  name: string,
+): string | undefined {
+  const value = fields.get(name);
+  return value === undefined ? undefined : value.trim();
+}
+
+function parseLabels(fileName: string, value: string | undefined): string[] {
+  if (value === undefined) return [];
+  const match = /^\[(.*)\]$/u.exec(value.trim());
+  if (!match) {
+    throw new Error(`${fileName} labels must use [label, other-label] syntax`);
+  }
+
+  if (match[1].trim().length === 0) return [];
+  const labels = match[1].split(",").map((label) => label.trim());
+  if (labels.some((label) => label.length === 0)) {
+    throw new Error(`${fileName} labels include an empty value`);
+  }
+  return labels;
+}
+
+function parseFrontmatter(fileName: string, raw: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const line of raw.split(/\r?\n/u)) {
+    if (line.trim().length === 0) continue;
+    const match = /^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/u.exec(line);
+    if (!match) throw new Error(`${fileName} has invalid frontmatter: ${line}`);
+    fields.set(match[1], match[2]);
+  }
+  return fields;
+}
+
+export function parseIssueFile(fileName: string, content: string): SetupIssue {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/u.exec(content);
+  if (!match) throw new Error(`${fileName} is missing frontmatter`);
+
+  const fields = parseFrontmatter(fileName, match[1]);
+  const title = frontmatterValue(fields, "title");
+  if (!title) {
+    throw new Error(`${fileName} is missing required frontmatter field: title`);
+  }
+
+  return {
+    fileName,
+    title,
+    labels: parseLabels(fileName, frontmatterValue(fields, "labels")),
+    body: match[2].replace(/\s*$/u, "") + "\n",
+  };
+}
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/issue-parser.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Write failing fixture tests**
+
+Create `src/cli/commands/setup-test-repo/fixtures.test.ts`.
+
+```ts
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  copyFixtureToRepository,
+  loadSetupIssues,
+  resolveFixtureDirectory,
+  validateFixtureDirectory,
+} from "./fixtures.ts";
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "patchmill-fixture-test-"));
+}
+
+test("resolveFixtureDirectory finds fixtures from the package root", async () => {
+  const fixtureDir = await resolveFixtureDirectory(process.cwd());
+  assert.match(fixtureDir, /fixtures\/patchmill-test-repo$/u);
+});
+
+test("validateFixtureDirectory rejects missing project brief", async () => {
+  const root = await tempDir();
+  await mkdir(join(root, "issues"), { recursive: true });
+  await writeFile(join(root, "README.md"), "# Demo\n");
+
+  await assert.rejects(
+    () => validateFixtureDirectory(root),
+    /missing PROJECT_BRIEF\.md/,
+  );
+
+  await rm(root, { recursive: true, force: true });
+});
+
+test("loadSetupIssues reads fixture issues in filename order", async () => {
+  const fixtureDir = await resolveFixtureDirectory(process.cwd());
+  const issues = await loadSetupIssues(fixtureDir);
+
+  assert.equal(issues.length, 12);
+  assert.equal(issues[0]?.fileName, "01-project-scaffold.md");
+  assert.equal(issues[11]?.fileName, "12-votes-disappear.md");
+});
+
+test("copyFixtureToRepository copies docs and issue prompts", async () => {
+  const fixtureDir = await resolveFixtureDirectory(process.cwd());
+  const destination = await tempDir();
+
+  await copyFixtureToRepository(fixtureDir, destination);
+
+  assert.match(
+    await readFile(join(destination, "README.md"), "utf8"),
+    /Team Lunch Poll/u,
+  );
+  assert.match(
+    await readFile(join(destination, "PROJECT_BRIEF.md"), "utf8"),
+    /Product goals/u,
+  );
+  assert.match(
+    await readFile(
+      join(destination, "issues", "01-project-scaffold.md"),
+      "utf8",
+    ),
+    /Create the Team Lunch Poll app scaffold/u,
+  );
+
+  await rm(destination, { recursive: true, force: true });
+});
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/fixtures.test.ts`
+
+Expected: FAIL because `fixtures.ts` does not exist.
+
+- [ ] **Step 4: Implement fixture resolution, validation, loading, and copy**
+
+Create `src/cli/commands/setup-test-repo/fixtures.ts`.
+
+```ts
+import { constants } from "node:fs";
+import { access, cp, readdir, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseIssueFile, type SetupIssue } from "./issue-parser.ts";
+
+const FIXTURE_RELATIVE_PATH = join("fixtures", "patchmill-test-repo");
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findPackageRoot(startDir: string): Promise<string> {
+  let current = resolve(startDir);
+  for (;;) {
+    if (await exists(join(current, "package.json"))) return current;
+    const parent = dirname(current);
+    if (parent === current) throw new Error("Could not find package root");
+    current = parent;
+  }
+}
+
+export async function resolveFixtureDirectory(
+  startDir = dirname(fileURLToPath(import.meta.url)),
+): Promise<string> {
+  const packageRoot = await findPackageRoot(startDir);
+  return join(packageRoot, FIXTURE_RELATIVE_PATH);
+}
+
+export async function validateFixtureDirectory(
+  fixtureDir: string,
+): Promise<void> {
+  const required = ["README.md", "PROJECT_BRIEF.md", "issues"];
+  for (const entry of required) {
+    if (!(await exists(join(fixtureDir, entry)))) {
+      throw new Error(`Fixture directory is missing ${entry}`);
+    }
+  }
+}
+
+export async function loadSetupIssues(
+  fixtureDir: string,
+): Promise<SetupIssue[]> {
+  await validateFixtureDirectory(fixtureDir);
+  const issueDir = join(fixtureDir, "issues");
+  const files = (await readdir(issueDir))
+    .filter((file) => file.endsWith(".md"))
+    .sort((a, b) => a.localeCompare(b));
+
+  return Promise.all(
+    files.map(async (file) =>
+      parseIssueFile(file, await readFile(join(issueDir, file), "utf8")),
+    ),
+  );
+}
+
+export async function copyFixtureToRepository(
+  fixtureDir: string,
+  destination: string,
+): Promise<void> {
+  await validateFixtureDirectory(fixtureDir);
+  await cp(join(fixtureDir, "README.md"), join(destination, "README.md"));
+  await cp(
+    join(fixtureDir, "PROJECT_BRIEF.md"),
+    join(destination, "PROJECT_BRIEF.md"),
+  );
+  await cp(join(fixtureDir, "issues"), join(destination, "issues"), {
+    recursive: true,
+  });
+}
+```
+
+Run:
+
+```bash
+node --test src/cli/commands/setup-test-repo/issue-parser.test.ts src/cli/commands/setup-test-repo/fixtures.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/commands/setup-test-repo/issue-parser.ts src/cli/commands/setup-test-repo/issue-parser.test.ts src/cli/commands/setup-test-repo/fixtures.ts src/cli/commands/setup-test-repo/fixtures.test.ts
+git commit -m "feat: load setup test repo fixtures"
+```
+
+## Task 3: Add setup-test-repo argument parsing
+
+**Files:**
+
+- Modify: `src/host/types.ts`
+- Create: `src/cli/commands/setup-test-repo/args.ts`
+- Create: `src/cli/commands/setup-test-repo/args.test.ts`
+
+- [ ] **Step 1: Add the shared repository target type**
+
+Add this type to `src/host/types.ts` after `LabelDefinition`.
+
+```ts
+export type RepositoryTarget = {
+  owner: string;
+  repo: string;
+  slug: string;
+};
+```
+
+- [ ] **Step 2: Write failing parser tests**
+
+Create `src/cli/commands/setup-test-repo/args.test.ts`.
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseArgs } from "./args.ts";
+
+test("parseArgs requires provider", () => {
+  assert.throws(
+    () => parseArgs(["--repo", "OWNER/REPO"]),
+    /--provider is required/,
+  );
+});
+
+test("parseArgs requires repo", () => {
+  assert.throws(
+    () => parseArgs(["--provider", "github-gh"]),
+    /--repo OWNER\/REPO is required/,
+  );
+});
+
+test("parseArgs rejects unsupported providers", () => {
+  assert.throws(
+    () => parseArgs(["--provider", "gitlab", "--repo", "OWNER/REPO"]),
+    /Unsupported provider: gitlab/,
+  );
+});
+
+test("parseArgs rejects malformed repositories", () => {
+  assert.throws(
+    () => parseArgs(["--provider", "github-gh", "--repo", "OWNER"]),
+    /--repo must use OWNER\/REPO/,
+  );
+});
+
+test("parseArgs parses GitHub target", () => {
+  assert.deepEqual(
+    parseArgs(["--provider", "github-gh", "--repo", "OWNER/REPO"]),
+    {
+      showHelp: false,
+      provider: "github-gh",
+      target: { owner: "OWNER", repo: "REPO", slug: "OWNER/REPO" },
+      reset: false,
+    },
+  );
+});
+
+test("parseArgs parses Forgejo login and reset", () => {
+  assert.deepEqual(
+    parseArgs([
+      "--provider=forgejo-tea",
+      "--repo=team/lunch",
+      "--login",
+      "demo-login",
+      "--reset",
+    ]),
+    {
+      showHelp: false,
+      provider: "forgejo-tea",
+      target: { owner: "team", repo: "lunch", slug: "team/lunch" },
+      login: "demo-login",
+      reset: true,
+    },
+  );
+});
+
+test("parseArgs rejects GitHub login", () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        "--provider",
+        "github-gh",
+        "--repo",
+        "OWNER/REPO",
+        "--login",
+        "unused",
+      ]),
+    /--login is only supported with forgejo-tea/,
+  );
+});
+
+test("parseArgs returns help without requiring provider or repo", () => {
+  assert.deepEqual(parseArgs(["--help"]), {
+    showHelp: true,
+    reset: false,
+  });
+});
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/args.test.ts`
+
+Expected: FAIL because `args.ts` does not exist.
+
+- [ ] **Step 3: Implement parser**
+
+Create `src/cli/commands/setup-test-repo/args.ts`.
+
+```ts
+import type { PatchmillHostProviderId } from "../../../config/types.ts";
+import type { RepositoryTarget } from "../../../host/types.ts";
+
+export type SetupTestRepoConfig = {
+  showHelp: boolean;
+  provider?: PatchmillHostProviderId;
+  target?: RepositoryTarget;
+  login?: string;
+  reset: boolean;
+};
+
+const SUPPORTED_PROVIDERS = new Set<PatchmillHostProviderId>([
+  "github-gh",
+  "forgejo-tea",
+]);
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--"))
+    throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parseRepo(value: string): RepositoryTarget {
+  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/u.exec(value);
+  if (!match) throw new Error("--repo must use OWNER/REPO");
+  return { owner: match[1], repo: match[2], slug: value };
+}
+
+function parseProvider(value: string): PatchmillHostProviderId {
+  if (SUPPORTED_PROVIDERS.has(value as PatchmillHostProviderId)) {
+    return value as PatchmillHostProviderId;
+  }
+  throw new Error(`Unsupported provider: ${value}`);
+}
+
+export function parseArgs(args: string[]): SetupTestRepoConfig {
+  const config: SetupTestRepoConfig = { showHelp: false, reset: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      config.showHelp = true;
+    } else if (arg === "--provider") {
+      config.provider = parseProvider(requireValue(args, index, arg));
+      index += 1;
+    } else if (arg.startsWith("--provider=")) {
+      config.provider = parseProvider(arg.slice("--provider=".length));
+    } else if (arg === "--repo") {
+      config.target = parseRepo(requireValue(args, index, arg));
+      index += 1;
+    } else if (arg.startsWith("--repo=")) {
+      config.target = parseRepo(arg.slice("--repo=".length));
+    } else if (arg === "--login") {
+      config.login = requireValue(args, index, arg);
+      index += 1;
+    } else if (arg.startsWith("--login=")) {
+      config.login = arg.slice("--login=".length);
+      if (!config.login) throw new Error("--login requires a value");
+    } else if (arg === "--reset") {
+      config.reset = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (config.showHelp) return config;
+  if (!config.provider) throw new Error("--provider is required");
+  if (!config.target) throw new Error("--repo OWNER/REPO is required");
+  if (config.login && config.provider !== "forgejo-tea") {
+    throw new Error("--login is only supported with forgejo-tea");
+  }
+
+  return config;
+}
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/args.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/host/types.ts src/cli/commands/setup-test-repo/args.ts src/cli/commands/setup-test-repo/args.test.ts
+git commit -m "feat: parse setup test repo arguments"
+```
+
+## Task 4: Add generic GitHub host capabilities
+
+**Files:**
+
+- Modify: `src/host/types.ts`
+- Modify: `src/host/factory.ts`
+- Modify: `src/host/factory.test.ts`
+- Modify: `src/host/github-gh.ts`
+- Modify: `src/host/github-gh.test.ts`
+
+- [ ] **Step 1: Add generic host capability types**
+
+In `src/host/types.ts`, add these types after `RepositoryTarget`.
+
+```ts
+export type HostIssueCreateInput = {
+  title: string;
+  body: string;
+  labels: string[];
+};
+
+export type RepositoryLifecycleHostProvider = {
+  repoExists(target: RepositoryTarget): Promise<boolean>;
+  createPublicRepo(target: RepositoryTarget): Promise<void>;
+  deleteRepo(target: RepositoryTarget): Promise<void>;
+  gitRemoteUrl(target: RepositoryTarget): Promise<string>;
+  publicRepoUrl(target: RepositoryTarget): Promise<string>;
+  cloneCommand(target: RepositoryTarget): string;
+};
+
+export type GitHostProvider = IssueHostProvider &
+  RepositoryLifecycleHostProvider & {
+    createIssue(issue: HostIssueCreateInput): Promise<void>;
+  };
+```
+
+- [ ] **Step 2: Write failing GitHub tests**
+
+Append these tests to `src/host/github-gh.test.ts`. Reuse the file's existing
+fake runner helpers when possible; if the helper names differ, adapt only the
+helper calls and keep the asserted commands exactly the same.
+
+```ts
+test("GitHub provider checks repository existence with gh repo view", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: '{"name":"patchmill-test"}', stderr: "" },
+  ]);
+
+  assert.equal(
+    await provider.repoExists({
+      owner: "OWNER",
+      repo: "patchmill-test",
+      slug: "OWNER/patchmill-test",
+    }),
+    true,
+  );
+  assert.deepEqual(calls[0], {
+    command: "gh",
+    args: ["repo", "view", "OWNER/patchmill-test", "--json", "name"],
+    cwd: "/repo",
+  });
+});
+
+test("GitHub provider returns false when gh repo view cannot find the repo", async () => {
+  const { provider } = createProviderWithResponses([
+    { code: 1, stdout: "", stderr: "Could not resolve to a Repository" },
+  ]);
+
+  assert.equal(
+    await provider.repoExists({
+      owner: "OWNER",
+      repo: "missing",
+      slug: "OWNER/missing",
+    }),
+    false,
+  );
+});
+
+test("GitHub provider creates and deletes public repositories", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  await provider.createPublicRepo(target);
+  await provider.deleteRepo(target);
+
+  assert.deepEqual(
+    calls.map((call) => call.args),
+    [
+      ["repo", "create", "OWNER/patchmill-test", "--public"],
+      ["repo", "delete", "OWNER/patchmill-test", "--yes"],
+    ],
+  );
+});
+
+test("GitHub provider exposes remote URL, public URL, and clone command", async () => {
+  const { provider } = createProviderWithResponses([]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  assert.equal(
+    await provider.gitRemoteUrl(target),
+    "https://github.com/OWNER/patchmill-test.git",
+  );
+  assert.equal(
+    await provider.publicRepoUrl(target),
+    "https://github.com/OWNER/patchmill-test",
+  );
+  assert.equal(
+    provider.cloneCommand(target),
+    "gh repo clone OWNER/patchmill-test",
+  );
+});
+
+test("GitHub provider creates issues with labels when provided", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: "https://github.com/OWNER/patchmill-test/issues/1\n",
+      stderr: "",
+    },
+  ]);
+
+  await provider.createIssue({
+    title: "Build the form",
+    body: "Create a useful form.\n",
+    labels: ["feature", "polish"],
+  });
+
+  assert.deepEqual(calls[0]?.args, [
+    "issue",
+    "create",
+    "--title",
+    "Build the form",
+    "--body",
+    "Create a useful form.\n",
+    "--label",
+    "feature,polish",
+  ]);
+});
+```
+
+Run: `node --test src/host/github-gh.test.ts`
+
+Expected: FAIL because `GitHubGhHostProvider` does not have the new methods.
+
+- [ ] **Step 3: Implement GitHub provider methods**
+
+In `src/host/github-gh.ts`, import the new types.
+
+```ts
+import type {
+  HostCliCheck,
+  HostIssueCreateInput,
+  IssueHostProvider,
+  IssueSummary,
+  LabelChangePlan,
+  LabelDefinition,
+  RepositoryTarget,
+} from "./types.ts";
+```
+
+Add these methods inside `GitHubGhHostProvider`.
+
+```ts
+async repoExists(target: RepositoryTarget): Promise<boolean> {
+  const result = await this.runGh([
+    "repo",
+    "view",
+    target.slug,
+    "--json",
+    "name",
+  ]);
+  return result.code === 0;
+}
+
+async createPublicRepo(target: RepositoryTarget): Promise<void> {
+  const result = await this.runGh(["repo", "create", target.slug, "--public"]);
+  if (result.code !== 0) {
+    throw new Error(
+      `gh repo create failed for ${target.slug}: ${commandOutput(result)}`,
+    );
+  }
+}
+
+async deleteRepo(target: RepositoryTarget): Promise<void> {
+  const result = await this.runGh(["repo", "delete", target.slug, "--yes"]);
+  if (result.code !== 0) {
+    throw new Error(
+      `gh repo delete failed for ${target.slug}: ${commandOutput(result)}`,
+    );
+  }
+}
+
+async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
+  return `https://github.com/${target.slug}.git`;
+}
+
+async publicRepoUrl(target: RepositoryTarget): Promise<string> {
+  return `https://github.com/${target.slug}`;
+}
+
+cloneCommand(target: RepositoryTarget): string {
+  return `gh repo clone ${target.slug}`;
+}
+
+async createIssue(issue: HostIssueCreateInput): Promise<void> {
+  const args = ["issue", "create", "--title", issue.title, "--body", issue.body];
+  if (issue.labels.length > 0) args.push("--label", issue.labels.join(","));
+
+  const result = await this.runGh(args);
+  if (result.code !== 0) {
+    throw new Error(
+      `gh issue create failed for ${issue.title}: ${commandOutput(result)}`,
+    );
+  }
+}
+```
+
+Run: `node --test src/host/github-gh.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Add the expanded factory without breaking existing callers**
+
+Modify `src/host/factory.ts` so existing callers can continue using
+`createIssueHostProvider()` while setup can request the expanded type.
+
+```ts
+import type { GitHostProvider, IssueHostProvider } from "./types.ts";
+
+export function createGitHostProvider(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  host: PatchmillHostConfig;
+}): GitHostProvider {
+  switch (options.host.provider) {
+    case "forgejo-tea":
+      return new ForgejoTeaHostProvider({
+        runner: options.runner,
+        repoRoot: options.repoRoot,
+        login: options.host.login,
+      });
+    case "github-gh":
+      return new GitHubGhHostProvider({
+        runner: options.runner,
+        repoRoot: options.repoRoot,
+      });
+  }
+}
+
+export function createIssueHostProvider(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  host: PatchmillHostConfig;
+}): IssueHostProvider {
+  return createGitHostProvider(options);
+}
+```
+
+Append this test to `src/host/factory.test.ts`.
+
+```ts
+test("createGitHostProvider exposes generic repository capabilities", () => {
+  const provider = createGitHostProvider({
+    runner,
+    repoRoot: "/repo",
+    host: { provider: "github-gh", login: "" },
+  });
+
+  assert.equal(typeof provider.repoExists, "function");
+  assert.equal(typeof provider.createPublicRepo, "function");
+  assert.equal(typeof provider.deleteRepo, "function");
+  assert.equal(typeof provider.gitRemoteUrl, "function");
+  assert.equal(typeof provider.publicRepoUrl, "function");
+  assert.equal(typeof provider.cloneCommand, "function");
+  assert.equal(typeof provider.createIssue, "function");
+});
+```
+
+Run: `node --test src/host/factory.test.ts src/host/github-gh.test.ts`
+
+Expected: PASS after importing `createGitHostProvider` in the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/host/types.ts src/host/factory.ts src/host/factory.test.ts src/host/github-gh.ts src/host/github-gh.test.ts
+git commit -m "feat: add generic github host repository commands"
+```
+
+## Task 5: Add generic Forgejo/Gitea host capabilities
+
+**Files:**
+
+- Create: `src/host/forgejo-tea-context.ts`
+- Create: `src/host/forgejo-tea-context.test.ts`
+- Modify: `src/cli/commands/triage/forgejo.ts`
+- Modify: `src/host/forgejo-tea.ts`
+- Modify: `src/host/forgejo-tea.test.ts`
+- Modify: `src/host/factory.test.ts`
+
+- [ ] **Step 1: Extract shared tea context tests**
+
+Create `src/host/forgejo-tea-context.test.ts`.
+
+```ts
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { withTeaContext } from "./forgejo-tea-context.ts";
+
+async function gitRepoWithOrigin(remoteUrl: string): Promise<string> {
+  const repoRoot = join(
+    tmpdir(),
+    `patchmill-tea-context-${Date.now()}-${Math.random()}`,
+  );
+  await mkdir(join(repoRoot, ".git"), { recursive: true });
+  await writeFile(
+    join(repoRoot, ".git", "config"),
+    `[remote "origin"]\n\turl = ${remoteUrl}\n`,
+  );
+  return repoRoot;
+}
+
+test("withTeaContext adds repo from origin remote", async () => {
+  const repoRoot = await gitRepoWithOrigin("git@example.test:OWNER/REPO.git");
+
+  assert.deepEqual(withTeaContext(["issues", "list"], repoRoot), [
+    "issues",
+    "list",
+    "--repo",
+    "OWNER/REPO",
+  ]);
+
+  await rm(repoRoot, { recursive: true, force: true });
+});
+
+test("withTeaContext adds login before -- body separator", async () => {
+  const repoRoot = await gitRepoWithOrigin(
+    "https://forgejo.example/OWNER/REPO.git",
+  );
+
+  assert.deepEqual(
+    withTeaContext(["comment", "1", "--", "hello"], repoRoot, "demo"),
+    ["comment", "1", "--repo", "OWNER/REPO", "--login", "demo", "--", "hello"],
+  );
+
+  await rm(repoRoot, { recursive: true, force: true });
+});
+```
+
+Run: `node --test src/host/forgejo-tea-context.test.ts`
+
+Expected: FAIL because `forgejo-tea-context.ts` does not exist.
+
+- [ ] **Step 2: Move existing tea context logic into src/host**
+
+Create `src/host/forgejo-tea-context.ts` by moving the existing generic helpers
+from `src/cli/commands/triage/forgejo.ts`: `insertBeforeSeparator`,
+`commonGitConfigPath`, `gitConfigPath`, `originRemoteUrl`,
+`repoSlugFromRemoteUrl`, `teaRepo`, and `withTeaContext`.
+
+Export only `withTeaContext`.
+
+```ts
+export function withTeaContext(
+  args: string[],
+  repoRoot: string,
+  teaLogin?: string,
+): string[] {
+  const repoArgs = insertBeforeSeparator(args, ["--repo", teaRepo(repoRoot)]);
+  if (!teaLogin) return repoArgs;
+  return insertBeforeSeparator(repoArgs, ["--login", teaLogin]);
+}
+```
+
+In `src/cli/commands/triage/forgejo.ts`, delete the moved helper definitions and
+add this import.
+
+```ts
+import { withTeaContext } from "../../../host/forgejo-tea-context.ts";
+```
+
+Run:
+
+```bash
+node --test src/host/forgejo-tea-context.test.ts src/host/forgejo-tea.test.ts
+```
+
+Expected: PASS. This step is a refactor; Forgejo triage behavior should stay the
+same.
+
+- [ ] **Step 3: Write failing Forgejo provider lifecycle tests**
+
+Append these tests to `src/host/forgejo-tea.test.ts`. Reuse existing fake runner
+helpers from the file.
+
+```ts
+test("Forgejo provider checks repository existence with tea repos search", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: JSON.stringify([
+        {
+          owner: { login: "OWNER" },
+          name: "patchmill-test",
+          url: "https://forgejo.example/OWNER/patchmill-test",
+          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
+        },
+      ]),
+      stderr: "",
+    },
+  ]);
+
+  assert.equal(
+    await provider.repoExists({
+      owner: "OWNER",
+      repo: "patchmill-test",
+      slug: "OWNER/patchmill-test",
+    }),
+    true,
+  );
+  assert.deepEqual(calls[0]?.args, [
+    "repos",
+    "search",
+    "patchmill-test",
+    "--owner",
+    "OWNER",
+    "--fields",
+    "owner,name,ssh,url",
+    "--limit",
+    "50",
+    "--output",
+    "json",
+    "--login",
+    "triage-agent",
+  ]);
+});
+
+test("Forgejo provider creates and deletes public repositories", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "{}", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  await provider.createPublicRepo(target);
+  await provider.deleteRepo(target);
+
+  assert.deepEqual(
+    calls.map((call) => call.args),
+    [
+      [
+        "repos",
+        "create",
+        "--name",
+        "patchmill-test",
+        "--owner",
+        "OWNER",
+        "--output",
+        "json",
+        "--login",
+        "triage-agent",
+      ],
+      [
+        "repos",
+        "delete",
+        "--name",
+        "patchmill-test",
+        "--owner",
+        "OWNER",
+        "--force",
+        "--login",
+        "triage-agent",
+      ],
+    ],
+  );
+});
+
+test("Forgejo provider reads clone and public URLs from repository info", async () => {
+  const { provider } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: JSON.stringify([
+        {
+          owner: "OWNER",
+          name: "patchmill-test",
+          url: "https://forgejo.example/OWNER/patchmill-test",
+          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
+        },
+      ]),
+      stderr: "",
+    },
+    {
+      code: 0,
+      stdout: JSON.stringify([
+        {
+          owner: "OWNER",
+          name: "patchmill-test",
+          url: "https://forgejo.example/OWNER/patchmill-test",
+          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
+        },
+      ]),
+      stderr: "",
+    },
+  ]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  assert.equal(
+    await provider.gitRemoteUrl(target),
+    "git@forgejo.example:OWNER/patchmill-test.git",
+  );
+  assert.equal(
+    await provider.publicRepoUrl(target),
+    "https://forgejo.example/OWNER/patchmill-test",
+  );
+  assert.equal(provider.cloneCommand(target), "tea clone OWNER/patchmill-test");
+});
+
+test("Forgejo provider creates issues with labels", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+
+  await provider.createIssue({
+    title: "Build the form",
+    body: "Create a useful form.\n",
+    labels: ["feature", "polish"],
+  });
+
+  assert.deepEqual(calls[0]?.args, [
+    "issues",
+    "create",
+    "--title",
+    "Build the form",
+    "--description",
+    "Create a useful form.\n",
+    "--labels",
+    "feature,polish",
+    "--repo",
+    "/repo",
+    "--login",
+    "triage-agent",
+  ]);
+});
+```
+
+Run: `node --test src/host/forgejo-tea.test.ts`
+
+Expected: FAIL because the provider does not have the new lifecycle methods.
+
+- [ ] **Step 4: Implement Forgejo provider lifecycle and issue methods**
+
+In `src/host/forgejo-tea.ts`, import the new types and shared context helper.
+
+```ts
+import { withTeaContext } from "./forgejo-tea-context.ts";
+import type {
+  HostCliCheck,
+  HostIssueCreateInput,
+  IssueHostProvider,
+  IssueSummary,
+  LabelChangePlan,
+  LabelDefinition,
+  RepositoryTarget,
+} from "./types.ts";
+```
+
+Add private repo info parsing helpers above the class.
+
+```ts
+type TeaRepoPayload = Record<string, unknown>;
+
+type TeaRepoInfo = {
+  webUrl: string;
+  cloneUrl: string;
+};
+
+function parseJson(stdout: string, context: string): unknown {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `${context} returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function ownerName(owner: unknown): string | undefined {
+  if (typeof owner === "string") return owner;
+  if (owner && typeof owner === "object") {
+    const value = owner as Record<string, unknown>;
+    if (typeof value.login === "string") return value.login;
+    if (typeof value.name === "string") return value.name;
+    if (typeof value.username === "string") return value.username;
+  }
+  return undefined;
+}
+
+function repoMatches(entry: TeaRepoPayload, target: RepositoryTarget): boolean {
+  return ownerName(entry.owner) === target.owner && entry.name === target.repo;
+}
+
+function repoInfo(
+  entry: TeaRepoPayload,
+  target: RepositoryTarget,
+): TeaRepoInfo {
+  if (typeof entry.url !== "string") {
+    throw new Error(
+      `tea repos search did not return a web URL for ${target.slug}`,
+    );
+  }
+  if (typeof entry.ssh !== "string") {
+    throw new Error(
+      `tea repos search did not return an SSH URL for ${target.slug}`,
+    );
+  }
+  return { webUrl: entry.url, cloneUrl: entry.ssh };
+}
+```
+
+Add these methods inside `ForgejoTeaHostProvider`.
+
+```ts
+private runTea(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const withLogin = this.options.login ? [...args, "--login", this.options.login] : args;
+  return this.options.runner.run("tea", withLogin, { cwd: this.options.repoRoot });
+}
+
+private async repositoryInfo(target: RepositoryTarget): Promise<TeaRepoInfo | undefined> {
+  const result = await this.runTea([
+    "repos",
+    "search",
+    target.repo,
+    "--owner",
+    target.owner,
+    "--fields",
+    "owner,name,ssh,url",
+    "--limit",
+    "50",
+    "--output",
+    "json",
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`tea repos search failed for ${target.slug}: ${commandOutput(result)}`);
+  }
+  const parsed = parseJson(result.stdout, "tea repos search");
+  if (!Array.isArray(parsed)) throw new Error("tea repos search returned a non-array payload");
+  const match = parsed.find(
+    (entry): entry is TeaRepoPayload =>
+      Boolean(entry) && typeof entry === "object" && repoMatches(entry as TeaRepoPayload, target),
+  );
+  return match ? repoInfo(match, target) : undefined;
+}
+
+async repoExists(target: RepositoryTarget): Promise<boolean> {
+  return (await this.repositoryInfo(target)) !== undefined;
+}
+
+async createPublicRepo(target: RepositoryTarget): Promise<void> {
+  const result = await this.runTea([
+    "repos",
+    "create",
+    "--name",
+    target.repo,
+    "--owner",
+    target.owner,
+    "--output",
+    "json",
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`tea repos create failed for ${target.slug}: ${commandOutput(result)}`);
+  }
+}
+
+async deleteRepo(target: RepositoryTarget): Promise<void> {
+  const result = await this.runTea([
+    "repos",
+    "delete",
+    "--name",
+    target.repo,
+    "--owner",
+    target.owner,
+    "--force",
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`tea repos delete failed for ${target.slug}: ${commandOutput(result)}`);
+  }
+}
+
+async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
+  const info = await this.repositoryInfo(target);
+  if (!info) throw new Error(`Repository not found: ${target.slug}`);
+  return info.cloneUrl;
+}
+
+async publicRepoUrl(target: RepositoryTarget): Promise<string> {
+  const info = await this.repositoryInfo(target);
+  if (!info) throw new Error(`Repository not found: ${target.slug}`);
+  return info.webUrl;
+}
+
+cloneCommand(target: RepositoryTarget): string {
+  return `tea clone ${target.slug}`;
+}
+
+async createIssue(issue: HostIssueCreateInput): Promise<void> {
+  const args = [
+    "issues",
+    "create",
+    "--title",
+    issue.title,
+    "--description",
+    issue.body,
+  ];
+  if (issue.labels.length > 0) args.push("--labels", issue.labels.join(","));
+
+  const result = await this.options.runner.run(
+    "tea",
+    withTeaContext(args, this.options.repoRoot, this.options.login),
+    { cwd: this.options.repoRoot },
+  );
+  if (result.code !== 0) {
+    throw new Error(`tea issues create failed for ${issue.title}: ${commandOutput(result)}`);
+  }
+}
+```
+
+Run:
+
+```bash
+node --test src/host/forgejo-tea-context.test.ts src/host/forgejo-tea.test.ts src/host/factory.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/host/forgejo-tea-context.ts src/host/forgejo-tea-context.test.ts src/cli/commands/triage/forgejo.ts src/host/forgejo-tea.ts src/host/forgejo-tea.test.ts src/host/factory.test.ts
+git commit -m "feat: add generic forgejo host repository commands"
+```
+
+## Task 6: Add setup command orchestration
+
+**Files:**
+
+- Create: `src/cli/commands/setup-test-repo/labels.ts`
+- Create: `src/cli/commands/setup-test-repo/main.ts`
+- Create: `src/cli/commands/setup-test-repo/main.test.ts`
+- Create: `src/cli/commands/setup-test-repo/host-boundary.test.ts`
+
+- [ ] **Step 1: Add setup-specific label definitions**
+
+Create `src/cli/commands/setup-test-repo/labels.ts`.
+
+```ts
+import type { LabelDefinition } from "../../../host/types.ts";
+
+export const SETUP_TEST_REPO_LABELS: LabelDefinition[] = [
+  {
+    name: "feature",
+    color: "0e8a16",
+    description: "New user-facing functionality.",
+  },
+  {
+    name: "bug",
+    color: "d73a4a",
+    description: "Something is broken or behaves incorrectly.",
+  },
+  {
+    name: "docs",
+    color: "0075ca",
+    description: "Documentation or usage guidance.",
+  },
+  {
+    name: "polish",
+    color: "a2eeef",
+    description: "Visual, UX, or cleanup improvement.",
+  },
+];
+```
+
+- [ ] **Step 2: Write failing orchestration tests**
+
+Create `src/cli/commands/setup-test-repo/main.test.ts`. Use a mocked provider
+and mocked runner so no real `git`, `gh`, or `tea` command runs.
+
+```ts
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { runSetupTestRepo } from "./main.ts";
+import type { CommandRunner } from "../triage/types.ts";
+import type {
+  GitHostProvider,
+  HostCliCheck,
+  HostIssueCreateInput,
+  LabelChangePlan,
+  LabelDefinition,
+  RepositoryTarget,
+} from "../../../host/types.ts";
+
+function okCli(): HostCliCheck {
+  return { ok: true, message: "ok" };
+}
+
+function createProvider(options: { exists?: boolean } = {}): {
+  provider: GitHostProvider;
+  calls: string[];
+  issues: HostIssueCreateInput[];
+  labels: LabelDefinition[];
+} {
+  const calls: string[] = [];
+  const issues: HostIssueCreateInput[] = [];
+  const labels: LabelDefinition[] = [];
+  const provider: GitHostProvider = {
+    id: "github-gh",
+    displayName: "GitHub via gh",
+    async checkCli() {
+      calls.push("checkCli");
+      return okCli();
+    },
+    missingLabelRemediation(label) {
+      return `create ${label.name}`;
+    },
+    async listOpenIssues() {
+      return [];
+    },
+    async viewIssue() {
+      throw new Error("not used");
+    },
+    async hydrateIssueComments(value) {
+      return value;
+    },
+    async listLabels() {
+      return [];
+    },
+    async createLabel(label) {
+      labels.push(label);
+    },
+    async applyLabels(_change: LabelChangePlan) {},
+    async commentIssue() {},
+    async repoExists() {
+      calls.push("repoExists");
+      return options.exists ?? false;
+    },
+    async createPublicRepo(target: RepositoryTarget) {
+      calls.push(`createPublicRepo:${target.slug}`);
+    },
+    async deleteRepo(target: RepositoryTarget) {
+      calls.push(`deleteRepo:${target.slug}`);
+    },
+    async gitRemoteUrl(target: RepositoryTarget) {
+      return `https://example.test/${target.slug}.git`;
+    },
+    async publicRepoUrl(target: RepositoryTarget) {
+      return `https://example.test/${target.slug}`;
+    },
+    cloneCommand(target: RepositoryTarget) {
+      return `gh repo clone ${target.slug}`;
+    },
+    async createIssue(issue: HostIssueCreateInput) {
+      issues.push(issue);
+    },
+  };
+  return { provider, calls, issues, labels };
+}
+
+function createGitRunner(): { runner: CommandRunner; gitCalls: string[][] } {
+  const gitCalls: string[][] = [];
+  return {
+    gitCalls,
+    runner: {
+      async run(command, args) {
+        if (command !== "git")
+          throw new Error(`Unexpected command: ${command}`);
+        gitCalls.push(args);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+  };
+}
+
+test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues", async () => {
+  const tempParent = await mkdtemp(join(tmpdir(), "patchmill-setup-test-"));
+  const { provider, calls, labels, issues } = createProvider({ exists: false });
+  const { runner, gitCalls } = createGitRunner();
+  const stdout: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      tempParent,
+      output: { stdout: (line) => stdout.push(line), stderr: () => undefined },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.deepEqual(calls, [
+    "checkCli",
+    "repoExists",
+    "createPublicRepo:OWNER/patchmill-test",
+  ]);
+  assert.deepEqual(
+    gitCalls.map((args) => args[0]),
+    ["--version", "init", "add", "commit", "remote", "push"],
+  );
+  assert.deepEqual(
+    labels.map((label) => label.name),
+    ["feature", "bug", "docs", "polish"],
+  );
+  assert.equal(issues.length, 12);
+  assert.equal(issues[0]?.title, "Create the Team Lunch Poll app scaffold");
+  assert.match(stdout.join("\n"), /patchmill init/u);
+
+  await rm(tempParent, { recursive: true, force: true });
+});
+
+test("runSetupTestRepo refuses existing repo without reset", async () => {
+  const { provider } = createProvider({ exists: true });
+  const { runner } = createGitRunner();
+  const stderr: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      output: { stdout: () => undefined, stderr: (line) => stderr.push(line) },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.match(stderr.join("\n"), /already exists/u);
+  assert.match(stderr.join("\n"), /--reset/u);
+});
+
+test("runSetupTestRepo deletes and recreates when reset is supplied", async () => {
+  const { provider, calls } = createProvider({ exists: true });
+  const { runner } = createGitRunner();
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test", "--reset"],
+    {
+      runner,
+      output: { stdout: () => undefined, stderr: () => undefined },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.deepEqual(calls, [
+    "checkCli",
+    "repoExists",
+    "deleteRepo:OWNER/patchmill-test",
+    "createPublicRepo:OWNER/patchmill-test",
+  ]);
+});
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/main.test.ts`
+
+Expected: FAIL because `main.ts` does not exist.
+
+- [ ] **Step 3: Implement setup command orchestration**
+
+Create `src/cli/commands/setup-test-repo/main.ts`.
+
+```ts
+#!/usr/bin/env node
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createCommandRunner } from "../triage/command.ts";
+import type { CommandRunner } from "../triage/types.ts";
+import { createGitHostProvider } from "../../../host/factory.ts";
+import type { GitHostProvider, RepositoryTarget } from "../../../host/types.ts";
+import { parseArgs } from "./args.ts";
+import {
+  copyFixtureToRepository,
+  loadSetupIssues,
+  resolveFixtureDirectory,
+} from "./fixtures.ts";
+import { SETUP_TEST_REPO_LABELS } from "./labels.ts";
+
+export const HELP_TEXT = `Usage:
+  patchmill setup-test-repo --provider github-gh --repo OWNER/REPO [--reset]
+  patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN [--reset]
+
+Create or reset a disposable public Team Lunch Poll repository for trying Patchmill.
+
+Options:
+  --help, -h             Show this help and exit.
+  --provider PROVIDER    Required. One of: github-gh, forgejo-tea.
+  --repo OWNER/REPO      Required. Disposable target repository.
+  --login LOGIN          Optional named tea login for forgejo-tea.
+  --reset                Delete and recreate the target repository before seeding.
+`;
+
+export type SetupTestRepoOutput = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+};
+
+export type SetupTestRepoDependencies = {
+  runner?: CommandRunner;
+  output?: SetupTestRepoOutput;
+  tempParent?: string;
+  createProvider?: (options: {
+    runner: CommandRunner;
+    repoRoot: string;
+    provider: "github-gh" | "forgejo-tea";
+    login: string;
+  }) => GitHostProvider;
+};
+
+const DEFAULT_OUTPUT: SetupTestRepoOutput = {
+  stdout: (line) => console.log(line),
+  stderr: (line) => console.error(line),
+};
+
+async function runGit(
+  runner: CommandRunner,
+  repoRoot: string,
+  args: string[],
+): Promise<void> {
+  const result = await runner.run("git", args, { cwd: repoRoot });
+  if (result.code !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+async function ensureGit(runner: CommandRunner): Promise<void> {
+  const result = await runner.run("git", ["--version"]);
+  if (result.code !== 0) {
+    throw new Error(`git --version failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function createProviderFromFactory(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  provider: "github-gh" | "forgejo-tea";
+  login: string;
+}): GitHostProvider {
+  return createGitHostProvider({
+    runner: options.runner,
+    repoRoot: options.repoRoot,
+    host: { provider: options.provider, login: options.login },
+  });
+}
+
+async function prepareRepository(options: {
+  provider: GitHostProvider;
+  target: RepositoryTarget;
+  reset: boolean;
+  output: SetupTestRepoOutput;
+}): Promise<void> {
+  const exists = await options.provider.repoExists(options.target);
+  if (exists && !options.reset) {
+    throw new Error(
+      `Repository ${options.target.slug} already exists. Rerun with --reset only if it is disposable and safe to delete.`,
+    );
+  }
+
+  if (options.reset) {
+    options.output.stdout(
+      `Resetting ${options.provider.displayName} repository ${options.target.slug}`,
+    );
+    if (exists) await options.provider.deleteRepo(options.target);
+  }
+
+  await options.provider.createPublicRepo(options.target);
+}
+
+async function seedGitRepository(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  remoteUrl: string;
+}): Promise<void> {
+  await runGit(options.runner, options.repoRoot, ["init", "-b", "main"]);
+  await runGit(options.runner, options.repoRoot, [
+    "add",
+    "README.md",
+    "PROJECT_BRIEF.md",
+    "issues",
+  ]);
+  await runGit(options.runner, options.repoRoot, [
+    "commit",
+    "-m",
+    "Seed Team Lunch Poll demo",
+  ]);
+  await runGit(options.runner, options.repoRoot, [
+    "remote",
+    "add",
+    "origin",
+    options.remoteUrl,
+  ]);
+  await runGit(options.runner, options.repoRoot, [
+    "push",
+    "-u",
+    "origin",
+    "main",
+  ]);
+}
+
+export async function runSetupTestRepo(
+  args: string[],
+  dependencies: SetupTestRepoDependencies = {},
+): Promise<number> {
+  const output = dependencies.output ?? DEFAULT_OUTPUT;
+  try {
+    const config = parseArgs(args);
+    if (config.showHelp) {
+      output.stdout(HELP_TEXT);
+      return 0;
+    }
+    if (!config.provider || !config.target)
+      throw new Error("Invalid setup-test-repo configuration");
+
+    const runner = dependencies.runner ?? createCommandRunner();
+    await ensureGit(runner);
+
+    const tempParent = dependencies.tempParent ?? tmpdir();
+    const repoRoot = await mkdtemp(join(tempParent, "patchmill-test-repo-"));
+    try {
+      const provider = (
+        dependencies.createProvider ?? createProviderFromFactory
+      )({
+        runner,
+        repoRoot,
+        provider: config.provider,
+        login: config.login ?? "",
+      });
+
+      const cli = await provider.checkCli();
+      if (!cli.ok) {
+        throw new Error([cli.message, ...cli.remediation].join("\n"));
+      }
+
+      await prepareRepository({
+        provider,
+        target: config.target,
+        reset: config.reset,
+        output,
+      });
+
+      const fixtureDir = await resolveFixtureDirectory();
+      const issues = await loadSetupIssues(fixtureDir);
+      await copyFixtureToRepository(fixtureDir, repoRoot);
+      await seedGitRepository({
+        runner,
+        repoRoot,
+        remoteUrl: await provider.gitRemoteUrl(config.target),
+      });
+
+      for (const label of SETUP_TEST_REPO_LABELS)
+        await provider.createLabel(label);
+      for (const issue of issues) await provider.createIssue(issue);
+
+      output.stdout(`Seeded ${await provider.publicRepoUrl(config.target)}`);
+      output.stdout("");
+      output.stdout("Next steps:");
+      output.stdout(`  ${provider.cloneCommand(config.target)}`);
+      output.stdout(`  cd ${config.target.repo}`);
+      output.stdout("  patchmill init");
+      output.stdout("  patchmill triage --dry-run");
+      output.stdout("  patchmill triage");
+      return 0;
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  } catch (error) {
+    output.stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  return runSetupTestRepo(args);
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isMain) {
+  process.exitCode = await main();
+}
+```
+
+Run: `node --test src/cli/commands/setup-test-repo/main.test.ts`
+
+Expected: PASS after adjusting any fake runner assumptions exposed by the test.
+
+- [ ] **Step 4: Add the host boundary test**
+
+Create `src/cli/commands/setup-test-repo/host-boundary.test.ts`.
+
+```ts
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const commandDir = dirname(fileURLToPath(import.meta.url));
+
+async function tsFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...(await tsFiles(path)));
+    if (entry.isFile() && entry.name.endsWith(".ts")) files.push(path);
+  }
+  return files;
+}
+
+test("setup-test-repo command does not invoke provider CLIs directly", async () => {
+  for (const file of await tsFiles(commandDir)) {
+    const content = await readFile(file, "utf8");
+    assert.doesNotMatch(content, /\.run\(\s*["'](?:gh|tea)["']/u, file);
+    assert.doesNotMatch(
+      content,
+      /\b(?:spawn|exec|execFile)\(\s*["'](?:gh|tea)["']/u,
+      file,
+    );
+  }
+});
+```
+
+Run:
+
+```bash
+node --test src/cli/commands/setup-test-repo/*.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/commands/setup-test-repo/labels.ts src/cli/commands/setup-test-repo/main.ts src/cli/commands/setup-test-repo/main.test.ts src/cli/commands/setup-test-repo/host-boundary.test.ts
+git commit -m "feat: orchestrate setup test repo command"
+```
+
+## Task 7: Register the public CLI command
+
+**Files:**
+
+- Modify: `src/cli/main.ts`
+- Modify: `src/cli/main.test.ts`
+
+- [ ] **Step 1: Write failing CLI registration tests**
+
+Append these tests to `src/cli/main.test.ts`.
+
+```ts
+test("resolveCommand maps setup-test-repo to the public command name", () => {
+  assert.deepEqual(
+    resolveCommand(
+      ["setup-test-repo", "--provider", "github-gh"],
+      ["setup-test-repo"],
+    ),
+    {
+      command: "setup-test-repo",
+      args: ["--provider", "github-gh"],
+    },
+  );
+});
+
+test("createCliMain dispatches setup-test-repo command", async () => {
+  const calls: string[][] = [];
+  const main = createCliMain(
+    new Map([
+      [
+        "setup-test-repo",
+        async (args) => {
+          calls.push(args);
+          return 0;
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(
+    await main([
+      "setup-test-repo",
+      "--provider",
+      "github-gh",
+      "--repo",
+      "OWNER/REPO",
+    ]),
+    0,
+  );
+  assert.deepEqual(calls, [
+    ["--provider", "github-gh", "--repo", "OWNER/REPO"],
+  ]);
+});
+```
+
+Update the help test to assert the new command appears.
+
+```ts
+assert.match(
+  HELP_TEXT,
+  /setup-test-repo\s+Create or reset a disposable Patchmill demo repository\./,
+);
+```
+
+Run: `node --test src/cli/main.test.ts`
+
+Expected: FAIL because the help text and command map do not include
+`setup-test-repo`.
+
+- [ ] **Step 2: Register setup-test-repo**
+
+In `src/cli/main.ts`, import the command.
+
+```ts
+import { main as setupTestRepoMain } from "./commands/setup-test-repo/main.ts";
+```
+
+Add the help row.
+
+```ts
+  setup-test-repo  Create or reset a disposable Patchmill demo repository.
+```
+
+Add the command to `COMMANDS`.
+
+```ts
+["setup-test-repo", setupTestRepoMain],
+```
+
+Run:
+`node --test src/cli/main.test.ts src/cli/commands/setup-test-repo/*.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/main.ts src/cli/main.test.ts
+git commit -m "feat: register setup test repo command"
+```
+
+## Task 8: Add README and reference documentation
+
+**Files:**
+
+- Modify: `README.md`
+- Create: `docs/setup-test-repo.md`
+
+- [ ] **Step 1: Update README first-use guidance**
+
+In `README.md`, add this section under `## First use`, before the production
+repository workflow.
+
+````markdown
+### Try Patchmill on a disposable demo repository
+
+Before pointing Patchmill at a production repository, create a disposable Team
+Lunch Poll demo repository and let Patchmill triage its seeded issues.
+
+For GitHub:
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+gh repo clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+```
+
+For Forgejo or Gitea with a named `tea` login:
+
+```bash
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
+tea clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+```
+
+Use an explicit disposable public repository for `OWNER/REPO`. The reset form
+deletes and recreates that repository:
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
+```
+
+The reusable demo prompts live in the Patchmill package under
+`fixtures/patchmill-test-repo/`. See `docs/setup-test-repo.md` for details.
+````
+
+- [ ] **Step 2: Add reference documentation**
+
+Create `docs/setup-test-repo.md`.
+
+````markdown
+# Setup Test Repo
+
+`patchmill setup-test-repo` creates a disposable public Team Lunch Poll
+repository for trying Patchmill safely before using it on production issues.
+
+## When to use it
+
+Use this command when you want to see `patchmill init` and `patchmill triage`
+work on realistic greenfield issues without risking an existing project.
+
+## Supported providers
+
+The command supports the same issue hosts Patchmill currently supports:
+
+- `github-gh` through the GitHub `gh` CLI.
+- `forgejo-tea` through the Forgejo/Gitea `tea` CLI.
+
+The provider is required. Patchmill does not infer it from git remotes or CLI
+state.
+
+## Create a disposable GitHub repository
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+```
+
+## Create a disposable Forgejo/Gitea repository
+
+```bash
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
+```
+
+## Reset a disposable repository
+
+`--reset` deletes and recreates the selected public repository. Use it only for
+a repository you are comfortable losing.
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
+```
+
+## Fixture contents
+
+The seeded repository receives these files from the installed Patchmill package:
+
+- `README.md`
+- `PROJECT_BRIEF.md`
+- `issues/*.md`
+
+The source fixture lives at `fixtures/patchmill-test-repo/` in the Patchmill
+package and source tree.
+
+## Manual Patchmill workflow
+
+After setup, clone the disposable repository and run:
+
+```bash
+patchmill init
+patchmill triage --dry-run
+patchmill triage
+```
+
+`setup-test-repo` does not run `patchmill init` for you. The goal is to provide
+a safe repository where you can exercise the same first-use workflow you would
+run on a real project.
+````
+
+- [ ] **Step 3: Verify markdown**
+
+Run:
+
+```bash
+npx markdownlint-cli2 README.md docs/setup-test-repo.md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/setup-test-repo.md
+git commit -m "docs: document setup test repo workflow"
+```
+
+## Task 9: Verify packaging, full tests, and live GitHub setup
+
+**Files:**
+
+- Modify only if verification exposes a defect in files changed by earlier
+  tasks.
+
+- [ ] **Step 1: Run focused setup command tests**
+
+```bash
+node --test src/cli/commands/setup-test-repo/*.test.ts
+```
+
+Expected: all setup command tests pass.
+
+- [ ] **Step 2: Run host provider tests**
+
+```bash
+node --test src/host/*.test.ts
+```
+
+Expected: all host provider tests pass.
+
+- [ ] **Step 3: Run CLI tests**
+
+```bash
+npm run test:cli
+```
+
+Expected: CLI tests pass and include `setup-test-repo` coverage.
+
+- [ ] **Step 4: Run the full automated test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run lint and build**
+
+```bash
+npm run lint
+npm run build
+```
+
+Expected: lint exits 0 and `dist/` is rebuilt successfully.
+
+- [ ] **Step 6: Verify fixtures are included in the npm package**
+
+```bash
+npm pack --dry-run --json > .tmp-pack.json
+node -e "const pack=require('./.tmp-pack.json')[0]; const files=pack.files.map(f=>f.path); for (const p of ['fixtures/patchmill-test-repo/README.md','fixtures/patchmill-test-repo/PROJECT_BRIEF.md','fixtures/patchmill-test-repo/issues/12-votes-disappear.md']) { if (!files.includes(p)) throw new Error(p + ' missing'); } console.log('fixture files included')"
+rm .tmp-pack.json
+```
+
+Expected: the Node command prints `fixture files included`.
+
+- [ ] **Step 7: Run live GitHub verification**
+
+Use the agreed disposable Patchmill repository.
+
+```bash
+npm run patchmill -- setup-test-repo --provider github-gh --repo rochecompaan/patchmill-test --reset
+```
+
+Expected: the command exits 0, prints the GitHub public URL, and prints
+next-step commands.
+
+- [ ] **Step 8: Verify the live GitHub repository**
+
+```bash
+gh repo view rochecompaan/patchmill-test --json name,visibility,url
+gh label list --repo rochecompaan/patchmill-test --json name --limit 100
+gh issue list --repo rochecompaan/patchmill-test --state all --json number,title,labels --limit 100
+```
+
+Expected:
+
+- repository `rochecompaan/patchmill-test` exists and is public,
+- labels include `feature`, `bug`, `docs`, and `polish`,
+- there are 12 issues,
+- issue 1 is `Create the Team Lunch Poll app scaffold`,
+- issue 12 is `Votes sometimes disappear when I refresh`,
+- issue 11 and issue 12 have no seeded labels.
+
+Leave `rochecompaan/patchmill-test` live and seeded.
+
+- [ ] **Step 9: Optional Forgejo/Gitea verification**
+
+Run this only when a disposable Forgejo/Gitea repository target and `tea` login
+are available.
+
+```bash
+npm run patchmill -- setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
+tea repos --login LOGIN --output json OWNER/REPO
+tea issues list --login LOGIN --repo OWNER/REPO --state all --output json --limit 100
+```
+
+Expected: the repository exists, the seeded files are pushed, the four labels
+exist, and 12 issues exist.
+
+- [ ] **Step 10: Commit verification fixes or leave tree clean**
+
+If verification required code changes, commit them with the narrowest matching
+message. If no changes were required, confirm a clean tree.
+
+```bash
+git status --short
+```
+
+Expected: no output.
+
+## Self-review checklist
+
+- Spec coverage:
+  - Command naming and required explicit `--provider`/`--repo`: Task 3 and
+    Task 7.
+  - Provider support for `github-gh` and `forgejo-tea`: Task 4 and Task 5.
+  - No `src/host/setup-test-repo` subtree: file map and Task 6 boundary test.
+  - No direct setup command `gh`/`tea` calls: Task 6 boundary test.
+  - Reusable fixture prompts and copied repository files: Task 1 and Task 2.
+  - Reset safety: Task 6 orchestration tests.
+  - README and reference docs: Task 8.
+  - Package inclusion and live verification: Task 9.
+- Placeholder scan: no placeholder markers remain in this plan.
+- Type consistency:
+  - `RepositoryTarget`, `HostIssueCreateInput`, and `GitHostProvider` are
+    defined in Task 3 and Task 4 before orchestration uses them in Task 6.
+  - Provider lifecycle method names match across `src/host/types.ts`, provider
+    classes, and setup orchestration.
+  - `createGitHostProvider()` is introduced before `main.ts` imports it.

--- a/docs/setup-test-repo.md
+++ b/docs/setup-test-repo.md
@@ -1,0 +1,66 @@
+# Setup Test Repo
+
+`patchmill setup-test-repo` creates a disposable public Team Lunch Poll
+repository for trying Patchmill safely before using it on production issues.
+
+## When to use it
+
+Use this command when you want to see `patchmill init` and `patchmill triage`
+work on realistic greenfield issues without risking an existing project.
+
+## Supported providers
+
+The command supports the same issue hosts Patchmill currently supports:
+
+- `github-gh` through the GitHub `gh` CLI.
+- `forgejo-tea` through the Forgejo/Gitea `tea` CLI.
+
+The provider is required. Patchmill does not infer it from git remotes or CLI
+state.
+
+## Create a disposable GitHub repository
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+```
+
+## Create a disposable Forgejo/Gitea repository
+
+```bash
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
+```
+
+## Reset a disposable repository
+
+`--reset` deletes and recreates the selected public repository. Use it only for
+a repository you are comfortable losing.
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
+```
+
+## Fixture contents
+
+The seeded repository receives these files from the installed Patchmill package:
+
+- `README.md`
+- `PROJECT_BRIEF.md`
+- `issues/*.md`
+
+The source fixture lives at `fixtures/patchmill-test-repo/` in the Patchmill
+package and source tree.
+
+## Manual Patchmill workflow
+
+After setup, clone the disposable repository and run:
+
+```bash
+patchmill init
+patchmill triage --dry-run
+patchmill triage
+```
+
+`setup-test-repo` does not run `patchmill init` for you. The goal is to provide
+a safe repository where you can exercise the same first-use workflow you would
+run on a real project.

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -29,6 +29,9 @@ description and issue prompts for repeated use.
 - Expose the workflow as a packaged CLI command: `patchmill setup-test-repo`.
 - Let users run the demo setup after installing Patchmill, without cloning the
   Patchmill repository.
+- Update the README to present `patchmill setup-test-repo` as the quickest safe
+  way to see Patchmill in action without running it against a production
+  repository.
 - Set up a caller-specified public test repository by creating and seeding it.
 - Reset a caller-specified test repository to a clean state when `--reset` is
   passed.
@@ -309,10 +312,48 @@ patchmill setup-test-repo --repo rochecompaan/patchmill-test --reset
 
 Leave that repository live and seeded on GitHub.
 
+## README Promotion
+
+Update `README.md` so new users can discover the disposable test repository
+workflow before pointing Patchmill at production work.
+
+The README should include a short section near the first-use command overview
+that explains:
+
+- `patchmill setup-test-repo` creates a disposable greenfield GitHub repository
+  with reusable demo prompts and issues.
+- This is the recommended way to quickly see Patchmill in action without letting
+  it operate on a production repository.
+- The target must be an explicit disposable public repository passed as
+  `--repo OWNER/REPO`.
+- `--reset` deletes and recreates that repository, so users should only use it
+  with a repo they are comfortable losing.
+- After setup, users can clone the repo and run `patchmill init`,
+  `patchmill triage --dry-run`, and `patchmill triage`.
+
+Example README command flow:
+
+```bash
+patchmill setup-test-repo --repo OWNER/REPO
+gh repo clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+```
+
+The README should also show the reset form for rerunning the demo from a clean
+state:
+
+```bash
+patchmill setup-test-repo --repo OWNER/REPO --reset
+```
+
 ## Documentation
 
 Add documentation describing:
 
+- README guidance that promotes `patchmill setup-test-repo` as the safe quick
+  start path for trying Patchmill on a disposable repository,
 - the purpose of the reusable Patchmill test repository fixture,
 - that the target repository should be disposable,
 - how to choose a disposable `OWNER/REPO` target,

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -295,13 +295,15 @@ src/cli/commands/setup-test-repo/
   issue-parser.test.ts
   main.ts
   main.test.ts
-  provider.ts
-  provider.test.ts
-  providers/
-    forgejo-tea.ts
-    forgejo-tea.test.ts
-    github-gh.ts
-    github-gh.test.ts
+
+src/host/setup-test-repo/
+  factory.ts
+  factory.test.ts
+  forgejo-tea.ts
+  forgejo-tea.test.ts
+  github-gh.ts
+  github-gh.test.ts
+  types.ts
 ```
 
 Responsibilities:
@@ -312,15 +314,59 @@ Responsibilities:
   labels.
 - `fixtures.ts`: resolve and validate the bundled fixture directory from the
   installed package.
-- `provider.ts`: define the setup-specific provider adapter interface.
-- `providers/github-gh.ts`: implement repository lifecycle, labels, issues, git
-  remote, and clone instructions through `gh`.
-- `providers/forgejo-tea.ts`: implement repository lifecycle, labels, issues,
-  git remote, and clone instructions through `tea`.
+- `src/host/setup-test-repo/types.ts`: define the setup-specific provider
+  adapter interface.
+- `src/host/setup-test-repo/factory.ts`: resolve setup adapters by provider ID
+  and reuse the existing `src/host/factory.ts` issue-host factory where
+  applicable.
+- `src/host/setup-test-repo/github-gh.ts`: implement only GitHub-specific
+  repository lifecycle, issue creation, git remote, and clone instructions,
+  while reusing existing GitHub host-provider code for CLI readiness and label
+  creation.
+- `src/host/setup-test-repo/forgejo-tea.ts`: implement only
+  Forgejo/Gitea-specific repository lifecycle, issue creation, git remote, and
+  clone instructions, while reusing existing Forgejo/Gitea host-provider code
+  for CLI readiness, named-login handling, and label creation.
 - `main.ts`: orchestrate setup/reset, fixture copy, git push, label creation,
   issue creation, and final instructions.
 
 Register the command in `src/cli/main.ts` help and dispatch maps.
+
+## Host Provider Reuse Requirements
+
+`setup-test-repo` must reuse Patchmill's existing host-provider code in
+`src/host` instead of recreating provider-specific `gh` or `tea` integrations in
+the CLI command.
+
+Reuse rules:
+
+- No `gh` or `tea` subprocess calls should live in
+  `src/cli/commands/setup-test-repo/*`. The command layer parses arguments,
+  loads fixtures, and orchestrates high-level steps only.
+- Provider-specific subprocess calls belong under `src/host`, next to the
+  existing providers.
+- Reuse the existing `CommandRunner`, `HostCliCheck`, `LabelDefinition`,
+  provider IDs, and provider readiness behavior from `src/host/types.ts`,
+  `src/host/github-gh.ts`, `src/host/forgejo-tea.ts`, and `src/host/factory.ts`.
+- Reuse `createIssueHostProvider()` after the temporary git repository has the
+  target remote configured. That existing provider can perform common
+  repo-scoped operations that already exist today, especially CLI readiness and
+  label creation.
+- If lifecycle or issue-creation logic requires new provider-specific command
+  builders, add them in `src/host` and share them with the existing provider
+  modules where possible. Do not duplicate command formatting, login handling,
+  output parsing, color normalization, shell quoting, or error formatting in the
+  setup command directory.
+- If an existing helper is currently private but useful to setup providers,
+  refactor it into an exported `src/host` helper rather than copying it.
+- The setup-specific adapter should be a thin extension around current host
+  providers for missing capabilities: repository existence, public repository
+  creation, reset deletion, issue creation, git remote URL, public URL, and
+  clone instructions.
+
+This keeps all supported-provider knowledge in `src/host` and prevents
+`setup-test-repo` from becoming a second, divergent implementation of GitHub or
+Forgejo/Gitea support.
 
 ## Setup Provider Adapter
 
@@ -328,8 +374,9 @@ The existing `IssueHostProvider` interface supports Patchmill operations on an
 already-configured repository: list issues, inspect labels, comment, and apply
 labels. `setup-test-repo` needs repository lifecycle and issue creation before a
 repository has been initialized for Patchmill, so it should use a small
-setup-specific adapter rather than forcing lifecycle methods into
-`IssueHostProvider`.
+setup-specific adapter in `src/host/setup-test-repo`. Keep the adapter adjacent
+to the current host providers and delegate to current provider classes whenever
+the operation already exists.
 
 The adapter should support:
 
@@ -350,9 +397,13 @@ Provider implementation notes:
   matching the existing Patchmill GitHub provider.
 - `forgejo-tea` should use `tea` and pass `--login LOGIN` when supplied,
   matching the existing Patchmill Forgejo/Gitea named-login behavior.
+- `checkCli()` and label creation should delegate to the existing
+  `GitHubGhHostProvider` and `ForgejoTeaHostProvider` where possible after the
+  temporary repository remote is configured.
 - If `tea` lacks a convenient high-level subcommand for a specific lifecycle
   operation, the provider may use `tea api` behind the adapter. Keep those API
-  details isolated to `providers/forgejo-tea.ts`.
+  details isolated to `src/host/setup-test-repo/forgejo-tea.ts` or shared
+  helpers under `src/host`.
 
 ## Safety and Error Handling
 
@@ -394,10 +445,16 @@ Implementation verification should include:
   invalid labels,
 - fixture resolution tests proving bundled fixture files can be found,
 - setup provider adapter tests for both `github-gh` and `forgejo-tea`,
+- host-provider reuse tests proving setup adapters delegate shared operations to
+  existing `src/host` providers instead of duplicating readiness and label
+  behavior,
 - orchestration tests using mocked provider adapters for create-only,
   existing-repo-without-reset failure, and reset flows,
 - mocked CLI-contract tests for provider commands generated by `github-gh` and
   `forgejo-tea`,
+- an architectural/static check that `src/cli/commands/setup-test-repo/*` does
+  not invoke `gh` or `tea` directly; provider-specific CLI calls must remain
+  under `src/host`,
 - local validation that all fixture issue files parse,
 - package/build verification that fixture files are included in the installable
   package,

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -2,20 +2,28 @@
 
 ## Summary
 
-Add a packaged Patchmill command for creating a reusable GitHub demo repository
-that tests Patchmill's `init` and `triage` commands against a greenfield
-project. Users should be able to install Patchmill and run:
+Add a packaged Patchmill command for creating a reusable disposable repository
+on a supported issue host. The repository lets users test Patchmill's `init` and
+`triage` commands against a greenfield project without pointing Patchmill at a
+production repository.
+
+Users should be able to install Patchmill and run the command against the same
+issue-host providers Patchmill already supports:
 
 ```bash
-patchmill setup-test-repo --repo OWNER/REPO
-patchmill setup-test-repo --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO --reset
+
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
 ```
 
 The target repository is supplied explicitly on every run as
-`--repo OWNER/REPO`. There is no default target. Setup creates and seeds a
-public GitHub repository; `--reset` deletes and recreates an existing disposable
-repository before seeding it with a project brief, issue prompts, basic labels,
-and GitHub issues.
+`--repo OWNER/REPO`. There is no default target and no repository inference.
+Setup creates and seeds a public repository on the selected provider. `--reset`
+deletes and recreates an existing disposable repository before seeding it with a
+project brief, issue prompts, basic labels, and issues.
 
 The reusable source content ships with Patchmill and is copied into the target
 demo repository on each setup or reset. This lets users try Patchmill end to end
@@ -24,9 +32,12 @@ description and issue prompts for repeated use.
 
 ## Goals
 
-- Provide a realistic GitHub repository for manually testing `patchmill init`
-  and `patchmill triage`.
+- Provide a realistic disposable repository for manually testing
+  `patchmill init` and `patchmill triage`.
 - Expose the workflow as a packaged CLI command: `patchmill setup-test-repo`.
+- Support the issue-host providers Patchmill already supports:
+  - `github-gh`: GitHub through `gh`.
+  - `forgejo-tea`: Forgejo/Gitea through `tea`.
 - Let users run the demo setup after installing Patchmill, without cloning the
   Patchmill repository.
 - Update the README to present `patchmill setup-test-repo` as the quickest safe
@@ -37,13 +48,15 @@ description and issue prompts for repeated use.
   passed.
 - Require the caller to pass `--repo OWNER/REPO`; there is no default target and
   the command never infers a target from the current git remote.
-- Allow any GitHub user or organization to reuse the prompts and command in a
-  disposable public repository they control.
+- Require the caller to pass `--provider`; there is no provider inference
+  because the repository may not exist yet.
+- Allow any supported-host user or organization to reuse the prompts and command
+  in a disposable public repository they control.
 - Preserve all reusable project description and issue prompt content in the
   Patchmill package.
 - Copy the project description and prompts into the seeded demo repository for
   transparency.
-- Seed 10–12 natural GitHub issues for a small greenfield web app.
+- Seed 10–12 natural issues for a small greenfield web app.
 - Include mostly ready-to-build issues plus 1–2 deliberately messy issues for
   triage testing.
 - Create basic type labels while leaving some issues unlabeled so triage can
@@ -53,7 +66,9 @@ description and issue prompts for repeated use.
 
 - Do not provide a default repository target.
 - Do not infer the target repository from the current directory, git remote, or
-  GitHub CLI context.
+  host CLI context.
+- Do not infer the provider from the target repository or current git remote.
+- Do not add support for providers Patchmill does not already support.
 - Do not name the command `patchmill test`; that would be confused with running
   tests for the current project.
 - Do not run `patchmill init` from `setup-test-repo`; running init is part of
@@ -80,6 +95,29 @@ Rationale:
 - The noun `test-repo` avoids implying that Patchmill will run a test suite.
 - `patchmill test` is rejected because it is too ambiguous and would likely be
   read as "run Patchmill tests" or "test this repository."
+
+## Provider-Aware Command Shape
+
+Use explicit provider and repository arguments:
+
+```bash
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO
+```
+
+Rules:
+
+- `--provider` is required.
+- Accepted provider values are `github-gh` and `forgejo-tea`.
+- `--repo OWNER/REPO` is required for all providers.
+- `OWNER/REPO` is provider-neutral; both `gh` and `tea` use this repository slug
+  shape.
+- `--login LOGIN` is only meaningful for providers with named-login support.
+  `forgejo-tea` uses it to select a `tea` login. `github-gh` ignores named
+  logins and uses the active `gh` authentication context, matching the existing
+  `github-gh` provider behavior.
+- `--reset` is optional and destructive. It deletes and recreates the target
+  repository before seeding it.
 
 ## Demo Project
 
@@ -138,8 +176,8 @@ Rules:
 
 - `title` is required.
 - `labels` is optional.
-- Missing `labels` means the GitHub issue is created without labels.
-- Issue bodies are natural user-facing GitHub prompts.
+- Missing `labels` means the host issue is created without labels.
+- Issue bodies are natural user-facing prompts.
 - Issue files do not include expected triage outcomes or hidden evaluator
   metadata.
 
@@ -180,18 +218,19 @@ Seed 10–12 issues. The approved starting set is 12 issues:
 The primary workflow is this Patchmill CLI command:
 
 ```bash
-patchmill setup-test-repo --repo OWNER/REPO
-patchmill setup-test-repo --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
 ```
 
-The command requires an explicit `--repo OWNER/REPO` argument and always creates
-or recreates the target repository as public. There is no default repository
-target.
+The command requires explicit `--provider` and `--repo OWNER/REPO` arguments. It
+creates or recreates the target repository as public on the selected provider.
+There is no default repository target.
 
-Example:
+Examples:
 
 ```bash
-patchmill setup-test-repo --repo rochecompaan/patchmill-test --reset
+patchmill setup-test-repo --provider github-gh --repo rochecompaan/patchmill-test --reset
+patchmill setup-test-repo --provider forgejo-tea --repo demo-org/patchmill-test --login forgejo-demo --reset
 ```
 
 The `--reset` flag is required for the destructive delete/recreate operation. If
@@ -200,26 +239,42 @@ with instructions to rerun with `--reset` when the caller intends to replace it.
 
 Workflow:
 
-1. Verify required external tools are available: `gh` and `git`.
-2. Validate the required `--repo OWNER/REPO` argument.
-3. Determine whether the caller requested `--reset`.
-4. If `--reset` is omitted, create the target public repository only when it
+1. Validate the required `--provider` and `--repo OWNER/REPO` arguments.
+2. Resolve the setup provider adapter for `github-gh` or `forgejo-tea`.
+3. Verify required external tools are available for the selected provider:
+   - `git` for all providers.
+   - `gh` for `github-gh`.
+   - `tea` for `forgejo-tea`.
+4. Check provider authentication or login readiness.
+5. Determine whether the caller requested `--reset`.
+6. If `--reset` is omitted, create the target public repository only when it
    does not already exist.
-5. If `--reset` is provided, print the exact target repository and public URL,
-   delete the target repository if it exists, and recreate it as a public GitHub
+7. If `--reset` is provided, print the exact target provider, repository, and
+   public URL; delete the target repository if it exists; and recreate it as a
+   public repository.
+8. Create a temporary local git repository.
+9. Copy fixture files from the installed Patchmill package into the temporary
    repository.
-6. Create a temporary local git repository.
-7. Copy fixture files from the installed Patchmill package into the temporary
-   repository.
-8. Commit and push `main` to the target GitHub repository.
-9. Create basic labels with `gh label create` or `gh api`.
-10. Parse `issues/*.md` and create GitHub issues.
-11. Print next-step commands for manual testing.
+10. Commit and push `main` to the target repository using a provider-supplied
+    git remote URL.
+11. Create basic labels through the selected provider.
+12. Parse `issues/*.md` and create issues through the selected provider.
+13. Print provider-specific next-step commands for manual testing.
 
-Example final output for the requested target:
+Example final output for a GitHub target:
 
 ```bash
 gh repo clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+patchmill triage
+```
+
+Example final output for a Forgejo/Gitea target:
+
+```bash
+tea clone OWNER/REPO
 cd REPO
 patchmill init
 patchmill triage --dry-run
@@ -236,78 +291,129 @@ src/cli/commands/setup-test-repo/
   args.test.ts
   fixtures.ts
   fixtures.test.ts
-  github.ts
-  github.test.ts
   issue-parser.ts
   issue-parser.test.ts
   main.ts
   main.test.ts
+  provider.ts
+  provider.test.ts
+  providers/
+    forgejo-tea.ts
+    forgejo-tea.test.ts
+    github-gh.ts
+    github-gh.test.ts
 ```
 
 Responsibilities:
 
-- `args.ts`: parse `--repo OWNER/REPO`, `--reset`, and help output.
+- `args.ts`: parse `--provider`, `--repo OWNER/REPO`, `--login`, `--reset`, and
+  help output.
 - `issue-parser.ts`: parse issue markdown frontmatter and validate titles and
   labels.
 - `fixtures.ts`: resolve and validate the bundled fixture directory from the
   installed package.
-- `github.ts`: wrap `gh` and `git` subprocess operations behind testable
-  functions.
+- `provider.ts`: define the setup-specific provider adapter interface.
+- `providers/github-gh.ts`: implement repository lifecycle, labels, issues, git
+  remote, and clone instructions through `gh`.
+- `providers/forgejo-tea.ts`: implement repository lifecycle, labels, issues,
+  git remote, and clone instructions through `tea`.
 - `main.ts`: orchestrate setup/reset, fixture copy, git push, label creation,
   issue creation, and final instructions.
 
 Register the command in `src/cli/main.ts` help and dispatch maps.
 
+## Setup Provider Adapter
+
+The existing `IssueHostProvider` interface supports Patchmill operations on an
+already-configured repository: list issues, inspect labels, comment, and apply
+labels. `setup-test-repo` needs repository lifecycle and issue creation before a
+repository has been initialized for Patchmill, so it should use a small
+setup-specific adapter rather than forcing lifecycle methods into
+`IssueHostProvider`.
+
+The adapter should support:
+
+- `id` and `displayName`, using existing provider IDs.
+- `checkCli()` for provider tool/auth readiness.
+- `repoExists(owner, repo)`.
+- `createPublicRepo(owner, repo)`.
+- `deleteRepo(owner, repo)` for reset mode.
+- `gitRemoteUrl(owner, repo)` for pushing the seeded commit.
+- `publicRepoUrl(owner, repo)` for output and verification.
+- `cloneCommand(owner, repo)` for final instructions.
+- `createLabel(owner, repo, label)`.
+- `createIssue(owner, repo, issue)`.
+
+Provider implementation notes:
+
+- `github-gh` should use `gh` and the active `gh` authentication context,
+  matching the existing Patchmill GitHub provider.
+- `forgejo-tea` should use `tea` and pass `--login LOGIN` when supplied,
+  matching the existing Patchmill Forgejo/Gitea named-login behavior.
+- If `tea` lacks a convenient high-level subcommand for a specific lifecycle
+  operation, the provider may use `tea api` behind the adapter. Keep those API
+  details isolated to `providers/forgejo-tea.ts`.
+
 ## Safety and Error Handling
 
-The setup flow requires an explicit target. The reset mode is intentionally
-destructive and requires `--reset`.
+The setup flow requires an explicit provider and target. The reset mode is
+intentionally destructive and requires `--reset`.
 
 Safety rules:
 
+- Refuse to run unless `--provider` is provided.
+- Refuse unsupported provider IDs.
 - Refuse to run unless `--repo OWNER/REPO` is provided.
 - Refuse malformed repository names.
 - Refuse to infer a target repository from the current directory, git remote, or
-  GitHub CLI context.
+  host CLI context.
+- Refuse to infer provider from the current directory, git remote, or host CLI
+  context.
 - Require `--reset` for the destructive delete/recreate operation.
 - Print each major step, including every destructive reset step.
-- Print the exact target repository and public URL before deletion.
+- Print the exact provider, target repository, and public URL before deletion.
 - Treat a missing repository during reset deletion as acceptable.
-- Fail fast when `gh` or `git` is missing.
+- Fail fast when required provider tools are missing.
+- Fail when provider authentication/login is unavailable.
 - Fail when bundled fixture files are missing.
 - Fail when issue frontmatter is invalid.
 - Use a temporary directory for git operations.
 - Clean up the temporary directory automatically.
 
 Failure recovery is rerunning the command. If the command fails after creation
-or recreation, the partially seeded repository may remain on GitHub, but the
-next run with `--reset` deletes and recreates it.
+or recreation, the partially seeded repository may remain on the selected host,
+but the next run with `--reset` deletes and recreates it.
 
 ## Verification
 
 Implementation verification should include:
 
-- argument parser tests for missing `--repo`, malformed repo names, `--reset`,
-  and help output,
+- argument parser tests for missing `--provider`, unsupported providers, missing
+  `--repo`, malformed repo names, `--login`, `--reset`, and help output,
 - issue parser tests for valid issue files, missing titles, optional labels, and
   invalid labels,
 - fixture resolution tests proving bundled fixture files can be found,
-- orchestration tests using mocked `gh`/`git` operations for create-only,
+- setup provider adapter tests for both `github-gh` and `forgejo-tea`,
+- orchestration tests using mocked provider adapters for create-only,
   existing-repo-without-reset failure, and reset flows,
+- mocked CLI-contract tests for provider commands generated by `github-gh` and
+  `forgejo-tea`,
 - local validation that all fixture issue files parse,
 - package/build verification that fixture files are included in the installable
   package,
-- running `patchmill setup-test-repo` against GitHub with an explicit repository
-  argument and `--reset`,
+- running `patchmill setup-test-repo` against GitHub with an explicit provider,
+  repository argument, and `--reset`,
 - confirming the public repository exists at the requested GitHub URL,
-- confirming the seeded repository contains the copied project files,
-- confirming the expected labels exist,
-- confirming the expected 10–12 issues exist.
+- confirming the seeded GitHub repository contains the copied project files,
+- confirming the expected GitHub labels exist,
+- confirming the expected 10–12 GitHub issues exist,
+- optional live Forgejo/Gitea verification when a disposable Forgejo/Gitea repo
+  and `tea` login are available.
 
-For Patchmill's own verification, use:
+For Patchmill's own live GitHub verification, use:
 
 ```bash
-patchmill setup-test-repo --repo rochecompaan/patchmill-test --reset
+patchmill setup-test-repo --provider github-gh --repo rochecompaan/patchmill-test --reset
 ```
 
 Leave that repository live and seeded on GitHub.
@@ -320,22 +426,34 @@ workflow before pointing Patchmill at production work.
 The README should include a short section near the first-use command overview
 that explains:
 
-- `patchmill setup-test-repo` creates a disposable greenfield GitHub repository
-  with reusable demo prompts and issues.
+- `patchmill setup-test-repo` creates a disposable greenfield repository on a
+  supported issue host with reusable demo prompts and issues.
 - This is the recommended way to quickly see Patchmill in action without letting
   it operate on a production repository.
 - The target must be an explicit disposable public repository passed as
   `--repo OWNER/REPO`.
+- The provider must be explicit, with examples for `github-gh` and
+  `forgejo-tea`.
 - `--reset` deletes and recreates that repository, so users should only use it
   with a repo they are comfortable losing.
 - After setup, users can clone the repo and run `patchmill init`,
   `patchmill triage --dry-run`, and `patchmill triage`.
 
-Example README command flow:
+Example README GitHub command flow:
 
 ```bash
-patchmill setup-test-repo --repo OWNER/REPO
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO
 gh repo clone OWNER/REPO
+cd REPO
+patchmill init
+patchmill triage --dry-run
+```
+
+Example README Forgejo/Gitea command flow:
+
+```bash
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN
+tea clone OWNER/REPO
 cd REPO
 patchmill init
 patchmill triage --dry-run
@@ -345,7 +463,8 @@ The README should also show the reset form for rerunning the demo from a clean
 state:
 
 ```bash
-patchmill setup-test-repo --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider github-gh --repo OWNER/REPO --reset
+patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN --reset
 ```
 
 ## Documentation
@@ -357,11 +476,14 @@ Add documentation describing:
 - the purpose of the reusable Patchmill test repository fixture,
 - that the target repository should be disposable,
 - how to choose a disposable `OWNER/REPO` target,
-- how to run `patchmill setup-test-repo --repo OWNER/REPO`,
-- how to reset an existing disposable repository with
-  `patchmill setup-test-repo --repo OWNER/REPO --reset`,
-- that `--reset` deletes and recreates the public GitHub repository,
+- how to choose a supported provider,
+- how to run `patchmill setup-test-repo --provider github-gh --repo OWNER/REPO`,
+- how to run
+  `patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN`,
+- how to reset an existing disposable repository with `--reset`,
+- that `--reset` deletes and recreates the public repository on the selected
+  provider,
 - where the reusable project brief and issue prompts live in the installed
   package/source tree,
-- how to clone the recreated repository,
+- how to clone the recreated repository for each supported provider,
 - how to manually test `patchmill init` and `patchmill triage` afterward.

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -240,7 +240,7 @@ with instructions to rerun with `--reset` when the caller intends to replace it.
 Workflow:
 
 1. Validate the required `--provider` and `--repo OWNER/REPO` arguments.
-2. Resolve the setup provider adapter for `github-gh` or `forgejo-tea`.
+2. Resolve the selected existing host provider for `github-gh` or `forgejo-tea`.
 3. Verify required external tools are available for the selected provider:
    - `git` for all providers.
    - `gh` for `github-gh`.
@@ -283,7 +283,7 @@ patchmill triage
 
 ## Implementation Components
 
-Add a new command directory:
+Add a new command directory for setup orchestration only:
 
 ```text
 src/cli/commands/setup-test-repo/
@@ -295,15 +295,18 @@ src/cli/commands/setup-test-repo/
   issue-parser.test.ts
   main.ts
   main.test.ts
+  host-boundary.test.ts
+```
 
-src/host/setup-test-repo/
-  factory.ts
-  factory.test.ts
-  forgejo-tea.ts
-  forgejo-tea.test.ts
-  github-gh.ts
-  github-gh.test.ts
-  types.ts
+Extend the existing host provider modules with generic provider capabilities:
+
+```text
+src/host/types.ts
+src/host/factory.ts
+src/host/github-gh.ts
+src/host/github-gh.test.ts
+src/host/forgejo-tea.ts
+src/host/forgejo-tea.test.ts
 ```
 
 Responsibilities:
@@ -314,21 +317,21 @@ Responsibilities:
   labels.
 - `fixtures.ts`: resolve and validate the bundled fixture directory from the
   installed package.
-- `src/host/setup-test-repo/types.ts`: define the setup-specific provider
-  adapter interface.
-- `src/host/setup-test-repo/factory.ts`: resolve setup adapters by provider ID
-  and reuse the existing `src/host/factory.ts` issue-host factory where
-  applicable.
-- `src/host/setup-test-repo/github-gh.ts`: implement only GitHub-specific
-  repository lifecycle, issue creation, git remote, and clone instructions,
-  while reusing existing GitHub host-provider code for CLI readiness and label
-  creation.
-- `src/host/setup-test-repo/forgejo-tea.ts`: implement only
-  Forgejo/Gitea-specific repository lifecycle, issue creation, git remote, and
-  clone instructions, while reusing existing Forgejo/Gitea host-provider code
-  for CLI readiness, named-login handling, and label creation.
 - `main.ts`: orchestrate setup/reset, fixture copy, git push, label creation,
-  issue creation, and final instructions.
+  issue creation, and final instructions by calling generic host-provider
+  capabilities.
+- `host-boundary.test.ts`: enforce that the setup command does not invoke `gh`
+  or `tea` directly and does not grow provider-specific integration code.
+- `src/host/types.ts`: add provider-neutral types for repository targets,
+  issue-creation input, and repository lifecycle capabilities.
+- `src/host/factory.ts`: continue resolving provider IDs to the existing host
+  provider classes, exposing the expanded generic capabilities.
+- `src/host/github-gh.ts`: add generic GitHub repository lifecycle, issue
+  creation, git remote URL, public URL, and clone-command capabilities to the
+  existing `GitHubGhHostProvider`.
+- `src/host/forgejo-tea.ts`: add generic Forgejo/Gitea repository lifecycle,
+  issue creation, git remote URL, public URL, and clone-command capabilities to
+  the existing `ForgejoTeaHostProvider`.
 
 Register the command in `src/cli/main.ts` help and dispatch maps.
 
@@ -336,60 +339,68 @@ Register the command in `src/cli/main.ts` help and dispatch maps.
 
 `setup-test-repo` must reuse Patchmill's existing host-provider code in
 `src/host` instead of recreating provider-specific `gh` or `tea` integrations in
-the CLI command.
+the CLI command. The `src/host` directory should contain only generic operations
+for interacting with supported git providers; Team Lunch Poll fixture handling
+and setup-test-repo orchestration belong in `src/cli/commands/setup-test-repo`.
 
 Reuse rules:
 
 - No `gh` or `tea` subprocess calls should live in
   `src/cli/commands/setup-test-repo/*`. The command layer parses arguments,
   loads fixtures, and orchestrates high-level steps only.
-- Provider-specific subprocess calls belong under `src/host`, next to the
-  existing providers.
+- Provider-specific subprocess calls belong in the existing provider modules:
+  `src/host/github-gh.ts` and `src/host/forgejo-tea.ts`.
+- Do not create a setup-specific provider subtree such as
+  `src/host/setup-test-repo`. If a capability is a generic operation on a git
+  provider, add it to the existing provider module and shared host types.
 - Reuse the existing `CommandRunner`, `HostCliCheck`, `LabelDefinition`,
-  provider IDs, and provider readiness behavior from `src/host/types.ts`,
-  `src/host/github-gh.ts`, `src/host/forgejo-tea.ts`, and `src/host/factory.ts`.
-- Reuse `createIssueHostProvider()` after the temporary git repository has the
-  target remote configured. That existing provider can perform common
-  repo-scoped operations that already exist today, especially CLI readiness and
-  label creation.
-- If lifecycle or issue-creation logic requires new provider-specific command
-  builders, add them in `src/host` and share them with the existing provider
-  modules where possible. Do not duplicate command formatting, login handling,
-  output parsing, color normalization, shell quoting, or error formatting in the
-  setup command directory.
+  `IssueHostProvider`, provider IDs, and provider readiness behavior from
+  `src/host/types.ts`, `src/host/github-gh.ts`, `src/host/forgejo-tea.ts`, and
+  `src/host/factory.ts`.
+- Add generic repository lifecycle and issue-creation capabilities to the
+  existing host providers rather than wrapping them in a parallel setup adapter.
+  These capabilities are broadly useful host operations: repository existence,
+  public repository creation, repository deletion, issue creation, git remote
+  URL, public URL, and clone command.
+- After the temporary git repository has the target remote configured, reuse the
+  existing repo-scoped provider behavior for readiness checks, label creation,
+  and issue creation where possible.
+- If lifecycle or issue-creation logic requires provider-specific command
+  builders, add them to the existing provider modules or shared `src/host`
+  helpers. Do not duplicate command formatting, login handling, output parsing,
+  color normalization, shell quoting, or error formatting in the setup command
+  directory.
 - If an existing helper is currently private but useful to setup providers,
   refactor it into an exported `src/host` helper rather than copying it.
-- The setup-specific adapter should be a thin extension around current host
-  providers for missing capabilities: repository existence, public repository
-  creation, reset deletion, issue creation, git remote URL, public URL, and
-  clone instructions.
 
 This keeps all supported-provider knowledge in `src/host` and prevents
 `setup-test-repo` from becoming a second, divergent implementation of GitHub or
 Forgejo/Gitea support.
 
-## Setup Provider Adapter
+## Generic Host Provider Capabilities
 
 The existing `IssueHostProvider` interface supports Patchmill operations on an
 already-configured repository: list issues, inspect labels, comment, and apply
 labels. `setup-test-repo` needs repository lifecycle and issue creation before a
-repository has been initialized for Patchmill, so it should use a small
-setup-specific adapter in `src/host/setup-test-repo`. Keep the adapter adjacent
-to the current host providers and delegate to current provider classes whenever
-the operation already exists.
+repository has been initialized for Patchmill. Add those missing capabilities to
+the existing host-provider modules as generic provider operations, not as
+test-repo-specific setup code.
 
-The adapter should support:
+The existing provider classes should support:
 
 - `id` and `displayName`, using existing provider IDs.
 - `checkCli()` for provider tool/auth readiness.
-- `repoExists(owner, repo)`.
-- `createPublicRepo(owner, repo)`.
-- `deleteRepo(owner, repo)` for reset mode.
-- `gitRemoteUrl(owner, repo)` for pushing the seeded commit.
-- `publicRepoUrl(owner, repo)` for output and verification.
-- `cloneCommand(owner, repo)` for final instructions.
-- `createLabel(owner, repo, label)`.
-- `createIssue(owner, repo, issue)`.
+- `repoExists(target)`.
+- `createPublicRepo(target)`.
+- `deleteRepo(target)` for reset mode.
+- `gitRemoteUrl(target)` for pushing the seeded commit.
+- `publicRepoUrl(target)` for output and verification.
+- `cloneCommand(target)` for final instructions.
+- `createIssue(issue)` as a repo-scoped operation after the target remote is
+  configured.
+
+Existing `createLabel(label)` remains the generic label-creation operation for
+the configured repository and should be reused by `setup-test-repo`.
 
 Provider implementation notes:
 
@@ -401,9 +412,8 @@ Provider implementation notes:
   `GitHubGhHostProvider` and `ForgejoTeaHostProvider` where possible after the
   temporary repository remote is configured.
 - If `tea` lacks a convenient high-level subcommand for a specific lifecycle
-  operation, the provider may use `tea api` behind the adapter. Keep those API
-  details isolated to `src/host/setup-test-repo/forgejo-tea.ts` or shared
-  helpers under `src/host`.
+  operation, `ForgejoTeaHostProvider` may use `tea api`. Keep those API details
+  isolated to `src/host/forgejo-tea.ts` or shared helpers under `src/host`.
 
 ## Safety and Error Handling
 
@@ -444,14 +454,15 @@ Implementation verification should include:
 - issue parser tests for valid issue files, missing titles, optional labels, and
   invalid labels,
 - fixture resolution tests proving bundled fixture files can be found,
-- setup provider adapter tests for both `github-gh` and `forgejo-tea`,
-- host-provider reuse tests proving setup adapters delegate shared operations to
-  existing `src/host` providers instead of duplicating readiness and label
+- generic host-provider capability tests for both `GitHubGhHostProvider` and
+  `ForgejoTeaHostProvider`,
+- host-provider reuse tests proving setup orchestration calls existing
+  `src/host` provider capabilities instead of duplicating readiness and label
   behavior,
-- orchestration tests using mocked provider adapters for create-only,
+- orchestration tests using mocked host-provider capabilities for create-only,
   existing-repo-without-reset failure, and reset flows,
-- mocked CLI-contract tests for provider commands generated by `github-gh` and
-  `forgejo-tea`,
+- mocked CLI-contract tests for provider commands generated by
+  `src/host/github-gh.ts` and `src/host/forgejo-tea.ts`,
 - an architectural/static check that `src/cli/commands/setup-test-repo/*` does
   not invoke `gh` or `tea` directly; provider-specific CLI calls must remain
   under `src/host`,

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -1,0 +1,229 @@
+# Patchmill Test Repository Design
+
+## Summary
+
+Create a reusable GitHub demo repository at `rochecompaan/patchmill-test` for
+testing Patchmill's `init` and `triage` commands against a greenfield project.
+The repository is disposable: reset means deleting and recreating it, then
+seeding it with a project brief, issue prompts, basic labels, and GitHub issues.
+
+The reusable source content lives in the Patchmill repository and is copied into
+the recreated demo repository on each reset. This keeps the live GitHub
+repository clean and disposable while preserving the project description and
+prompts for repeated use.
+
+## Goals
+
+- Provide a realistic GitHub repository for manually testing `patchmill init`
+  and `patchmill triage`.
+- Reset the test repository to a clean state by deleting and recreating
+  `rochecompaan/patchmill-test`.
+- Keep the public repository URL stable:
+  `https://github.com/rochecompaan/patchmill-test`.
+- Preserve all reusable project description and issue prompt content in the
+  Patchmill repository.
+- Copy the project description and prompts into the seeded demo repository for
+  transparency.
+- Seed 10–12 natural GitHub issues for a small greenfield web app.
+- Include mostly ready-to-build issues plus 1–2 deliberately messy issues for
+  triage testing.
+- Create basic type labels while leaving some issues unlabeled so triage can
+  demonstrate classification.
+
+## Non-goals
+
+- Do not create a configurable generic repository reset tool.
+- Do not support arbitrary GitHub owners or repository names.
+- Do not run `patchmill init` from the reset script; running init is part of the
+  manual test.
+- Do not create or refresh a local clone of `patchmill-test`; print clone
+  instructions instead.
+- Do not include expected triage outcomes in issue files.
+- Do not scaffold a runnable application in the reset repository. The seeded
+  issues should drive the app build from an almost empty repository.
+
+## Demo Project
+
+The demo project is **Team Lunch Poll**, a small web application where a team
+can create a lunch poll, add restaurant or meal options, vote, and view results.
+
+The recreated repository starts nearly empty. It contains human-facing
+documentation and prompt files only. Patchmill agents should be able to build
+the project from the seeded issues.
+
+## Fixture Layout
+
+Patchmill owns the reusable fixture content under this project-local directory:
+
+```text
+test-fixtures/patchmill-test/
+  README.md
+  PROJECT_BRIEF.md
+  issues/
+    01-project-scaffold.md
+    02-domain-model.md
+    03-create-poll-form.md
+    04-voting-flow.md
+    05-results-view.md
+    06-local-persistence.md
+    07-validation-empty-states.md
+    08-responsive-polish.md
+    09-automated-tests.md
+    10-readme-docs.md
+    11-make-it-social.md
+    12-votes-disappear.md
+```
+
+The live `patchmill-test` repository receives a copy of `README.md`,
+`PROJECT_BRIEF.md`, and the issue prompt files. The Patchmill repository remains
+the source of truth.
+
+## Issue File Format
+
+Each issue is a markdown file with simple frontmatter:
+
+```markdown
+---
+title: Build the initial Team Lunch Poll app shell
+labels: [feature]
+---
+
+Issue body...
+```
+
+Rules:
+
+- `title` is required.
+- `labels` is optional.
+- Missing `labels` means the GitHub issue is created without labels.
+- Issue bodies are natural user-facing GitHub prompts.
+- Issue files do not include expected triage outcomes or hidden evaluator
+  metadata.
+
+## Seeded Labels
+
+The reset script creates basic type labels before creating issues. Initial
+labels should include:
+
+- `feature`
+- `bug`
+- `docs`
+- `polish`
+
+Some issues intentionally omit labels so `patchmill triage` can be tested for
+adding the `feature` or `bug` labels.
+
+## Initial Issue Set
+
+Seed 10–12 issues. The approved starting set is 12 issues:
+
+1. **Create the Team Lunch Poll app scaffold** — ready feature issue.
+2. **Define the poll, option, and vote data model** — ready feature issue.
+3. **Build the create-poll form** — ready feature issue.
+4. **Add the option voting flow** — ready feature issue.
+5. **Show live results and winner state** — ready feature issue.
+6. **Persist polls locally** — ready feature issue.
+7. **Add validation, empty states, and error states** — ready feature issue.
+8. **Improve responsive visual polish** — ready polish issue.
+9. **Add automated tests for core poll flows** — ready test/feature issue.
+10. **Document setup and usage** — ready docs issue.
+11. **Make lunch polls more social** — deliberately vague issue that should
+    invite clarification.
+12. **Votes sometimes disappear when I refresh** — deliberately underspecified
+    bug-like issue, useful for triage because the app does not exist yet.
+
+## Reset and Seed Workflow
+
+The primary workflow is this Patchmill-local shell script:
+
+```bash
+scripts/reset-patchmill-test-repo.sh
+```
+
+The script is hardcoded to `rochecompaan/patchmill-test` and always recreates
+the repository as public. It does not accept an owner or repository override.
+
+Workflow:
+
+1. Verify required tools are available: `gh`, `git`, and `node`.
+2. Delete `rochecompaan/patchmill-test` if it exists.
+3. Recreate `rochecompaan/patchmill-test` as a public GitHub repository.
+4. Create a temporary local git repository.
+5. Copy fixture files into the temporary repository.
+6. Commit and push `main` to the recreated GitHub repository.
+7. Create basic labels with `gh label create` or `gh api`.
+8. Use a small Node helper to parse `issues/*.md` and create GitHub issues.
+9. Print next-step commands for manual testing.
+
+Example final output:
+
+```bash
+gh repo clone rochecompaan/patchmill-test
+cd patchmill-test
+patchmill init
+patchmill triage --dry-run
+patchmill triage
+```
+
+## Node Helper
+
+Use a small Node helper for parsing issue markdown files and producing
+predictable issue creation commands or JSON records. The helper owns:
+
+- frontmatter parsing,
+- validation of required `title`,
+- validation that `labels`, when present, is an array of strings,
+- preserving issue body markdown exactly after the frontmatter,
+- deterministic ordering by filename.
+
+The shell wrapper owns destructive GitHub lifecycle operations and calls the
+helper during issue creation.
+
+## Safety and Error Handling
+
+The reset flow is intentionally destructive but narrowly scoped.
+
+Safety rules:
+
+- Refuse to operate on any repository other than hardcoded
+  `rochecompaan/patchmill-test`.
+- Print each major destructive step.
+- Treat a missing repository during deletion as acceptable.
+- Fail fast when `gh`, `git`, or `node` is missing.
+- Fail when fixture files are missing.
+- Fail when issue frontmatter is invalid.
+- Use a temporary directory for git operations.
+- Clean up the temporary directory automatically.
+
+Failure recovery is rerunning the reset script. If the script fails after
+recreation, the partially seeded repository may remain on GitHub, but the next
+run deletes and recreates it.
+
+## Verification
+
+Implementation verification should include:
+
+- parser/helper tests for valid issue files, missing titles, optional labels,
+  and invalid labels,
+- local validation that all fixture issue files parse,
+- running the reset script against GitHub,
+- confirming the public repository exists at
+  `https://github.com/rochecompaan/patchmill-test`,
+- confirming the seeded repository contains the copied project files,
+- confirming the expected labels exist,
+- confirming the expected 10–12 issues exist.
+
+The implementation should leave `rochecompaan/patchmill-test` live and seeded on
+GitHub.
+
+## Documentation
+
+Add documentation describing:
+
+- the purpose of `patchmill-test`,
+- that the repository is disposable,
+- how to run the reset/seed script,
+- that the script deletes and recreates the public GitHub repository,
+- where the reusable project brief and issue prompts live,
+- how to clone the recreated repository,
+- how to manually test `patchmill init` and `patchmill triage` afterward.

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -351,20 +351,21 @@ Reuse rules:
 - Provider-specific subprocess calls belong in the existing provider modules:
   `src/host/github-gh.ts` and `src/host/forgejo-tea.ts`.
 - Do not create a setup-specific provider subtree such as
-  `src/host/setup-test-repo`. If a capability is a generic operation on a git
-  provider, add it to the existing provider module and shared host types.
+  `src/host/setup-test-repo`. Provider-specific subprocess calls still belong in
+  the existing provider modules, but setup should use a separate target-explicit
+  host interface instead of widening the triage interface.
 - Reuse the existing `CommandRunner`, `HostCliCheck`, `LabelDefinition`,
   `IssueHostProvider`, provider IDs, and provider readiness behavior from
   `src/host/types.ts`, `src/host/github-gh.ts`, `src/host/forgejo-tea.ts`, and
   `src/host/factory.ts`.
-- Add generic repository lifecycle and issue-creation capabilities to the
-  existing host providers rather than wrapping them in a parallel setup adapter.
-  These capabilities are broadly useful host operations: repository existence,
-  public repository creation, repository deletion, issue creation, git remote
-  URL, public URL, and clone command.
-- After the temporary git repository has the target remote configured, reuse the
-  existing repo-scoped provider behavior for readiness checks, label creation,
-  and issue creation where possible.
+- Add repository lifecycle and issue-creation capabilities through a dedicated
+  setup/admin host interface. Do not add these methods to the
+  `IssueHostProvider` contract used by triage. Triage remains configured-repo
+  scoped; setup remains explicit-target scoped.
+- All setup label and issue operations must accept the explicit
+  `RepositoryTarget`. Do not rely on temporary git remotes, cwd inference,
+  `GH_REPO`, or `tea --repo` inference to decide which repository receives
+  labels and issues.
 - If lifecycle or issue-creation logic requires provider-specific command
   builders, add them to the existing provider modules or shared `src/host`
   helpers. Do not duplicate command formatting, login handling, output parsing,
@@ -377,30 +378,33 @@ This keeps all supported-provider knowledge in `src/host` and prevents
 `setup-test-repo` from becoming a second, divergent implementation of GitHub or
 Forgejo/Gitea support.
 
-## Generic Host Provider Capabilities
+## Setup Host Provider Capabilities
 
 The existing `IssueHostProvider` interface supports Patchmill operations on an
 already-configured repository: list issues, inspect labels, comment, and apply
-labels. `setup-test-repo` needs repository lifecycle and issue creation before a
-repository has been initialized for Patchmill. Add those missing capabilities to
-the existing host-provider modules as generic provider operations, not as
-test-repo-specific setup code.
+labels. `setup-test-repo` has a different target model: it creates, deletes, and
+seeds an explicit repository that may not exist yet. Keep those concepts
+separate by adding a dedicated `RepositorySetupHostProvider` interface while
+implementing provider-specific commands in the existing provider classes.
 
-The existing provider classes should support:
+The setup provider interface should support:
 
 - `id` and `displayName`, using existing provider IDs.
 - `checkCli()` for provider tool/auth readiness.
-- `repoExists(target)`.
+- `getRepository(target)`, returning repository public and git remote URLs when
+  the target exists and `undefined` only for a verified not-found response.
 - `createPublicRepo(target)`.
 - `deleteRepo(target)` for reset mode.
-- `gitRemoteUrl(target)` for pushing the seeded commit.
-- `publicRepoUrl(target)` for output and verification.
 - `cloneCommand(target)` for final instructions.
-- `createIssue(issue)` as a repo-scoped operation after the target remote is
-  configured.
+- `listLabels(target)` for reading labels on the explicit target repository.
+- `createLabel(target, label)` for creating labels on the explicit target
+  repository.
+- `createIssue(target, issue)` for creating issues on the explicit target
+  repository.
 
-Existing `createLabel(label)` remains the generic label-creation operation for
-the configured repository and should be reused by `setup-test-repo`.
+Existing `IssueHostProvider` methods such as `listLabels()` and
+`createLabel(label)` remain configured-repo operations for triage. They should
+not be the setup command's target boundary.
 
 Provider implementation notes:
 
@@ -408,9 +412,9 @@ Provider implementation notes:
   matching the existing Patchmill GitHub provider.
 - `forgejo-tea` should use `tea` and pass `--login LOGIN` when supplied,
   matching the existing Patchmill Forgejo/Gitea named-login behavior.
-- `checkCli()` and label creation should delegate to the existing
-  `GitHubGhHostProvider` and `ForgejoTeaHostProvider` where possible after the
-  temporary repository remote is configured.
+- `checkCli()` can be reused from the existing provider classes, but setup label
+  creation and issue creation must pass the explicit target through to the host
+  command builder.
 - If `tea` lacks a convenient high-level subcommand for a specific lifecycle
   operation, `ForgejoTeaHostProvider` may use `tea api`. Keep those API details
   isolated to `src/host/forgejo-tea.ts` or shared helpers under `src/host`.
@@ -441,9 +445,12 @@ Safety rules:
 - Use a temporary directory for git operations.
 - Clean up the temporary directory automatically.
 
-Failure recovery is rerunning the command. If the command fails after creation
-or recreation, the partially seeded repository may remain on the selected host,
-but the next run with `--reset` deletes and recreates it.
+Before mutating the selected host, setup should validate and copy fixtures and
+create the local seed commit in the temporary repository. If setup creates or
+recreates a remote repository and a later push, label, or issue step fails, it
+should best-effort delete the repository it just created and report the rollback
+result. This avoids leaving an obviously half-seeded disposable repository when
+the failure happens after remote creation.
 
 ## Verification
 
@@ -454,13 +461,13 @@ Implementation verification should include:
 - issue parser tests for valid issue files, missing titles, optional labels, and
   invalid labels,
 - fixture resolution tests proving bundled fixture files can be found,
-- generic host-provider capability tests for both `GitHubGhHostProvider` and
-  `ForgejoTeaHostProvider`,
-- host-provider reuse tests proving setup orchestration calls existing
-  `src/host` provider capabilities instead of duplicating readiness and label
-  behavior,
+- setup host-provider capability tests for both `GitHubGhHostProvider` and
+  `ForgejoTeaHostProvider`, including explicit-target label and issue commands,
+- host-provider boundary tests proving setup orchestration calls `src/host`
+  provider capabilities instead of duplicating provider-specific CLI behavior,
 - orchestration tests using mocked host-provider capabilities for create-only,
-  existing-repo-without-reset failure, and reset flows,
+  existing-repo-without-reset failure, reset flows, local-validation-before-host
+  mutation, and rollback after post-create seeding failure,
 - mocked CLI-contract tests for provider commands generated by
   `src/host/github-gh.ts` and `src/host/forgejo-tea.ts`,
 - an architectural/static check that `src/cli/commands/setup-test-repo/*` does

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -2,8 +2,9 @@
 
 ## Summary
 
-Create a reusable GitHub demo repository at `rochecompaan/patchmill-test` for
-testing Patchmill's `init` and `triage` commands against a greenfield project.
+Create a reusable GitHub demo repository seeding workflow for testing
+Patchmill's `init` and `triage` commands against a greenfield project. The
+target repository is supplied explicitly on every run as `--repo OWNER/REPO`.
 The repository is disposable: reset means deleting and recreating it, then
 seeding it with a project brief, issue prompts, basic labels, and GitHub issues.
 
@@ -16,10 +17,12 @@ prompts for repeated use.
 
 - Provide a realistic GitHub repository for manually testing `patchmill init`
   and `patchmill triage`.
-- Reset the test repository to a clean state by deleting and recreating
-  `rochecompaan/patchmill-test`.
-- Keep the public repository URL stable:
-  `https://github.com/rochecompaan/patchmill-test`.
+- Reset a caller-specified test repository to a clean state by deleting and
+  recreating it.
+- Require the caller to pass `--repo OWNER/REPO`; there is no default target and
+  the script never infers a target from the current git remote.
+- Allow any GitHub user or organization to reuse the prompts and script in a
+  disposable public repository they control.
 - Preserve all reusable project description and issue prompt content in the
   Patchmill repository.
 - Copy the project description and prompts into the seeded demo repository for
@@ -32,11 +35,12 @@ prompts for repeated use.
 
 ## Non-goals
 
-- Do not create a configurable generic repository reset tool.
-- Do not support arbitrary GitHub owners or repository names.
+- Do not provide a default repository target.
+- Do not infer the target repository from the current directory, git remote, or
+  GitHub CLI context.
 - Do not run `patchmill init` from the reset script; running init is part of the
   manual test.
-- Do not create or refresh a local clone of `patchmill-test`; print clone
+- Do not create or refresh a local clone of the target repository; print clone
   instructions instead.
 - Do not include expected triage outcomes in issue files.
 - Do not scaffold a runnable application in the reset repository. The seeded
@@ -74,9 +78,8 @@ test-fixtures/patchmill-test/
     12-votes-disappear.md
 ```
 
-The live `patchmill-test` repository receives a copy of `README.md`,
-`PROJECT_BRIEF.md`, and the issue prompt files. The Patchmill repository remains
-the source of truth.
+The live test repository receives a copy of `README.md`, `PROJECT_BRIEF.md`, and
+the issue prompt files. The Patchmill repository remains the source of truth.
 
 ## Issue File Format
 
@@ -140,26 +143,38 @@ The primary workflow is this Patchmill-local shell script:
 scripts/reset-patchmill-test-repo.sh
 ```
 
-The script is hardcoded to `rochecompaan/patchmill-test` and always recreates
-the repository as public. It does not accept an owner or repository override.
+The script requires an explicit `--repo OWNER/REPO` argument and always
+recreates the target repository as public. There is no default repository
+target.
+
+Example:
+
+```bash
+scripts/reset-patchmill-test-repo.sh --repo rochecompaan/patchmill-test --yes
+```
+
+The `--yes` flag is required for the destructive delete/recreate operation.
 
 Workflow:
 
 1. Verify required tools are available: `gh`, `git`, and `node`.
-2. Delete `rochecompaan/patchmill-test` if it exists.
-3. Recreate `rochecompaan/patchmill-test` as a public GitHub repository.
-4. Create a temporary local git repository.
-5. Copy fixture files into the temporary repository.
-6. Commit and push `main` to the recreated GitHub repository.
-7. Create basic labels with `gh label create` or `gh api`.
-8. Use a small Node helper to parse `issues/*.md` and create GitHub issues.
-9. Print next-step commands for manual testing.
+2. Validate the required `--repo OWNER/REPO` argument.
+3. Require `--yes` before deleting or recreating a repository.
+4. Print the exact target repository and public URL.
+5. Delete the target repository if it exists.
+6. Recreate the target repository as a public GitHub repository.
+7. Create a temporary local git repository.
+8. Copy fixture files into the temporary repository.
+9. Commit and push `main` to the recreated GitHub repository.
+10. Create basic labels with `gh label create` or `gh api`.
+11. Use a small Node helper to parse `issues/*.md` and create GitHub issues.
+12. Print next-step commands for manual testing.
 
-Example final output:
+Example final output for the requested target:
 
 ```bash
-gh repo clone rochecompaan/patchmill-test
-cd patchmill-test
+gh repo clone OWNER/REPO
+cd REPO
 patchmill init
 patchmill triage --dry-run
 patchmill triage
@@ -181,13 +196,17 @@ helper during issue creation.
 
 ## Safety and Error Handling
 
-The reset flow is intentionally destructive but narrowly scoped.
+The reset flow is intentionally destructive and requires an explicit target.
 
 Safety rules:
 
-- Refuse to operate on any repository other than hardcoded
-  `rochecompaan/patchmill-test`.
+- Refuse to run unless `--repo OWNER/REPO` is provided.
+- Refuse malformed repository names.
+- Refuse to infer a target repository from the current directory, git remote, or
+  GitHub CLI context.
+- Require `--yes` for the destructive delete/recreate operation.
 - Print each major destructive step.
+- Print the exact target repository and public URL before deletion.
 - Treat a missing repository during deletion as acceptable.
 - Fail fast when `gh`, `git`, or `node` is missing.
 - Fail when fixture files are missing.
@@ -206,23 +225,23 @@ Implementation verification should include:
 - parser/helper tests for valid issue files, missing titles, optional labels,
   and invalid labels,
 - local validation that all fixture issue files parse,
-- running the reset script against GitHub,
-- confirming the public repository exists at
-  `https://github.com/rochecompaan/patchmill-test`,
+- running the reset script against GitHub with an explicit repository argument,
+- confirming the public repository exists at the requested GitHub URL,
 - confirming the seeded repository contains the copied project files,
 - confirming the expected labels exist,
 - confirming the expected 10–12 issues exist.
 
-The implementation should leave `rochecompaan/patchmill-test` live and seeded on
-GitHub.
+For Patchmill's own verification, use `--repo rochecompaan/patchmill-test` and
+leave that repository live and seeded on GitHub.
 
 ## Documentation
 
 Add documentation describing:
 
-- the purpose of `patchmill-test`,
+- the purpose of the reusable Patchmill test repository fixture,
 - that the repository is disposable,
-- how to run the reset/seed script,
+- how to choose a disposable `OWNER/REPO` target,
+- how to run the reset/seed script with `--repo OWNER/REPO --yes`,
 - that the script deletes and recreates the public GitHub repository,
 - where the reusable project brief and issue prompts live,
 - how to clone the recreated repository,

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -2,23 +2,25 @@
 
 ## Summary
 
-Create a reusable GitHub demo repository seeding workflow for testing
-Patchmill's `init` and `triage` commands against a greenfield project. The
-target repository is supplied explicitly on every run as `--repo OWNER/REPO`.
-The repository is disposable: reset means deleting and recreating it, then
-seeding it with a project brief, issue prompts, basic labels, and GitHub issues.
+Create a reusable GitHub demo repository setup workflow for testing Patchmill's
+`init` and `triage` commands against a greenfield project. The target repository
+is supplied explicitly on every run as `--repo OWNER/REPO`. The repository is
+disposable: setup creates and seeds it, and `--reset` deletes and recreates it
+before seeding it with a project brief, issue prompts, basic labels, and GitHub
+issues.
 
 The reusable source content lives in the Patchmill repository and is copied into
-the recreated demo repository on each reset. This keeps the live GitHub
-repository clean and disposable while preserving the project description and
-prompts for repeated use.
+the target demo repository on each setup or reset. This keeps the live GitHub
+repository disposable while preserving the project description and prompts for
+repeated use.
 
 ## Goals
 
 - Provide a realistic GitHub repository for manually testing `patchmill init`
   and `patchmill triage`.
-- Reset a caller-specified test repository to a clean state by deleting and
-  recreating it.
+- Set up a caller-specified test repository by creating and seeding it.
+- Reset a caller-specified test repository to a clean state when `--reset` is
+  passed.
 - Require the caller to pass `--repo OWNER/REPO`; there is no default target and
   the script never infers a target from the current git remote.
 - Allow any GitHub user or organization to reuse the prompts and script in a
@@ -38,12 +40,12 @@ prompts for repeated use.
 - Do not provide a default repository target.
 - Do not infer the target repository from the current directory, git remote, or
   GitHub CLI context.
-- Do not run `patchmill init` from the reset script; running init is part of the
+- Do not run `patchmill init` from the setup script; running init is part of the
   manual test.
 - Do not create or refresh a local clone of the target repository; print clone
   instructions instead.
 - Do not include expected triage outcomes in issue files.
-- Do not scaffold a runnable application in the reset repository. The seeded
+- Do not scaffold a runnable application in the target repository. The seeded
   issues should drive the app build from an almost empty repository.
 
 ## Demo Project
@@ -105,7 +107,7 @@ Rules:
 
 ## Seeded Labels
 
-The reset script creates basic type labels before creating issues. Initial
+The setup script creates basic type labels before creating issues. Initial
 labels should include:
 
 - `feature`
@@ -135,40 +137,44 @@ Seed 10–12 issues. The approved starting set is 12 issues:
 12. **Votes sometimes disappear when I refresh** — deliberately underspecified
     bug-like issue, useful for triage because the app does not exist yet.
 
-## Reset and Seed Workflow
+## Setup and Reset Workflow
 
 The primary workflow is this Patchmill-local shell script:
 
 ```bash
-scripts/reset-patchmill-test-repo.sh
+scripts/setup-patchmill-test-repo.sh
 ```
 
-The script requires an explicit `--repo OWNER/REPO` argument and always
-recreates the target repository as public. There is no default repository
+The script requires an explicit `--repo OWNER/REPO` argument and always creates
+or recreates the target repository as public. There is no default repository
 target.
 
 Example:
 
 ```bash
-scripts/reset-patchmill-test-repo.sh --repo rochecompaan/patchmill-test --yes
+scripts/setup-patchmill-test-repo.sh --repo rochecompaan/patchmill-test --reset
 ```
 
-The `--yes` flag is required for the destructive delete/recreate operation.
+The `--reset` flag is required for the destructive delete/recreate operation. If
+`--reset` is omitted and the target repository already exists, the script fails
+with instructions to rerun with `--reset` when the caller intends to replace it.
 
 Workflow:
 
 1. Verify required tools are available: `gh`, `git`, and `node`.
 2. Validate the required `--repo OWNER/REPO` argument.
-3. Require `--yes` before deleting or recreating a repository.
-4. Print the exact target repository and public URL.
-5. Delete the target repository if it exists.
-6. Recreate the target repository as a public GitHub repository.
-7. Create a temporary local git repository.
-8. Copy fixture files into the temporary repository.
-9. Commit and push `main` to the recreated GitHub repository.
-10. Create basic labels with `gh label create` or `gh api`.
-11. Use a small Node helper to parse `issues/*.md` and create GitHub issues.
-12. Print next-step commands for manual testing.
+3. Determine whether the caller requested `--reset`.
+4. If `--reset` is omitted, create the target public repository only when it
+   does not already exist.
+5. If `--reset` is provided, print the exact target repository and public URL,
+   delete the target repository if it exists, and recreate it as a public GitHub
+   repository.
+6. Create a temporary local git repository.
+7. Copy fixture files into the temporary repository.
+8. Commit and push `main` to the target GitHub repository.
+9. Create basic labels with `gh label create` or `gh api`.
+10. Use a small Node helper to parse `issues/*.md` and create GitHub issues.
+11. Print next-step commands for manual testing.
 
 Example final output for the requested target:
 
@@ -191,12 +197,13 @@ predictable issue creation commands or JSON records. The helper owns:
 - preserving issue body markdown exactly after the frontmatter,
 - deterministic ordering by filename.
 
-The shell wrapper owns destructive GitHub lifecycle operations and calls the
-helper during issue creation.
+The shell wrapper owns GitHub lifecycle operations and calls the helper during
+issue creation.
 
 ## Safety and Error Handling
 
-The reset flow is intentionally destructive and requires an explicit target.
+The setup flow requires an explicit target. The reset mode is intentionally
+destructive and requires `--reset`.
 
 Safety rules:
 
@@ -204,8 +211,8 @@ Safety rules:
 - Refuse malformed repository names.
 - Refuse to infer a target repository from the current directory, git remote, or
   GitHub CLI context.
-- Require `--yes` for the destructive delete/recreate operation.
-- Print each major destructive step.
+- Require `--reset` for the destructive delete/recreate operation.
+- Print each major step, including every destructive reset step.
 - Print the exact target repository and public URL before deletion.
 - Treat a missing repository during deletion as acceptable.
 - Fail fast when `gh`, `git`, or `node` is missing.
@@ -214,9 +221,9 @@ Safety rules:
 - Use a temporary directory for git operations.
 - Clean up the temporary directory automatically.
 
-Failure recovery is rerunning the reset script. If the script fails after
-recreation, the partially seeded repository may remain on GitHub, but the next
-run deletes and recreates it.
+Failure recovery is rerunning the setup script. If the script fails after
+creation or recreation, the partially seeded repository may remain on GitHub,
+but the next run with `--reset` deletes and recreates it.
 
 ## Verification
 
@@ -225,14 +232,16 @@ Implementation verification should include:
 - parser/helper tests for valid issue files, missing titles, optional labels,
   and invalid labels,
 - local validation that all fixture issue files parse,
-- running the reset script against GitHub with an explicit repository argument,
+- running the setup script against GitHub with an explicit repository argument
+  and `--reset`,
 - confirming the public repository exists at the requested GitHub URL,
 - confirming the seeded repository contains the copied project files,
 - confirming the expected labels exist,
 - confirming the expected 10–12 issues exist.
 
-For Patchmill's own verification, use `--repo rochecompaan/patchmill-test` and
-leave that repository live and seeded on GitHub.
+For Patchmill's own verification, use
+`--repo rochecompaan/patchmill-test --reset` and leave that repository live and
+seeded on GitHub.
 
 ## Documentation
 
@@ -241,8 +250,10 @@ Add documentation describing:
 - the purpose of the reusable Patchmill test repository fixture,
 - that the repository is disposable,
 - how to choose a disposable `OWNER/REPO` target,
-- how to run the reset/seed script with `--repo OWNER/REPO --yes`,
-- that the script deletes and recreates the public GitHub repository,
+- how to run the setup script with `--repo OWNER/REPO`,
+- how to reset an existing disposable repository with
+  `--repo OWNER/REPO --reset`,
+- that `--reset` deletes and recreates the public GitHub repository,
 - where the reusable project brief and issue prompts live,
 - how to clone the recreated repository,
 - how to manually test `patchmill init` and `patchmill triage` afterward.

--- a/docs/specs/2026-06-05-patchmill-test-repo-design.md
+++ b/docs/specs/2026-06-05-patchmill-test-repo-design.md
@@ -1,32 +1,43 @@
-# Patchmill Test Repository Design
+# Patchmill Test Repository Command Design
 
 ## Summary
 
-Create a reusable GitHub demo repository setup workflow for testing Patchmill's
-`init` and `triage` commands against a greenfield project. The target repository
-is supplied explicitly on every run as `--repo OWNER/REPO`. The repository is
-disposable: setup creates and seeds it, and `--reset` deletes and recreates it
-before seeding it with a project brief, issue prompts, basic labels, and GitHub
-issues.
+Add a packaged Patchmill command for creating a reusable GitHub demo repository
+that tests Patchmill's `init` and `triage` commands against a greenfield
+project. Users should be able to install Patchmill and run:
 
-The reusable source content lives in the Patchmill repository and is copied into
-the target demo repository on each setup or reset. This keeps the live GitHub
-repository disposable while preserving the project description and prompts for
-repeated use.
+```bash
+patchmill setup-test-repo --repo OWNER/REPO
+patchmill setup-test-repo --repo OWNER/REPO --reset
+```
+
+The target repository is supplied explicitly on every run as
+`--repo OWNER/REPO`. There is no default target. Setup creates and seeds a
+public GitHub repository; `--reset` deletes and recreates an existing disposable
+repository before seeding it with a project brief, issue prompts, basic labels,
+and GitHub issues.
+
+The reusable source content ships with Patchmill and is copied into the target
+demo repository on each setup or reset. This lets users try Patchmill end to end
+without cloning the Patchmill source repository, while preserving the project
+description and issue prompts for repeated use.
 
 ## Goals
 
 - Provide a realistic GitHub repository for manually testing `patchmill init`
   and `patchmill triage`.
-- Set up a caller-specified test repository by creating and seeding it.
+- Expose the workflow as a packaged CLI command: `patchmill setup-test-repo`.
+- Let users run the demo setup after installing Patchmill, without cloning the
+  Patchmill repository.
+- Set up a caller-specified public test repository by creating and seeding it.
 - Reset a caller-specified test repository to a clean state when `--reset` is
   passed.
 - Require the caller to pass `--repo OWNER/REPO`; there is no default target and
-  the script never infers a target from the current git remote.
-- Allow any GitHub user or organization to reuse the prompts and script in a
+  the command never infers a target from the current git remote.
+- Allow any GitHub user or organization to reuse the prompts and command in a
   disposable public repository they control.
 - Preserve all reusable project description and issue prompt content in the
-  Patchmill repository.
+  Patchmill package.
 - Copy the project description and prompts into the seeded demo repository for
   transparency.
 - Seed 10–12 natural GitHub issues for a small greenfield web app.
@@ -40,13 +51,32 @@ repeated use.
 - Do not provide a default repository target.
 - Do not infer the target repository from the current directory, git remote, or
   GitHub CLI context.
-- Do not run `patchmill init` from the setup script; running init is part of the
-  manual test.
+- Do not name the command `patchmill test`; that would be confused with running
+  tests for the current project.
+- Do not run `patchmill init` from `setup-test-repo`; running init is part of
+  the manual test.
 - Do not create or refresh a local clone of the target repository; print clone
   instructions instead.
 - Do not include expected triage outcomes in issue files.
 - Do not scaffold a runnable application in the target repository. The seeded
   issues should drive the app build from an almost empty repository.
+
+## Command Naming
+
+Use:
+
+```bash
+patchmill setup-test-repo
+```
+
+Rationale:
+
+- `setup-test-repo` describes the user-visible effect: creating a disposable
+  test repository for Patchmill.
+- The verb `setup` fits a command that creates and seeds a resource.
+- The noun `test-repo` avoids implying that Patchmill will run a test suite.
+- `patchmill test` is rejected because it is too ambiguous and would likely be
+  read as "run Patchmill tests" or "test this repository."
 
 ## Demo Project
 
@@ -59,10 +89,10 @@ the project from the seeded issues.
 
 ## Fixture Layout
 
-Patchmill owns the reusable fixture content under this project-local directory:
+Patchmill owns the reusable fixture content in a package-included directory:
 
 ```text
-test-fixtures/patchmill-test/
+fixtures/patchmill-test-repo/
   README.md
   PROJECT_BRIEF.md
   issues/
@@ -80,8 +110,13 @@ test-fixtures/patchmill-test/
     12-votes-disappear.md
 ```
 
+The fixture directory must be included in the npm package, for example by adding
+`fixtures` to `package.json` `files`. Runtime code should resolve the fixture
+path from the installed package root rather than from the caller's current
+working directory.
+
 The live test repository receives a copy of `README.md`, `PROJECT_BRIEF.md`, and
-the issue prompt files. The Patchmill repository remains the source of truth.
+the issue prompt files. The Patchmill package remains the source of truth.
 
 ## Issue File Format
 
@@ -107,8 +142,8 @@ Rules:
 
 ## Seeded Labels
 
-The setup script creates basic type labels before creating issues. Initial
-labels should include:
+The command creates basic type labels before creating issues. Initial labels
+should include:
 
 - `feature`
 - `bug`
@@ -139,29 +174,30 @@ Seed 10–12 issues. The approved starting set is 12 issues:
 
 ## Setup and Reset Workflow
 
-The primary workflow is this Patchmill-local shell script:
+The primary workflow is this Patchmill CLI command:
 
 ```bash
-scripts/setup-patchmill-test-repo.sh
+patchmill setup-test-repo --repo OWNER/REPO
+patchmill setup-test-repo --repo OWNER/REPO --reset
 ```
 
-The script requires an explicit `--repo OWNER/REPO` argument and always creates
+The command requires an explicit `--repo OWNER/REPO` argument and always creates
 or recreates the target repository as public. There is no default repository
 target.
 
 Example:
 
 ```bash
-scripts/setup-patchmill-test-repo.sh --repo rochecompaan/patchmill-test --reset
+patchmill setup-test-repo --repo rochecompaan/patchmill-test --reset
 ```
 
 The `--reset` flag is required for the destructive delete/recreate operation. If
-`--reset` is omitted and the target repository already exists, the script fails
+`--reset` is omitted and the target repository already exists, the command fails
 with instructions to rerun with `--reset` when the caller intends to replace it.
 
 Workflow:
 
-1. Verify required tools are available: `gh`, `git`, and `node`.
+1. Verify required external tools are available: `gh` and `git`.
 2. Validate the required `--repo OWNER/REPO` argument.
 3. Determine whether the caller requested `--reset`.
 4. If `--reset` is omitted, create the target public repository only when it
@@ -170,10 +206,11 @@ Workflow:
    delete the target repository if it exists, and recreate it as a public GitHub
    repository.
 6. Create a temporary local git repository.
-7. Copy fixture files into the temporary repository.
+7. Copy fixture files from the installed Patchmill package into the temporary
+   repository.
 8. Commit and push `main` to the target GitHub repository.
 9. Create basic labels with `gh label create` or `gh api`.
-10. Use a small Node helper to parse `issues/*.md` and create GitHub issues.
+10. Parse `issues/*.md` and create GitHub issues.
 11. Print next-step commands for manual testing.
 
 Example final output for the requested target:
@@ -186,19 +223,37 @@ patchmill triage --dry-run
 patchmill triage
 ```
 
-## Node Helper
+## Implementation Components
 
-Use a small Node helper for parsing issue markdown files and producing
-predictable issue creation commands or JSON records. The helper owns:
+Add a new command directory:
 
-- frontmatter parsing,
-- validation of required `title`,
-- validation that `labels`, when present, is an array of strings,
-- preserving issue body markdown exactly after the frontmatter,
-- deterministic ordering by filename.
+```text
+src/cli/commands/setup-test-repo/
+  args.ts
+  args.test.ts
+  fixtures.ts
+  fixtures.test.ts
+  github.ts
+  github.test.ts
+  issue-parser.ts
+  issue-parser.test.ts
+  main.ts
+  main.test.ts
+```
 
-The shell wrapper owns GitHub lifecycle operations and calls the helper during
-issue creation.
+Responsibilities:
+
+- `args.ts`: parse `--repo OWNER/REPO`, `--reset`, and help output.
+- `issue-parser.ts`: parse issue markdown frontmatter and validate titles and
+  labels.
+- `fixtures.ts`: resolve and validate the bundled fixture directory from the
+  installed package.
+- `github.ts`: wrap `gh` and `git` subprocess operations behind testable
+  functions.
+- `main.ts`: orchestrate setup/reset, fixture copy, git push, label creation,
+  issue creation, and final instructions.
+
+Register the command in `src/cli/main.ts` help and dispatch maps.
 
 ## Safety and Error Handling
 
@@ -214,46 +269,58 @@ Safety rules:
 - Require `--reset` for the destructive delete/recreate operation.
 - Print each major step, including every destructive reset step.
 - Print the exact target repository and public URL before deletion.
-- Treat a missing repository during deletion as acceptable.
-- Fail fast when `gh`, `git`, or `node` is missing.
-- Fail when fixture files are missing.
+- Treat a missing repository during reset deletion as acceptable.
+- Fail fast when `gh` or `git` is missing.
+- Fail when bundled fixture files are missing.
 - Fail when issue frontmatter is invalid.
 - Use a temporary directory for git operations.
 - Clean up the temporary directory automatically.
 
-Failure recovery is rerunning the setup script. If the script fails after
-creation or recreation, the partially seeded repository may remain on GitHub,
-but the next run with `--reset` deletes and recreates it.
+Failure recovery is rerunning the command. If the command fails after creation
+or recreation, the partially seeded repository may remain on GitHub, but the
+next run with `--reset` deletes and recreates it.
 
 ## Verification
 
 Implementation verification should include:
 
-- parser/helper tests for valid issue files, missing titles, optional labels,
-  and invalid labels,
+- argument parser tests for missing `--repo`, malformed repo names, `--reset`,
+  and help output,
+- issue parser tests for valid issue files, missing titles, optional labels, and
+  invalid labels,
+- fixture resolution tests proving bundled fixture files can be found,
+- orchestration tests using mocked `gh`/`git` operations for create-only,
+  existing-repo-without-reset failure, and reset flows,
 - local validation that all fixture issue files parse,
-- running the setup script against GitHub with an explicit repository argument
-  and `--reset`,
+- package/build verification that fixture files are included in the installable
+  package,
+- running `patchmill setup-test-repo` against GitHub with an explicit repository
+  argument and `--reset`,
 - confirming the public repository exists at the requested GitHub URL,
 - confirming the seeded repository contains the copied project files,
 - confirming the expected labels exist,
 - confirming the expected 10–12 issues exist.
 
-For Patchmill's own verification, use
-`--repo rochecompaan/patchmill-test --reset` and leave that repository live and
-seeded on GitHub.
+For Patchmill's own verification, use:
+
+```bash
+patchmill setup-test-repo --repo rochecompaan/patchmill-test --reset
+```
+
+Leave that repository live and seeded on GitHub.
 
 ## Documentation
 
 Add documentation describing:
 
 - the purpose of the reusable Patchmill test repository fixture,
-- that the repository is disposable,
+- that the target repository should be disposable,
 - how to choose a disposable `OWNER/REPO` target,
-- how to run the setup script with `--repo OWNER/REPO`,
+- how to run `patchmill setup-test-repo --repo OWNER/REPO`,
 - how to reset an existing disposable repository with
-  `--repo OWNER/REPO --reset`,
+  `patchmill setup-test-repo --repo OWNER/REPO --reset`,
 - that `--reset` deletes and recreates the public GitHub repository,
-- where the reusable project brief and issue prompts live,
+- where the reusable project brief and issue prompts live in the installed
+  package/source tree,
 - how to clone the recreated repository,
 - how to manually test `patchmill init` and `patchmill triage` afterward.

--- a/fixtures/patchmill-test-repo/PROJECT_BRIEF.md
+++ b/fixtures/patchmill-test-repo/PROJECT_BRIEF.md
@@ -1,0 +1,24 @@
+# Team Lunch Poll Project Brief
+
+Team Lunch Poll is a lightweight web app for teams that need to decide where or
+what to eat together.
+
+## Product goals
+
+- Create a poll with a lunch question and a short list of options.
+- Let teammates vote for one option.
+- Show results clearly enough for the team to pick a winner.
+- Keep the first version simple, local, and easy to run.
+
+## Suggested implementation shape
+
+A good first implementation can be a small TypeScript web app using local state
+and browser storage. A full backend, authentication system, and deployment setup
+are outside the first demo scope unless an issue explicitly asks for them.
+
+## User experience principles
+
+- The app should feel friendly and low-friction.
+- Empty states should explain what to do next.
+- Validation messages should help the user fix input quickly.
+- The interface should work on desktop and mobile screens.

--- a/fixtures/patchmill-test-repo/README.md
+++ b/fixtures/patchmill-test-repo/README.md
@@ -1,0 +1,24 @@
+# Team Lunch Poll
+
+Team Lunch Poll is a small greenfield demo app for trying Patchmill on a safe,
+disposable repository.
+
+The app should let a team create a lunch poll, add meal or restaurant options,
+vote on those options, and see the current winner. The repository intentionally
+starts with documentation and issue prompts only. Patchmill agents should build
+the application from the seeded issues.
+
+## Demo workflow
+
+After this repository is seeded, try Patchmill manually:
+
+```bash
+patchmill init
+patchmill triage --dry-run
+patchmill triage
+```
+
+## Source of truth
+
+This repository is disposable. The reusable project brief and issue prompts live
+in the Patchmill package under `fixtures/patchmill-test-repo/`.

--- a/fixtures/patchmill-test-repo/issues/01-project-scaffold.md
+++ b/fixtures/patchmill-test-repo/issues/01-project-scaffold.md
@@ -1,0 +1,12 @@
+---
+title: Create the Team Lunch Poll app scaffold
+labels: [feature]
+---
+
+Set up the initial Team Lunch Poll web app so contributors have a working place
+to build from.
+
+Please include a minimal app shell with a heading, a short description of the
+product, and a placeholder area where poll creation and results will appear.
+Choose a simple TypeScript-friendly setup and document the commands needed to
+install dependencies, run the app locally, and run checks.

--- a/fixtures/patchmill-test-repo/issues/02-domain-model.md
+++ b/fixtures/patchmill-test-repo/issues/02-domain-model.md
@@ -1,0 +1,11 @@
+---
+title: Define the poll, option, and vote data model
+labels: [feature]
+---
+
+Define the core data structures for Team Lunch Poll.
+
+The app needs a poll with a question, a collection of lunch options, and votes
+that can be counted per option. Keep the model small enough for local browser
+state, but make the names clear so future issues can build forms, voting, and
+results on top of it.

--- a/fixtures/patchmill-test-repo/issues/03-create-poll-form.md
+++ b/fixtures/patchmill-test-repo/issues/03-create-poll-form.md
@@ -1,0 +1,10 @@
+---
+title: Build the create-poll form
+labels: [feature]
+---
+
+Add a form that lets someone create a lunch poll.
+
+The form should collect a poll question and at least two options. A user should
+be able to add another option before saving the poll. After saving, the app
+should show the poll instead of the empty placeholder.

--- a/fixtures/patchmill-test-repo/issues/04-voting-flow.md
+++ b/fixtures/patchmill-test-repo/issues/04-voting-flow.md
@@ -1,0 +1,10 @@
+---
+title: Add the option voting flow
+labels: [feature]
+---
+
+Let a teammate vote for one lunch option in the current poll.
+
+Each option should have an obvious vote action. After a vote is cast, the UI
+should make it clear which option received the vote and prevent accidental
+double-voting in the same browser session.

--- a/fixtures/patchmill-test-repo/issues/05-results-view.md
+++ b/fixtures/patchmill-test-repo/issues/05-results-view.md
@@ -1,0 +1,10 @@
+---
+title: Show live results and winner state
+labels: [feature]
+---
+
+Display vote totals for the current poll.
+
+The results view should update after each vote, show counts for every option,
+and highlight the current winner. If there is a tie, show that the poll is tied
+instead of pretending there is a single winner.

--- a/fixtures/patchmill-test-repo/issues/06-local-persistence.md
+++ b/fixtures/patchmill-test-repo/issues/06-local-persistence.md
@@ -1,0 +1,11 @@
+---
+title: Persist polls locally
+labels: [feature]
+---
+
+Persist the current poll and votes in browser storage so a refresh does not wipe
+out the demo.
+
+Use a simple local persistence approach. The app should load saved poll data on
+startup and provide a clear way to reset the current poll when someone wants to
+start over.

--- a/fixtures/patchmill-test-repo/issues/07-validation-empty-states.md
+++ b/fixtures/patchmill-test-repo/issues/07-validation-empty-states.md
@@ -1,0 +1,10 @@
+---
+title: Add validation, empty states, and error states
+labels: [feature]
+---
+
+Make the app resilient when users enter incomplete poll information.
+
+The create-poll form should explain what is missing when the question is blank,
+when an option is blank, or when fewer than two usable options are provided. The
+empty state should guide a new user toward creating their first lunch poll.

--- a/fixtures/patchmill-test-repo/issues/08-responsive-polish.md
+++ b/fixtures/patchmill-test-repo/issues/08-responsive-polish.md
@@ -1,0 +1,10 @@
+---
+title: Improve responsive visual polish
+labels: [polish]
+---
+
+Give Team Lunch Poll a friendly responsive layout.
+
+The app should be comfortable to use on a phone and on a laptop. Improve
+spacing, typography, button states, and result presentation without adding a
+large design system or unrelated UI features.

--- a/fixtures/patchmill-test-repo/issues/09-automated-tests.md
+++ b/fixtures/patchmill-test-repo/issues/09-automated-tests.md
@@ -1,0 +1,10 @@
+---
+title: Add automated tests for core poll flows
+labels: [feature]
+---
+
+Add automated tests for the most important Team Lunch Poll behavior.
+
+Cover creating a poll, voting for an option, showing results, and preserving the
+poll through the chosen local persistence layer. Keep the test setup easy for a
+new contributor to run.

--- a/fixtures/patchmill-test-repo/issues/10-readme-docs.md
+++ b/fixtures/patchmill-test-repo/issues/10-readme-docs.md
@@ -1,0 +1,10 @@
+---
+title: Document setup and usage
+labels: [docs]
+---
+
+Improve the repository README for people trying the Team Lunch Poll demo.
+
+Document the project purpose, local setup commands, test commands, and a short
+walkthrough of creating a poll and voting. Include notes about the current local
+persistence behavior so users know where their demo data lives.

--- a/fixtures/patchmill-test-repo/issues/11-make-it-social.md
+++ b/fixtures/patchmill-test-repo/issues/11-make-it-social.md
@@ -1,0 +1,9 @@
+---
+title: Make lunch polls more social
+---
+
+The poll should feel more social and fun for a team.
+
+Maybe people should be able to react to options, add comments, invite teammates,
+or see who voted. I am not sure which of these matters most for the first
+version. Please figure out a good direction.

--- a/fixtures/patchmill-test-repo/issues/12-votes-disappear.md
+++ b/fixtures/patchmill-test-repo/issues/12-votes-disappear.md
@@ -1,0 +1,8 @@
+---
+title: Votes sometimes disappear when I refresh
+---
+
+I heard that votes can disappear after refreshing the page.
+
+There is not much detail yet. Please look into what could cause vote data to be
+lost and propose or make the smallest useful fix for the demo app.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bin",
     "src",
     "dist",
+    "fixtures",
     "docs",
     "skills",
     "extensions",

--- a/src/cli/commands/setup-test-repo/args.test.ts
+++ b/src/cli/commands/setup-test-repo/args.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseArgs } from "./args.ts";
+
+test("parseArgs requires provider", () => {
+  assert.throws(
+    () => parseArgs(["--repo", "OWNER/REPO"]),
+    /--provider is required/,
+  );
+});
+
+test("parseArgs requires repo", () => {
+  assert.throws(
+    () => parseArgs(["--provider", "github-gh"]),
+    /--repo OWNER\/REPO is required/,
+  );
+});
+
+test("parseArgs rejects unsupported providers", () => {
+  assert.throws(
+    () => parseArgs(["--provider", "gitlab", "--repo", "OWNER/REPO"]),
+    /Unsupported provider: gitlab/,
+  );
+});
+
+test("parseArgs rejects malformed repositories", () => {
+  assert.throws(
+    () => parseArgs(["--provider", "github-gh", "--repo", "OWNER"]),
+    /--repo must use OWNER\/REPO/,
+  );
+});
+
+test("parseArgs parses GitHub target", () => {
+  assert.deepEqual(
+    parseArgs(["--provider", "github-gh", "--repo", "OWNER/REPO"]),
+    {
+      showHelp: false,
+      provider: "github-gh",
+      target: { owner: "OWNER", repo: "REPO", slug: "OWNER/REPO" },
+      reset: false,
+    },
+  );
+});
+
+test("parseArgs parses Forgejo login and reset", () => {
+  assert.deepEqual(
+    parseArgs([
+      "--provider=forgejo-tea",
+      "--repo=team/lunch",
+      "--login",
+      "demo-login",
+      "--reset",
+    ]),
+    {
+      showHelp: false,
+      provider: "forgejo-tea",
+      target: { owner: "team", repo: "lunch", slug: "team/lunch" },
+      login: "demo-login",
+      reset: true,
+    },
+  );
+});
+
+test("parseArgs rejects GitHub login", () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        "--provider",
+        "github-gh",
+        "--repo",
+        "OWNER/REPO",
+        "--login",
+        "unused",
+      ]),
+    /--login is only supported with forgejo-tea/,
+  );
+});
+
+test("parseArgs returns help without requiring provider or repo", () => {
+  assert.deepEqual(parseArgs(["--help"]), {
+    showHelp: true,
+    reset: false,
+  });
+});

--- a/src/cli/commands/setup-test-repo/args.ts
+++ b/src/cli/commands/setup-test-repo/args.ts
@@ -1,0 +1,75 @@
+import type { PatchmillHostProviderId } from "../../../config/types.ts";
+import type { RepositoryTarget } from "../../../host/types.ts";
+
+export type SetupTestRepoConfig = {
+  showHelp: boolean;
+  provider?: PatchmillHostProviderId;
+  target?: RepositoryTarget;
+  login?: string;
+  reset: boolean;
+};
+
+const SUPPORTED_PROVIDERS = new Set<PatchmillHostProviderId>([
+  "github-gh",
+  "forgejo-tea",
+]);
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--"))
+    throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parseRepo(value: string): RepositoryTarget {
+  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/u.exec(value);
+  if (!match) throw new Error("--repo must use OWNER/REPO");
+  return { owner: match[1], repo: match[2], slug: value };
+}
+
+function parseProvider(value: string): PatchmillHostProviderId {
+  if (SUPPORTED_PROVIDERS.has(value as PatchmillHostProviderId)) {
+    return value as PatchmillHostProviderId;
+  }
+  throw new Error(`Unsupported provider: ${value}`);
+}
+
+export function parseArgs(args: string[]): SetupTestRepoConfig {
+  const config: SetupTestRepoConfig = { showHelp: false, reset: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      config.showHelp = true;
+    } else if (arg === "--provider") {
+      config.provider = parseProvider(requireValue(args, index, arg));
+      index += 1;
+    } else if (arg.startsWith("--provider=")) {
+      config.provider = parseProvider(arg.slice("--provider=".length));
+    } else if (arg === "--repo") {
+      config.target = parseRepo(requireValue(args, index, arg));
+      index += 1;
+    } else if (arg.startsWith("--repo=")) {
+      config.target = parseRepo(arg.slice("--repo=".length));
+    } else if (arg === "--login") {
+      config.login = requireValue(args, index, arg);
+      index += 1;
+    } else if (arg.startsWith("--login=")) {
+      config.login = arg.slice("--login=".length);
+      if (!config.login) throw new Error("--login requires a value");
+    } else if (arg === "--reset") {
+      config.reset = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (config.showHelp) return config;
+  if (!config.provider) throw new Error("--provider is required");
+  if (!config.target) throw new Error("--repo OWNER/REPO is required");
+  if (config.login && config.provider !== "forgejo-tea") {
+    throw new Error("--login is only supported with forgejo-tea");
+  }
+
+  return config;
+}

--- a/src/cli/commands/setup-test-repo/fixtures.test.ts
+++ b/src/cli/commands/setup-test-repo/fixtures.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  copyFixtureToRepository,
+  loadSetupIssues,
+  resolveFixtureDirectory,
+  validateFixtureDirectory,
+} from "./fixtures.ts";
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "patchmill-fixture-test-"));
+}
+
+test("resolveFixtureDirectory finds fixtures from the package root", async () => {
+  const fixtureDir = await resolveFixtureDirectory(process.cwd());
+  assert.match(fixtureDir, /fixtures\/patchmill-test-repo$/u);
+});
+
+test("validateFixtureDirectory rejects missing project brief", async () => {
+  const root = await tempDir();
+  await mkdir(join(root, "issues"), { recursive: true });
+  await writeFile(join(root, "README.md"), "# Demo\n");
+
+  await assert.rejects(
+    () => validateFixtureDirectory(root),
+    /missing PROJECT_BRIEF\.md/,
+  );
+
+  await rm(root, { recursive: true, force: true });
+});
+
+test("loadSetupIssues reads fixture issues in filename order", async () => {
+  const fixtureDir = await resolveFixtureDirectory(process.cwd());
+  const issues = await loadSetupIssues(fixtureDir);
+
+  assert.equal(issues.length, 12);
+  assert.equal(issues[0]?.fileName, "01-project-scaffold.md");
+  assert.equal(issues[11]?.fileName, "12-votes-disappear.md");
+});
+
+test("copyFixtureToRepository copies docs and issue prompts", async () => {
+  const fixtureDir = await resolveFixtureDirectory(process.cwd());
+  const destination = await tempDir();
+
+  await copyFixtureToRepository(fixtureDir, destination);
+
+  assert.match(
+    await readFile(join(destination, "README.md"), "utf8"),
+    /Team Lunch Poll/u,
+  );
+  assert.match(
+    await readFile(join(destination, "PROJECT_BRIEF.md"), "utf8"),
+    /Product goals/u,
+  );
+  assert.match(
+    await readFile(
+      join(destination, "issues", "01-project-scaffold.md"),
+      "utf8",
+    ),
+    /Create the Team Lunch Poll app scaffold/u,
+  );
+
+  await rm(destination, { recursive: true, force: true });
+});

--- a/src/cli/commands/setup-test-repo/fixtures.ts
+++ b/src/cli/commands/setup-test-repo/fixtures.ts
@@ -1,0 +1,75 @@
+import { constants } from "node:fs";
+import { access, cp, readdir, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseIssueFile, type SetupIssue } from "./issue-parser.ts";
+
+const FIXTURE_RELATIVE_PATH = join("fixtures", "patchmill-test-repo");
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findPackageRoot(startDir: string): Promise<string> {
+  let current = resolve(startDir);
+  for (;;) {
+    if (await exists(join(current, "package.json"))) return current;
+    const parent = dirname(current);
+    if (parent === current) throw new Error("Could not find package root");
+    current = parent;
+  }
+}
+
+export async function resolveFixtureDirectory(
+  startDir = dirname(fileURLToPath(import.meta.url)),
+): Promise<string> {
+  const packageRoot = await findPackageRoot(startDir);
+  return join(packageRoot, FIXTURE_RELATIVE_PATH);
+}
+
+export async function validateFixtureDirectory(
+  fixtureDir: string,
+): Promise<void> {
+  const required = ["README.md", "PROJECT_BRIEF.md", "issues"];
+  for (const entry of required) {
+    if (!(await exists(join(fixtureDir, entry)))) {
+      throw new Error(`Fixture directory is missing ${entry}`);
+    }
+  }
+}
+
+export async function loadSetupIssues(
+  fixtureDir: string,
+): Promise<SetupIssue[]> {
+  await validateFixtureDirectory(fixtureDir);
+  const issueDir = join(fixtureDir, "issues");
+  const files = (await readdir(issueDir))
+    .filter((file) => file.endsWith(".md"))
+    .sort((a, b) => a.localeCompare(b));
+
+  return Promise.all(
+    files.map(async (file) =>
+      parseIssueFile(file, await readFile(join(issueDir, file), "utf8")),
+    ),
+  );
+}
+
+export async function copyFixtureToRepository(
+  fixtureDir: string,
+  destination: string,
+): Promise<void> {
+  await validateFixtureDirectory(fixtureDir);
+  await cp(join(fixtureDir, "README.md"), join(destination, "README.md"));
+  await cp(
+    join(fixtureDir, "PROJECT_BRIEF.md"),
+    join(destination, "PROJECT_BRIEF.md"),
+  );
+  await cp(join(fixtureDir, "issues"), join(destination, "issues"), {
+    recursive: true,
+  });
+}

--- a/src/cli/commands/setup-test-repo/host-boundary.test.ts
+++ b/src/cli/commands/setup-test-repo/host-boundary.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const commandDir = dirname(fileURLToPath(import.meta.url));
+
+async function tsFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...(await tsFiles(path)));
+    if (entry.isFile() && entry.name.endsWith(".ts")) files.push(path);
+  }
+  return files;
+}
+
+test("setup-test-repo command does not invoke provider CLIs directly", async () => {
+  for (const file of await tsFiles(commandDir)) {
+    const content = await readFile(file, "utf8");
+    assert.doesNotMatch(content, /\.run\(\s*["'](?:gh|tea)["']/u, file);
+    assert.doesNotMatch(
+      content,
+      /\b(?:spawn|exec|execFile)\(\s*["'](?:gh|tea)["']/u,
+      file,
+    );
+  }
+});

--- a/src/cli/commands/setup-test-repo/issue-parser.test.ts
+++ b/src/cli/commands/setup-test-repo/issue-parser.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseIssueFile } from "./issue-parser.ts";
+
+test("parseIssueFile parses title, labels, and body", () => {
+  const issue = parseIssueFile(
+    "01-example.md",
+    [
+      "---",
+      "title: Build the form",
+      "labels: [feature, polish]",
+      "---",
+      "",
+      "Create a useful form.",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(issue, {
+    fileName: "01-example.md",
+    title: "Build the form",
+    labels: ["feature", "polish"],
+    body: "Create a useful form.\n",
+  });
+});
+
+test("parseIssueFile allows missing labels", () => {
+  const issue = parseIssueFile(
+    "11-vague.md",
+    ["---", "title: Make it social", "---", "", "Needs discovery."].join("\n"),
+  );
+
+  assert.deepEqual(issue.labels, []);
+  assert.equal(issue.body, "Needs discovery.\n");
+});
+
+test("parseIssueFile rejects missing title", () => {
+  assert.throws(
+    () => parseIssueFile("bad.md", "---\nlabels: [feature]\n---\nBody"),
+    /bad\.md is missing required frontmatter field: title/,
+  );
+});
+
+test("parseIssueFile rejects invalid label syntax", () => {
+  assert.throws(
+    () =>
+      parseIssueFile("bad.md", "---\ntitle: Bad\nlabels: feature\n---\nBody"),
+    /bad\.md labels must use \[label, other-label\] syntax/,
+  );
+});
+
+test("parseIssueFile rejects empty labels", () => {
+  assert.throws(
+    () =>
+      parseIssueFile(
+        "bad.md",
+        "---\ntitle: Bad\nlabels: [feature, ]\n---\nBody",
+      ),
+    /bad\.md labels include an empty value/,
+  );
+});

--- a/src/cli/commands/setup-test-repo/issue-parser.ts
+++ b/src/cli/commands/setup-test-repo/issue-parser.ts
@@ -1,0 +1,58 @@
+export type SetupIssue = {
+  fileName: string;
+  title: string;
+  labels: string[];
+  body: string;
+};
+
+function frontmatterValue(
+  fields: Map<string, string>,
+  name: string,
+): string | undefined {
+  const value = fields.get(name);
+  return value === undefined ? undefined : value.trim();
+}
+
+function parseLabels(fileName: string, value: string | undefined): string[] {
+  if (value === undefined) return [];
+  const match = /^\[(.*)\]$/u.exec(value.trim());
+  if (!match) {
+    throw new Error(`${fileName} labels must use [label, other-label] syntax`);
+  }
+
+  if (match[1].trim().length === 0) return [];
+  const labels = match[1].split(",").map((label) => label.trim());
+  if (labels.some((label) => label.length === 0)) {
+    throw new Error(`${fileName} labels include an empty value`);
+  }
+  return labels;
+}
+
+function parseFrontmatter(fileName: string, raw: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const line of raw.split(/\r?\n/u)) {
+    if (line.trim().length === 0) continue;
+    const match = /^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/u.exec(line);
+    if (!match) throw new Error(`${fileName} has invalid frontmatter: ${line}`);
+    fields.set(match[1], match[2]);
+  }
+  return fields;
+}
+
+export function parseIssueFile(fileName: string, content: string): SetupIssue {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/u.exec(content);
+  if (!match) throw new Error(`${fileName} is missing frontmatter`);
+
+  const fields = parseFrontmatter(fileName, match[1]);
+  const title = frontmatterValue(fields, "title");
+  if (!title) {
+    throw new Error(`${fileName} is missing required frontmatter field: title`);
+  }
+
+  return {
+    fileName,
+    title,
+    labels: parseLabels(fileName, frontmatterValue(fields, "labels")),
+    body: match[2].replace(/^\r?\n/u, "").replace(/\s*$/u, "") + "\n",
+  };
+}

--- a/src/cli/commands/setup-test-repo/labels.ts
+++ b/src/cli/commands/setup-test-repo/labels.ts
@@ -1,0 +1,24 @@
+import type { LabelDefinition } from "../../../host/types.ts";
+
+export const SETUP_TEST_REPO_LABELS: LabelDefinition[] = [
+  {
+    name: "feature",
+    color: "0e8a16",
+    description: "New user-facing functionality.",
+  },
+  {
+    name: "bug",
+    color: "d73a4a",
+    description: "Something is broken or behaves incorrectly.",
+  },
+  {
+    name: "docs",
+    color: "0075ca",
+    description: "Documentation or usage guidance.",
+  },
+  {
+    name: "polish",
+    color: "a2eeef",
+    description: "Visual, UX, or cleanup improvement.",
+  },
+];

--- a/src/cli/commands/setup-test-repo/main.test.ts
+++ b/src/cli/commands/setup-test-repo/main.test.ts
@@ -131,8 +131,16 @@ test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues",
   ]);
   assert.deepEqual(
     gitCalls.map((args) => args[0]),
-    ["--version", "init", "add", "commit", "remote", "push"],
+    ["--version", "init", "add", "-c", "remote", "push"],
   );
+  const commitArgs = gitCalls.find((args) => args.includes("commit"));
+  assert.deepEqual(commitArgs?.slice(0, 5), [
+    "-c",
+    "user.name=Patchmill",
+    "-c",
+    "user.email=patchmill@example.invalid",
+    "commit",
+  ]);
   assert.deepEqual(
     labels.map((label) => label.name),
     ["feature", "bug", "docs", "polish"],
@@ -198,12 +206,13 @@ test("runSetupTestRepo refuses existing repo without reset", async () => {
 test("runSetupTestRepo deletes and recreates when reset is supplied", async () => {
   const { provider, calls } = createProvider({ exists: true });
   const { runner } = createGitRunner();
+  const stdout: string[] = [];
 
   const code = await runSetupTestRepo(
     ["--provider", "github-gh", "--repo", "OWNER/patchmill-test", "--reset"],
     {
       runner,
-      output: { stdout: () => undefined, stderr: () => undefined },
+      output: { stdout: (line) => stdout.push(line), stderr: () => undefined },
       createProvider: () => provider,
     },
   );
@@ -215,6 +224,15 @@ test("runSetupTestRepo deletes and recreates when reset is supplied", async () =
     "deleteRepo:OWNER/patchmill-test",
     "createPublicRepo:OWNER/patchmill-test",
   ]);
+  assert.match(
+    stdout.join("\n"),
+    /https:\/\/example\.test\/OWNER\/patchmill-test/u,
+  );
+  assert.match(stdout.join("\n"), /Deleting OWNER\/patchmill-test/u);
+  assert.match(
+    stdout.join("\n"),
+    /Creating public repository OWNER\/patchmill-test/u,
+  );
 });
 
 test("runSetupTestRepo reports provider CLI failures", async () => {

--- a/src/cli/commands/setup-test-repo/main.test.ts
+++ b/src/cli/commands/setup-test-repo/main.test.ts
@@ -6,11 +6,11 @@ import { test } from "node:test";
 import { HELP_TEXT, runSetupTestRepo } from "./main.ts";
 import type { CommandRunner } from "../triage/types.ts";
 import type {
-  GitHostProvider,
   HostCliCheck,
   HostIssueCreateInput,
-  LabelChangePlan,
   LabelDefinition,
+  RepositoryInfo,
+  RepositorySetupHostProvider,
   RepositoryTarget,
 } from "../../../host/types.ts";
 
@@ -23,64 +23,64 @@ function createProvider(
     exists?: boolean;
     cli?: HostCliCheck;
     existingLabels?: string[];
+    failCreateIssue?: boolean;
+    events?: string[];
   } = {},
 ): {
-  provider: GitHostProvider;
+  provider: RepositorySetupHostProvider;
   calls: string[];
-  issues: HostIssueCreateInput[];
-  labels: LabelDefinition[];
+  issues: Array<{ target: RepositoryTarget; issue: HostIssueCreateInput }>;
+  labels: Array<{ target: RepositoryTarget; label: LabelDefinition }>;
 } {
   const calls: string[] = [];
-  const issues: HostIssueCreateInput[] = [];
-  const labels: LabelDefinition[] = [];
-  const provider: GitHostProvider = {
+  const events = options.events;
+  const issues: Array<{
+    target: RepositoryTarget;
+    issue: HostIssueCreateInput;
+  }> = [];
+  const labels: Array<{ target: RepositoryTarget; label: LabelDefinition }> =
+    [];
+  let repositoryExists = options.exists ?? false;
+  const info = (target: RepositoryTarget): RepositoryInfo => ({
+    publicUrl: `https://example.test/${target.slug}`,
+    gitRemoteUrl: `https://example.test/${target.slug}.git`,
+  });
+  const provider: RepositorySetupHostProvider = {
     id: "github-gh",
     displayName: "GitHub via gh",
     async checkCli() {
       calls.push("checkCli");
+      events?.push("checkCli");
       return options.cli ?? okCli();
     },
-    missingLabelRemediation(label) {
-      return `create ${label.name}`;
+    async getRepository(target: RepositoryTarget) {
+      calls.push(`getRepository:${target.slug}`);
+      events?.push(`getRepository:${target.slug}`);
+      return repositoryExists ? info(target) : undefined;
     },
-    async listOpenIssues() {
-      return [];
-    },
-    async viewIssue() {
-      throw new Error("not used");
-    },
-    async hydrateIssueComments(value) {
-      return value;
-    },
-    async listLabels() {
+    async listLabels(target: RepositoryTarget) {
+      calls.push(`listLabels:${target.slug}`);
       return options.existingLabels ?? [];
     },
-    async createLabel(label) {
-      labels.push(label);
-    },
-    async applyLabels(_change: LabelChangePlan) {},
-    async commentIssue() {},
-    async repoExists() {
-      calls.push("repoExists");
-      return options.exists ?? false;
-    },
     async createPublicRepo(target: RepositoryTarget) {
+      repositoryExists = true;
+      events?.push(`createPublicRepo:${target.slug}`);
       calls.push(`createPublicRepo:${target.slug}`);
     },
     async deleteRepo(target: RepositoryTarget) {
+      repositoryExists = false;
+      events?.push(`deleteRepo:${target.slug}`);
       calls.push(`deleteRepo:${target.slug}`);
-    },
-    async gitRemoteUrl(target: RepositoryTarget) {
-      return `https://example.test/${target.slug}.git`;
-    },
-    async publicRepoUrl(target: RepositoryTarget) {
-      return `https://example.test/${target.slug}`;
     },
     cloneCommand(target: RepositoryTarget) {
       return `gh repo clone ${target.slug}`;
     },
-    async createIssue(issue: HostIssueCreateInput) {
-      issues.push(issue);
+    async createLabel(target: RepositoryTarget, label: LabelDefinition) {
+      labels.push({ target, label });
+    },
+    async createIssue(target: RepositoryTarget, issue: HostIssueCreateInput) {
+      if (options.failCreateIssue) throw new Error("issue create failed");
+      issues.push({ target, issue });
     },
   };
   return { provider, calls, issues, labels };
@@ -107,6 +107,22 @@ function createGitRunner(options: { failOn?: string } = {}): {
   };
 }
 
+function createEventedGitRunner(
+  events: string[],
+  options: { failOn?: string } = {},
+): CommandRunner {
+  return {
+    async run(command, args) {
+      if (command !== "git") throw new Error(`Unexpected command: ${command}`);
+      events.push(`git:${args[0]}`);
+      if (args[0] === options.failOn) {
+        return { code: 1, stdout: "", stderr: `git ${args[0]} failed` };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  };
+}
+
 test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues", async () => {
   const tempParent = await mkdtemp(join(tmpdir(), "patchmill-setup-test-"));
   const { provider, calls, labels, issues } = createProvider({ exists: false });
@@ -126,8 +142,10 @@ test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues",
   assert.equal(code, 0);
   assert.deepEqual(calls, [
     "checkCli",
-    "repoExists",
+    "getRepository:OWNER/patchmill-test",
     "createPublicRepo:OWNER/patchmill-test",
+    "getRepository:OWNER/patchmill-test",
+    "listLabels:OWNER/patchmill-test",
   ]);
   assert.deepEqual(
     gitCalls.map((args) => args[0]),
@@ -142,11 +160,20 @@ test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues",
     "commit",
   ]);
   assert.deepEqual(
-    labels.map((label) => label.name),
+    labels.map(({ label }) => label.name),
     ["feature", "bug", "docs", "polish"],
   );
   assert.equal(issues.length, 12);
-  assert.equal(issues[0]?.title, "Create the Team Lunch Poll app scaffold");
+  assert.equal(
+    issues[0]?.issue.title,
+    "Create the Team Lunch Poll app scaffold",
+  );
+  assert.ok(
+    issues.every(({ target }) => target.slug === "OWNER/patchmill-test"),
+  );
+  assert.ok(
+    labels.every(({ target }) => target.slug === "OWNER/patchmill-test"),
+  );
   assert.match(
     stdout.join("\n"),
     /https:\/\/example\.test\/OWNER\/patchmill-test/u,
@@ -177,7 +204,7 @@ test("runSetupTestRepo skips labels that already exist on the host", async () =>
 
   assert.equal(code, 0);
   assert.deepEqual(
-    labels.map((label) => label.name),
+    labels.map(({ label }) => label.name),
     ["feature", "docs", "polish"],
   );
 
@@ -220,9 +247,11 @@ test("runSetupTestRepo deletes and recreates when reset is supplied", async () =
   assert.equal(code, 0);
   assert.deepEqual(calls, [
     "checkCli",
-    "repoExists",
+    "getRepository:OWNER/patchmill-test",
     "deleteRepo:OWNER/patchmill-test",
     "createPublicRepo:OWNER/patchmill-test",
+    "getRepository:OWNER/patchmill-test",
+    "listLabels:OWNER/patchmill-test",
   ]);
   assert.match(
     stdout.join("\n"),
@@ -233,6 +262,58 @@ test("runSetupTestRepo deletes and recreates when reset is supplied", async () =
     stdout.join("\n"),
     /Creating public repository OWNER\/patchmill-test/u,
   );
+});
+
+test("runSetupTestRepo prepares and commits local fixtures before mutating the host", async () => {
+  const tempParent = await mkdtemp(join(tmpdir(), "patchmill-setup-test-"));
+  const events: string[] = [];
+  const { provider } = createProvider({ exists: false, events });
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner: createEventedGitRunner(events),
+      tempParent,
+      output: { stdout: () => undefined, stderr: () => undefined },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.ok(
+    events.indexOf("git:commit") <
+      events.indexOf("createPublicRepo:OWNER/patchmill-test"),
+    events.join("\n"),
+  );
+
+  await rm(tempParent, { recursive: true, force: true });
+});
+
+test("runSetupTestRepo rolls back the created repository when seeding fails", async () => {
+  const tempParent = await mkdtemp(join(tmpdir(), "patchmill-setup-test-"));
+  const { provider, calls } = createProvider({
+    exists: false,
+    failCreateIssue: true,
+  });
+  const { runner } = createGitRunner();
+  const stderr: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      tempParent,
+      output: { stdout: () => undefined, stderr: (line) => stderr.push(line) },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.ok(calls.includes("deleteRepo:OWNER/patchmill-test"));
+  assert.match(stderr.join("\n"), /issue create failed/u);
+  assert.match(stderr.join("\n"), /Rolled back OWNER\/patchmill-test/u);
+
+  await rm(tempParent, { recursive: true, force: true });
 });
 
 test("runSetupTestRepo reports provider CLI failures", async () => {

--- a/src/cli/commands/setup-test-repo/main.test.ts
+++ b/src/cli/commands/setup-test-repo/main.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { HELP_TEXT, runSetupTestRepo } from "./main.ts";
+import type { CommandRunner } from "../triage/types.ts";
+import type {
+  GitHostProvider,
+  HostCliCheck,
+  HostIssueCreateInput,
+  LabelChangePlan,
+  LabelDefinition,
+  RepositoryTarget,
+} from "../../../host/types.ts";
+
+function okCli(): HostCliCheck {
+  return { ok: true, message: "ok" };
+}
+
+function createProvider(
+  options: { exists?: boolean; cli?: HostCliCheck } = {},
+): {
+  provider: GitHostProvider;
+  calls: string[];
+  issues: HostIssueCreateInput[];
+  labels: LabelDefinition[];
+} {
+  const calls: string[] = [];
+  const issues: HostIssueCreateInput[] = [];
+  const labels: LabelDefinition[] = [];
+  const provider: GitHostProvider = {
+    id: "github-gh",
+    displayName: "GitHub via gh",
+    async checkCli() {
+      calls.push("checkCli");
+      return options.cli ?? okCli();
+    },
+    missingLabelRemediation(label) {
+      return `create ${label.name}`;
+    },
+    async listOpenIssues() {
+      return [];
+    },
+    async viewIssue() {
+      throw new Error("not used");
+    },
+    async hydrateIssueComments(value) {
+      return value;
+    },
+    async listLabels() {
+      return [];
+    },
+    async createLabel(label) {
+      labels.push(label);
+    },
+    async applyLabels(_change: LabelChangePlan) {},
+    async commentIssue() {},
+    async repoExists() {
+      calls.push("repoExists");
+      return options.exists ?? false;
+    },
+    async createPublicRepo(target: RepositoryTarget) {
+      calls.push(`createPublicRepo:${target.slug}`);
+    },
+    async deleteRepo(target: RepositoryTarget) {
+      calls.push(`deleteRepo:${target.slug}`);
+    },
+    async gitRemoteUrl(target: RepositoryTarget) {
+      return `https://example.test/${target.slug}.git`;
+    },
+    async publicRepoUrl(target: RepositoryTarget) {
+      return `https://example.test/${target.slug}`;
+    },
+    cloneCommand(target: RepositoryTarget) {
+      return `gh repo clone ${target.slug}`;
+    },
+    async createIssue(issue: HostIssueCreateInput) {
+      issues.push(issue);
+    },
+  };
+  return { provider, calls, issues, labels };
+}
+
+function createGitRunner(options: { failOn?: string } = {}): {
+  runner: CommandRunner;
+  gitCalls: string[][];
+} {
+  const gitCalls: string[][] = [];
+  return {
+    gitCalls,
+    runner: {
+      async run(command, args) {
+        if (command !== "git")
+          throw new Error(`Unexpected command: ${command}`);
+        gitCalls.push(args);
+        if (args[0] === options.failOn) {
+          return { code: 1, stdout: "", stderr: `git ${args[0]} failed` };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+  };
+}
+
+test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues", async () => {
+  const tempParent = await mkdtemp(join(tmpdir(), "patchmill-setup-test-"));
+  const { provider, calls, labels, issues } = createProvider({ exists: false });
+  const { runner, gitCalls } = createGitRunner();
+  const stdout: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      tempParent,
+      output: { stdout: (line) => stdout.push(line), stderr: () => undefined },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.deepEqual(calls, [
+    "checkCli",
+    "repoExists",
+    "createPublicRepo:OWNER/patchmill-test",
+  ]);
+  assert.deepEqual(
+    gitCalls.map((args) => args[0]),
+    ["--version", "init", "add", "commit", "remote", "push"],
+  );
+  assert.deepEqual(
+    labels.map((label) => label.name),
+    ["feature", "bug", "docs", "polish"],
+  );
+  assert.equal(issues.length, 12);
+  assert.equal(issues[0]?.title, "Create the Team Lunch Poll app scaffold");
+  assert.match(
+    stdout.join("\n"),
+    /https:\/\/example\.test\/OWNER\/patchmill-test/u,
+  );
+  assert.match(stdout.join("\n"), /gh repo clone OWNER\/patchmill-test/u);
+  assert.match(stdout.join("\n"), /patchmill init/u);
+
+  await rm(tempParent, { recursive: true, force: true });
+});
+
+test("runSetupTestRepo refuses existing repo without reset", async () => {
+  const { provider } = createProvider({ exists: true });
+  const { runner } = createGitRunner();
+  const stderr: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      output: { stdout: () => undefined, stderr: (line) => stderr.push(line) },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.match(stderr.join("\n"), /already exists/u);
+  assert.match(stderr.join("\n"), /--reset/u);
+});
+
+test("runSetupTestRepo deletes and recreates when reset is supplied", async () => {
+  const { provider, calls } = createProvider({ exists: true });
+  const { runner } = createGitRunner();
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test", "--reset"],
+    {
+      runner,
+      output: { stdout: () => undefined, stderr: () => undefined },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.deepEqual(calls, [
+    "checkCli",
+    "repoExists",
+    "deleteRepo:OWNER/patchmill-test",
+    "createPublicRepo:OWNER/patchmill-test",
+  ]);
+});
+
+test("runSetupTestRepo reports provider CLI failures", async () => {
+  const { provider } = createProvider({
+    cli: {
+      ok: false,
+      message: "gh auth status failed",
+      remediation: ["run gh auth login"],
+    },
+  });
+  const { runner } = createGitRunner();
+  const stderr: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      output: { stdout: () => undefined, stderr: (line) => stderr.push(line) },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.match(stderr.join("\n"), /gh auth status failed/u);
+  assert.match(stderr.join("\n"), /run gh auth login/u);
+});
+
+test("runSetupTestRepo reports git command failures", async () => {
+  const { provider } = createProvider({ exists: false });
+  const { runner } = createGitRunner({ failOn: "push" });
+  const stderr: string[] = [];
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      output: { stdout: () => undefined, stderr: (line) => stderr.push(line) },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 1);
+  assert.match(stderr.join("\n"), /git push -u origin main failed/u);
+});
+
+test("runSetupTestRepo prints help without dependencies", async () => {
+  const stdout: string[] = [];
+  const code = await runSetupTestRepo(["--help"], {
+    output: { stdout: (line) => stdout.push(line), stderr: () => undefined },
+  });
+
+  assert.equal(code, 0);
+  assert.deepEqual(stdout, [HELP_TEXT]);
+});

--- a/src/cli/commands/setup-test-repo/main.test.ts
+++ b/src/cli/commands/setup-test-repo/main.test.ts
@@ -19,7 +19,11 @@ function okCli(): HostCliCheck {
 }
 
 function createProvider(
-  options: { exists?: boolean; cli?: HostCliCheck } = {},
+  options: {
+    exists?: boolean;
+    cli?: HostCliCheck;
+    existingLabels?: string[];
+  } = {},
 ): {
   provider: GitHostProvider;
   calls: string[];
@@ -49,7 +53,7 @@ function createProvider(
       return value;
     },
     async listLabels() {
-      return [];
+      return options.existingLabels ?? [];
     },
     async createLabel(label) {
       labels.push(label);
@@ -141,6 +145,33 @@ test("runSetupTestRepo creates a new repo, pushes fixtures, labels, and issues",
   );
   assert.match(stdout.join("\n"), /gh repo clone OWNER\/patchmill-test/u);
   assert.match(stdout.join("\n"), /patchmill init/u);
+
+  await rm(tempParent, { recursive: true, force: true });
+});
+
+test("runSetupTestRepo skips labels that already exist on the host", async () => {
+  const tempParent = await mkdtemp(join(tmpdir(), "patchmill-setup-test-"));
+  const { provider, labels } = createProvider({
+    exists: false,
+    existingLabels: ["bug"],
+  });
+  const { runner } = createGitRunner();
+
+  const code = await runSetupTestRepo(
+    ["--provider", "github-gh", "--repo", "OWNER/patchmill-test"],
+    {
+      runner,
+      tempParent,
+      output: { stdout: () => undefined, stderr: () => undefined },
+      createProvider: () => provider,
+    },
+  );
+
+  assert.equal(code, 0);
+  assert.deepEqual(
+    labels.map((label) => label.name),
+    ["feature", "docs", "polish"],
+  );
 
   await rm(tempParent, { recursive: true, force: true });
 });

--- a/src/cli/commands/setup-test-repo/main.ts
+++ b/src/cli/commands/setup-test-repo/main.ts
@@ -5,8 +5,12 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { createCommandRunner } from "../triage/command.ts";
 import type { CommandRunner } from "../triage/types.ts";
-import { createGitHostProvider } from "../../../host/factory.ts";
-import type { GitHostProvider, RepositoryTarget } from "../../../host/types.ts";
+import { createRepositorySetupHostProvider } from "../../../host/factory.ts";
+import type {
+  RepositoryInfo,
+  RepositorySetupHostProvider,
+  RepositoryTarget,
+} from "../../../host/types.ts";
 import { parseArgs } from "./args.ts";
 import {
   copyFixtureToRepository,
@@ -43,7 +47,7 @@ export type SetupTestRepoDependencies = {
     repoRoot: string;
     provider: "github-gh" | "forgejo-tea";
     login: string;
-  }) => GitHostProvider;
+  }) => RepositorySetupHostProvider;
 };
 
 const DEFAULT_OUTPUT: SetupTestRepoOutput = {
@@ -76,8 +80,8 @@ function createProviderFromFactory(options: {
   repoRoot: string;
   provider: "github-gh" | "forgejo-tea";
   login: string;
-}): GitHostProvider {
-  return createGitHostProvider({
+}): RepositorySetupHostProvider {
+  return createRepositorySetupHostProvider({
     runner: options.runner,
     repoRoot: options.repoRoot,
     host: { provider: options.provider, login: options.login },
@@ -85,26 +89,24 @@ function createProviderFromFactory(options: {
 }
 
 async function prepareRepository(options: {
-  provider: GitHostProvider;
+  provider: RepositorySetupHostProvider;
   target: RepositoryTarget;
   reset: boolean;
   output: SetupTestRepoOutput;
-}): Promise<void> {
-  const exists = await options.provider.repoExists(options.target);
-  if (exists && !options.reset) {
+  markCreated: () => void;
+}): Promise<RepositoryInfo> {
+  const existing = await options.provider.getRepository(options.target);
+  if (existing && !options.reset) {
     throw new Error(
       `Repository ${options.target.slug} already exists. Rerun with --reset only if it is disposable and safe to delete.`,
     );
   }
 
   if (options.reset) {
-    const publicUrl = exists
-      ? await options.provider.publicRepoUrl(options.target)
-      : undefined;
     options.output.stdout(
-      `Resetting ${options.provider.displayName} repository ${options.target.slug}${publicUrl ? ` (${publicUrl})` : ""}`,
+      `Resetting ${options.provider.displayName} repository ${options.target.slug}${existing ? ` (${existing.publicUrl})` : ""}`,
     );
-    if (exists) {
+    if (existing) {
       options.output.stdout(`Deleting ${options.target.slug}`);
       await options.provider.deleteRepo(options.target);
     }
@@ -112,12 +114,19 @@ async function prepareRepository(options: {
   }
 
   await options.provider.createPublicRepo(options.target);
+  options.markCreated();
+  const created = await options.provider.getRepository(options.target);
+  if (!created) {
+    throw new Error(
+      `Repository ${options.target.slug} was created but could not be read back from ${options.provider.displayName}`,
+    );
+  }
+  return created;
 }
 
-async function seedGitRepository(options: {
+async function createSeedCommit(options: {
   runner: CommandRunner;
   repoRoot: string;
-  remoteUrl: string;
 }): Promise<void> {
   await runGit(options.runner, options.repoRoot, ["init", "-b", "main"]);
   await runGit(options.runner, options.repoRoot, [
@@ -135,6 +144,13 @@ async function seedGitRepository(options: {
     "-m",
     "Seed Team Lunch Poll demo",
   ]);
+}
+
+async function pushSeedCommit(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  remoteUrl: string;
+}): Promise<void> {
   await runGit(options.runner, options.repoRoot, [
     "remote",
     "add",
@@ -149,10 +165,30 @@ async function seedGitRepository(options: {
   ]);
 }
 
-async function createMissingLabels(provider: GitHostProvider): Promise<void> {
-  const existingLabels = new Set(await provider.listLabels());
+async function createMissingLabels(
+  provider: RepositorySetupHostProvider,
+  target: RepositoryTarget,
+): Promise<void> {
+  const existingLabels = new Set(await provider.listLabels(target));
   for (const label of SETUP_TEST_REPO_LABELS) {
-    if (!existingLabels.has(label.name)) await provider.createLabel(label);
+    if (!existingLabels.has(label.name))
+      await provider.createLabel(target, label);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function rollbackCreatedRepository(options: {
+  provider: RepositorySetupHostProvider;
+  target: RepositoryTarget;
+}): Promise<string> {
+  try {
+    await options.provider.deleteRepo(options.target);
+    return `Rolled back ${options.target.slug} after setup failure.`;
+  } catch (rollbackError) {
+    return `Rollback failed for ${options.target.slug}: ${errorMessage(rollbackError)}`;
   }
 }
 
@@ -191,26 +227,49 @@ export async function runSetupTestRepo(
         throw new Error([cli.message, ...cli.remediation].join("\n"));
       }
 
-      await prepareRepository({
-        provider,
-        target: config.target,
-        reset: config.reset,
-        output,
-      });
-
       const fixtureDir = await resolveFixtureDirectory();
       const issues = await loadSetupIssues(fixtureDir);
       await copyFixtureToRepository(fixtureDir, repoRoot);
-      await seedGitRepository({
+      await createSeedCommit({
         runner,
         repoRoot,
-        remoteUrl: await provider.gitRemoteUrl(config.target),
       });
 
-      await createMissingLabels(provider);
-      for (const issue of issues) await provider.createIssue(issue);
+      let createdRemote = false;
+      try {
+        const repository = await prepareRepository({
+          provider,
+          target: config.target,
+          reset: config.reset,
+          output,
+          markCreated: () => {
+            createdRemote = true;
+          },
+        });
 
-      output.stdout(`Seeded ${await provider.publicRepoUrl(config.target)}`);
+        await pushSeedCommit({
+          runner,
+          repoRoot,
+          remoteUrl: repository.gitRemoteUrl,
+        });
+
+        await createMissingLabels(provider, config.target);
+        for (const issue of issues)
+          await provider.createIssue(config.target, issue);
+
+        output.stdout(`Seeded ${repository.publicUrl}`);
+      } catch (error) {
+        if (createdRemote) {
+          const rollbackMessage = await rollbackCreatedRepository({
+            provider,
+            target: config.target,
+          });
+          throw new Error(`${errorMessage(error)}\n${rollbackMessage}`, {
+            cause: error,
+          });
+        }
+        throw error;
+      }
       output.stdout("");
       output.stdout("Next steps:");
       output.stdout(`  ${provider.cloneCommand(config.target)}`);

--- a/src/cli/commands/setup-test-repo/main.ts
+++ b/src/cli/commands/setup-test-repo/main.ts
@@ -98,10 +98,17 @@ async function prepareRepository(options: {
   }
 
   if (options.reset) {
+    const publicUrl = exists
+      ? await options.provider.publicRepoUrl(options.target)
+      : undefined;
     options.output.stdout(
-      `Resetting ${options.provider.displayName} repository ${options.target.slug}`,
+      `Resetting ${options.provider.displayName} repository ${options.target.slug}${publicUrl ? ` (${publicUrl})` : ""}`,
     );
-    if (exists) await options.provider.deleteRepo(options.target);
+    if (exists) {
+      options.output.stdout(`Deleting ${options.target.slug}`);
+      await options.provider.deleteRepo(options.target);
+    }
+    options.output.stdout(`Creating public repository ${options.target.slug}`);
   }
 
   await options.provider.createPublicRepo(options.target);
@@ -120,6 +127,10 @@ async function seedGitRepository(options: {
     "issues",
   ]);
   await runGit(options.runner, options.repoRoot, [
+    "-c",
+    "user.name=Patchmill",
+    "-c",
+    "user.email=patchmill@example.invalid",
     "commit",
     "-m",
     "Seed Team Lunch Poll demo",

--- a/src/cli/commands/setup-test-repo/main.ts
+++ b/src/cli/commands/setup-test-repo/main.ts
@@ -138,6 +138,13 @@ async function seedGitRepository(options: {
   ]);
 }
 
+async function createMissingLabels(provider: GitHostProvider): Promise<void> {
+  const existingLabels = new Set(await provider.listLabels());
+  for (const label of SETUP_TEST_REPO_LABELS) {
+    if (!existingLabels.has(label.name)) await provider.createLabel(label);
+  }
+}
+
 export async function runSetupTestRepo(
   args: string[],
   dependencies: SetupTestRepoDependencies = {},
@@ -189,9 +196,7 @@ export async function runSetupTestRepo(
         remoteUrl: await provider.gitRemoteUrl(config.target),
       });
 
-      for (const label of SETUP_TEST_REPO_LABELS) {
-        await provider.createLabel(label);
-      }
+      await createMissingLabels(provider);
       for (const issue of issues) await provider.createIssue(issue);
 
       output.stdout(`Seeded ${await provider.publicRepoUrl(config.target)}`);

--- a/src/cli/commands/setup-test-repo/main.ts
+++ b/src/cli/commands/setup-test-repo/main.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createCommandRunner } from "../triage/command.ts";
+import type { CommandRunner } from "../triage/types.ts";
+import { createGitHostProvider } from "../../../host/factory.ts";
+import type { GitHostProvider, RepositoryTarget } from "../../../host/types.ts";
+import { parseArgs } from "./args.ts";
+import {
+  copyFixtureToRepository,
+  loadSetupIssues,
+  resolveFixtureDirectory,
+} from "./fixtures.ts";
+import { SETUP_TEST_REPO_LABELS } from "./labels.ts";
+
+export const HELP_TEXT = `Usage:
+  patchmill setup-test-repo --provider github-gh --repo OWNER/REPO [--reset]
+  patchmill setup-test-repo --provider forgejo-tea --repo OWNER/REPO --login LOGIN [--reset]
+
+Create or reset a disposable public Team Lunch Poll repository for trying Patchmill.
+
+Options:
+  --help, -h             Show this help and exit.
+  --provider PROVIDER    Required. One of: github-gh, forgejo-tea.
+  --repo OWNER/REPO      Required. Disposable target repository.
+  --login LOGIN          Optional named tea login for forgejo-tea.
+  --reset                Delete and recreate the target repository before seeding.
+`;
+
+export type SetupTestRepoOutput = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+};
+
+export type SetupTestRepoDependencies = {
+  runner?: CommandRunner;
+  output?: SetupTestRepoOutput;
+  tempParent?: string;
+  createProvider?: (options: {
+    runner: CommandRunner;
+    repoRoot: string;
+    provider: "github-gh" | "forgejo-tea";
+    login: string;
+  }) => GitHostProvider;
+};
+
+const DEFAULT_OUTPUT: SetupTestRepoOutput = {
+  stdout: (line) => console.log(line),
+  stderr: (line) => console.error(line),
+};
+
+async function runGit(
+  runner: CommandRunner,
+  repoRoot: string,
+  args: string[],
+): Promise<void> {
+  const result = await runner.run("git", args, { cwd: repoRoot });
+  if (result.code !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+async function ensureGit(runner: CommandRunner): Promise<void> {
+  const result = await runner.run("git", ["--version"]);
+  if (result.code !== 0) {
+    throw new Error(`git --version failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function createProviderFromFactory(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  provider: "github-gh" | "forgejo-tea";
+  login: string;
+}): GitHostProvider {
+  return createGitHostProvider({
+    runner: options.runner,
+    repoRoot: options.repoRoot,
+    host: { provider: options.provider, login: options.login },
+  });
+}
+
+async function prepareRepository(options: {
+  provider: GitHostProvider;
+  target: RepositoryTarget;
+  reset: boolean;
+  output: SetupTestRepoOutput;
+}): Promise<void> {
+  const exists = await options.provider.repoExists(options.target);
+  if (exists && !options.reset) {
+    throw new Error(
+      `Repository ${options.target.slug} already exists. Rerun with --reset only if it is disposable and safe to delete.`,
+    );
+  }
+
+  if (options.reset) {
+    options.output.stdout(
+      `Resetting ${options.provider.displayName} repository ${options.target.slug}`,
+    );
+    if (exists) await options.provider.deleteRepo(options.target);
+  }
+
+  await options.provider.createPublicRepo(options.target);
+}
+
+async function seedGitRepository(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  remoteUrl: string;
+}): Promise<void> {
+  await runGit(options.runner, options.repoRoot, ["init", "-b", "main"]);
+  await runGit(options.runner, options.repoRoot, [
+    "add",
+    "README.md",
+    "PROJECT_BRIEF.md",
+    "issues",
+  ]);
+  await runGit(options.runner, options.repoRoot, [
+    "commit",
+    "-m",
+    "Seed Team Lunch Poll demo",
+  ]);
+  await runGit(options.runner, options.repoRoot, [
+    "remote",
+    "add",
+    "origin",
+    options.remoteUrl,
+  ]);
+  await runGit(options.runner, options.repoRoot, [
+    "push",
+    "-u",
+    "origin",
+    "main",
+  ]);
+}
+
+export async function runSetupTestRepo(
+  args: string[],
+  dependencies: SetupTestRepoDependencies = {},
+): Promise<number> {
+  const output = dependencies.output ?? DEFAULT_OUTPUT;
+  try {
+    const config = parseArgs(args);
+    if (config.showHelp) {
+      output.stdout(HELP_TEXT);
+      return 0;
+    }
+    if (!config.provider || !config.target) {
+      throw new Error("Invalid setup-test-repo configuration");
+    }
+
+    const runner = dependencies.runner ?? createCommandRunner();
+    await ensureGit(runner);
+
+    const tempParent = dependencies.tempParent ?? tmpdir();
+    const repoRoot = await mkdtemp(join(tempParent, "patchmill-test-repo-"));
+    try {
+      const provider = (
+        dependencies.createProvider ?? createProviderFromFactory
+      )({
+        runner,
+        repoRoot,
+        provider: config.provider,
+        login: config.login ?? "",
+      });
+
+      const cli = await provider.checkCli();
+      if (!cli.ok) {
+        throw new Error([cli.message, ...cli.remediation].join("\n"));
+      }
+
+      await prepareRepository({
+        provider,
+        target: config.target,
+        reset: config.reset,
+        output,
+      });
+
+      const fixtureDir = await resolveFixtureDirectory();
+      const issues = await loadSetupIssues(fixtureDir);
+      await copyFixtureToRepository(fixtureDir, repoRoot);
+      await seedGitRepository({
+        runner,
+        repoRoot,
+        remoteUrl: await provider.gitRemoteUrl(config.target),
+      });
+
+      for (const label of SETUP_TEST_REPO_LABELS) {
+        await provider.createLabel(label);
+      }
+      for (const issue of issues) await provider.createIssue(issue);
+
+      output.stdout(`Seeded ${await provider.publicRepoUrl(config.target)}`);
+      output.stdout("");
+      output.stdout("Next steps:");
+      output.stdout(`  ${provider.cloneCommand(config.target)}`);
+      output.stdout(`  cd ${config.target.repo}`);
+      output.stdout("  patchmill init");
+      output.stdout("  patchmill triage --dry-run");
+      output.stdout("  patchmill triage");
+      return 0;
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  } catch (error) {
+    output.stderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  return runSetupTestRepo(args);
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isMain) {
+  process.exitCode = await main();
+}

--- a/src/cli/commands/triage/forgejo.ts
+++ b/src/cli/commands/triage/forgejo.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { withTeaContext } from "../../../host/forgejo-tea-context.ts";
 import type {
   CommandRunner,
   IssueSummary,
@@ -10,84 +9,6 @@ import type {
 const ISSUE_PAGE_SIZE = 1000;
 const ISSUE_FIELDS =
   "index,title,body,state,labels,author,updated,comments,url";
-
-function insertBeforeSeparator(args: string[], extraArgs: string[]): string[] {
-  const separator = args.indexOf("--");
-  if (separator === -1) return [...args, ...extraArgs];
-  return [...args.slice(0, separator), ...extraArgs, ...args.slice(separator)];
-}
-
-function commonGitConfigPath(gitDir: string): string {
-  const commonDirPath = join(gitDir, "commondir");
-  if (!existsSync(commonDirPath)) return join(gitDir, "config");
-  const commonDir = readFileSync(commonDirPath, "utf8").trim();
-  return join(resolve(gitDir, commonDir), "config");
-}
-
-function gitConfigPath(repoRoot: string): string | undefined {
-  const gitPath = join(repoRoot, ".git");
-  if (!existsSync(gitPath)) return undefined;
-  if (statSync(gitPath).isDirectory()) return commonGitConfigPath(gitPath);
-  const gitMetadata = readFileSync(gitPath, "utf8");
-  if (/^gitdir:/u.test(gitMetadata)) {
-    const gitDir = gitMetadata.replace(/^gitdir:\s*/u, "").trim();
-    return commonGitConfigPath(resolve(repoRoot, gitDir));
-  }
-  return undefined;
-}
-
-function originRemoteUrl(config: string): string | undefined {
-  const lines = config.split(/\r?\n/u);
-  let inOrigin = false;
-  for (const line of lines) {
-    const section = /^\s*\[remote\s+"([^"]+)"\]\s*$/u.exec(line);
-    if (section) {
-      inOrigin = section[1] === "origin";
-      continue;
-    }
-    if (!inOrigin) continue;
-    const url = /^\s*url\s*=\s*(\S+)\s*$/u.exec(line);
-    if (url) return url[1];
-  }
-  return undefined;
-}
-
-function repoSlugFromRemoteUrl(url: string): string | undefined {
-  const trimmed = url.replace(/\.git$/u, "");
-  const sshUrl = /^ssh:\/\/[^@]+@[^/]+\/(.+)$/u.exec(trimmed);
-  if (sshUrl) return sshUrl[1];
-  const scpLikeUrl = /^[^@]+@[^:]+:(.+)$/u.exec(trimmed);
-  if (scpLikeUrl) return scpLikeUrl[1];
-  try {
-    const parsed = new URL(trimmed);
-    return parsed.pathname.replace(/^\/+/, "");
-  } catch {
-    return undefined;
-  }
-}
-
-function teaRepo(repoRoot: string): string {
-  try {
-    const configPath = gitConfigPath(repoRoot);
-    if (!configPath || !existsSync(configPath)) return repoRoot;
-    const remoteUrl = originRemoteUrl(readFileSync(configPath, "utf8"));
-    return remoteUrl
-      ? (repoSlugFromRemoteUrl(remoteUrl) ?? repoRoot)
-      : repoRoot;
-  } catch {
-    return repoRoot;
-  }
-}
-
-function withTeaContext(
-  args: string[],
-  repoRoot: string,
-  teaLogin?: string,
-): string[] {
-  const repoArgs = insertBeforeSeparator(args, ["--repo", teaRepo(repoRoot)]);
-  if (!teaLogin) return repoArgs;
-  return insertBeforeSeparator(repoArgs, ["--login", teaLogin]);
-}
 
 function parseJson(stdout: string, context: string): unknown {
   try {

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -23,6 +23,19 @@ test("resolveCommand maps run-once to the public command name", () => {
   });
 });
 
+test("resolveCommand maps setup-test-repo to the public command name", () => {
+  assert.deepEqual(
+    resolveCommand(
+      ["setup-test-repo", "--provider", "github-gh"],
+      ["setup-test-repo"],
+    ),
+    {
+      command: "setup-test-repo",
+      args: ["--provider", "github-gh"],
+    },
+  );
+});
+
 test("resolveCommand maps init to the public command name", () => {
   assert.deepEqual(resolveCommand(["init"], ["init"]), {
     command: "init",
@@ -63,6 +76,10 @@ test("createCliMain prints top-level help", async () => {
   assert.equal(await main(["--help"]), 0);
   assert.match(HELP_TEXT, /init\s+Create a minimal patchmill\.config\.json\./);
   assert.match(HELP_TEXT, /doctor\s+Run read-only readiness checks\./);
+  assert.match(
+    HELP_TEXT,
+    /setup-test-repo\s+Create or reset a disposable Patchmill demo repository\./,
+  );
   assert.deepEqual(stdout, [HELP_TEXT]);
   assert.deepEqual(stderr, []);
 });
@@ -83,6 +100,35 @@ test("createCliMain dispatches selected command with remaining args", async () =
 
   assert.equal(await main(["triage", "--dry-run"]), 17);
   assert.deepEqual(calls, [["--dry-run"]]);
+});
+
+test("createCliMain dispatches setup-test-repo command", async () => {
+  const calls: string[][] = [];
+  const main = createCliMain(
+    new Map([
+      [
+        "setup-test-repo",
+        async (args) => {
+          calls.push(args);
+          return 0;
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(
+    await main([
+      "setup-test-repo",
+      "--provider",
+      "github-gh",
+      "--repo",
+      "OWNER/REPO",
+    ]),
+    0,
+  );
+  assert.deepEqual(calls, [
+    ["--provider", "github-gh", "--repo", "OWNER/REPO"],
+  ]);
 });
 
 test("createCliMain dispatches init and doctor commands", async () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,7 @@
 import { main as doctorMain } from "./commands/doctor/main.ts";
 import { main as initMain } from "./commands/init/main.ts";
 import { main as runOnceMain } from "./commands/run-once/main.ts";
+import { main as setupTestRepoMain } from "./commands/setup-test-repo/main.ts";
 import { main as triageMain } from "./commands/triage/main.ts";
 
 export const HELP_TEXT = `Usage:
@@ -11,6 +12,7 @@ Commands:
   doctor      Run read-only readiness checks.
   triage      Classify repository issues for agent readiness.
   run-once    Claim and process one agent-ready issue.
+  setup-test-repo  Create or reset a disposable Patchmill demo repository.
 `;
 
 export type CommandHandler = (args: string[]) => number | Promise<number>;
@@ -91,6 +93,7 @@ const COMMANDS = new Map<string, CommandHandler>([
   ["doctor", doctorMain],
   ["triage", triageMain],
   ["run-once", runOnceMain],
+  ["setup-test-repo", setupTestRepoMain],
 ]);
 
 export const main = createCliMain(COMMANDS);

--- a/src/host/factory.test.ts
+++ b/src/host/factory.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createIssueHostProvider } from "./factory.ts";
+import { createGitHostProvider, createIssueHostProvider } from "./factory.ts";
 import { ForgejoTeaHostProvider } from "./forgejo-tea.ts";
 import { GitHubGhHostProvider } from "./github-gh.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
@@ -31,4 +31,20 @@ test("createIssueHostProvider constructs GitHub gh provider", () => {
 
   assert.ok(provider instanceof GitHubGhHostProvider);
   assert.equal(provider.id, "github-gh");
+});
+
+test("createGitHostProvider exposes generic repository capabilities", () => {
+  const provider = createGitHostProvider({
+    runner,
+    repoRoot: "/repo",
+    host: { provider: "github-gh", login: "" },
+  });
+
+  assert.equal(typeof provider.repoExists, "function");
+  assert.equal(typeof provider.createPublicRepo, "function");
+  assert.equal(typeof provider.deleteRepo, "function");
+  assert.equal(typeof provider.gitRemoteUrl, "function");
+  assert.equal(typeof provider.publicRepoUrl, "function");
+  assert.equal(typeof provider.cloneCommand, "function");
+  assert.equal(typeof provider.createIssue, "function");
 });

--- a/src/host/factory.test.ts
+++ b/src/host/factory.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createGitHostProvider, createIssueHostProvider } from "./factory.ts";
+import {
+  createIssueHostProvider,
+  createRepositorySetupHostProvider,
+} from "./factory.ts";
 import { ForgejoTeaHostProvider } from "./forgejo-tea.ts";
 import { GitHubGhHostProvider } from "./github-gh.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
@@ -33,18 +36,18 @@ test("createIssueHostProvider constructs GitHub gh provider", () => {
   assert.equal(provider.id, "github-gh");
 });
 
-test("createGitHostProvider exposes generic repository capabilities", () => {
-  const provider = createGitHostProvider({
+test("createRepositorySetupHostProvider exposes setup repository capabilities", () => {
+  const provider = createRepositorySetupHostProvider({
     runner,
     repoRoot: "/repo",
     host: { provider: "github-gh", login: "" },
   });
 
-  assert.equal(typeof provider.repoExists, "function");
+  assert.equal(typeof provider.getRepository, "function");
   assert.equal(typeof provider.createPublicRepo, "function");
   assert.equal(typeof provider.deleteRepo, "function");
-  assert.equal(typeof provider.gitRemoteUrl, "function");
-  assert.equal(typeof provider.publicRepoUrl, "function");
   assert.equal(typeof provider.cloneCommand, "function");
+  assert.equal(typeof provider.listLabels, "function");
+  assert.equal(typeof provider.createLabel, "function");
   assert.equal(typeof provider.createIssue, "function");
 });

--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -2,13 +2,13 @@ import type { PatchmillHostConfig } from "../config/types.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
 import { ForgejoTeaHostProvider } from "./forgejo-tea.ts";
 import { GitHubGhHostProvider } from "./github-gh.ts";
-import type { IssueHostProvider } from "./types.ts";
+import type { GitHostProvider, IssueHostProvider } from "./types.ts";
 
-export function createIssueHostProvider(options: {
+export function createGitHostProvider(options: {
   runner: CommandRunner;
   repoRoot: string;
   host: PatchmillHostConfig;
-}): IssueHostProvider {
+}): GitHostProvider {
   switch (options.host.provider) {
     case "forgejo-tea":
       return new ForgejoTeaHostProvider({
@@ -22,4 +22,12 @@ export function createIssueHostProvider(options: {
         repoRoot: options.repoRoot,
       });
   }
+}
+
+export function createIssueHostProvider(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  host: PatchmillHostConfig;
+}): IssueHostProvider {
+  return createGitHostProvider(options);
 }

--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -2,13 +2,16 @@ import type { PatchmillHostConfig } from "../config/types.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
 import { ForgejoTeaHostProvider } from "./forgejo-tea.ts";
 import { GitHubGhHostProvider } from "./github-gh.ts";
-import type { GitHostProvider, IssueHostProvider } from "./types.ts";
+import type {
+  IssueHostProvider,
+  RepositorySetupHostProvider,
+} from "./types.ts";
 
-export function createGitHostProvider(options: {
+function createHostProvider(options: {
   runner: CommandRunner;
   repoRoot: string;
   host: PatchmillHostConfig;
-}): GitHostProvider {
+}): ForgejoTeaHostProvider | GitHubGhHostProvider {
   switch (options.host.provider) {
     case "forgejo-tea":
       return new ForgejoTeaHostProvider({
@@ -24,10 +27,18 @@ export function createGitHostProvider(options: {
   }
 }
 
+export function createRepositorySetupHostProvider(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  host: PatchmillHostConfig;
+}): RepositorySetupHostProvider {
+  return createHostProvider(options);
+}
+
 export function createIssueHostProvider(options: {
   runner: CommandRunner;
   repoRoot: string;
   host: PatchmillHostConfig;
 }): IssueHostProvider {
-  return createGitHostProvider(options);
+  return createHostProvider(options);
 }

--- a/src/host/forgejo-tea-context.test.ts
+++ b/src/host/forgejo-tea-context.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { withTeaContext } from "./forgejo-tea-context.ts";
+
+async function gitRepoWithOrigin(remoteUrl: string): Promise<string> {
+  const repoRoot = join(
+    tmpdir(),
+    `patchmill-tea-context-${Date.now()}-${Math.random()}`,
+  );
+  await mkdir(join(repoRoot, ".git"), { recursive: true });
+  await writeFile(
+    join(repoRoot, ".git", "config"),
+    `[remote "origin"]\n\turl = ${remoteUrl}\n`,
+  );
+  return repoRoot;
+}
+
+test("withTeaContext adds repo from origin remote", async () => {
+  const repoRoot = await gitRepoWithOrigin("git@example.test:OWNER/REPO.git");
+
+  assert.deepEqual(withTeaContext(["issues", "list"], repoRoot), [
+    "issues",
+    "list",
+    "--repo",
+    "OWNER/REPO",
+  ]);
+
+  await rm(repoRoot, { recursive: true, force: true });
+});
+
+test("withTeaContext adds login before -- body separator", async () => {
+  const repoRoot = await gitRepoWithOrigin(
+    "https://forgejo.example/OWNER/REPO.git",
+  );
+
+  assert.deepEqual(
+    withTeaContext(["comment", "1", "--", "hello"], repoRoot, "demo"),
+    ["comment", "1", "--repo", "OWNER/REPO", "--login", "demo", "--", "hello"],
+  );
+
+  await rm(repoRoot, { recursive: true, force: true });
+});

--- a/src/host/forgejo-tea-context.ts
+++ b/src/host/forgejo-tea-context.ts
@@ -74,7 +74,15 @@ export function withTeaContext(
   repoRoot: string,
   teaLogin?: string,
 ): string[] {
-  const repoArgs = insertBeforeSeparator(args, ["--repo", teaRepo(repoRoot)]);
+  return withTeaRepositoryContext(args, teaRepo(repoRoot), teaLogin);
+}
+
+export function withTeaRepositoryContext(
+  args: string[],
+  repoSlug: string,
+  teaLogin?: string,
+): string[] {
+  const repoArgs = insertBeforeSeparator(args, ["--repo", repoSlug]);
   if (!teaLogin) return repoArgs;
   return insertBeforeSeparator(repoArgs, ["--login", teaLogin]);
 }

--- a/src/host/forgejo-tea-context.ts
+++ b/src/host/forgejo-tea-context.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+function insertBeforeSeparator(args: string[], extraArgs: string[]): string[] {
+  const separator = args.indexOf("--");
+  if (separator === -1) return [...args, ...extraArgs];
+  return [...args.slice(0, separator), ...extraArgs, ...args.slice(separator)];
+}
+
+function commonGitConfigPath(gitDir: string): string {
+  const commonDirPath = join(gitDir, "commondir");
+  if (!existsSync(commonDirPath)) return join(gitDir, "config");
+  const commonDir = readFileSync(commonDirPath, "utf8").trim();
+  return join(resolve(gitDir, commonDir), "config");
+}
+
+function gitConfigPath(repoRoot: string): string | undefined {
+  const gitPath = join(repoRoot, ".git");
+  if (!existsSync(gitPath)) return undefined;
+  if (statSync(gitPath).isDirectory()) return commonGitConfigPath(gitPath);
+  const gitMetadata = readFileSync(gitPath, "utf8");
+  if (/^gitdir:/u.test(gitMetadata)) {
+    const gitDir = gitMetadata.replace(/^gitdir:\s*/u, "").trim();
+    return commonGitConfigPath(resolve(repoRoot, gitDir));
+  }
+  return undefined;
+}
+
+function originRemoteUrl(config: string): string | undefined {
+  const lines = config.split(/\r?\n/u);
+  let inOrigin = false;
+  for (const line of lines) {
+    const section = /^\s*\[remote\s+"([^"]+)"\]\s*$/u.exec(line);
+    if (section) {
+      inOrigin = section[1] === "origin";
+      continue;
+    }
+    if (!inOrigin) continue;
+    const url = /^\s*url\s*=\s*(\S+)\s*$/u.exec(line);
+    if (url) return url[1];
+  }
+  return undefined;
+}
+
+function repoSlugFromRemoteUrl(url: string): string | undefined {
+  const trimmed = url.replace(/\.git$/u, "");
+  const sshUrl = /^ssh:\/\/[^@]+@[^/]+\/(.+)$/u.exec(trimmed);
+  if (sshUrl) return sshUrl[1];
+  const scpLikeUrl = /^[^@]+@[^:]+:(.+)$/u.exec(trimmed);
+  if (scpLikeUrl) return scpLikeUrl[1];
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.pathname.replace(/^\/+/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function teaRepo(repoRoot: string): string {
+  try {
+    const configPath = gitConfigPath(repoRoot);
+    if (!configPath || !existsSync(configPath)) return repoRoot;
+    const remoteUrl = originRemoteUrl(readFileSync(configPath, "utf8"));
+    return remoteUrl
+      ? (repoSlugFromRemoteUrl(remoteUrl) ?? repoRoot)
+      : repoRoot;
+  } catch {
+    return repoRoot;
+  }
+}
+
+export function withTeaContext(
+  args: string[],
+  repoRoot: string,
+  teaLogin?: string,
+): string[] {
+  const repoArgs = insertBeforeSeparator(args, ["--repo", teaRepo(repoRoot)]);
+  if (!teaLogin) return repoArgs;
+  return insertBeforeSeparator(repoArgs, ["--login", teaLogin]);
+}

--- a/src/host/forgejo-tea.test.ts
+++ b/src/host/forgejo-tea.test.ts
@@ -19,6 +19,11 @@ type RecordedCall = {
 
 const repoRoot = "/repo";
 const login = "bot";
+const target = {
+  owner: "OWNER",
+  repo: "patchmill-test",
+  slug: "OWNER/patchmill-test",
+};
 
 function createFakeRunner(
   respond: (
@@ -253,6 +258,32 @@ test("ForgejoTeaHostProvider delegates label listing to tea", async () => {
   assert.equal(flagValue(runner.calls[0]!.args, "--output"), "json");
 });
 
+test("Forgejo setup provider lists labels on an explicit repository", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: JSON.stringify([{ name: "feature" }, { name: "bug" }]),
+      stderr: "",
+    },
+  ]);
+
+  const labels = await provider.listLabels(target);
+
+  assert.deepEqual(labels, ["bug", "feature"]);
+  assert.deepEqual(calls[0]?.args, [
+    "labels",
+    "list",
+    "--repo",
+    "OWNER/patchmill-test",
+    "--limit",
+    "1000",
+    "--output",
+    "json",
+    "--login",
+    "triage-agent",
+  ]);
+});
+
 test("ForgejoTeaHostProvider emits shell-safe missing-label remediation", () => {
   const label: LabelDefinition = {
     name: "agent ready; echo 'owned'",
@@ -291,6 +322,34 @@ test("ForgejoTeaHostProvider delegates label creation to tea", async () => {
     flagValue(runner.calls[0]!.args, "--description"),
     label.description,
   );
+});
+
+test("Forgejo setup provider creates labels on an explicit repository", async () => {
+  const label: LabelDefinition = {
+    name: "feature",
+    color: "0e8a16",
+    description: "New functionality",
+  };
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+
+  await provider.createLabel(target, label);
+
+  assert.deepEqual(calls[0]?.args, [
+    "labels",
+    "create",
+    "--repo",
+    "OWNER/patchmill-test",
+    "--name",
+    "feature",
+    "--color",
+    "0e8a16",
+    "--description",
+    "New functionality",
+    "--login",
+    "triage-agent",
+  ]);
 });
 
 test("ForgejoTeaHostProvider delegates label application to tea", async () => {
@@ -339,7 +398,7 @@ test("ForgejoTeaHostProvider delegates issue comments to tea", async () => {
   assert.equal(runner.calls[0]!.args[separatorIndex + 1], body);
 });
 
-test("Forgejo provider checks repository existence with tea repos search", async () => {
+test("Forgejo setup provider returns repository info with tea repos search", async () => {
   const { provider, calls } = createProviderWithResponses([
     {
       code: 0,
@@ -355,14 +414,10 @@ test("Forgejo provider checks repository existence with tea repos search", async
     },
   ]);
 
-  assert.equal(
-    await provider.repoExists({
-      owner: "OWNER",
-      repo: "patchmill-test",
-      slug: "OWNER/patchmill-test",
-    }),
-    true,
-  );
+  assert.deepEqual(await provider.getRepository(target), {
+    publicUrl: "https://forgejo.example/OWNER/patchmill-test",
+    gitRemoteUrl: "git@forgejo.example:OWNER/patchmill-test.git",
+  });
   assert.deepEqual(calls[0]?.args, [
     "repos",
     "search",
@@ -380,16 +435,19 @@ test("Forgejo provider checks repository existence with tea repos search", async
   ]);
 });
 
+test("Forgejo setup provider returns undefined when tea search finds no repository", async () => {
+  const { provider } = createProviderWithResponses([
+    { code: 0, stdout: "[]", stderr: "" },
+  ]);
+
+  assert.equal(await provider.getRepository(target), undefined);
+});
+
 test("Forgejo provider creates and deletes public repositories", async () => {
   const { provider, calls } = createProviderWithResponses([
     { code: 0, stdout: "{}", stderr: "" },
     { code: 0, stdout: "", stderr: "" },
   ]);
-  const target = {
-    owner: "OWNER",
-    repo: "patchmill-test",
-    slug: "OWNER/patchmill-test",
-  };
 
   await provider.createPublicRepo(target);
   await provider.deleteRepo(target);
@@ -424,7 +482,7 @@ test("Forgejo provider creates and deletes public repositories", async () => {
   );
 });
 
-test("Forgejo provider reads clone and public URLs from repository info", async () => {
+test("Forgejo provider reads repository info and clone command", async () => {
   const { provider } = createProviderWithResponses([
     {
       code: 0,
@@ -438,42 +496,21 @@ test("Forgejo provider reads clone and public URLs from repository info", async 
       ]),
       stderr: "",
     },
-    {
-      code: 0,
-      stdout: JSON.stringify([
-        {
-          owner: "OWNER",
-          name: "patchmill-test",
-          url: "https://forgejo.example/OWNER/patchmill-test",
-          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
-        },
-      ]),
-      stderr: "",
-    },
   ]);
-  const target = {
-    owner: "OWNER",
-    repo: "patchmill-test",
-    slug: "OWNER/patchmill-test",
-  };
 
-  assert.equal(
-    await provider.gitRemoteUrl(target),
-    "git@forgejo.example:OWNER/patchmill-test.git",
-  );
-  assert.equal(
-    await provider.publicRepoUrl(target),
-    "https://forgejo.example/OWNER/patchmill-test",
-  );
+  assert.deepEqual(await provider.getRepository(target), {
+    publicUrl: "https://forgejo.example/OWNER/patchmill-test",
+    gitRemoteUrl: "git@forgejo.example:OWNER/patchmill-test.git",
+  });
   assert.equal(provider.cloneCommand(target), "tea clone OWNER/patchmill-test");
 });
 
-test("Forgejo provider creates issues with labels", async () => {
+test("Forgejo setup provider creates issues with labels on an explicit repository", async () => {
   const { provider, calls } = createProviderWithResponses([
     { code: 0, stdout: "", stderr: "" },
   ]);
 
-  await provider.createIssue({
+  await provider.createIssue(target, {
     title: "Build the form",
     body: "Create a useful form.\n",
     labels: ["feature", "polish"],
@@ -482,14 +519,14 @@ test("Forgejo provider creates issues with labels", async () => {
   assert.deepEqual(calls[0]?.args, [
     "issues",
     "create",
+    "--repo",
+    "OWNER/patchmill-test",
     "--title",
     "Build the form",
     "--description",
     "Create a useful form.\n",
     "--labels",
     "feature,polish",
-    "--repo",
-    "/repo",
     "--login",
     "triage-agent",
   ]);

--- a/src/host/forgejo-tea.test.ts
+++ b/src/host/forgejo-tea.test.ts
@@ -41,6 +41,32 @@ function createProvider(runner: CommandRunner): ForgejoTeaHostProvider {
   return new ForgejoTeaHostProvider({ runner, repoRoot, login });
 }
 
+function createProviderWithResponses(responses: CommandResult[]): {
+  provider: ForgejoTeaHostProvider;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let index = 0;
+  const runner: CommandRunner = {
+    async run(command, args, options = {}) {
+      calls.push({ command, args: [...args], cwd: options.cwd });
+      const response = responses[index];
+      index += 1;
+      if (!response)
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      return response;
+    },
+  };
+  return {
+    provider: new ForgejoTeaHostProvider({
+      runner,
+      repoRoot,
+      login: "triage-agent",
+    }),
+    calls,
+  };
+}
+
 function assertTeaContext(call: RecordedCall): void {
   assert.equal(call.command, "tea");
   assert.equal(call.cwd, repoRoot);
@@ -311,4 +337,160 @@ test("ForgejoTeaHostProvider delegates issue comments to tea", async () => {
   const separatorIndex = runner.calls[0]!.args.indexOf("--");
   assert.ok(separatorIndex >= 0);
   assert.equal(runner.calls[0]!.args[separatorIndex + 1], body);
+});
+
+test("Forgejo provider checks repository existence with tea repos search", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: JSON.stringify([
+        {
+          owner: { login: "OWNER" },
+          name: "patchmill-test",
+          url: "https://forgejo.example/OWNER/patchmill-test",
+          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
+        },
+      ]),
+      stderr: "",
+    },
+  ]);
+
+  assert.equal(
+    await provider.repoExists({
+      owner: "OWNER",
+      repo: "patchmill-test",
+      slug: "OWNER/patchmill-test",
+    }),
+    true,
+  );
+  assert.deepEqual(calls[0]?.args, [
+    "repos",
+    "search",
+    "patchmill-test",
+    "--owner",
+    "OWNER",
+    "--fields",
+    "owner,name,ssh,url",
+    "--limit",
+    "50",
+    "--output",
+    "json",
+    "--login",
+    "triage-agent",
+  ]);
+});
+
+test("Forgejo provider creates and deletes public repositories", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "{}", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  await provider.createPublicRepo(target);
+  await provider.deleteRepo(target);
+
+  assert.deepEqual(
+    calls.map((call) => call.args),
+    [
+      [
+        "repos",
+        "create",
+        "--name",
+        "patchmill-test",
+        "--owner",
+        "OWNER",
+        "--output",
+        "json",
+        "--login",
+        "triage-agent",
+      ],
+      [
+        "repos",
+        "delete",
+        "--name",
+        "patchmill-test",
+        "--owner",
+        "OWNER",
+        "--force",
+        "--login",
+        "triage-agent",
+      ],
+    ],
+  );
+});
+
+test("Forgejo provider reads clone and public URLs from repository info", async () => {
+  const { provider } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: JSON.stringify([
+        {
+          owner: "OWNER",
+          name: "patchmill-test",
+          url: "https://forgejo.example/OWNER/patchmill-test",
+          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
+        },
+      ]),
+      stderr: "",
+    },
+    {
+      code: 0,
+      stdout: JSON.stringify([
+        {
+          owner: "OWNER",
+          name: "patchmill-test",
+          url: "https://forgejo.example/OWNER/patchmill-test",
+          ssh: "git@forgejo.example:OWNER/patchmill-test.git",
+        },
+      ]),
+      stderr: "",
+    },
+  ]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  assert.equal(
+    await provider.gitRemoteUrl(target),
+    "git@forgejo.example:OWNER/patchmill-test.git",
+  );
+  assert.equal(
+    await provider.publicRepoUrl(target),
+    "https://forgejo.example/OWNER/patchmill-test",
+  );
+  assert.equal(provider.cloneCommand(target), "tea clone OWNER/patchmill-test");
+});
+
+test("Forgejo provider creates issues with labels", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+
+  await provider.createIssue({
+    title: "Build the form",
+    body: "Create a useful form.\n",
+    labels: ["feature", "polish"],
+  });
+
+  assert.deepEqual(calls[0]?.args, [
+    "issues",
+    "create",
+    "--title",
+    "Build the form",
+    "--description",
+    "Create a useful form.\n",
+    "--labels",
+    "feature,polish",
+    "--repo",
+    "/repo",
+    "--login",
+    "triage-agent",
+  ]);
 });

--- a/src/host/forgejo-tea.ts
+++ b/src/host/forgejo-tea.ts
@@ -8,12 +8,15 @@ import {
   viewIssue as viewIssueWithTea,
 } from "../cli/commands/triage/forgejo.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
+import { withTeaContext } from "./forgejo-tea-context.ts";
 import type {
   HostCliCheck,
+  HostIssueCreateInput,
   IssueHostProvider,
   IssueSummary,
   LabelChangePlan,
   LabelDefinition,
+  RepositoryTarget,
 } from "./types.ts";
 
 export type ForgejoTeaHostOptions = {
@@ -36,6 +39,56 @@ function commandOutput(result: {
 function shellQuote(value: string): string {
   if (value.length === 0) return "''";
   return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+type TeaRepoPayload = Record<string, unknown>;
+
+type TeaRepoInfo = {
+  webUrl: string;
+  cloneUrl: string;
+};
+
+function parseJson(stdout: string, context: string): unknown {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `${context} returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function ownerName(owner: unknown): string | undefined {
+  if (typeof owner === "string") return owner;
+  if (owner && typeof owner === "object") {
+    const value = owner as Record<string, unknown>;
+    if (typeof value.login === "string") return value.login;
+    if (typeof value.name === "string") return value.name;
+    if (typeof value.username === "string") return value.username;
+  }
+  return undefined;
+}
+
+function repoMatches(entry: TeaRepoPayload, target: RepositoryTarget): boolean {
+  return ownerName(entry.owner) === target.owner && entry.name === target.repo;
+}
+
+function repoInfo(
+  entry: TeaRepoPayload,
+  target: RepositoryTarget,
+): TeaRepoInfo {
+  if (typeof entry.url !== "string") {
+    throw new Error(
+      `tea repos search did not return a web URL for ${target.slug}`,
+    );
+  }
+  if (typeof entry.ssh !== "string") {
+    throw new Error(
+      `tea repos search did not return an SSH URL for ${target.slug}`,
+    );
+  }
+  return { webUrl: entry.url, cloneUrl: entry.ssh };
 }
 
 export class ForgejoTeaHostProvider implements IssueHostProvider {
@@ -79,6 +132,131 @@ export class ForgejoTeaHostProvider implements IssueHostProvider {
       "--description",
       shellQuote(label.description),
     ].join(" ");
+  }
+
+  private runTea(
+    args: string[],
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const withLogin = this.options.login
+      ? [...args, "--login", this.options.login]
+      : args;
+    return this.options.runner.run("tea", withLogin, {
+      cwd: this.options.repoRoot,
+    });
+  }
+
+  private async repositoryInfo(
+    target: RepositoryTarget,
+  ): Promise<TeaRepoInfo | undefined> {
+    const result = await this.runTea([
+      "repos",
+      "search",
+      target.repo,
+      "--owner",
+      target.owner,
+      "--fields",
+      "owner,name,ssh,url",
+      "--limit",
+      "50",
+      "--output",
+      "json",
+    ]);
+    if (result.code !== 0) {
+      throw new Error(
+        `tea repos search failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+    const parsed = parseJson(result.stdout, "tea repos search");
+    if (!Array.isArray(parsed)) {
+      throw new Error("tea repos search returned a non-array payload");
+    }
+    const match = parsed.find(
+      (entry): entry is TeaRepoPayload =>
+        Boolean(entry) &&
+        typeof entry === "object" &&
+        repoMatches(entry as TeaRepoPayload, target),
+    );
+    return match ? repoInfo(match, target) : undefined;
+  }
+
+  async repoExists(target: RepositoryTarget): Promise<boolean> {
+    return (await this.repositoryInfo(target)) !== undefined;
+  }
+
+  async createPublicRepo(target: RepositoryTarget): Promise<void> {
+    const result = await this.runTea([
+      "repos",
+      "create",
+      "--name",
+      target.repo,
+      "--owner",
+      target.owner,
+      "--output",
+      "json",
+    ]);
+    if (result.code !== 0) {
+      throw new Error(
+        `tea repos create failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+  }
+
+  async deleteRepo(target: RepositoryTarget): Promise<void> {
+    const result = await this.runTea([
+      "repos",
+      "delete",
+      "--name",
+      target.repo,
+      "--owner",
+      target.owner,
+      "--force",
+    ]);
+    if (result.code !== 0) {
+      throw new Error(
+        `tea repos delete failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+  }
+
+  async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
+    const info = await this.repositoryInfo(target);
+    if (!info) throw new Error(`Repository not found: ${target.slug}`);
+    return info.cloneUrl;
+  }
+
+  async publicRepoUrl(target: RepositoryTarget): Promise<string> {
+    const info = await this.repositoryInfo(target);
+    if (!info) throw new Error(`Repository not found: ${target.slug}`);
+    return info.webUrl;
+  }
+
+  cloneCommand(target: RepositoryTarget): string {
+    return `tea clone ${target.slug}`;
+  }
+
+  async createIssue(issue: HostIssueCreateInput): Promise<void> {
+    const args = [
+      "issues",
+      "create",
+      "--title",
+      issue.title,
+      "--description",
+      issue.body,
+    ];
+    if (issue.labels.length > 0) {
+      args.push("--labels", issue.labels.join(","));
+    }
+
+    const result = await this.options.runner.run(
+      "tea",
+      withTeaContext(args, this.options.repoRoot, this.options.login),
+      { cwd: this.options.repoRoot },
+    );
+    if (result.code !== 0) {
+      throw new Error(
+        `tea issues create failed for ${issue.title}: ${commandOutput(result)}`,
+      );
+    }
   }
 
   listOpenIssues(): Promise<IssueSummary[]> {

--- a/src/host/forgejo-tea.ts
+++ b/src/host/forgejo-tea.ts
@@ -1,14 +1,13 @@
 import {
   applyIssueLabels,
   commentIssue,
-  createLabel,
+  createLabel as createLabelWithTea,
   hydrateIssueComments,
-  listLabels,
+  listLabels as listLabelsWithTea,
   listOpenIssues,
   viewIssue as viewIssueWithTea,
 } from "../cli/commands/triage/forgejo.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
-import { withTeaContext } from "./forgejo-tea-context.ts";
 import type {
   HostCliCheck,
   HostIssueCreateInput,
@@ -16,6 +15,8 @@ import type {
   IssueSummary,
   LabelChangePlan,
   LabelDefinition,
+  RepositoryInfo,
+  RepositorySetupHostProvider,
   RepositoryTarget,
 } from "./types.ts";
 
@@ -42,11 +43,6 @@ function shellQuote(value: string): string {
 }
 
 type TeaRepoPayload = Record<string, unknown>;
-
-type TeaRepoInfo = {
-  webUrl: string;
-  cloneUrl: string;
-};
 
 function parseJson(stdout: string, context: string): unknown {
   try {
@@ -77,7 +73,7 @@ function repoMatches(entry: TeaRepoPayload, target: RepositoryTarget): boolean {
 function repoInfo(
   entry: TeaRepoPayload,
   target: RepositoryTarget,
-): TeaRepoInfo {
+): RepositoryInfo {
   if (typeof entry.url !== "string") {
     throw new Error(
       `tea repos search did not return a web URL for ${target.slug}`,
@@ -88,10 +84,33 @@ function repoInfo(
       `tea repos search did not return an SSH URL for ${target.slug}`,
     );
   }
-  return { webUrl: entry.url, cloneUrl: entry.ssh };
+  return { publicUrl: entry.url, gitRemoteUrl: entry.ssh };
 }
 
-export class ForgejoTeaHostProvider implements IssueHostProvider {
+function parseLabelNames(stdout: string, context: string): string[] {
+  const parsed = parseJson(stdout, context);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${context} returned a non-array payload`);
+  }
+  return parsed
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (
+        entry &&
+        typeof entry === "object" &&
+        "name" in entry &&
+        typeof entry.name === "string"
+      ) {
+        return entry.name;
+      }
+      throw new Error(`Unexpected label payload: ${JSON.stringify(entry)}`);
+    })
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export class ForgejoTeaHostProvider
+  implements IssueHostProvider, RepositorySetupHostProvider
+{
   readonly id = "forgejo-tea" as const;
   readonly displayName = "Forgejo via tea";
 
@@ -145,9 +164,26 @@ export class ForgejoTeaHostProvider implements IssueHostProvider {
     });
   }
 
+  private runTeaForTarget(
+    target: RepositoryTarget,
+    args: string[],
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const [command, subcommand, ...rest] = args;
+    if (!command || !subcommand) {
+      throw new Error("tea target command requires a command and subcommand");
+    }
+    const withRepo = [command, subcommand, "--repo", target.slug, ...rest];
+    const withLogin = this.options.login
+      ? [...withRepo, "--login", this.options.login]
+      : withRepo;
+    return this.options.runner.run("tea", withLogin, {
+      cwd: this.options.repoRoot,
+    });
+  }
+
   private async repositoryInfo(
     target: RepositoryTarget,
-  ): Promise<TeaRepoInfo | undefined> {
+  ): Promise<RepositoryInfo | undefined> {
     const result = await this.runTea([
       "repos",
       "search",
@@ -179,8 +215,8 @@ export class ForgejoTeaHostProvider implements IssueHostProvider {
     return match ? repoInfo(match, target) : undefined;
   }
 
-  async repoExists(target: RepositoryTarget): Promise<boolean> {
-    return (await this.repositoryInfo(target)) !== undefined;
+  getRepository(target: RepositoryTarget): Promise<RepositoryInfo | undefined> {
+    return this.repositoryInfo(target);
   }
 
   async createPublicRepo(target: RepositoryTarget): Promise<void> {
@@ -218,23 +254,14 @@ export class ForgejoTeaHostProvider implements IssueHostProvider {
     }
   }
 
-  async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
-    const info = await this.repositoryInfo(target);
-    if (!info) throw new Error(`Repository not found: ${target.slug}`);
-    return info.cloneUrl;
-  }
-
-  async publicRepoUrl(target: RepositoryTarget): Promise<string> {
-    const info = await this.repositoryInfo(target);
-    if (!info) throw new Error(`Repository not found: ${target.slug}`);
-    return info.webUrl;
-  }
-
   cloneCommand(target: RepositoryTarget): string {
     return `tea clone ${target.slug}`;
   }
 
-  async createIssue(issue: HostIssueCreateInput): Promise<void> {
+  async createIssue(
+    target: RepositoryTarget,
+    issue: HostIssueCreateInput,
+  ): Promise<void> {
     const args = [
       "issues",
       "create",
@@ -247,11 +274,7 @@ export class ForgejoTeaHostProvider implements IssueHostProvider {
       args.push("--labels", issue.labels.join(","));
     }
 
-    const result = await this.options.runner.run(
-      "tea",
-      withTeaContext(args, this.options.repoRoot, this.options.login),
-      { cwd: this.options.repoRoot },
-    );
+    const result = await this.runTeaForTarget(target, args);
     if (result.code !== 0) {
       throw new Error(
         `tea issues create failed for ${issue.title}: ${commandOutput(result)}`,
@@ -286,21 +309,65 @@ export class ForgejoTeaHostProvider implements IssueHostProvider {
     return issues;
   }
 
-  listLabels(): Promise<string[]> {
-    return listLabels(
-      this.options.runner,
-      this.options.repoRoot,
-      this.options.login,
-    );
+  listLabels(): Promise<string[]>;
+  listLabels(target: RepositoryTarget): Promise<string[]>;
+  async listLabels(target?: RepositoryTarget): Promise<string[]> {
+    if (!target) {
+      return listLabelsWithTea(
+        this.options.runner,
+        this.options.repoRoot,
+        this.options.login,
+      );
+    }
+
+    const result = await this.runTeaForTarget(target, [
+      "labels",
+      "list",
+      "--limit",
+      "1000",
+      "--output",
+      "json",
+    ]);
+    if (result.code !== 0) {
+      throw new Error(
+        `tea labels list failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+    return parseLabelNames(result.stdout, "tea labels list");
   }
 
-  createLabel(label: LabelDefinition): Promise<void> {
-    return createLabel(
-      this.options.runner,
-      this.options.repoRoot,
-      label,
-      this.options.login,
-    );
+  createLabel(label: LabelDefinition): Promise<void>;
+  createLabel(target: RepositoryTarget, label: LabelDefinition): Promise<void>;
+  async createLabel(
+    first: RepositoryTarget | LabelDefinition,
+    second?: LabelDefinition,
+  ): Promise<void> {
+    if (!second) {
+      return createLabelWithTea(
+        this.options.runner,
+        this.options.repoRoot,
+        first as LabelDefinition,
+        this.options.login,
+      );
+    }
+
+    const target = first as RepositoryTarget;
+    const label = second;
+    const result = await this.runTeaForTarget(target, [
+      "labels",
+      "create",
+      "--name",
+      label.name,
+      "--color",
+      label.color,
+      "--description",
+      label.description,
+    ]);
+    if (result.code !== 0) {
+      throw new Error(
+        `tea labels create failed for ${label.name}: ${commandOutput(result)}`,
+      );
+    }
   }
 
   applyLabels(change: LabelChangePlan): Promise<void> {

--- a/src/host/github-gh.test.ts
+++ b/src/host/github-gh.test.ts
@@ -435,7 +435,7 @@ test("GitHub provider exposes remote URL, public URL, and clone command", async 
 
   assert.equal(
     await provider.gitRemoteUrl(target),
-    "https://github.com/OWNER/patchmill-test.git",
+    "git@github.com:OWNER/patchmill-test.git",
   );
   assert.equal(
     await provider.publicRepoUrl(target),

--- a/src/host/github-gh.test.ts
+++ b/src/host/github-gh.test.ts
@@ -473,3 +473,23 @@ test("GitHub provider creates issues with labels when provided", async () => {
     "feature,polish",
   ]);
 });
+
+test("GitHub provider clears ambient GH_REPO for gh commands", async () => {
+  let ghRepoOverrideWasCleared = false;
+  const provider = createProvider({
+    async run(_command, _args, options = {}) {
+      ghRepoOverrideWasCleared =
+        Object.hasOwn(options.env ?? {}, "GH_REPO") &&
+        options.env?.GH_REPO === undefined;
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  });
+
+  await provider.createIssue({
+    title: "Build the form",
+    body: "Create a useful form.\n",
+    labels: [],
+  });
+
+  assert.equal(ghRepoOverrideWasCleared, true);
+});

--- a/src/host/github-gh.test.ts
+++ b/src/host/github-gh.test.ts
@@ -35,6 +35,25 @@ function createProvider(runner: CommandRunner): GitHubGhHostProvider {
   return new GitHubGhHostProvider({ runner, repoRoot });
 }
 
+function createProviderWithResponses(responses: CommandResult[]): {
+  provider: GitHubGhHostProvider;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let index = 0;
+  const runner: CommandRunner = {
+    async run(command, args, options = {}) {
+      calls.push({ command, args: [...args], cwd: options.cwd });
+      const response = responses[index];
+      index += 1;
+      if (!response)
+        throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+      return response;
+    },
+  };
+  return { provider: createProvider(runner), calls };
+}
+
 function commandLines(runner: { calls: RecordedCall[] }): string[] {
   return runner.calls.map((call) => [call.command, ...call.args].join(" "));
 }
@@ -346,4 +365,111 @@ test("GitHubGhHostProvider emits shell-safe missing-label remediation", () => {
     }),
     "  gh label create 'agent ready; echo '\"'\"'owned'\"'\"'' --color 2ea043 --description 'Ready for $(implementation) & review'",
   );
+});
+
+test("GitHub provider checks repository existence with gh repo view", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: '{"name":"patchmill-test"}', stderr: "" },
+  ]);
+
+  assert.equal(
+    await provider.repoExists({
+      owner: "OWNER",
+      repo: "patchmill-test",
+      slug: "OWNER/patchmill-test",
+    }),
+    true,
+  );
+  assert.deepEqual(calls[0], {
+    command: "gh",
+    args: ["repo", "view", "OWNER/patchmill-test", "--json", "name"],
+    cwd: "/repo",
+  });
+});
+
+test("GitHub provider returns false when gh repo view cannot find the repo", async () => {
+  const { provider } = createProviderWithResponses([
+    { code: 1, stdout: "", stderr: "Could not resolve to a Repository" },
+  ]);
+
+  assert.equal(
+    await provider.repoExists({
+      owner: "OWNER",
+      repo: "missing",
+      slug: "OWNER/missing",
+    }),
+    false,
+  );
+});
+
+test("GitHub provider creates and deletes public repositories", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  ]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  await provider.createPublicRepo(target);
+  await provider.deleteRepo(target);
+
+  assert.deepEqual(
+    calls.map((call) => call.args),
+    [
+      ["repo", "create", "OWNER/patchmill-test", "--public"],
+      ["repo", "delete", "OWNER/patchmill-test", "--yes"],
+    ],
+  );
+});
+
+test("GitHub provider exposes remote URL, public URL, and clone command", async () => {
+  const { provider } = createProviderWithResponses([]);
+  const target = {
+    owner: "OWNER",
+    repo: "patchmill-test",
+    slug: "OWNER/patchmill-test",
+  };
+
+  assert.equal(
+    await provider.gitRemoteUrl(target),
+    "https://github.com/OWNER/patchmill-test.git",
+  );
+  assert.equal(
+    await provider.publicRepoUrl(target),
+    "https://github.com/OWNER/patchmill-test",
+  );
+  assert.equal(
+    provider.cloneCommand(target),
+    "gh repo clone OWNER/patchmill-test",
+  );
+});
+
+test("GitHub provider creates issues with labels when provided", async () => {
+  const { provider, calls } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: "https://github.com/OWNER/patchmill-test/issues/1\n",
+      stderr: "",
+    },
+  ]);
+
+  await provider.createIssue({
+    title: "Build the form",
+    body: "Create a useful form.\n",
+    labels: ["feature", "polish"],
+  });
+
+  assert.deepEqual(calls[0]?.args, [
+    "issue",
+    "create",
+    "--title",
+    "Build the form",
+    "--body",
+    "Create a useful form.\n",
+    "--label",
+    "feature,polish",
+  ]);
 });

--- a/src/host/github-gh.test.ts
+++ b/src/host/github-gh.test.ts
@@ -14,6 +14,11 @@ type RecordedCall = {
 };
 
 const repoRoot = "/repo";
+const target = {
+  owner: "OWNER",
+  repo: "patchmill-test",
+  slug: "OWNER/patchmill-test",
+};
 
 function scriptedRunner(
   responses: Record<string, CommandResult>,
@@ -243,6 +248,23 @@ test("GitHubGhHostProvider lists labels", async () => {
   ]);
 });
 
+test("GitHub setup provider lists labels on an explicit repository", async () => {
+  const runner = scriptedRunner({
+    "gh label list --repo OWNER/patchmill-test --limit 1000 --json name": {
+      code: 0,
+      stdout: JSON.stringify([{ name: "feature" }, { name: "bug" }]),
+      stderr: "",
+    },
+  });
+
+  const labels = await createProvider(runner).listLabels(target);
+
+  assert.deepEqual(labels, ["bug", "feature"]);
+  assert.deepEqual(commandLines(runner), [
+    "gh label list --repo OWNER/patchmill-test --limit 1000 --json name",
+  ]);
+});
+
 test("GitHubGhHostProvider strips leading hash when creating labels", async () => {
   const label: LabelDefinition = {
     name: "agent-ready",
@@ -268,6 +290,24 @@ test("GitHubGhHostProvider strips leading hash when creating labels", async () =
     flagValue(runner.calls[0]!.args, "--description"),
     label.description,
   );
+});
+
+test("GitHub setup provider creates labels on an explicit repository", async () => {
+  const label: LabelDefinition = {
+    name: "feature",
+    color: "#0e8a16",
+    description: "New functionality",
+  };
+  const runner = scriptedRunner({
+    "gh label create feature --repo OWNER/patchmill-test --color 0e8a16 --description New functionality":
+      { code: 0, stdout: "", stderr: "" },
+  });
+
+  await createProvider(runner).createLabel(target, label);
+
+  assert.deepEqual(commandLines(runner), [
+    "gh label create feature --repo OWNER/patchmill-test --color 0e8a16 --description New functionality",
+  ]);
 });
 
 test("GitHubGhHostProvider applies label additions and removals", async () => {
@@ -367,38 +407,61 @@ test("GitHubGhHostProvider emits shell-safe missing-label remediation", () => {
   );
 });
 
-test("GitHub provider checks repository existence with gh repo view", async () => {
+test("GitHub setup provider returns repository info with gh repo view", async () => {
   const { provider, calls } = createProviderWithResponses([
-    { code: 0, stdout: '{"name":"patchmill-test"}', stderr: "" },
+    {
+      code: 0,
+      stdout: JSON.stringify({
+        name: "patchmill-test",
+        url: "https://github.com/OWNER/patchmill-test",
+        sshUrl: "git@github.com:OWNER/patchmill-test.git",
+      }),
+      stderr: "",
+    },
   ]);
 
-  assert.equal(
-    await provider.repoExists({
-      owner: "OWNER",
-      repo: "patchmill-test",
-      slug: "OWNER/patchmill-test",
-    }),
-    true,
-  );
+  assert.deepEqual(await provider.getRepository(target), {
+    publicUrl: "https://github.com/OWNER/patchmill-test",
+    gitRemoteUrl: "git@github.com:OWNER/patchmill-test.git",
+  });
   assert.deepEqual(calls[0], {
     command: "gh",
-    args: ["repo", "view", "OWNER/patchmill-test", "--json", "name"],
+    args: ["repo", "view", "OWNER/patchmill-test", "--json", "name,url,sshUrl"],
     cwd: "/repo",
   });
 });
 
-test("GitHub provider returns false when gh repo view cannot find the repo", async () => {
+test("GitHub setup provider returns undefined when gh repo view cannot find the repo", async () => {
   const { provider } = createProviderWithResponses([
     { code: 1, stdout: "", stderr: "Could not resolve to a Repository" },
   ]);
 
-  assert.equal(
-    await provider.repoExists({
-      owner: "OWNER",
-      repo: "missing",
-      slug: "OWNER/missing",
-    }),
-    false,
+  assert.equal(await provider.getRepository(target), undefined);
+});
+
+test("GitHub setup provider rejects malformed repository info", async () => {
+  const { provider } = createProviderWithResponses([
+    {
+      code: 0,
+      stdout: JSON.stringify({ name: "patchmill-test", url: null }),
+      stderr: "",
+    },
+  ]);
+
+  await assert.rejects(
+    () => provider.getRepository(target),
+    /gh repo view did not return a public URL for OWNER\/patchmill-test/u,
+  );
+});
+
+test("GitHub setup provider throws when repo view fails for reasons other than not found", async () => {
+  const { provider } = createProviderWithResponses([
+    { code: 1, stdout: "", stderr: "HTTP 403: API rate limit exceeded" },
+  ]);
+
+  await assert.rejects(
+    () => provider.getRepository(target),
+    /gh repo view failed for OWNER\/patchmill-test: HTTP 403/u,
   );
 });
 
@@ -407,11 +470,6 @@ test("GitHub provider creates and deletes public repositories", async () => {
     { code: 0, stdout: "", stderr: "" },
     { code: 0, stdout: "", stderr: "" },
   ]);
-  const target = {
-    owner: "OWNER",
-    repo: "patchmill-test",
-    slug: "OWNER/patchmill-test",
-  };
 
   await provider.createPublicRepo(target);
   await provider.deleteRepo(target);
@@ -425,29 +483,16 @@ test("GitHub provider creates and deletes public repositories", async () => {
   );
 });
 
-test("GitHub provider exposes remote URL, public URL, and clone command", async () => {
+test("GitHub provider exposes clone command", () => {
   const { provider } = createProviderWithResponses([]);
-  const target = {
-    owner: "OWNER",
-    repo: "patchmill-test",
-    slug: "OWNER/patchmill-test",
-  };
 
-  assert.equal(
-    await provider.gitRemoteUrl(target),
-    "git@github.com:OWNER/patchmill-test.git",
-  );
-  assert.equal(
-    await provider.publicRepoUrl(target),
-    "https://github.com/OWNER/patchmill-test",
-  );
   assert.equal(
     provider.cloneCommand(target),
     "gh repo clone OWNER/patchmill-test",
   );
 });
 
-test("GitHub provider creates issues with labels when provided", async () => {
+test("GitHub setup provider creates issues with labels on an explicit repository", async () => {
   const { provider, calls } = createProviderWithResponses([
     {
       code: 0,
@@ -456,7 +501,7 @@ test("GitHub provider creates issues with labels when provided", async () => {
     },
   ]);
 
-  await provider.createIssue({
+  await provider.createIssue(target, {
     title: "Build the form",
     body: "Create a useful form.\n",
     labels: ["feature", "polish"],
@@ -465,6 +510,8 @@ test("GitHub provider creates issues with labels when provided", async () => {
   assert.deepEqual(calls[0]?.args, [
     "issue",
     "create",
+    "--repo",
+    "OWNER/patchmill-test",
     "--title",
     "Build the form",
     "--body",
@@ -485,7 +532,7 @@ test("GitHub provider clears ambient GH_REPO for gh commands", async () => {
     },
   });
 
-  await provider.createIssue({
+  await provider.createIssue(target, {
     title: "Build the form",
     body: "Create a useful form.\n",
     labels: [],

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -4,10 +4,12 @@ import type {
 } from "../cli/commands/triage/types.ts";
 import type {
   HostCliCheck,
+  HostIssueCreateInput,
   IssueHostProvider,
   IssueSummary,
   LabelChangePlan,
   LabelDefinition,
+  RepositoryTarget,
 } from "./types.ts";
 
 const ISSUE_LIST_JSON_FIELDS =
@@ -264,6 +266,71 @@ export class GitHubGhHostProvider implements IssueHostProvider {
       throw new Error(
         `gh issue comment failed for #${issueNumber}: ${commandOutput(result)}`,
       );
+  }
+
+  async repoExists(target: RepositoryTarget): Promise<boolean> {
+    const result = await this.runGh([
+      "repo",
+      "view",
+      target.slug,
+      "--json",
+      "name",
+    ]);
+    return result.code === 0;
+  }
+
+  async createPublicRepo(target: RepositoryTarget): Promise<void> {
+    const result = await this.runGh([
+      "repo",
+      "create",
+      target.slug,
+      "--public",
+    ]);
+    if (result.code !== 0) {
+      throw new Error(
+        `gh repo create failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+  }
+
+  async deleteRepo(target: RepositoryTarget): Promise<void> {
+    const result = await this.runGh(["repo", "delete", target.slug, "--yes"]);
+    if (result.code !== 0) {
+      throw new Error(
+        `gh repo delete failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+  }
+
+  async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
+    return `https://github.com/${target.slug}.git`;
+  }
+
+  async publicRepoUrl(target: RepositoryTarget): Promise<string> {
+    return `https://github.com/${target.slug}`;
+  }
+
+  cloneCommand(target: RepositoryTarget): string {
+    return `gh repo clone ${target.slug}`;
+  }
+
+  async createIssue(issue: HostIssueCreateInput): Promise<void> {
+    const args = [
+      "issue",
+      "create",
+      "--title",
+      issue.title,
+      "--body",
+      issue.body,
+    ];
+    if (issue.labels.length > 0) args.push("--label", issue.labels.join(","));
+
+    const result = await this.runGh(args);
+    if (result.code !== 0) {
+      throw new Error(
+        `gh issue create failed for ${issue.title}: ${commandOutput(result)}`,
+      );
+    }
   }
 
   async viewIssue(issueNumber: number): Promise<IssueSummary> {

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -303,7 +303,7 @@ export class GitHubGhHostProvider implements IssueHostProvider {
   }
 
   async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
-    return `https://github.com/${target.slug}.git`;
+    return `git@github.com:${target.slug}.git`;
   }
 
   async publicRepoUrl(target: RepositoryTarget): Promise<string> {

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -349,7 +349,10 @@ export class GitHubGhHostProvider implements IssueHostProvider {
   }
 
   private runGh(args: string[]): Promise<CommandResult> {
-    return this.options.runner.run("gh", args, { cwd: this.options.repoRoot });
+    return this.options.runner.run("gh", args, {
+      cwd: this.options.repoRoot,
+      env: { GH_REPO: undefined },
+    });
   }
 
   private cliFailure(command: string, result: CommandResult): HostCliCheck {

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -9,12 +9,15 @@ import type {
   IssueSummary,
   LabelChangePlan,
   LabelDefinition,
+  RepositoryInfo,
+  RepositorySetupHostProvider,
   RepositoryTarget,
 } from "./types.ts";
 
 const ISSUE_LIST_JSON_FIELDS =
   "number,title,body,state,labels,author,updatedAt,url";
 const ISSUE_VIEW_JSON_FIELDS = `${ISSUE_LIST_JSON_FIELDS},comments`;
+const REPOSITORY_VIEW_JSON_FIELDS = "name,url,sshUrl";
 
 export type GitHubGhHostOptions = {
   runner: CommandRunner;
@@ -150,7 +153,40 @@ function parseLabelNames(stdout: string, context: string): string[] {
     .sort((a, b) => a.localeCompare(b));
 }
 
-export class GitHubGhHostProvider implements IssueHostProvider {
+function parseRepositoryInfo(
+  stdout: string,
+  target: RepositoryTarget,
+): RepositoryInfo {
+  const parsed = parseJson(stdout, "gh repo view");
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("gh repo view returned unexpected repository payload");
+  }
+  const repository = parsed as Record<string, unknown>;
+  if (typeof repository.url !== "string") {
+    throw new Error(
+      `gh repo view did not return a public URL for ${target.slug}`,
+    );
+  }
+  if (typeof repository.sshUrl !== "string") {
+    throw new Error(
+      `gh repo view did not return an SSH URL for ${target.slug}`,
+    );
+  }
+  return {
+    publicUrl: repository.url,
+    gitRemoteUrl: repository.sshUrl,
+  };
+}
+
+function isRepositoryNotFound(result: CommandResult): boolean {
+  return /Could not resolve to a Repository|Not Found|repository not found/iu.test(
+    commandOutput(result),
+  );
+}
+
+export class GitHubGhHostProvider
+  implements IssueHostProvider, RepositorySetupHostProvider
+{
   readonly id = "github-gh" as const;
   readonly displayName = "GitHub via gh";
 
@@ -205,30 +241,40 @@ export class GitHubGhHostProvider implements IssueHostProvider {
     return issues;
   }
 
-  async listLabels(): Promise<string[]> {
-    const result = await this.runGh([
-      "label",
-      "list",
-      "--limit",
-      "1000",
-      "--json",
-      "name",
-    ]);
+  async listLabels(): Promise<string[]>;
+  async listLabels(target: RepositoryTarget): Promise<string[]>;
+  async listLabels(target?: RepositoryTarget): Promise<string[]> {
+    const args = ["label", "list"];
+    if (target) args.push("--repo", target.slug);
+    args.push("--limit", "1000", "--json", "name");
+
+    const result = await this.runGh(args);
     if (result.code !== 0)
       throw new Error(`gh label list failed: ${commandOutput(result)}`);
     return parseLabelNames(result.stdout, "gh label list");
   }
 
-  async createLabel(label: LabelDefinition): Promise<void> {
-    const result = await this.runGh([
-      "label",
-      "create",
-      label.name,
+  async createLabel(label: LabelDefinition): Promise<void>;
+  async createLabel(
+    target: RepositoryTarget,
+    label: LabelDefinition,
+  ): Promise<void>;
+  async createLabel(
+    first: RepositoryTarget | LabelDefinition,
+    second?: LabelDefinition,
+  ): Promise<void> {
+    const target = second ? (first as RepositoryTarget) : undefined;
+    const label = second ?? (first as LabelDefinition);
+    const args = ["label", "create", label.name];
+    if (target) args.push("--repo", target.slug);
+    args.push(
       "--color",
       stripLeadingHash(label.color),
       "--description",
       label.description,
-    ]);
+    );
+
+    const result = await this.runGh(args);
     if (result.code !== 0)
       throw new Error(
         `gh label create failed for ${label.name}: ${commandOutput(result)}`,
@@ -268,15 +314,23 @@ export class GitHubGhHostProvider implements IssueHostProvider {
       );
   }
 
-  async repoExists(target: RepositoryTarget): Promise<boolean> {
+  async getRepository(
+    target: RepositoryTarget,
+  ): Promise<RepositoryInfo | undefined> {
     const result = await this.runGh([
       "repo",
       "view",
       target.slug,
       "--json",
-      "name",
+      REPOSITORY_VIEW_JSON_FIELDS,
     ]);
-    return result.code === 0;
+    if (result.code !== 0) {
+      if (isRepositoryNotFound(result)) return undefined;
+      throw new Error(
+        `gh repo view failed for ${target.slug}: ${commandOutput(result)}`,
+      );
+    }
+    return parseRepositoryInfo(result.stdout, target);
   }
 
   async createPublicRepo(target: RepositoryTarget): Promise<void> {
@@ -302,22 +356,19 @@ export class GitHubGhHostProvider implements IssueHostProvider {
     }
   }
 
-  async gitRemoteUrl(target: RepositoryTarget): Promise<string> {
-    return `git@github.com:${target.slug}.git`;
-  }
-
-  async publicRepoUrl(target: RepositoryTarget): Promise<string> {
-    return `https://github.com/${target.slug}`;
-  }
-
   cloneCommand(target: RepositoryTarget): string {
     return `gh repo clone ${target.slug}`;
   }
 
-  async createIssue(issue: HostIssueCreateInput): Promise<void> {
+  async createIssue(
+    target: RepositoryTarget,
+    issue: HostIssueCreateInput,
+  ): Promise<void> {
     const args = [
       "issue",
       "create",
+      "--repo",
+      target.slug,
       "--title",
       issue.title,
       "--body",

--- a/src/host/types.ts
+++ b/src/host/types.ts
@@ -24,6 +24,26 @@ export type RepositoryTarget = {
   slug: string;
 };
 
+export type HostIssueCreateInput = {
+  title: string;
+  body: string;
+  labels: string[];
+};
+
+export type RepositoryLifecycleHostProvider = {
+  repoExists(target: RepositoryTarget): Promise<boolean>;
+  createPublicRepo(target: RepositoryTarget): Promise<void>;
+  deleteRepo(target: RepositoryTarget): Promise<void>;
+  gitRemoteUrl(target: RepositoryTarget): Promise<string>;
+  publicRepoUrl(target: RepositoryTarget): Promise<string>;
+  cloneCommand(target: RepositoryTarget): string;
+};
+
+export type GitHostProvider = IssueHostProvider &
+  RepositoryLifecycleHostProvider & {
+    createIssue(issue: HostIssueCreateInput): Promise<void>;
+  };
+
 export type LabelChangePlan = {
   issueNumber: number;
   oldLabels: string[];

--- a/src/host/types.ts
+++ b/src/host/types.ts
@@ -30,19 +30,26 @@ export type HostIssueCreateInput = {
   labels: string[];
 };
 
-export type RepositoryLifecycleHostProvider = {
-  repoExists(target: RepositoryTarget): Promise<boolean>;
-  createPublicRepo(target: RepositoryTarget): Promise<void>;
-  deleteRepo(target: RepositoryTarget): Promise<void>;
-  gitRemoteUrl(target: RepositoryTarget): Promise<string>;
-  publicRepoUrl(target: RepositoryTarget): Promise<string>;
-  cloneCommand(target: RepositoryTarget): string;
+export type RepositoryInfo = {
+  publicUrl: string;
+  gitRemoteUrl: string;
 };
 
-export type GitHostProvider = IssueHostProvider &
-  RepositoryLifecycleHostProvider & {
-    createIssue(issue: HostIssueCreateInput): Promise<void>;
-  };
+export type RepositorySetupHostProvider = {
+  readonly id: PatchmillHostProviderId;
+  readonly displayName: string;
+  checkCli(): Promise<HostCliCheck>;
+  getRepository(target: RepositoryTarget): Promise<RepositoryInfo | undefined>;
+  createPublicRepo(target: RepositoryTarget): Promise<void>;
+  deleteRepo(target: RepositoryTarget): Promise<void>;
+  cloneCommand(target: RepositoryTarget): string;
+  listLabels(target: RepositoryTarget): Promise<string[]>;
+  createLabel(target: RepositoryTarget, label: LabelDefinition): Promise<void>;
+  createIssue(
+    target: RepositoryTarget,
+    issue: HostIssueCreateInput,
+  ): Promise<void>;
+};
 
 export type LabelChangePlan = {
   issueNumber: number;

--- a/src/host/types.ts
+++ b/src/host/types.ts
@@ -18,6 +18,12 @@ export type LabelDefinition = {
   description: string;
 };
 
+export type RepositoryTarget = {
+  owner: string;
+  repo: string;
+  slug: string;
+};
+
 export type LabelChangePlan = {
   issueNumber: number;
   oldLabels: string[];


### PR DESCRIPTION
## Summary
- Add `patchmill setup-test-repo` for creating/resetting disposable Team Lunch Poll demo repositories.
- Add reusable fixtures, issue parsing/loading, setup labels, and GitHub/Forgejo generic repository host capabilities.
- Document the disposable first-use workflow and include fixtures in package output.

## Test Plan
- [x] `node --test src/cli/commands/setup-test-repo/*.test.ts`
- [x] `node --test src/host/*.test.ts`
- [x] `npm run test:cli`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm pack --dry-run --json` fixture inclusion check
- [x] Live GitHub setup/verification: `rochecompaan/patchmill-test`

## Notes
- Forgejo/Gitea live verification was skipped because no disposable target/login was supplied.
