### PR TITLE
Add configurable workflow approval gates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,18 @@ pieces your repository needs.
       "blocked": "blocked"
     }
   },
+  "workflow": {
+    "specApproval": {
+      "required": false,
+      "reviewLabel": "spec-review",
+      "approvedLabel": "spec-approved"
+    },
+    "planApproval": {
+      "required": false,
+      "reviewLabel": "plan-review",
+      "approvedLabel": "plan-approved"
+    }
+  },
   "skills": {
     "triage": ".patchmill/skills/patchmill-issue-triage",
     "planning": ".patchmill/skills/writing-plans",
@@ -202,6 +214,48 @@ buckets. Keep the dashed `labels["in-progress"]` key exactly as shown in JSON.
 `triage.stateMap` keys are repository label names. Values are limited to
 `agent-ready`, `needs-info`, `agent-unsuitable`, and `blocked`, and the
 configured `labels.ready` label must map to `agent-ready`.
+
+## Workflow approval gates
+
+`workflow.specApproval` and `workflow.planApproval` configure approval labels
+that control when `patchmill run-once` may proceed. These labels are workflow
+signals, not triage buckets, so they are not nested under the flat `labels`
+object and are not added to `triage.stateMap`.
+
+```json
+{
+  "workflow": {
+    "specApproval": {
+      "required": true,
+      "reviewLabel": "spec-review",
+      "approvedLabel": "spec-approved"
+    },
+    "planApproval": {
+      "required": true,
+      "reviewLabel": "plan-review",
+      "approvedLabel": "plan-approved"
+    }
+  }
+}
+```
+
+When specification approval is required, automatic `run-once` selection ignores
+ready issues that do not have `workflow.specApproval.approvedLabel`. Explicit
+`patchmill run-once --issue <number>` fails with an `approval-required` result
+for the requested issue instead of silently choosing another issue.
+
+When plan approval is required, Patchmill creates or finds the issue plan,
+comments that the plan is ready, applies `workflow.planApproval.reviewLabel`,
+restores the ready label, removes `in-progress`, records the run as finished,
+and stops. After a human applies `workflow.planApproval.approvedLabel`, a later
+`run-once` reuses the existing plan and proceeds to implementation. During the
+claim step, Patchmill removes the active plan-review label when the approved
+label is present.
+
+`projectPolicy.planRequiresApproval` remains as a compatibility alias. If
+`workflow.planApproval.required` is omitted, Patchmill derives plan approval
+from `projectPolicy.planRequiresApproval`. If both are present,
+`workflow.planApproval.required` wins.
 
 ### Blocked triage state
 

--- a/docs/issue-agent-workflows.md
+++ b/docs/issue-agent-workflows.md
@@ -159,7 +159,10 @@ flowchart TD
   F --> G{Eligible issue?}
   E --> H[Read run state/checkpoints]
   G -->|no| Z[Return no-issue]
-  G -->|yes| H
+  G -->|yes| G1{Spec approval required and missing?}
+  G1 -->|yes, automatic selection| Z
+  G1 -->|yes, explicit --issue| AR[Return approval-required]
+  G1 -->|no| H
   H --> I{Dry run?}
   I -->|yes| Y[Return selected issue]
   I -->|no| J[Assert clean worktree]
@@ -172,10 +175,11 @@ flowchart TD
   O1 -->|blocked| BQ[Move to needs-info and comment blocker]
   O1 -->|plan-created| P[Record plan path/commit]
   N -->|yes| P2[Use existing plan]
-  P --> R{Plan-only or approval required?}
+  P --> R{Plan-only or plan approval missing?}
   P2 --> R
-  R -->|yes| R1[Comment plan ready, restore ready label, finish]
-  R -->|no| S[Render subagent support guidance]
+  R -->|plan-only| R1[Comment plan ready, restore ready label, finish]
+  R -->|approval missing| R2[Comment plan ready, add plan-review, restore ready label, finish]
+  R -->|approved or not required| S[Render subagent support guidance]
   S --> T[Ensure issue worktree and branch]
   T --> U[Run Pi implementation prompt in worktree]
   U --> V{Pi result}
@@ -196,6 +200,12 @@ flowchart TD
 `in-progress` run with valid run state. Otherwise it selects an open issue
 carrying the configured ready label and no excluded/protection labels. Priority
 labels determine ordering, then lower issue number wins.
+
+When `workflow.specApproval.required` is true, the automatic candidate set is
+filtered before priority ordering so a high-priority unapproved issue does not
+starve a lower-priority approved issue. Explicit `--issue` selection validates
+the requested issue and returns `approval-required` with the missing spec
+approved label if the approval is absent.
 
 Before mutating, it checks the repository worktree is clean, ignoring configured
 local state paths such as the run-state directory and issue todo root. It
@@ -262,6 +272,12 @@ or:
 
 A blocked plan moves the issue from `in-progress` to `needs-info` and posts the
 blocker questions.
+
+Plan approval is a workflow stop. When required and missing, Patchmill comments
+that the plan is ready, applies the configured plan-review label, restores the
+ready label, removes `in-progress`, records the run as finished, and exits with
+`plan-created` or `plan-found`. Once the configured plan-approved label is
+present, a later `run-once` reuses the plan and proceeds to implementation.
 
 ### Implementation Pi prompt
 

--- a/docs/plans/2026-06-12-configurable-spec-plan-approval.md
+++ b/docs/plans/2026-06-12-configurable-spec-plan-approval.md
@@ -1,0 +1,2171 @@
+# Configurable Specification and Plan Approval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add repository-configurable specification and plan approval gates that
+block `run-once` until required workflow approval labels are present.
+
+**Architecture:** Introduce a workflow-owned approval policy model, keep triage
+labels separate from workflow labels, and route `run-once` decisions through a
+small approval-gates module. Configuration loading preserves compatibility with
+`projectPolicy.planRequiresApproval`, while the pipeline consumes normalized
+approval decisions for selection, plan-review stops, and approved-plan resume.
+
+**Tech Stack:** TypeScript, Node test runner, Patchmill CLI run-once pipeline,
+Forgejo/Gitea `tea` and GitHub `gh` host abstractions, Markdown docs.
+
+---
+
+## File structure
+
+- Modify `src/config/types.ts` to add top-level workflow approval config types.
+- Modify `src/config/defaults.ts` and `src/config/defaults.test.ts` to expose
+  default workflow approval label names.
+- Modify `src/config/load.ts` and `src/config/load.test.ts` to parse and merge
+  `workflow.specApproval` and `workflow.planApproval` without losing default
+  labels.
+- Create `src/workflow/approval-policy.ts` and
+  `src/workflow/approval-policy.test.ts` for normalized approval policy,
+  compatibility alias resolution, and workflow label definitions.
+- Modify `src/cli/commands/triage/labels.ts` and
+  `src/cli/commands/triage/labels.test.ts` so label checks can aggregate triage
+  labels plus workflow approval labels without adding approval labels to flat
+  triage policy.
+- Modify `src/cli/commands/labels/setup.ts` and
+  `src/cli/commands/labels/setup.test.ts` to accept extra required label
+  definitions.
+- Modify `src/cli/commands/init/main.ts`, `src/cli/commands/init/main.test.ts`,
+  `src/cli/commands/doctor/main.ts`, and `src/cli/commands/doctor/checks.ts` so
+  init/doctor create or validate the combined label set.
+- Modify `src/cli/commands/run-once/types.ts` for the approval policy config
+  field and the `approval-required` pipeline result.
+- Modify `src/cli/commands/run-once/args.ts`,
+  `src/cli/commands/run-once/args.test.ts`, and
+  `src/cli/commands/run-once/main.ts` to wire normalized approval policy into
+  CLI config and JSON summaries.
+- Create `src/cli/commands/run-once/approval-gates.ts` and
+  `src/cli/commands/run-once/approval-gates.test.ts` for spec selection checks,
+  explicit approval-required errors, plan-review stop decisions, and review
+  label cleanup decisions.
+- Modify `src/cli/commands/run-once/selection.ts` and
+  `src/cli/commands/run-once/selection.test.ts` so automatic selection skips
+  spec-unapproved candidates while explicit selection fails with a typed
+  approval-required error.
+- Modify `src/cli/commands/run-once/pipeline.ts` and
+  `src/cli/commands/run-once/pipeline.test.ts` to use approval-gate decisions
+  for spec approval, plan approval stops, plan-review labeling, ready
+  restoration, and approved-plan resume.
+- Modify `docs/configuration.md` and `docs/issue-agent-workflows.md` for the new
+  workflow config and run-once approval states.
+
+## Task 1: Add workflow approval config loading
+
+**Files:**
+
+- Modify: `src/config/types.ts`
+- Modify: `src/config/defaults.ts`
+- Modify: `src/config/defaults.test.ts`
+- Modify: `src/config/load.ts`
+- Modify: `src/config/load.test.ts`
+
+- [ ] **Step 1: Write failing default config tests**
+
+Add workflow expectations to `src/config/defaults.test.ts` inside
+`defaults match the current patchmill baseline configuration`:
+
+```ts
+assert.deepEqual(DEFAULT_PATCHMILL_CONFIG.workflow, {
+  specApproval: {
+    reviewLabel: "spec-review",
+    approvedLabel: "spec-approved",
+  },
+  planApproval: {
+    reviewLabel: "plan-review",
+    approvedLabel: "plan-approved",
+  },
+});
+```
+
+Also add the same `workflow` object to the large `assert.deepEqual` literal in
+that test:
+
+```ts
+workflow: {
+  specApproval: {
+    reviewLabel: "spec-review",
+    approvedLabel: "spec-approved",
+  },
+  planApproval: {
+    reviewLabel: "plan-review",
+    approvedLabel: "plan-approved",
+  },
+},
+```
+
+- [ ] **Step 2: Write failing workflow load tests**
+
+Add these tests near the other `loadPatchmillConfig` parser tests in
+`src/config/load.test.ts`:
+
+```ts
+test("loadPatchmillConfig parses workflow approval config and preserves default labels", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-workflow-config-"));
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        specApproval: { required: true },
+        planApproval: {
+          reviewLabel: "awaiting-plan-review",
+          approvedLabel: "plan-reviewed",
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  const config = await loadPatchmillConfig(repoRoot, {}, []);
+
+  assert.deepEqual(config.workflow, {
+    specApproval: {
+      required: true,
+      reviewLabel: "spec-review",
+      approvedLabel: "spec-approved",
+    },
+    planApproval: {
+      reviewLabel: "awaiting-plan-review",
+      approvedLabel: "plan-reviewed",
+    },
+  });
+});
+
+test("loadPatchmillConfig rejects invalid workflow approval config", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-workflow-invalid-"));
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        planApproval: { required: "yes" },
+      },
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => loadPatchmillConfig(repoRoot, {}, []),
+    /workflow\.planApproval\.required must be a boolean/,
+  );
+});
+```
+
+- [ ] **Step 3: Run the failing config tests**
+
+Run:
+
+```bash
+node --test src/config/defaults.test.ts src/config/load.test.ts
+```
+
+Expected: failures report that `workflow` is missing from
+`DEFAULT_PATCHMILL_CONFIG` and parser output.
+
+- [ ] **Step 4: Add workflow config types**
+
+In `src/config/types.ts`, add these types after `PatchmillTriageConfig` and add
+`workflow` to `PatchmillConfig`:
+
+```ts
+export type PatchmillWorkflowApprovalConfig = {
+  required?: boolean;
+  reviewLabel: string;
+  approvedLabel: string;
+};
+
+export type PatchmillWorkflowConfig = {
+  specApproval: PatchmillWorkflowApprovalConfig;
+  planApproval: PatchmillWorkflowApprovalConfig;
+};
+```
+
+Update `PatchmillConfig`:
+
+```ts
+export type PatchmillConfig = {
+  host: PatchmillHostConfig;
+  pi: PatchmillPiConfig;
+  labels: PatchmillLabelsConfig;
+  triage: PatchmillTriageConfig;
+  workflow: PatchmillWorkflowConfig;
+  skills: PatchmillSkillsConfig;
+  paths: PatchmillPathsConfig;
+  git: PatchmillGitConfig;
+  cleanupHook?: string;
+  projectPolicy: PatchmillProjectPolicyConfig;
+};
+```
+
+- [ ] **Step 5: Add default workflow config**
+
+In `src/config/defaults.ts`, add a constant after `DEFAULT_PATCHMILL_LABELS`:
+
+```ts
+const DEFAULT_PATCHMILL_WORKFLOW = {
+  specApproval: {
+    reviewLabel: "spec-review",
+    approvedLabel: "spec-approved",
+  },
+  planApproval: {
+    reviewLabel: "plan-review",
+    approvedLabel: "plan-approved",
+  },
+};
+```
+
+Then add it to `DEFAULT_PATCHMILL_CONFIG` after `triage`:
+
+```ts
+workflow: DEFAULT_PATCHMILL_WORKFLOW,
+```
+
+- [ ] **Step 6: Implement workflow config cloning and merging**
+
+In `src/config/load.ts`, add these type aliases below `PartialProjectPolicy`:
+
+```ts
+type PartialWorkflowApprovalConfig = Partial<
+  PatchmillConfig["workflow"]["specApproval"]
+>;
+
+type PartialWorkflowConfig = Partial<{
+  specApproval: PartialWorkflowApprovalConfig;
+  planApproval: PartialWorkflowApprovalConfig;
+}>;
+```
+
+Add `workflow` to `PartialConfig`:
+
+```ts
+workflow: PartialWorkflowConfig;
+```
+
+Add these helpers near the other clone and merge helpers:
+
+```ts
+function cloneWorkflowApprovalConfig(
+  approval: PatchmillConfig["workflow"]["specApproval"],
+): PatchmillConfig["workflow"]["specApproval"] {
+  return {
+    ...(approval.required !== undefined ? { required: approval.required } : {}),
+    reviewLabel: approval.reviewLabel,
+    approvedLabel: approval.approvedLabel,
+  };
+}
+
+function mergeWorkflowApprovalConfig(
+  base: PatchmillConfig["workflow"]["specApproval"],
+  update: PartialWorkflowApprovalConfig | undefined,
+): PatchmillConfig["workflow"]["specApproval"] {
+  return {
+    ...(update?.required !== undefined
+      ? { required: update.required }
+      : base.required !== undefined
+        ? { required: base.required }
+        : {}),
+    reviewLabel: update?.reviewLabel ?? base.reviewLabel,
+    approvedLabel: update?.approvedLabel ?? base.approvedLabel,
+  };
+}
+
+function cloneWorkflowConfig(
+  workflow: PatchmillConfig["workflow"],
+): PatchmillConfig["workflow"] {
+  return {
+    specApproval: cloneWorkflowApprovalConfig(workflow.specApproval),
+    planApproval: cloneWorkflowApprovalConfig(workflow.planApproval),
+  };
+}
+
+function mergeWorkflowConfig(
+  base: PatchmillConfig["workflow"],
+  update: PartialWorkflowConfig | undefined,
+): PatchmillConfig["workflow"] {
+  return {
+    specApproval: mergeWorkflowApprovalConfig(
+      base.specApproval,
+      update?.specApproval,
+    ),
+    planApproval: mergeWorkflowApprovalConfig(
+      base.planApproval,
+      update?.planApproval,
+    ),
+  };
+}
+```
+
+In `mergeConfig`, include:
+
+```ts
+workflow: mergeWorkflowConfig(base.workflow, update.workflow),
+```
+
+In `absolutizePaths`, include a clone:
+
+```ts
+workflow: cloneWorkflowConfig(config.workflow),
+```
+
+- [ ] **Step 7: Implement workflow config parsing**
+
+In `src/config/load.ts`, add this helper near `readTriageConfig`:
+
+```ts
+function readWorkflowApprovalConfig(
+  source: Record<string, unknown>,
+  key: "specApproval" | "planApproval",
+): PartialWorkflowApprovalConfig | undefined {
+  const value = readOptionalSection(source, key);
+  if (!value) return undefined;
+
+  const parsed: PartialWorkflowApprovalConfig = {};
+  const required = readOptionalBoolean(
+    value,
+    "required",
+    `workflow.${key}.required`,
+  );
+  const reviewLabel = readOptionalString(
+    value,
+    "reviewLabel",
+    `workflow.${key}.reviewLabel`,
+  );
+  const approvedLabel = readOptionalString(
+    value,
+    "approvedLabel",
+    `workflow.${key}.approvedLabel`,
+  );
+
+  if (required !== undefined) parsed.required = required;
+  if (reviewLabel !== undefined) parsed.reviewLabel = reviewLabel;
+  if (approvedLabel !== undefined) parsed.approvedLabel = approvedLabel;
+
+  for (const entry of Object.keys(value)) {
+    if (!["required", "reviewLabel", "approvedLabel"].includes(entry)) {
+      throw configError(
+        `workflow.${key}.${entry}`,
+        "a supported workflow approval setting",
+        value[entry],
+      );
+    }
+  }
+
+  return hasEntries(parsed) ? parsed : undefined;
+}
+
+function readWorkflowConfig(
+  source: Record<string, unknown>,
+): PartialWorkflowConfig | undefined {
+  const value = source.workflow;
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw configError("workflow", "an object", value);
+
+  const parsed: PartialWorkflowConfig = {};
+  const specApproval = readWorkflowApprovalConfig(value, "specApproval");
+  const planApproval = readWorkflowApprovalConfig(value, "planApproval");
+  if (specApproval !== undefined) parsed.specApproval = specApproval;
+  if (planApproval !== undefined) parsed.planApproval = planApproval;
+
+  for (const entry of Object.keys(value)) {
+    if (!["specApproval", "planApproval"].includes(entry)) {
+      throw configError(
+        `workflow.${entry}`,
+        "a supported workflow setting",
+        value[entry],
+      );
+    }
+  }
+
+  return hasEntries(parsed) ? parsed : undefined;
+}
+```
+
+Call it in `parseConfigFile` after `readTriageConfig(data)`:
+
+```ts
+const workflow = readWorkflowConfig(data);
+if (workflow !== undefined) {
+  config.workflow = workflow;
+}
+```
+
+- [ ] **Step 8: Run config tests and commit**
+
+Run:
+
+```bash
+node --test src/config/defaults.test.ts src/config/load.test.ts
+npm run lint:ts
+```
+
+Expected: config tests pass and TypeScript lint reports no errors.
+
+Commit:
+
+```bash
+git add src/config/types.ts src/config/defaults.ts src/config/defaults.test.ts src/config/load.ts src/config/load.test.ts
+git commit -m "feat(config): add workflow approval config"
+```
+
+## Task 2: Normalize approval policy and aggregate workflow labels
+
+**Files:**
+
+- Create: `src/workflow/approval-policy.ts`
+- Create: `src/workflow/approval-policy.test.ts`
+- Modify: `src/cli/commands/triage/labels.ts`
+- Modify: `src/cli/commands/triage/labels.test.ts`
+- Modify: `src/cli/commands/labels/setup.ts`
+- Modify: `src/cli/commands/labels/setup.test.ts`
+- Modify: `src/cli/commands/init/main.ts`
+- Modify: `src/cli/commands/init/main.test.ts`
+- Modify: `src/cli/commands/doctor/main.ts`
+- Modify: `src/cli/commands/doctor/checks.ts`
+
+- [ ] **Step 1: Write failing approval-policy tests**
+
+Create `src/workflow/approval-policy.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_PATCHMILL_CONFIG } from "../config/defaults.ts";
+import { createTriagePolicy } from "../policy/triage.ts";
+import { createWorkflowApprovalPolicy } from "./approval-policy.ts";
+
+const projectPolicy = DEFAULT_PATCHMILL_CONFIG.projectPolicy;
+
+test("createWorkflowApprovalPolicy defaults both gates to not required", () => {
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    { ...projectPolicy, planRequiresApproval: false },
+  );
+
+  assert.equal(policy.specApproval.required, false);
+  assert.equal(policy.specApproval.reviewLabel, "spec-review");
+  assert.equal(policy.specApproval.approvedLabel, "spec-approved");
+  assert.equal(policy.planApproval.required, false);
+  assert.equal(policy.planApproval.reviewLabel, "plan-review");
+  assert.equal(policy.planApproval.approvedLabel, "plan-approved");
+});
+
+test("createWorkflowApprovalPolicy treats projectPolicy.planRequiresApproval as plan alias", () => {
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    { ...projectPolicy, planRequiresApproval: true },
+  );
+
+  assert.equal(policy.planApproval.required, true);
+});
+
+test("createWorkflowApprovalPolicy lets workflow.planApproval.required override the alias", () => {
+  const policy = createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      planApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+        required: false,
+      },
+    },
+    { ...projectPolicy, planRequiresApproval: true },
+  );
+
+  assert.equal(policy.planApproval.required, false);
+});
+
+test("createWorkflowApprovalPolicy exposes workflow label definitions outside triage labels", () => {
+  const triagePolicy = createTriagePolicy(
+    DEFAULT_PATCHMILL_CONFIG.labels,
+    DEFAULT_PATCHMILL_CONFIG.triage,
+  );
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    projectPolicy,
+  );
+
+  assert.deepEqual(
+    policy.labelDefinitions.map((label) => label.name),
+    ["spec-review", "spec-approved", "plan-review", "plan-approved"],
+  );
+  assert.equal(
+    triagePolicy.allowedLabels.some((label) => label.name === "spec-review"),
+    false,
+  );
+});
+```
+
+- [ ] **Step 2: Write failing label aggregation tests**
+
+In `src/cli/commands/triage/labels.test.ts`, add:
+
+```ts
+test("missingLabelDefinitions can include workflow approval labels", () => {
+  const workflowLabels = [
+    {
+      name: "spec-review",
+      color: "#5319e7",
+      description: "Awaiting specification review",
+    },
+    {
+      name: "spec-approved",
+      color: "#0e8a16",
+      description: "Specification approved for automation",
+    },
+  ];
+
+  const missing = missingLabelDefinitions(
+    [ready, "bug"],
+    undefined,
+    workflowLabels,
+  );
+
+  assert.ok(missing.some((label) => label.name === "needs-info"));
+  assert.ok(missing.some((label) => label.name === "spec-review"));
+  assert.ok(missing.some((label) => label.name === "spec-approved"));
+});
+```
+
+In `src/cli/commands/labels/setup.test.ts`, add:
+
+```ts
+test("ensureRequiredLabels creates extra workflow labels with triage labels", async () => {
+  const { host, created } = fakeHost({ existingLabels: requiredLabelNames });
+
+  const result = await ensureRequiredLabels({
+    host,
+    policy,
+    extraLabels: [
+      {
+        name: "plan-review",
+        color: "#5319e7",
+        description: "Awaiting implementation plan review",
+      },
+    ],
+    isInteractive: false,
+    assumeYes: true,
+    command: "doctor",
+  });
+
+  assert.equal(result.status, "created");
+  assert.deepEqual(created, ["plan-review"]);
+});
+```
+
+- [ ] **Step 3: Run the failing policy and label tests**
+
+Run:
+
+```bash
+node --test src/workflow/approval-policy.test.ts src/cli/commands/triage/labels.test.ts src/cli/commands/labels/setup.test.ts
+```
+
+Expected: failures report the missing approval-policy module and missing
+`extraLabels` support.
+
+- [ ] **Step 4: Implement normalized approval policy**
+
+Create `src/workflow/approval-policy.ts`:
+
+```ts
+import type { PatchmillWorkflowConfig } from "../config/types.ts";
+import type { LabelDefinition } from "../host/types.ts";
+import type { PatchmillProjectPolicy } from "../policy/types.ts";
+
+export type WorkflowApprovalKind = "spec" | "plan";
+
+export type WorkflowApprovalStagePolicy = {
+  kind: WorkflowApprovalKind;
+  required: boolean;
+  reviewLabel: string;
+  approvedLabel: string;
+};
+
+export type WorkflowApprovalPolicy = {
+  specApproval: WorkflowApprovalStagePolicy;
+  planApproval: WorkflowApprovalStagePolicy;
+  labelDefinitions: LabelDefinition[];
+};
+
+function workflowLabelDefinition(
+  name: string,
+  color: string,
+  description: string,
+): LabelDefinition {
+  return { name, color, description };
+}
+
+function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
+  const seen = new Set<string>();
+  return labels.filter((label) => {
+    if (seen.has(label.name)) return false;
+    seen.add(label.name);
+    return true;
+  });
+}
+
+export function createWorkflowApprovalPolicy(
+  workflow: PatchmillWorkflowConfig,
+  projectPolicy: Pick<PatchmillProjectPolicy, "planRequiresApproval">,
+): WorkflowApprovalPolicy {
+  const specApproval: WorkflowApprovalStagePolicy = {
+    kind: "spec",
+    required: workflow.specApproval.required ?? false,
+    reviewLabel: workflow.specApproval.reviewLabel,
+    approvedLabel: workflow.specApproval.approvedLabel,
+  };
+  const planApproval: WorkflowApprovalStagePolicy = {
+    kind: "plan",
+    required:
+      workflow.planApproval.required ?? projectPolicy.planRequiresApproval,
+    reviewLabel: workflow.planApproval.reviewLabel,
+    approvedLabel: workflow.planApproval.approvedLabel,
+  };
+
+  return {
+    specApproval,
+    planApproval,
+    labelDefinitions: dedupeLabelDefinitions([
+      workflowLabelDefinition(
+        specApproval.reviewLabel,
+        "#5319e7",
+        "Awaiting specification review",
+      ),
+      workflowLabelDefinition(
+        specApproval.approvedLabel,
+        "#0e8a16",
+        "Specification approved for automation",
+      ),
+      workflowLabelDefinition(
+        planApproval.reviewLabel,
+        "#5319e7",
+        "Awaiting implementation plan review",
+      ),
+      workflowLabelDefinition(
+        planApproval.approvedLabel,
+        "#0e8a16",
+        "Implementation plan approved for automation",
+      ),
+    ]),
+  };
+}
+```
+
+- [ ] **Step 5: Add extra label aggregation**
+
+In `src/cli/commands/triage/labels.ts`, change `missingLabelDefinitions` to
+accept extra definitions:
+
+```ts
+function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
+  const seen = new Set<string>();
+  return labels.filter((label) => {
+    if (seen.has(label.name)) return false;
+    seen.add(label.name);
+    return true;
+  });
+}
+
+export function missingLabelDefinitions(
+  existingNames: string[],
+  triagePolicy = DEFAULT_TRIAGE_POLICY,
+  extraLabels: readonly LabelDefinition[] = [],
+): LabelDefinition[] {
+  const existing = new Set(existingNames);
+  return dedupeLabelDefinitions([
+    ...triagePolicy.allowedLabels,
+    ...extraLabels,
+  ]).filter((label) => !existing.has(label.name));
+}
+```
+
+In `src/cli/commands/labels/setup.ts`, add `extraLabels` to options:
+
+```ts
+export type LabelSetupOptions = {
+  host: IssueHostProvider;
+  policy: PatchmillTriagePolicy;
+  extraLabels?: readonly LabelDefinition[];
+  prompt?: (question: string) => Promise<string>;
+  isInteractive: boolean;
+  assumeYes: boolean;
+  command: "init" | "doctor";
+};
+```
+
+Pass it into `missingLabelDefinitions`:
+
+```ts
+const missing = missingLabelDefinitions(
+  await options.host.listLabels(),
+  options.policy,
+  options.extraLabels,
+);
+```
+
+- [ ] **Step 6: Wire label setup and doctor to workflow labels**
+
+In `src/cli/commands/init/main.ts`, import `createWorkflowApprovalPolicy` and
+build extra labels from `result.config`:
+
+```ts
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+```
+
+Replace the label policy block with:
+
+```ts
+const policy = createTriagePolicy(result.config.labels, result.config.triage);
+const approvalPolicy = createWorkflowApprovalPolicy(
+  result.config.workflow,
+  result.config.projectPolicy,
+);
+const labelSetup = await (options.setupLabels ?? ensureRequiredLabels)({
+  host,
+  policy,
+  extraLabels: approvalPolicy.labelDefinitions,
+  prompt: options.prompt ?? defaultPrompt,
+  isInteractive,
+  assumeYes: config.yes,
+  command: "init",
+});
+```
+
+In `src/cli/commands/doctor/main.ts`, import `createWorkflowApprovalPolicy` and
+pass extra labels to `ensureRequiredLabels`:
+
+```ts
+const policy = createTriagePolicy(loaded.config.labels, loaded.config.triage);
+const approvalPolicy = createWorkflowApprovalPolicy(
+  loaded.config.workflow,
+  loaded.config.projectPolicy,
+);
+const result = await ensureRequiredLabels({
+  host,
+  policy,
+  extraLabels: approvalPolicy.labelDefinitions,
+  prompt: promptLine,
+  isInteractive,
+  assumeYes: args.yes,
+  command: "doctor",
+});
+```
+
+In `src/cli/commands/doctor/checks.ts`, import `createWorkflowApprovalPolicy`,
+compute it before the label check, and pass its label definitions to
+`missingLabelDefinitions`:
+
+```ts
+const policy = createTriagePolicy(config.labels, config.triage);
+const approvalPolicy = createWorkflowApprovalPolicy(
+  config.workflow,
+  config.projectPolicy,
+);
+const allLabelDefinitions = [
+  ...policy.allowedLabels,
+  ...approvalPolicy.labelDefinitions,
+];
+const missing = missingLabelDefinitions(
+  await host.listLabels(),
+  policy,
+  approvalPolicy.labelDefinitions,
+);
+if (missing.length === 0) {
+  results.push(
+    pass("labels", allLabelDefinitions.map((label) => label.name).join(", ")),
+  );
+} else {
+  results.push(
+    fail("labels", `missing ${missing.map((label) => label.name).join(", ")}`, [
+      "Patchmill doctor is read-only and did not create labels.",
+      "",
+      "Run the approved repair flow:",
+      "  patchmill doctor --fix",
+      "",
+      "You can edit label names in patchmill.config.json before running --fix.",
+    ]),
+  );
+}
+```
+
+- [ ] **Step 7: Update affected label setup expectations**
+
+In `src/cli/commands/labels/setup.test.ts`, keep tests that use no `extraLabels`
+unchanged. In init and doctor tests where mock `setupLabels` or label messages
+assert the options shape, add assertions that
+`extraLabels.map((label) => label.name)` equals:
+
+```ts
+["spec-review", "spec-approved", "plan-review", "plan-approved"];
+```
+
+When a test uses full default label counts after calling the real
+`ensureRequiredLabels` with extra labels, update the expected count from `15` to
+`19` and assert the four workflow names are present.
+
+- [ ] **Step 8: Run policy and label tests, then commit**
+
+Run:
+
+```bash
+node --test src/workflow/approval-policy.test.ts src/cli/commands/triage/labels.test.ts src/cli/commands/labels/setup.test.ts src/cli/commands/init/main.test.ts src/cli/commands/doctor/main.test.ts src/cli/commands/doctor/checks.test.ts
+npm run lint:ts
+```
+
+Expected: all listed tests pass and TypeScript lint reports no errors.
+
+Commit:
+
+```bash
+git add src/workflow/approval-policy.ts src/workflow/approval-policy.test.ts src/cli/commands/triage/labels.ts src/cli/commands/triage/labels.test.ts src/cli/commands/labels/setup.ts src/cli/commands/labels/setup.test.ts src/cli/commands/init/main.ts src/cli/commands/init/main.test.ts src/cli/commands/doctor/main.ts src/cli/commands/doctor/checks.ts
+git commit -m "feat(workflow): normalize approval policy labels"
+```
+
+## Task 3: Wire approval policy through run-once CLI config
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/types.ts`
+- Modify: `src/cli/commands/run-once/args.ts`
+- Modify: `src/cli/commands/run-once/args.test.ts`
+- Modify: `src/cli/commands/run-once/main.ts`
+
+- [ ] **Step 1: Write failing run-once config and summary tests**
+
+In `src/cli/commands/run-once/args.test.ts`, replace the default
+`requirePlanApproval` expectation in
+`parseArgs executes by default when no args are provided` with:
+
+```ts
+assert.equal(config.approvalPolicy.specApproval.required, false);
+assert.equal(config.approvalPolicy.planApproval.required, false);
+assert.equal(config.approvalPolicy.planApproval.approvedLabel, "plan-approved");
+```
+
+Add this test near the existing `loadCliConfig` tests:
+
+```ts
+test("loadCliConfig resolves workflow plan approval ahead of legacy project policy", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-run-once-approval-"),
+  );
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        specApproval: { required: true, approvedLabel: "spec-ok" },
+        planApproval: { required: false, approvedLabel: "plan-ok" },
+      },
+      projectPolicy: { planRequiresApproval: true },
+    }),
+    "utf8",
+  );
+
+  const config = await loadCliConfig(["--dry-run"], repoRoot, {});
+
+  assert.equal(config.approvalPolicy.specApproval.required, true);
+  assert.equal(config.approvalPolicy.specApproval.approvedLabel, "spec-ok");
+  assert.equal(config.approvalPolicy.planApproval.required, false);
+  assert.equal(config.approvalPolicy.planApproval.approvedLabel, "plan-ok");
+});
+```
+
+Add a `summarizeResult` test:
+
+```ts
+test("summarizeResult includes approval-required details", () => {
+  assert.deepEqual(
+    summarizeResult({
+      status: "approval-required",
+      issue: {
+        number: 42,
+        title: "Needs spec approval",
+        body: "Body",
+        labels: ["agent-ready"],
+        state: "open",
+      },
+      approvalKind: "spec",
+      missingLabel: "spec-approved",
+      logPath: ".patchmill/runs/run.jsonl",
+    }),
+    {
+      status: "approval-required",
+      issueNumber: 42,
+      approvalKind: "spec",
+      missingLabel: "spec-approved",
+      logPath: ".patchmill/runs/run.jsonl",
+    },
+  );
+});
+```
+
+- [ ] **Step 2: Run the failing run-once args tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/args.test.ts
+```
+
+Expected: failures report missing `approvalPolicy` and missing
+`approval-required` summary support.
+
+- [ ] **Step 3: Update run-once types**
+
+In `src/cli/commands/run-once/types.ts`, import `WorkflowApprovalPolicy`:
+
+```ts
+import type { WorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+```
+
+Replace `requirePlanApproval: boolean;` in `AgentIssueConfig` with:
+
+```ts
+approvalPolicy: WorkflowApprovalPolicy;
+```
+
+Add this result type after `AgentIssuePlanCreatedResult`:
+
+```ts
+export type AgentIssueApprovalRequiredResult = {
+  status: "approval-required";
+  issue: IssueSummary;
+  approvalKind: "spec" | "plan";
+  missingLabel: string;
+};
+```
+
+Add it to `AgentIssuePipelineResult` before the `blocked` case:
+
+```ts
+| AgentIssueApprovalRequiredResult
+```
+
+- [ ] **Step 4: Build approval policy in parseArgs**
+
+In `src/cli/commands/run-once/args.ts`, import the approval policy factory:
+
+```ts
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+```
+
+In `parseArgs`, compute the policy after `projectPolicy`:
+
+```ts
+const approvalPolicy = createWorkflowApprovalPolicy(
+  patchmillConfig.workflow,
+  projectPolicy,
+);
+```
+
+Replace `requirePlanApproval: projectPolicy.planRequiresApproval,` with:
+
+```ts
+approvalPolicy,
+```
+
+- [ ] **Step 5: Summarize approval-required JSON**
+
+In `src/cli/commands/run-once/main.ts`, add the JSON result variant:
+
+```ts
+| {
+    status: "approval-required";
+    issueNumber: number;
+    approvalKind: "spec" | "plan";
+    missingLabel: string;
+  }
+```
+
+In `summarizeResult`, add this case before `blocked`:
+
+```ts
+case "approval-required":
+  return {
+    status: result.status,
+    issueNumber: result.issue.number,
+    approvalKind: result.approvalKind,
+    missingLabel: result.missingLabel,
+    ...withLogPath,
+  };
+```
+
+In `main`, make approval-required a non-zero completion like blocked:
+
+```ts
+return result.status === "blocked" || result.status === "approval-required"
+  ? 1
+  : 0;
+```
+
+- [ ] **Step 6: Update run-once tests that construct configs**
+
+In `src/cli/commands/run-once/pipeline.test.ts`, import
+`createWorkflowApprovalPolicy` and update `makeConfig` to set `approvalPolicy`:
+
+```ts
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+```
+
+Inside `makeConfig`, replace `requirePlanApproval: false,` with:
+
+```ts
+approvalPolicy: createWorkflowApprovalPolicy(
+  DEFAULT_PATCHMILL_CONFIG.workflow,
+  DEFAULT_PATCHMILL_POLICY,
+),
+```
+
+For tests that currently pass `{ requirePlanApproval: true }`, replace the
+override with:
+
+```ts
+approvalPolicy: createWorkflowApprovalPolicy(
+  {
+    ...DEFAULT_PATCHMILL_CONFIG.workflow,
+    planApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+      required: true,
+    },
+  },
+  DEFAULT_PATCHMILL_POLICY,
+),
+```
+
+- [ ] **Step 7: Run run-once args tests and commit**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/args.test.ts src/cli/commands/run-once/pipeline.test.ts --test-name-pattern="plan approval|required|parseArgs|loadCliConfig|summarizeResult"
+npm run lint:ts
+```
+
+Expected: focused run-once tests pass and TypeScript lint reports no errors.
+
+Commit:
+
+```bash
+git add src/cli/commands/run-once/types.ts src/cli/commands/run-once/args.ts src/cli/commands/run-once/args.test.ts src/cli/commands/run-once/main.ts src/cli/commands/run-once/pipeline.test.ts
+git commit -m "feat(run-once): pass approval policy through config"
+```
+
+## Task 4: Add spec approval selection gates
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/approval-gates.ts`
+- Create: `src/cli/commands/run-once/approval-gates.test.ts`
+- Modify: `src/cli/commands/run-once/selection.ts`
+- Modify: `src/cli/commands/run-once/selection.test.ts`
+
+- [ ] **Step 1: Write failing approval-gates tests for spec approval**
+
+Create `src/cli/commands/run-once/approval-gates.test.ts` with these initial
+tests:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import {
+  ApprovalRequiredError,
+  assertExplicitIssueApprovals,
+  issueMeetsAutomaticApprovals,
+} from "./approval-gates.ts";
+import type { IssueSummary } from "./types.ts";
+
+function approvalPolicy(overrides = {}) {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      specApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+        required: true,
+        ...overrides,
+      },
+    },
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+}
+
+function issue(labels: string[]): IssueSummary {
+  return { number: 7, title: "Issue", body: "Body", labels, state: "open" };
+}
+
+test("issueMeetsAutomaticApprovals accepts missing spec approval when the gate is disabled", () => {
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+
+  assert.equal(
+    issueMeetsAutomaticApprovals(issue(["agent-ready"]), policy),
+    true,
+  );
+});
+
+test("issueMeetsAutomaticApprovals filters missing spec approval when required", () => {
+  const policy = approvalPolicy();
+
+  assert.equal(
+    issueMeetsAutomaticApprovals(issue(["agent-ready"]), policy),
+    false,
+  );
+  assert.equal(
+    issueMeetsAutomaticApprovals(
+      issue(["agent-ready", "spec-approved"]),
+      policy,
+    ),
+    true,
+  );
+});
+
+test("assertExplicitIssueApprovals throws a typed missing-spec approval error", () => {
+  const policy = approvalPolicy({ approvedLabel: "spec-ok" });
+
+  assert.throws(
+    () => assertExplicitIssueApprovals(issue(["agent-ready"]), policy),
+    (error: unknown) => {
+      assert(error instanceof ApprovalRequiredError);
+      assert.equal(error.approvalKind, "spec");
+      assert.equal(error.missingLabel, "spec-ok");
+      assert.equal(error.issue.number, 7);
+      return true;
+    },
+  );
+});
+```
+
+- [ ] **Step 2: Write failing selection tests**
+
+In `src/cli/commands/run-once/selection.test.ts`, import
+`createWorkflowApprovalPolicy` and add:
+
+```ts
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import { ApprovalRequiredError } from "./approval-gates.ts";
+```
+
+Add helper:
+
+```ts
+function specApprovalPolicy(approvedLabel = "spec-approved") {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      specApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+        required: true,
+        approvedLabel,
+      },
+    },
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+}
+```
+
+Add tests:
+
+```ts
+test("selectIssue skips spec-unapproved automatic candidates and can choose lower priority approved work", () => {
+  const selected = selectIssue(
+    [issue(1, [ready, critical]), issue(2, [ready, high, "spec-approved"])],
+    { readyLabel: ready, approvalPolicy: specApprovalPolicy() },
+  );
+
+  assert.equal(selected?.number, 2);
+});
+
+test("selectIssue rejects explicit issue missing required spec approval", () => {
+  assert.throws(
+    () =>
+      selectIssue([issue(5, [ready])], {
+        readyLabel: ready,
+        issueNumber: 5,
+        approvalPolicy: specApprovalPolicy("spec-ok"),
+      }),
+    (error: unknown) => {
+      assert(error instanceof ApprovalRequiredError);
+      assert.equal(error.missingLabel, "spec-ok");
+      return true;
+    },
+  );
+});
+```
+
+- [ ] **Step 3: Run the failing gate and selection tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/approval-gates.test.ts src/cli/commands/run-once/selection.test.ts
+```
+
+Expected: failures report the missing approval-gates module and unsupported
+`approvalPolicy` selection option.
+
+- [ ] **Step 4: Implement spec approval helpers**
+
+Create `src/cli/commands/run-once/approval-gates.ts`:
+
+```ts
+import type { WorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import type { IssueSummary } from "./types.ts";
+
+export class ApprovalRequiredError extends Error {
+  readonly name = "ApprovalRequiredError";
+
+  constructor(
+    readonly issue: IssueSummary,
+    readonly approvalKind: "spec" | "plan",
+    readonly missingLabel: string,
+  ) {
+    super(
+      `Issue #${issue.number} requires ${approvalKind} approval label ${missingLabel}`,
+    );
+  }
+}
+
+export function issueMeetsAutomaticApprovals(
+  issue: IssueSummary,
+  policy: WorkflowApprovalPolicy | undefined,
+): boolean {
+  if (!policy?.specApproval.required) return true;
+  return issue.labels.includes(policy.specApproval.approvedLabel);
+}
+
+export function assertExplicitIssueApprovals(
+  issue: IssueSummary,
+  policy: WorkflowApprovalPolicy | undefined,
+): void {
+  if (!policy?.specApproval.required) return;
+  if (issue.labels.includes(policy.specApproval.approvedLabel)) return;
+  throw new ApprovalRequiredError(
+    issue,
+    "spec",
+    policy.specApproval.approvedLabel,
+  );
+}
+```
+
+- [ ] **Step 5: Wire selection to spec approval helpers**
+
+In `src/cli/commands/run-once/types.ts`, add `approvalPolicy` to
+`IssueSelectionOptions`:
+
+```ts
+export type IssueSelectionOptions = Pick<
+  AgentIssueConfig,
+  "issueNumber" | "readyLabel" | "triagePolicy" | "approvalPolicy"
+> & {
+  priorityLabels?: readonly string[];
+  excludedLabels?: readonly string[];
+};
+```
+
+In `src/cli/commands/run-once/selection.ts`, import helpers:
+
+```ts
+import {
+  assertExplicitIssueApprovals,
+  issueMeetsAutomaticApprovals,
+} from "./approval-gates.ts";
+```
+
+Add `approvalPolicy` to `ResolvedIssueSelectionOptions`:
+
+```ts
+approvalPolicy: IssueSelectionOptions["approvalPolicy"];
+```
+
+Set it in `resolveSelectionOptions`:
+
+```ts
+approvalPolicy: options.approvalPolicy,
+```
+
+Update automatic eligibility:
+
+```ts
+function isEligible(
+  issue: IssueSummary,
+  options: ResolvedIssueSelectionOptions,
+): boolean {
+  return (
+    issue.state === "open" &&
+    issue.labels.includes(options.readyLabel) &&
+    blockingLabels(issue.labels, options.excludedLabels).length === 0 &&
+    issueMeetsAutomaticApprovals(issue, options.approvalPolicy)
+  );
+}
+```
+
+In explicit selection, after blocked-label checks and before `return issue;`,
+add:
+
+```ts
+assertExplicitIssueApprovals(issue, resolved.approvalPolicy);
+```
+
+- [ ] **Step 6: Run gate and selection tests, then commit**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/approval-gates.test.ts src/cli/commands/run-once/selection.test.ts
+npm run lint:ts
+```
+
+Expected: all listed tests pass and TypeScript lint reports no errors.
+
+Commit:
+
+```bash
+git add src/cli/commands/run-once/approval-gates.ts src/cli/commands/run-once/approval-gates.test.ts src/cli/commands/run-once/types.ts src/cli/commands/run-once/selection.ts src/cli/commands/run-once/selection.test.ts
+git commit -m "feat(run-once): gate selection on spec approval"
+```
+
+## Task 5: Model plan approval stop and approved-plan resume decisions
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/approval-gates.ts`
+- Modify: `src/cli/commands/run-once/approval-gates.test.ts`
+
+- [ ] **Step 1: Write failing plan approval decision tests**
+
+Append these tests to `src/cli/commands/run-once/approval-gates.test.ts`:
+
+```ts
+import {
+  approvedWorkflowReviewLabelsToRemove,
+  decidePlanApprovalGate,
+} from "./approval-gates.ts";
+
+function planApprovalPolicy(
+  required: boolean,
+  approvedLabel = "plan-approved",
+) {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      planApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+        required,
+        approvedLabel,
+      },
+    },
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+}
+
+test("decidePlanApprovalGate proceeds when plan approval is disabled", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["agent-ready"],
+    planOnly: false,
+    policy: planApprovalPolicy(false),
+  });
+
+  assert.deepEqual(decision, { action: "proceed" });
+});
+
+test("decidePlanApprovalGate stops for review when plan approval is required and missing", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress"],
+    planOnly: false,
+    policy: planApprovalPolicy(true),
+  });
+
+  assert.deepEqual(decision, {
+    action: "stop-for-plan-review",
+    reviewLabel: "plan-review",
+    missingLabel: "plan-approved",
+  });
+});
+
+test("decidePlanApprovalGate proceeds when the approved plan label is present", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress", "plan-approved"],
+    planOnly: false,
+    policy: planApprovalPolicy(true),
+  });
+
+  assert.deepEqual(decision, { action: "proceed" });
+});
+
+test("decidePlanApprovalGate stops for plan-only without workflow review labels", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress"],
+    planOnly: true,
+    policy: planApprovalPolicy(false),
+  });
+
+  assert.deepEqual(decision, { action: "stop-for-plan-only" });
+});
+
+test("approvedWorkflowReviewLabelsToRemove clears active plan review after approval", () => {
+  const labels = approvedWorkflowReviewLabelsToRemove(
+    ["agent-ready", "plan-review", "plan-approved"],
+    planApprovalPolicy(true),
+  );
+
+  assert.deepEqual(labels, ["plan-review"]);
+});
+```
+
+- [ ] **Step 2: Run the failing approval-gates tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/approval-gates.test.ts
+```
+
+Expected: failures report missing plan approval decision exports.
+
+- [ ] **Step 3: Implement plan approval decisions**
+
+In `src/cli/commands/run-once/approval-gates.ts`, add these types and helpers:
+
+```ts
+export type PlanApprovalGateDecision =
+  | { action: "proceed" }
+  | { action: "stop-for-plan-only" }
+  | {
+      action: "stop-for-plan-review";
+      reviewLabel: string;
+      missingLabel: string;
+    };
+
+export function decidePlanApprovalGate(options: {
+  labels: string[];
+  planOnly: boolean;
+  policy: WorkflowApprovalPolicy;
+}): PlanApprovalGateDecision {
+  if (options.planOnly) return { action: "stop-for-plan-only" };
+  const approval = options.policy.planApproval;
+  if (!approval.required) return { action: "proceed" };
+  if (options.labels.includes(approval.approvedLabel)) {
+    return { action: "proceed" };
+  }
+  return {
+    action: "stop-for-plan-review",
+    reviewLabel: approval.reviewLabel,
+    missingLabel: approval.approvedLabel,
+  };
+}
+
+export function approvedWorkflowReviewLabelsToRemove(
+  labels: string[],
+  policy: WorkflowApprovalPolicy,
+): string[] {
+  const remove: string[] = [];
+  if (
+    labels.includes(policy.planApproval.reviewLabel) &&
+    labels.includes(policy.planApproval.approvedLabel)
+  ) {
+    remove.push(policy.planApproval.reviewLabel);
+  }
+  return remove;
+}
+```
+
+- [ ] **Step 4: Run approval-gates tests and commit**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/approval-gates.test.ts
+npm run lint:ts
+```
+
+Expected: approval-gates tests pass and TypeScript lint reports no errors.
+
+Commit:
+
+```bash
+git add src/cli/commands/run-once/approval-gates.ts src/cli/commands/run-once/approval-gates.test.ts
+git commit -m "feat(run-once): model approval gate decisions"
+```
+
+## Task 6: Apply approval gates in the run-once pipeline
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.ts`
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+
+- [ ] **Step 1: Write failing pipeline tests for spec approval**
+
+In `src/cli/commands/run-once/pipeline.test.ts`, add this helper near
+`makeConfig`:
+
+```ts
+function approvalPolicy(
+  overrides: {
+    specRequired?: boolean;
+    specApprovedLabel?: string;
+    planRequired?: boolean;
+    planReviewLabel?: string;
+    planApprovedLabel?: string;
+  } = {},
+) {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      specApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+        required: overrides.specRequired,
+        approvedLabel:
+          overrides.specApprovedLabel ??
+          DEFAULT_PATCHMILL_CONFIG.workflow.specApproval.approvedLabel,
+      },
+      planApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+        required: overrides.planRequired,
+        reviewLabel:
+          overrides.planReviewLabel ??
+          DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.reviewLabel,
+        approvedLabel:
+          overrides.planApprovedLabel ??
+          DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.approvedLabel,
+      },
+    },
+    DEFAULT_PATCHMILL_POLICY,
+  );
+}
+```
+
+Add tests near the existing selection tests:
+
+```ts
+test("runOneIssue automatic selection skips spec-unapproved issues", async () => {
+  const config = await makeConfig({
+    approvalPolicy: approvalPolicy({ specRequired: true }),
+  });
+  const runner = createMockRunner((call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout:
+          page === "1"
+            ? issueListPayload([
+                issue(1, ["agent-ready", "priority:critical"], "Needs spec"),
+                issue(
+                  2,
+                  ["agent-ready", "priority:high", "spec-approved"],
+                  "Spec approved",
+                ),
+              ])
+            : "[]",
+        stderr: "",
+      };
+    }
+
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "dry-run");
+  assert.equal(result.issue.number, 2);
+});
+
+test("runOneIssue returns approval-required for explicit spec-unapproved issue", async () => {
+  const config = await makeConfig({
+    issueNumber: 7,
+    approvalPolicy: approvalPolicy({
+      specRequired: true,
+      specApprovedLabel: "spec-ok",
+    }),
+  });
+  const runner = createMockRunner((call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "7"
+    ) {
+      return {
+        code: 0,
+        stdout: issueViewPayload(issue(7, ["agent-ready"])),
+        stderr: "",
+      };
+    }
+
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "approval-required");
+  assert.equal(result.issue.number, 7);
+  assert.equal(result.approvalKind, "spec");
+  assert.equal(result.missingLabel, "spec-ok");
+  assert.equal(
+    runner.calls.some((call) => call.command === "git"),
+    false,
+  );
+});
+```
+
+- [ ] **Step 2: Update and extend failing plan approval pipeline tests**
+
+In the existing tests named
+`runOneIssue stops after finding an existing plan when plan approval is required`
+and `runOneIssue stops after creating a plan when plan approval is required`,
+replace the config override with:
+
+```ts
+approvalPolicy: approvalPolicy({ planRequired: true }),
+```
+
+In the existing-plan test, assert the ready restoration edit adds both ready and
+plan-review labels:
+
+```ts
+const editCalls = runner.calls.filter(
+  (call) =>
+    call.command === "tea" &&
+    call.args[0] === "issues" &&
+    call.args[1] === "edit",
+);
+const restoreCall = editCalls.at(-1);
+assert.ok(restoreCall);
+assert.equal(
+  restoreCall.args[restoreCall.args.indexOf("--add-labels") + 1],
+  "agent-ready,plan-review",
+);
+```
+
+Add this approved-plan resume test near the plan approval tests:
+
+```ts
+test("runOneIssue proceeds when plan approval label is present and clears plan-review", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    approvalPolicy: approvalPolicy({ planRequired: true }),
+  });
+  const planPath = "docs/plans/2026-05-14-issue-49-approved-plan.md";
+  await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
+  const selected = issue(
+    49,
+    ["agent-ready", "plan-review", "plan-approved", "bug"],
+    "Approved plan",
+  );
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "list"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "git" && call.args[0] === "show-ref")
+      return { code: 1, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "add"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    )
+      return {
+        code: 0,
+        stdout: labelListPayload([
+          "agent-ready",
+          "in-progress",
+          "agent-done",
+          "plan-review",
+          "plan-approved",
+        ]),
+        stderr: "",
+      };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "tea" && call.args[0] === "comment")
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "pi") {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          status: "pr-created",
+          prUrl: "https://forgejo/pr/49",
+          branch: "agent/issue-49-approved-plan",
+          commits: ["abc123"],
+          validation: [
+            "node --test src/cli/commands/run-once/pipeline.test.ts",
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created");
+  const claimCall = runner.calls.find(
+    (call) =>
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit" &&
+      call.args.includes("--remove-labels"),
+  );
+  assert.ok(claimCall);
+  assert.equal(
+    claimCall.args[claimCall.args.indexOf("--remove-labels") + 1],
+    "agent-ready,plan-review",
+  );
+  assert.equal(
+    claimCall.args[claimCall.args.indexOf("--add-labels") + 1],
+    "in-progress",
+  );
+});
+```
+
+- [ ] **Step 3: Run the failing focused pipeline tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern="spec-unapproved|plan approval|approved plan"
+```
+
+Expected: failures show missing approval-required handling and current plan
+approval stops do not add the workflow review label.
+
+- [ ] **Step 4: Catch explicit approval-required selection errors**
+
+In `src/cli/commands/run-once/pipeline.ts`, import approval helpers:
+
+```ts
+import {
+  ApprovalRequiredError,
+  approvedWorkflowReviewLabelsToRemove,
+  decidePlanApprovalGate,
+} from "./approval-gates.ts";
+```
+
+Wrap selection with a typed catch near the start of `runOneIssue`:
+
+```ts
+let selected: { issue: IssueSummary; resumed: boolean } | undefined;
+try {
+  selected = await selectResumableIssue(issues, config);
+} catch (error) {
+  if (error instanceof ApprovalRequiredError) {
+    return withLogPath(
+      {
+        status: "approval-required",
+        issue: error.issue,
+        approvalKind: error.approvalKind,
+        missingLabel: error.missingLabel,
+      },
+      options,
+    );
+  }
+  throw error;
+}
+```
+
+In `selectResumableIssue`, pass `approvalPolicy` to both `selectIssue` calls:
+
+```ts
+const selected = selectIssue(issues, {
+  issueNumber: config.issueNumber,
+  readyLabel: ready,
+  triagePolicy: config.triagePolicy,
+  approvalPolicy: config.approvalPolicy,
+});
+```
+
+and:
+
+```ts
+const selected = selectIssue(issues, {
+  issueNumber: config.issueNumber,
+  readyLabel: ready,
+  triagePolicy: config.triagePolicy,
+  approvalPolicy: config.approvalPolicy,
+});
+```
+
+- [ ] **Step 5: Clear approved plan-review labels during claim**
+
+In `runOneIssue`, before computing `labels`, add:
+
+```ts
+const workflowReviewLabelsToRemove = approvedWorkflowReviewLabelsToRemove(
+  issue.labels,
+  config.approvalPolicy,
+);
+```
+
+Change the fresh-claim label calculation to remove those labels:
+
+```ts
+let labels = resumed
+  ? issue.labels.includes(inProgress)
+    ? issue.labels
+    : nextLabels(
+        issue.labels,
+        [ready, ...workflowReviewLabelsToRemove],
+        [inProgress],
+      )
+  : nextLabels(
+      issue.labels,
+      [ready, ...workflowReviewLabelsToRemove],
+      [inProgress],
+    );
+```
+
+- [ ] **Step 6: Ensure workflow labels can be created on demand**
+
+Change `ensureAutomationLabel` in `pipeline.ts` to accept extra workflow labels:
+
+```ts
+async function ensureAutomationLabel(
+  host: IssueHostProvider,
+  triagePolicy: PatchmillTriagePolicy | undefined,
+  extraLabels: readonly LabelDefinition[],
+  name: string,
+): Promise<void> {
+  const missing = missingLabelDefinitions(
+    await host.listLabels(),
+    triagePolicy ?? DEFAULT_TRIAGE_POLICY,
+    extraLabels,
+  );
+  const label = missing.find((definition) => definition.name === name);
+  if (!label) return;
+  await host.createLabel(label);
+}
+```
+
+Add `LabelDefinition` to the host type import:
+
+```ts
+import type {
+  IssueHostProvider,
+  LabelDefinition,
+} from "../../../host/types.ts";
+```
+
+Update existing calls:
+
+```ts
+await ensureAutomationLabel(host, config.triagePolicy, [], inProgress);
+await ensureAutomationLabel(host, config.triagePolicy, [], needsInfo);
+await ensureAutomationLabel(host, config.triagePolicy, [], done);
+```
+
+- [ ] **Step 7: Replace inline plan approval branch with gate decision**
+
+Replace this condition in `pipeline.ts`:
+
+```ts
+if (config.planOnly || config.requirePlanApproval) {
+```
+
+with:
+
+```ts
+const planGate = decidePlanApprovalGate({
+  labels,
+  planOnly: config.planOnly,
+  policy: config.approvalPolicy,
+});
+
+if (planGate.action !== "proceed") {
+  const labelsToAdd =
+    planGate.action === "stop-for-plan-review"
+      ? [ready, planGate.reviewLabel]
+      : [ready];
+  const finalLabels = nextLabels(labels, [inProgress], labelsToAdd);
+```
+
+Inside the branch, before the ready-label restoration `host.applyLabels`, ensure
+the plan review label when the decision requires it:
+
+```ts
+if (planGate.action === "stop-for-plan-review") {
+  await ensureAutomationLabel(
+    host,
+    config.triagePolicy,
+    config.approvalPolicy.labelDefinitions,
+    planGate.reviewLabel,
+  );
+}
+```
+
+Keep the existing plan-ready comment, run-state writes, final result, and
+`plan-created`/`plan-found` return shape. The final labels must remove
+`in-progress`, restore the ready label, and add `planGate.reviewLabel` only for
+`stop-for-plan-review`.
+
+- [ ] **Step 8: Run focused pipeline tests and commit**
+
+Run:
+
+```bash
+node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern="spec-unapproved|plan approval|approved plan"
+npm run lint:ts
+```
+
+Expected: focused pipeline tests pass and TypeScript lint reports no errors.
+
+Commit:
+
+```bash
+git add src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts
+git commit -m "feat(run-once): enforce approval gates"
+```
+
+## Task 7: Document workflow approval configuration and states
+
+**Files:**
+
+- Modify: `docs/configuration.md`
+- Modify: `docs/issue-agent-workflows.md`
+
+- [ ] **Step 1: Update configuration docs**
+
+In `docs/configuration.md`, add `workflow` to the complete example after
+`triage`:
+
+```json
+"workflow": {
+  "specApproval": {
+    "required": false,
+    "reviewLabel": "spec-review",
+    "approvedLabel": "spec-approved"
+  },
+  "planApproval": {
+    "required": false,
+    "reviewLabel": "plan-review",
+    "approvedLabel": "plan-approved"
+  }
+},
+```
+
+Add this section after `## Triage state map`:
+
+````md
+## Workflow approval gates
+
+`workflow.specApproval` and `workflow.planApproval` configure approval labels
+that control when `patchmill run-once` may proceed. These labels are workflow
+signals, not triage buckets, so they are not nested under the flat `labels`
+object and are not added to `triage.stateMap`.
+
+```json
+{
+  "workflow": {
+    "specApproval": {
+      "required": true,
+      "reviewLabel": "spec-review",
+      "approvedLabel": "spec-approved"
+    },
+    "planApproval": {
+      "required": true,
+      "reviewLabel": "plan-review",
+      "approvedLabel": "plan-approved"
+    }
+  }
+}
+```
+
+When specification approval is required, automatic `run-once` selection ignores
+ready issues that do not have `workflow.specApproval.approvedLabel`. Explicit
+`patchmill run-once --issue <number>` fails with an `approval-required` result
+for the requested issue instead of silently choosing another issue.
+
+When plan approval is required, Patchmill creates or finds the issue plan,
+comments that the plan is ready, applies `workflow.planApproval.reviewLabel`,
+restores the ready label, removes `in-progress`, records the run as finished,
+and stops. After a human applies `workflow.planApproval.approvedLabel`, a later
+`run-once` reuses the existing plan and proceeds to implementation. During the
+claim step, Patchmill removes the active plan-review label when the approved
+label is present.
+
+`projectPolicy.planRequiresApproval` remains as a compatibility alias. If
+`workflow.planApproval.required` is omitted, Patchmill derives plan approval
+from `projectPolicy.planRequiresApproval`. If both are present,
+`workflow.planApproval.required` wins.
+````
+
+- [ ] **Step 2: Update workflow docs and diagram**
+
+In `docs/issue-agent-workflows.md`, update the run-once Mermaid flow so the
+selection path contains a spec approval gate before the clean worktree step:
+
+```md
+G -->|yes| G1{Spec approval required and missing?} G1 -->|yes, automatic
+selection| Z G1 -->|yes, explicit --issue| AR[Return approval-required] G1
+-->|no| H
+```
+
+Update the plan branch so approval review labels are explicit:
+
+```md
+P --> R{Plan-only or plan approval missing?} P2 --> R R -->|plan-only|
+R1[Comment plan ready, restore ready label, finish] R -->|approval missing|
+R2[Comment plan ready, add plan-review, restore ready label, finish] R
+-->|approved or not required| S[Render subagent support guidance]
+```
+
+Add these bullets to `### Issue selection and safety gates`:
+
+```md
+When `workflow.specApproval.required` is true, the automatic candidate set is
+filtered before priority ordering so a high-priority unapproved issue does not
+starve a lower-priority approved issue. Explicit `--issue` selection validates
+the requested issue and returns `approval-required` with the missing spec
+approved label if the approval is absent.
+```
+
+Add this paragraph near the plan-creation prompt section:
+
+```md
+Plan approval is a workflow stop. When required and missing, Patchmill comments
+that the plan is ready, applies the configured plan-review label, restores the
+ready label, removes `in-progress`, records the run as finished, and exits with
+`plan-created` or `plan-found`. Once the configured plan-approved label is
+present, a later `run-once` reuses the plan and proceeds to implementation.
+```
+
+- [ ] **Step 3: Verify docs formatting**
+
+Run:
+
+```bash
+npx markdownlint-cli2 docs/configuration.md docs/issue-agent-workflows.md
+```
+
+Expected: markdownlint reports `0 error(s)`.
+
+- [ ] **Step 4: Commit docs**
+
+Commit:
+
+```bash
+git add docs/configuration.md docs/issue-agent-workflows.md
+git commit -m "docs: document workflow approval gates"
+```
+
+## Task 8: Full verification and final review
+
+**Files:**
+
+- Review: all files changed by Tasks 1-7
+
+- [ ] **Step 1: Run focused suites**
+
+Run:
+
+```bash
+node --test src/config/defaults.test.ts src/config/load.test.ts src/workflow/approval-policy.test.ts src/cli/commands/triage/labels.test.ts src/cli/commands/labels/setup.test.ts src/cli/commands/run-once/approval-gates.test.ts src/cli/commands/run-once/selection.test.ts src/cli/commands/run-once/args.test.ts src/cli/commands/run-once/pipeline.test.ts src/cli/commands/init/main.test.ts src/cli/commands/doctor/main.test.ts src/cli/commands/doctor/checks.test.ts
+```
+
+Expected: all listed tests pass.
+
+- [ ] **Step 2: Run repository validation**
+
+Run:
+
+```bash
+npm test
+npm run lint
+npm run build
+```
+
+Expected: tests pass, lint reports no errors, and TypeScript build completes.
+
+- [ ] **Step 3: Review the diff for spec coverage**
+
+Run:
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD -- src/config src/workflow src/cli/commands/run-once src/cli/commands/labels src/cli/commands/init src/cli/commands/doctor docs/configuration.md docs/issue-agent-workflows.md
+```
+
+Confirm these implementation points are visible in the diff:
+
+- top-level `workflow.specApproval` and `workflow.planApproval` config;
+- `projectPolicy.planRequiresApproval` alias resolution for plan approval;
+- workflow label definitions aggregated into setup and doctor checks;
+- automatic selection filters by spec approval before priority ordering;
+- explicit `--issue` can return `approval-required` with the missing spec label;
+- plan approval stop adds the configured plan-review label and restores ready;
+- approved plan issues proceed to implementation and clear `plan-review` during
+  claim.
+
+- [ ] **Step 4: Commit final fixes if verification changed files**
+
+If verification required fixes in the approval-gate integration, stage the files
+from the scoped implementation areas and commit them:
+
+```bash
+git add src/config src/workflow src/cli/commands/run-once src/cli/commands/triage/labels.ts src/cli/commands/triage/labels.test.ts src/cli/commands/labels src/cli/commands/init src/cli/commands/doctor docs/configuration.md docs/issue-agent-workflows.md
+git commit -m "fix(run-once): complete approval gate integration"
+```
+
+If no files changed after verification, record that no final fix commit was
+needed in the implementation handoff.
+
+## Self-review checklist
+
+- Spec coverage: Tasks cover configuration, alias compatibility, approval policy
+  labels, setup/doctor aggregation, automatic selection, explicit issue failure,
+  plan approval stops, approved-plan resume, and docs.
+- Placeholder scan: This plan contains no placeholder sections or deferred
+  implementation steps.
+- Type consistency: The plan consistently uses `WorkflowApprovalPolicy`,
+  `approvalPolicy`, `approvalKind`, `missingLabel`, `specApproval`, and
+  `planApproval` across config, policy, selection, pipeline, and JSON summary
+  steps.

--- a/docs/specs/2026-06-11-configurable-spec-plan-approval-design.md
+++ b/docs/specs/2026-06-11-configurable-spec-plan-approval-design.md
@@ -1,0 +1,182 @@
+# Configurable specification and plan approval design
+
+## Summary
+
+Patchmill should make specification and plan approval explicit workflow gates
+instead of assuming that an issue labeled ready can immediately move from
+planning to implementation. Repositories will be able to configure whether
+specification approval, plan approval, both, or neither are required before
+implementation. The default behavior remains compatible with the current
+workflow.
+
+The first implementation will add a workflow approval model, durable label-based
+approval signals, and run-once gating. It will not attempt to generate full
+specifications automatically; it will provide the configuration and safety gates
+needed for that workflow to be added cleanly.
+
+## Goals
+
+- Add first-class workflow configuration for specification and plan approval.
+- Preserve existing behavior unless a repository opts into the new gates.
+- Treat existing `projectPolicy.planRequiresApproval` as a compatibility alias
+  for plan approval.
+- Prevent implementation when required specification or plan approval is
+  missing.
+- Allow plan approval to unblock implementation after a prior plan-only approval
+  stop.
+- Use host-portable labels as the v1 durable approval signal.
+- Document the new configuration and workflow states.
+
+## Non-goals
+
+- Automatically drafting or updating issue-hosted specifications.
+- Upserting editable issue comments for specs or plans.
+- Hashing artifact contents and invalidating approvals when issue/spec/plan
+  content changes.
+- Adding an interactive brainstorming/specification command.
+- Moving plan storage from repository files to issue comments.
+
+Those capabilities should be added later once the approval model is stable.
+
+## Configuration
+
+Add a top-level `workflow` config object:
+
+```json
+{
+  "workflow": {
+    "requireSpecApproval": false,
+    "requirePlanApproval": false,
+    "specStorage": "issue-comment",
+    "planStorage": "repository"
+  }
+}
+```
+
+Fields:
+
+- `requireSpecApproval`: when true, implementation is blocked until the issue
+  has the configured spec-approved label.
+- `requirePlanApproval`: when true, Patchmill creates or finds a plan, posts a
+  plan-ready comment, applies the configured plan-review label, restores the
+  ready label, and stops until the issue has the configured plan-approved label.
+- `specStorage`: v1 accepts `"issue-comment"`; it documents where reviewed
+  specifications are expected to live. Additional storage modes can be added
+  later.
+- `planStorage`: v1 accepts `"repository"`; it preserves the current plan-file
+  workflow. Additional storage modes can be added later.
+
+Existing `projectPolicy.planRequiresApproval` remains supported. When
+`workflow.requirePlanApproval` is absent, Patchmill derives it from
+`projectPolicy.planRequiresApproval`. When both are present,
+`workflow.requirePlanApproval` wins.
+
+## Labels
+
+Extend `labels` with optional workflow labels:
+
+```json
+{
+  "labels": {
+    "specReview": "spec-review",
+    "specApproved": "spec-approved",
+    "planReview": "plan-review",
+    "planApproved": "plan-approved"
+  }
+}
+```
+
+Default labels are added to the generated config and setup/doctor label checks.
+These labels are distinct from canonical triage states. They are
+workflow-control signals rather than replacements for `agent-ready`,
+`needs-info`, `blocked`, or `in-progress`.
+
+## Run-once behavior
+
+### Selection
+
+`patchmill run-once` continues to select issues by the configured ready label
+and existing protection/exclusion labels. Before claiming a selected issue, it
+validates workflow approvals:
+
+- If `workflow.requireSpecApproval` is true and the issue lacks
+  `labels.specApproved`, return `no-issue` for automatic selection.
+- If a specific issue was requested with `--issue` and the required spec
+  approval is missing, return a clear blocked/error result explaining the
+  missing approval label.
+- If `workflow.requirePlanApproval` is true and a plan already exists but the
+  issue lacks `labels.planApproved`, stop before implementation and post/ensure
+  the plan-ready path where possible.
+
+### Plan approval stop
+
+When plan approval is required and no approved plan label is present:
+
+1. claim the issue as usual;
+2. create or find the plan;
+3. post the existing plan-ready comment;
+4. apply the configured plan-review label;
+5. restore the ready label and remove `in-progress`;
+6. record run state as finished;
+7. return `plan-created` or `plan-found`.
+
+This preserves the current manual-review stop while making the approval state
+explicit.
+
+### Resuming after plan approval
+
+After a human applies `labels.planApproved`, the next `run-once` may select the
+issue again. If the plan file already exists, Patchmill reuses it and proceeds
+to implementation instead of stopping again. It may remove `labels.planReview`
+during claim or leave it as historical metadata; v1 should remove `planReview`
+when moving to `in-progress` to keep the active state clear.
+
+### Specification approval
+
+When spec approval is required, `run-once` does not create a plan or worktree
+unless `labels.specApproved` is present. This intentionally leaves spec drafting
+and review to triage or a future interactive spec command.
+
+## Triage behavior
+
+The initial implementation does not need to change triage classification logic
+beyond label definitions and documentation. Triage skills can be updated later
+to produce `spec-review` rather than `agent-ready` when enough information
+exists but spec approval is required.
+
+For now, the run-once gate is the safety boundary: even if triage applies
+`agent-ready`, implementation will not proceed without required approvals.
+
+## Host provider impact
+
+The v1 design uses capabilities that already exist in the host abstraction:
+
+- read issue labels;
+- create labels;
+- apply labels;
+- comment on issues;
+- view/list issues.
+
+No host-specific comment editing or issue body mutation is required.
+
+## Testing
+
+Automated tests should cover:
+
+- default config preserves current behavior;
+- `workflow.requirePlanApproval` overrides `projectPolicy.planRequiresApproval`;
+- partial config merging preserves default workflow labels and storage modes;
+- selection or pipeline gating skips unapproved spec-required issues;
+- plan-approval stop applies `plan-review` and restores the ready label;
+- approved plan issues proceed to implementation when the plan exists.
+
+Documentation/config-only details can be verified by type checks and existing
+docs commands rather than adding tests that restate static prose.
+
+## Future extensions
+
+- Issue-hosted spec drafting using the configured brainstorming/spec skill.
+- Issue-hosted plan comments with upsert markers.
+- Artifact hashes tying approval labels to a specific spec or plan version.
+- Approval comments from trusted users as an alternative to labels.
+- Staleness detection when issue content changes after approval.

--- a/docs/specs/2026-06-11-configurable-spec-plan-approval-design.md
+++ b/docs/specs/2026-06-11-configurable-spec-plan-approval-design.md
@@ -40,73 +40,122 @@ Those capabilities should be added later once the approval model is stable.
 
 ## Configuration
 
-Add a top-level `workflow` config object:
+Add a top-level `workflow` config object with approval policy owned by the
+workflow domain:
 
 ```json
 {
   "workflow": {
-    "requireSpecApproval": false,
-    "requirePlanApproval": false,
-    "specStorage": "issue-comment",
-    "planStorage": "repository"
+    "specApproval": {
+      "required": false,
+      "reviewLabel": "spec-review",
+      "approvedLabel": "spec-approved"
+    },
+    "planApproval": {
+      "required": false,
+      "reviewLabel": "plan-review",
+      "approvedLabel": "plan-approved"
+    }
   }
 }
 ```
 
 Fields:
 
-- `requireSpecApproval`: when true, implementation is blocked until the issue
-  has the configured spec-approved label.
-- `requirePlanApproval`: when true, Patchmill creates or finds a plan, posts a
-  plan-ready comment, applies the configured plan-review label, restores the
-  ready label, and stops until the issue has the configured plan-approved label.
-- `specStorage`: v1 accepts `"issue-comment"`; it documents where reviewed
-  specifications are expected to live. Additional storage modes can be added
-  later.
-- `planStorage`: v1 accepts `"repository"`; it preserves the current plan-file
-  workflow. Additional storage modes can be added later.
+- `workflow.specApproval.required`: when true, implementation is blocked until
+  the issue has `workflow.specApproval.approvedLabel`.
+- `workflow.specApproval.reviewLabel`: the workflow-owned label that can mark an
+  issue as awaiting specification review.
+- `workflow.specApproval.approvedLabel`: the workflow-owned label that confirms
+  specification approval.
+- `workflow.planApproval.required`: when true, Patchmill creates or finds a
+  plan, posts a plan-ready comment, applies `workflow.planApproval.reviewLabel`,
+  restores the ready label, and stops until the issue has
+  `workflow.planApproval.approvedLabel`.
+- `workflow.planApproval.reviewLabel`: the workflow-owned label that marks an
+  issue as awaiting plan review.
+- `workflow.planApproval.approvedLabel`: the workflow-owned label that confirms
+  plan approval.
 
 Existing `projectPolicy.planRequiresApproval` remains supported. When
-`workflow.requirePlanApproval` is absent, Patchmill derives it from
+`workflow.planApproval.required` is absent, Patchmill derives it from
 `projectPolicy.planRequiresApproval`. When both are present,
-`workflow.requirePlanApproval` wins.
+`workflow.planApproval.required` wins.
 
-## Labels
+## Storage assumptions
 
-Extend `labels` with optional workflow labels:
+V1 does not expose `specStorage` or `planStorage` config. Specification review
+is assumed to happen in issue discussion/comments by convention, and plans
+continue to use the existing repository plan-file workflow. Add storage
+configuration only when Patchmill has multiple real storage implementations to
+choose from.
 
-```json
-{
-  "labels": {
-    "specReview": "spec-review",
-    "specApproved": "spec-approved",
-    "planReview": "plan-review",
-    "planApproved": "plan-approved"
-  }
-}
-```
+## Label ownership
 
-Default labels are added to the generated config and setup/doctor label checks.
-These labels are distinct from canonical triage states. They are
-workflow-control signals rather than replacements for `agent-ready`,
-`needs-info`, `blocked`, or `in-progress`.
+Workflow approval labels are not part of the flat triage `labels` object. They
+belong to `workflow.specApproval` and `workflow.planApproval` because they are
+workflow-control signals rather than canonical triage states such as
+`agent-ready`, `needs-info`, `blocked`, or `in-progress`.
+
+Setup, doctor, and host label creation should aggregate required label
+definitions from both triage policy and normalized workflow approval policy.
+This keeps approval labels discoverable without leaking them into generic triage
+label configuration.
+
+## Implementation boundaries
+
+Implementation must introduce approval-specific modules before wiring behavior
+into `run-once`:
+
+- `src/workflow/approval-policy.ts` owns the normalized approval model. It
+  resolves config defaults, the `projectPolicy.planRequiresApproval`
+  compatibility alias, workflow-owned label names, and the workflow label
+  definitions that setup/doctor should create or validate.
+- `src/cli/commands/run-once/approval-gates.ts` owns run-once approval
+  decisions. It consumes the normalized policy plus issue and plan state, then
+  returns a small decision object for selection and pipeline code to act on.
+
+`src/cli/commands/run-once/pipeline.ts` should consume these normalized policy
+and decision objects rather than adding scattered branches for spec approval,
+plan approval, plan-review labeling, ready restoration, or resume semantics.
+
+The decision shape should distinguish at least:
+
+- automatic-selection eligibility for spec approval;
+- explicit-issue `approval-required` failures with the missing label and
+  approval kind;
+- plan-review stops that describe the labels/comments/state transitions the
+  pipeline must apply;
+- approved/proceed decisions.
 
 ## Run-once behavior
 
 ### Selection
 
-`patchmill run-once` continues to select issues by the configured ready label
-and existing protection/exclusion labels. Before claiming a selected issue, it
-validates workflow approvals:
+`patchmill run-once` has separate automatic and explicit issue-selection paths.
 
-- If `workflow.requireSpecApproval` is true and the issue lacks
-  `labels.specApproved`, return `no-issue` for automatic selection.
-- If a specific issue was requested with `--issue` and the required spec
-  approval is missing, return a clear blocked/error result explaining the
-  missing approval label.
-- If `workflow.requirePlanApproval` is true and a plan already exists but the
-  issue lacks `labels.planApproved`, stop before implementation and post/ensure
-  the plan-ready path where possible.
+Automatic selection continues to consider issues by the configured ready label
+and existing protection/exclusion labels, but required specification approval is
+part of candidate eligibility. When normalized spec approval is required,
+automatic selection must filter out issues that lack
+`workflow.specApproval.approvedLabel` before choosing the best candidate. If no
+ready, unblocked, spec-approved candidate remains, return `no-issue`.
+
+Explicit `--issue` selection does not silently fall back to another issue. It
+should validate the requested issue fail-fast: if required spec approval is
+missing, return a typed `approval-required` result/error that includes the
+missing `workflow.specApproval.approvedLabel` and identifies the missing
+approval as specification approval.
+
+Plan approval remains a workflow stop rather than an automatic-selection filter:
+if normalized plan approval is required and a plan already exists but the issue
+lacks `workflow.planApproval.approvedLabel`, return a plan-review decision
+before implementation and post/ensure the plan-ready path where possible.
+
+Implementation should apply the spec-approval predicate before or inside
+`selectIssue`/candidate eligibility. Do not select a single automatic issue and
+then translate missing spec approval into `no-issue`, because a higher-priority
+unapproved issue could otherwise starve lower-priority ready and approved work.
 
 ### Plan approval stop
 
@@ -115,7 +164,7 @@ When plan approval is required and no approved plan label is present:
 1. claim the issue as usual;
 2. create or find the plan;
 3. post the existing plan-ready comment;
-4. apply the configured plan-review label;
+4. apply `workflow.planApproval.reviewLabel`;
 5. restore the ready label and remove `in-progress`;
 6. record run state as finished;
 7. return `plan-created` or `plan-found`.
@@ -125,24 +174,26 @@ explicit.
 
 ### Resuming after plan approval
 
-After a human applies `labels.planApproved`, the next `run-once` may select the
-issue again. If the plan file already exists, Patchmill reuses it and proceeds
-to implementation instead of stopping again. It may remove `labels.planReview`
-during claim or leave it as historical metadata; v1 should remove `planReview`
-when moving to `in-progress` to keep the active state clear.
+After a human applies `workflow.planApproval.approvedLabel`, the next `run-once`
+may select the issue again. If the plan file already exists, Patchmill reuses it
+and proceeds to implementation instead of stopping again. It may remove
+`workflow.planApproval.reviewLabel` during claim or leave it as historical
+metadata; v1 should remove the review label when moving to `in-progress` to keep
+the active state clear.
 
 ### Specification approval
 
 When spec approval is required, `run-once` does not create a plan or worktree
-unless `labels.specApproved` is present. This intentionally leaves spec drafting
-and review to triage or a future interactive spec command.
+unless `workflow.specApproval.approvedLabel` is present. This intentionally
+leaves spec drafting and review to triage or a future interactive spec command.
 
 ## Triage behavior
 
 The initial implementation does not need to change triage classification logic
-beyond label definitions and documentation. Triage skills can be updated later
-to produce `spec-review` rather than `agent-ready` when enough information
-exists but spec approval is required.
+beyond aggregating workflow label definitions for setup/doctor/documentation.
+Triage skills can be updated later to apply `workflow.specApproval.reviewLabel`
+rather than `agent-ready` when enough information exists but spec approval is
+required.
 
 For now, the run-once gate is the safety boundary: even if triage applies
 `agent-ready`, implementation will not proceed without required approvals.
@@ -164,10 +215,19 @@ No host-specific comment editing or issue body mutation is required.
 Automated tests should cover:
 
 - default config preserves current behavior;
-- `workflow.requirePlanApproval` overrides `projectPolicy.planRequiresApproval`;
-- partial config merging preserves default workflow labels and storage modes;
-- selection or pipeline gating skips unapproved spec-required issues;
-- plan-approval stop applies `plan-review` and restores the ready label;
+- `workflow.planApproval.required` overrides
+  `projectPolicy.planRequiresApproval`;
+- partial config merging preserves default workflow approval labels;
+- normalized approval policy exposes workflow label definitions for setup/doctor
+  aggregation without adding them to flat triage labels;
+- automatic selection skips unapproved spec-required issues and can still pick a
+  lower-priority ready, unblocked, spec-approved issue;
+- explicit `--issue` selection returns a typed `approval-required` result/error
+  when required spec approval is missing;
+- approval-gate decisions cover plan-review stops without requiring inline
+  approval branches in `run-once/pipeline.ts`;
+- plan-approval stop applies `workflow.planApproval.reviewLabel` and restores
+  the ready label;
 - approved plan issues proceed to implementation when the plan exists.
 
 Documentation/config-only details can be verified by type checks and existing

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -153,6 +153,10 @@ const REQUIRED_LABELS = [
   "priority:high",
   "priority:medium",
   "priority:low",
+  "spec-review",
+  "spec-approved",
+  "plan-review",
+  "plan-approved",
 ];
 
 function successMocks(

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -5,8 +5,7 @@ import { localPiAgentDir, piAgentEnv } from "../init/pi-agent-settings.ts";
 import { runPiSmokeTest } from "../init/pi-smoke-test.ts";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
-import { createTriagePolicy } from "../../../policy/triage.ts";
-import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import {
   assertCleanWorktree,
   cleanStatusIgnoredPaths,
@@ -478,25 +477,16 @@ export async function runDoctorChecks(
     }
 
     try {
-      const policy = createTriagePolicy(config.labels, config.triage);
-      const approvalPolicy = createWorkflowApprovalPolicy(
-        config.workflow,
-        config.projectPolicy,
-      );
-      const allLabelDefinitions = [
-        ...policy.allowedLabels,
-        ...approvalPolicy.labelDefinitions,
-      ];
+      const labelCatalog = createPatchmillLabelCatalog(config);
       const missing = missingLabelDefinitions(
         await host.listLabels(),
-        policy,
-        approvalPolicy.labelDefinitions,
+        labelCatalog,
       );
       if (missing.length === 0) {
         results.push(
           pass(
             "labels",
-            allLabelDefinitions.map((label) => label.name).join(", "),
+            labelCatalog.labelDefinitions.map((label) => label.name).join(", "),
           ),
         );
       } else {

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -6,6 +6,7 @@ import { runPiSmokeTest } from "../init/pi-smoke-test.ts";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import {
   assertCleanWorktree,
   cleanStatusIgnoredPaths,
@@ -478,12 +479,24 @@ export async function runDoctorChecks(
 
     try {
       const policy = createTriagePolicy(config.labels, config.triage);
-      const missing = missingLabelDefinitions(await host.listLabels(), policy);
+      const approvalPolicy = createWorkflowApprovalPolicy(
+        config.workflow,
+        config.projectPolicy,
+      );
+      const allLabelDefinitions = [
+        ...policy.allowedLabels,
+        ...approvalPolicy.labelDefinitions,
+      ];
+      const missing = missingLabelDefinitions(
+        await host.listLabels(),
+        policy,
+        approvalPolicy.labelDefinitions,
+      );
       if (missing.length === 0) {
         results.push(
           pass(
             "labels",
-            policy.allowedLabels.map((label) => label.name).join(", "),
+            allLabelDefinitions.map((label) => label.name).join(", "),
           ),
         );
       } else {

--- a/src/cli/commands/doctor/main.ts
+++ b/src/cli/commands/doctor/main.ts
@@ -13,8 +13,7 @@ import { formatDoctorReport, hasDoctorFailures } from "./reporting.ts";
 import type { CommandRunner } from "../triage/types.ts";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
-import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
-import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import {
   ensureRequiredLabels,
   type LabelSetupResult,
@@ -74,16 +73,9 @@ async function runDoctorLabelSetup(
     repoRoot: options.repoRoot,
     host: loaded.config.host,
   });
-  const policy = createTriagePolicy(loaded.config.labels, loaded.config.triage);
-  const approvalPolicy = createWorkflowApprovalPolicy(
-    loaded.config.workflow,
-    loaded.config.projectPolicy,
-  );
-
   return ensureRequiredLabels({
     host,
-    policy,
-    extraLabels: approvalPolicy.labelDefinitions,
+    labelCatalog: createPatchmillLabelCatalog(loaded.config),
     prompt: options.prompt,
     isInteractive: options.isInteractive,
     assumeYes: options.assumeYes,

--- a/src/cli/commands/doctor/main.ts
+++ b/src/cli/commands/doctor/main.ts
@@ -13,6 +13,7 @@ import { formatDoctorReport, hasDoctorFailures } from "./reporting.ts";
 import type { CommandRunner } from "../triage/types.ts";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
 import {
   ensureRequiredLabels,
@@ -74,10 +75,15 @@ async function runDoctorLabelSetup(
     host: loaded.config.host,
   });
   const policy = createTriagePolicy(loaded.config.labels, loaded.config.triage);
+  const approvalPolicy = createWorkflowApprovalPolicy(
+    loaded.config.workflow,
+    loaded.config.projectPolicy,
+  );
 
   return ensureRequiredLabels({
     host,
     policy,
+    extraLabels: approvalPolicy.labelDefinitions,
     prompt: options.prompt,
     isInteractive: options.isInteractive,
     assumeYes: options.assumeYes,

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -338,8 +338,12 @@ test("runInit prints missing label review and edit guidance when label setup is 
         runPiSmokeTest: failingPiSmokeTest,
         isInteractive: false,
         checkPiAvailable: async () => false,
-        setupLabels: async () => {
+        setupLabels: async (options) => {
           labelSetupCalled = true;
+          assert.deepEqual(
+            options.extraLabels?.map((label) => label.name),
+            ["spec-review", "spec-approved", "plan-review", "plan-approved"],
+          );
           return {
             status: "skipped",
             missingCount: 1,
@@ -379,6 +383,10 @@ test("runInit --yes approves setup-time label creation", async () => {
         checkPiAvailable: async () => false,
         setupLabels: async (options) => {
           assumeYes = options.assumeYes;
+          assert.deepEqual(
+            options.extraLabels?.map((label) => label.name),
+            ["spec-review", "spec-approved", "plan-review", "plan-approved"],
+          );
           return {
             status: "satisfied",
             missingCount: 0,

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -341,7 +341,9 @@ test("runInit prints missing label review and edit guidance when label setup is 
         setupLabels: async (options) => {
           labelSetupCalled = true;
           assert.deepEqual(
-            options.extraLabels?.map((label) => label.name),
+            options.labelCatalog.workflowApprovalPolicy.labelDefinitions.map(
+              (label) => label.name,
+            ),
             ["spec-review", "spec-approved", "plan-review", "plan-approved"],
           );
           return {
@@ -384,7 +386,9 @@ test("runInit --yes approves setup-time label creation", async () => {
         setupLabels: async (options) => {
           assumeYes = options.assumeYes;
           assert.deepEqual(
-            options.extraLabels?.map((label) => label.name),
+            options.labelCatalog.workflowApprovalPolicy.labelDefinitions.map(
+              (label) => label.name,
+            ),
             ["spec-review", "spec-approved", "plan-review", "plan-approved"],
           );
           return {

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -8,10 +8,11 @@ import { createInterface } from "node:readline/promises";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "./args.ts";
 import { createCommandRunner } from "../triage/command.ts";
+import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import { GLOBAL_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
-import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { ensureRequiredLabels } from "../labels/setup.ts";
 import {
   installProjectSkills,
@@ -213,13 +214,20 @@ export async function runInit(
       repoRoot: config.repoRoot,
       host: result.config.host,
     });
-    const policy = createTriagePolicy(
-      DEFAULT_PATCHMILL_CONFIG.labels,
-      DEFAULT_PATCHMILL_CONFIG.triage,
+    const labelConfig = {
+      ...DEFAULT_PATCHMILL_CONFIG,
+      host: result.config.host,
+      skills: { ...DEFAULT_PATCHMILL_CONFIG.skills, ...result.config.skills },
+    };
+    const policy = createTriagePolicy(labelConfig.labels, labelConfig.triage);
+    const approvalPolicy = createWorkflowApprovalPolicy(
+      labelConfig.workflow,
+      labelConfig.projectPolicy,
     );
     const labelSetup = await (options.setupLabels ?? ensureRequiredLabels)({
       host,
       policy,
+      extraLabels: approvalPolicy.labelDefinitions,
       prompt: options.prompt ?? defaultPrompt,
       isInteractive,
       assumeYes: config.yes,

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -9,10 +9,9 @@ import { pathToFileURL } from "node:url";
 import { parseArgs } from "./args.ts";
 import { createCommandRunner } from "../triage/command.ts";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
-import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import { GLOBAL_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
-import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import { ensureRequiredLabels } from "../labels/setup.ts";
 import {
   installProjectSkills,
@@ -219,15 +218,10 @@ export async function runInit(
       host: result.config.host,
       skills: { ...DEFAULT_PATCHMILL_CONFIG.skills, ...result.config.skills },
     };
-    const policy = createTriagePolicy(labelConfig.labels, labelConfig.triage);
-    const approvalPolicy = createWorkflowApprovalPolicy(
-      labelConfig.workflow,
-      labelConfig.projectPolicy,
-    );
+    const labelCatalog = createPatchmillLabelCatalog(labelConfig);
     const labelSetup = await (options.setupLabels ?? ensureRequiredLabels)({
       host,
-      policy,
-      extraLabels: approvalPolicy.labelDefinitions,
+      labelCatalog,
       prompt: options.prompt ?? defaultPrompt,
       isInteractive,
       assumeYes: config.yes,

--- a/src/cli/commands/labels/setup.test.ts
+++ b/src/cli/commands/labels/setup.test.ts
@@ -134,6 +134,28 @@ test("ensureRequiredLabels creates missing labels after approval", async () => {
   assert.match(result.message, /Created 15 labels/);
 });
 
+test("ensureRequiredLabels creates extra workflow labels with triage labels", async () => {
+  const { host, created } = fakeHost({ existingLabels: requiredLabelNames });
+
+  const result = await ensureRequiredLabels({
+    host,
+    policy,
+    extraLabels: [
+      {
+        name: "plan-review",
+        color: "#5319e7",
+        description: "Awaiting implementation plan review",
+      },
+    ],
+    isInteractive: false,
+    assumeYes: true,
+    command: "doctor",
+  });
+
+  assert.equal(result.status, "created");
+  assert.deepEqual(created, ["plan-review"]);
+});
+
 test("ensureRequiredLabels creates without prompting when assumeYes is set", async () => {
   const { host, created } = fakeHost({
     existingLabels: requiredLabelNames.filter((name) => name !== "agent-ready"),

--- a/src/cli/commands/labels/setup.test.ts
+++ b/src/cli/commands/labels/setup.test.ts
@@ -8,14 +8,16 @@ import type {
   LabelChangePlan,
   LabelDefinition,
 } from "../../../host/types.ts";
-import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import { ensureRequiredLabels } from "./setup.ts";
 
-const policy = createTriagePolicy(
-  DEFAULT_PATCHMILL_CONFIG.labels,
-  DEFAULT_PATCHMILL_CONFIG.triage,
+const labelCatalog = createPatchmillLabelCatalog(DEFAULT_PATCHMILL_CONFIG);
+const triageLabelNames = labelCatalog.triagePolicy.allowedLabels.map(
+  (label) => label.name,
 );
-const requiredLabelNames = policy.allowedLabels.map((label) => label.name);
+const requiredLabelNames = labelCatalog.labelDefinitions.map(
+  (label) => label.name,
+);
 
 type FakeHostOptions = {
   existingLabels?: string[];
@@ -69,7 +71,7 @@ test("ensureRequiredLabels reports satisfied when no labels are missing", async 
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
+    labelCatalog,
     isInteractive: false,
     assumeYes: false,
     command: "init",
@@ -90,7 +92,7 @@ test("ensureRequiredLabels lists labels and skips creation when prompt is declin
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
+    labelCatalog,
     isInteractive: true,
     assumeYes: false,
     command: "init",
@@ -119,7 +121,7 @@ test("ensureRequiredLabels creates missing labels after approval", async () => {
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
+    labelCatalog,
     isInteractive: true,
     assumeYes: false,
     command: "doctor",
@@ -131,29 +133,27 @@ test("ensureRequiredLabels creates missing labels after approval", async () => {
   assert.equal(result.createdCount, requiredLabelNames.length);
   assert.deepEqual(created, requiredLabelNames);
   assert.match(result.message, /Patchmill needs these labels on GitHub via gh/);
-  assert.match(result.message, /Created 15 labels/);
+  assert.match(result.message, /Created 19 labels/);
 });
 
-test("ensureRequiredLabels creates extra workflow labels with triage labels", async () => {
-  const { host, created } = fakeHost({ existingLabels: requiredLabelNames });
+test("ensureRequiredLabels creates workflow labels from the catalog", async () => {
+  const { host, created } = fakeHost({ existingLabels: triageLabelNames });
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
-    extraLabels: [
-      {
-        name: "plan-review",
-        color: "#5319e7",
-        description: "Awaiting implementation plan review",
-      },
-    ],
+    labelCatalog,
     isInteractive: false,
     assumeYes: true,
     command: "doctor",
   });
 
   assert.equal(result.status, "created");
-  assert.deepEqual(created, ["plan-review"]);
+  assert.deepEqual(created, [
+    "spec-review",
+    "spec-approved",
+    "plan-review",
+    "plan-approved",
+  ]);
 });
 
 test("ensureRequiredLabels creates without prompting when assumeYes is set", async () => {
@@ -164,7 +164,7 @@ test("ensureRequiredLabels creates without prompting when assumeYes is set", asy
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
+    labelCatalog,
     isInteractive: false,
     assumeYes: true,
     command: "doctor",
@@ -187,7 +187,7 @@ test("ensureRequiredLabels skips in non-interactive mode without assumeYes", asy
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
+    labelCatalog,
     isInteractive: false,
     assumeYes: false,
     command: "init",
@@ -207,7 +207,7 @@ test("ensureRequiredLabels reports creation failures with label names", async ()
 
   const result = await ensureRequiredLabels({
     host,
-    policy,
+    labelCatalog,
     isInteractive: false,
     assumeYes: true,
     command: "doctor",

--- a/src/cli/commands/labels/setup.ts
+++ b/src/cli/commands/labels/setup.ts
@@ -2,7 +2,7 @@ import type {
   IssueHostProvider,
   LabelDefinition,
 } from "../../../host/types.ts";
-import type { PatchmillTriagePolicy } from "../../../policy/triage.ts";
+import type { PatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import { missingLabelDefinitions } from "../triage/labels.ts";
 
 export type LabelSetupResult = {
@@ -14,8 +14,7 @@ export type LabelSetupResult = {
 
 export type LabelSetupOptions = {
   host: IssueHostProvider;
-  policy: PatchmillTriagePolicy;
-  extraLabels?: readonly LabelDefinition[];
+  labelCatalog: PatchmillLabelCatalog;
   prompt?: (question: string) => Promise<string>;
   isInteractive: boolean;
   assumeYes: boolean;
@@ -97,8 +96,7 @@ export async function ensureRequiredLabels(
 ): Promise<LabelSetupResult> {
   const missing = missingLabelDefinitions(
     await options.host.listLabels(),
-    options.policy,
-    options.extraLabels,
+    options.labelCatalog,
   );
 
   if (missing.length === 0) {

--- a/src/cli/commands/labels/setup.ts
+++ b/src/cli/commands/labels/setup.ts
@@ -15,6 +15,7 @@ export type LabelSetupResult = {
 export type LabelSetupOptions = {
   host: IssueHostProvider;
   policy: PatchmillTriagePolicy;
+  extraLabels?: readonly LabelDefinition[];
   prompt?: (question: string) => Promise<string>;
   isInteractive: boolean;
   assumeYes: boolean;
@@ -97,6 +98,7 @@ export async function ensureRequiredLabels(
   const missing = missingLabelDefinitions(
     await options.host.listLabels(),
     options.policy,
+    options.extraLabels,
   );
 
   if (missing.length === 0) {

--- a/src/cli/commands/run-once/approval-gates.test.ts
+++ b/src/cli/commands/run-once/approval-gates.test.ts
@@ -123,6 +123,22 @@ test("decidePlanApprovalGate proceeds when the approved plan label is present", 
   assert.deepEqual(decision, { action: "proceed" });
 });
 
+test("decidePlanApprovalGate ignores stale approval on a newly-created plan", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress", "plan-approved"],
+    planOnly: false,
+    planCreatedThisRun: true,
+    policy: planApprovalPolicy(true),
+  });
+
+  assert.deepEqual(decision, {
+    action: "stop-for-plan-review",
+    reviewLabel: "plan-review",
+    missingLabel: "plan-approved",
+    staleApprovedLabel: "plan-approved",
+  });
+});
+
 test("decidePlanApprovalGate stops for plan-only without workflow review labels", () => {
   const decision = decidePlanApprovalGate({
     labels: ["in-progress"],

--- a/src/cli/commands/run-once/approval-gates.test.ts
+++ b/src/cli/commands/run-once/approval-gates.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import {
+  ApprovalRequiredError,
+  assertExplicitIssueApprovals,
+  issueMeetsAutomaticApprovals,
+} from "./approval-gates.ts";
+import type { IssueSummary } from "./types.ts";
+
+function approvalPolicy(overrides = {}) {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      specApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+        required: true,
+        ...overrides,
+      },
+    },
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+}
+
+function issue(labels: string[]): IssueSummary {
+  return { number: 7, title: "Issue", body: "Body", labels, state: "open" };
+}
+
+test("issueMeetsAutomaticApprovals accepts missing spec approval when the gate is disabled", () => {
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+
+  assert.equal(
+    issueMeetsAutomaticApprovals(issue(["agent-ready"]), policy),
+    true,
+  );
+});
+
+test("issueMeetsAutomaticApprovals filters missing spec approval when required", () => {
+  const policy = approvalPolicy();
+
+  assert.equal(
+    issueMeetsAutomaticApprovals(issue(["agent-ready"]), policy),
+    false,
+  );
+  assert.equal(
+    issueMeetsAutomaticApprovals(
+      issue(["agent-ready", "spec-approved"]),
+      policy,
+    ),
+    true,
+  );
+});
+
+test("assertExplicitIssueApprovals throws a typed missing-spec approval error", () => {
+  const policy = approvalPolicy({ approvedLabel: "spec-ok" });
+
+  assert.throws(
+    () => assertExplicitIssueApprovals(issue(["agent-ready"]), policy),
+    (error: unknown) => {
+      assert(error instanceof ApprovalRequiredError);
+      assert.equal(error.approvalKind, "spec");
+      assert.equal(error.missingLabel, "spec-ok");
+      assert.equal(error.issue.number, 7);
+      return true;
+    },
+  );
+});

--- a/src/cli/commands/run-once/approval-gates.test.ts
+++ b/src/cli/commands/run-once/approval-gates.test.ts
@@ -4,7 +4,9 @@ import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import {
   ApprovalRequiredError,
+  approvedWorkflowReviewLabelsToRemove,
   assertExplicitIssueApprovals,
+  decidePlanApprovalGate,
   issueMeetsAutomaticApprovals,
 } from "./approval-gates.ts";
 import type { IssueSummary } from "./types.ts";
@@ -68,4 +70,74 @@ test("assertExplicitIssueApprovals throws a typed missing-spec approval error", 
       return true;
     },
   );
+});
+
+function planApprovalPolicy(
+  required: boolean,
+  approvedLabel = "plan-approved",
+) {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      planApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+        required,
+        approvedLabel,
+      },
+    },
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
+}
+
+test("decidePlanApprovalGate proceeds when plan approval is disabled", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["agent-ready"],
+    planOnly: false,
+    policy: planApprovalPolicy(false),
+  });
+
+  assert.deepEqual(decision, { action: "proceed" });
+});
+
+test("decidePlanApprovalGate stops for review when plan approval is required and missing", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress"],
+    planOnly: false,
+    policy: planApprovalPolicy(true),
+  });
+
+  assert.deepEqual(decision, {
+    action: "stop-for-plan-review",
+    reviewLabel: "plan-review",
+    missingLabel: "plan-approved",
+  });
+});
+
+test("decidePlanApprovalGate proceeds when the approved plan label is present", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress", "plan-approved"],
+    planOnly: false,
+    policy: planApprovalPolicy(true),
+  });
+
+  assert.deepEqual(decision, { action: "proceed" });
+});
+
+test("decidePlanApprovalGate stops for plan-only without workflow review labels", () => {
+  const decision = decidePlanApprovalGate({
+    labels: ["in-progress"],
+    planOnly: true,
+    policy: planApprovalPolicy(false),
+  });
+
+  assert.deepEqual(decision, { action: "stop-for-plan-only" });
+});
+
+test("approvedWorkflowReviewLabelsToRemove clears active plan review after approval", () => {
+  const labels = approvedWorkflowReviewLabelsToRemove(
+    ["agent-ready", "plan-review", "plan-approved"],
+    planApprovalPolicy(true),
+  );
+
+  assert.deepEqual(labels, ["plan-review"]);
 });

--- a/src/cli/commands/run-once/approval-gates.test.ts
+++ b/src/cli/commands/run-once/approval-gates.test.ts
@@ -12,17 +12,14 @@ import {
 import type { IssueSummary } from "./types.ts";
 
 function approvalPolicy(overrides = {}) {
-  return createWorkflowApprovalPolicy(
-    {
-      ...DEFAULT_PATCHMILL_CONFIG.workflow,
-      specApproval: {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
-        required: true,
-        ...overrides,
-      },
+  return createWorkflowApprovalPolicy({
+    ...DEFAULT_PATCHMILL_CONFIG.workflow,
+    specApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+      required: true,
+      ...overrides,
     },
-    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
-  );
+  });
 }
 
 function issue(labels: string[]): IssueSummary {
@@ -32,7 +29,6 @@ function issue(labels: string[]): IssueSummary {
 test("issueMeetsAutomaticApprovals accepts missing spec approval when the gate is disabled", () => {
   const policy = createWorkflowApprovalPolicy(
     DEFAULT_PATCHMILL_CONFIG.workflow,
-    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
   );
 
   assert.equal(
@@ -76,17 +72,14 @@ function planApprovalPolicy(
   required: boolean,
   approvedLabel = "plan-approved",
 ) {
-  return createWorkflowApprovalPolicy(
-    {
-      ...DEFAULT_PATCHMILL_CONFIG.workflow,
-      planApproval: {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
-        required,
-        approvedLabel,
-      },
+  return createWorkflowApprovalPolicy({
+    ...DEFAULT_PATCHMILL_CONFIG.workflow,
+    planApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+      required,
+      approvedLabel,
     },
-    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
-  );
+  });
 }
 
 test("decidePlanApprovalGate proceeds when plan approval is disabled", () => {

--- a/src/cli/commands/run-once/approval-gates.ts
+++ b/src/cli/commands/run-once/approval-gates.ts
@@ -41,3 +41,44 @@ export function assertExplicitIssueApprovals(
     policy.specApproval.approvedLabel,
   );
 }
+
+export type PlanApprovalGateDecision =
+  | { action: "proceed" }
+  | { action: "stop-for-plan-only" }
+  | {
+      action: "stop-for-plan-review";
+      reviewLabel: string;
+      missingLabel: string;
+    };
+
+export function decidePlanApprovalGate(options: {
+  labels: string[];
+  planOnly: boolean;
+  policy: WorkflowApprovalPolicy;
+}): PlanApprovalGateDecision {
+  if (options.planOnly) return { action: "stop-for-plan-only" };
+  const approval = options.policy.planApproval;
+  if (!approval.required) return { action: "proceed" };
+  if (options.labels.includes(approval.approvedLabel)) {
+    return { action: "proceed" };
+  }
+  return {
+    action: "stop-for-plan-review",
+    reviewLabel: approval.reviewLabel,
+    missingLabel: approval.approvedLabel,
+  };
+}
+
+export function approvedWorkflowReviewLabelsToRemove(
+  labels: string[],
+  policy: WorkflowApprovalPolicy,
+): string[] {
+  const remove: string[] = [];
+  if (
+    labels.includes(policy.planApproval.reviewLabel) &&
+    labels.includes(policy.planApproval.approvedLabel)
+  ) {
+    remove.push(policy.planApproval.reviewLabel);
+  }
+  return remove;
+}

--- a/src/cli/commands/run-once/approval-gates.ts
+++ b/src/cli/commands/run-once/approval-gates.ts
@@ -1,0 +1,43 @@
+import type { WorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import type { IssueSummary } from "./types.ts";
+
+export class ApprovalRequiredError extends Error {
+  readonly name = "ApprovalRequiredError";
+  readonly issue: IssueSummary;
+  readonly approvalKind: "spec" | "plan";
+  readonly missingLabel: string;
+
+  constructor(
+    issue: IssueSummary,
+    approvalKind: "spec" | "plan",
+    missingLabel: string,
+  ) {
+    super(
+      `Issue #${issue.number} requires ${approvalKind} approval label ${missingLabel}`,
+    );
+    this.issue = issue;
+    this.approvalKind = approvalKind;
+    this.missingLabel = missingLabel;
+  }
+}
+
+export function issueMeetsAutomaticApprovals(
+  issue: IssueSummary,
+  policy: WorkflowApprovalPolicy | undefined,
+): boolean {
+  if (!policy?.specApproval.required) return true;
+  return issue.labels.includes(policy.specApproval.approvedLabel);
+}
+
+export function assertExplicitIssueApprovals(
+  issue: IssueSummary,
+  policy: WorkflowApprovalPolicy | undefined,
+): void {
+  if (!policy?.specApproval.required) return;
+  if (issue.labels.includes(policy.specApproval.approvedLabel)) return;
+  throw new ApprovalRequiredError(
+    issue,
+    "spec",
+    policy.specApproval.approvedLabel,
+  );
+}

--- a/src/cli/commands/run-once/approval-gates.ts
+++ b/src/cli/commands/run-once/approval-gates.ts
@@ -49,23 +49,32 @@ export type PlanApprovalGateDecision =
       action: "stop-for-plan-review";
       reviewLabel: string;
       missingLabel: string;
+      staleApprovedLabel?: string;
     };
 
 export function decidePlanApprovalGate(options: {
   labels: string[];
   planOnly: boolean;
+  planCreatedThisRun?: boolean;
   policy: WorkflowApprovalPolicy;
 }): PlanApprovalGateDecision {
   if (options.planOnly) return { action: "stop-for-plan-only" };
   const approval = options.policy.planApproval;
   if (!approval.required) return { action: "proceed" };
-  if (options.labels.includes(approval.approvedLabel)) {
+  if (
+    !options.planCreatedThisRun &&
+    options.labels.includes(approval.approvedLabel)
+  ) {
     return { action: "proceed" };
   }
   return {
     action: "stop-for-plan-review",
     reviewLabel: approval.reviewLabel,
     missingLabel: approval.approvedLabel,
+    ...(options.planCreatedThisRun &&
+    options.labels.includes(approval.approvedLabel)
+      ? { staleApprovedLabel: approval.approvedLabel }
+      : {}),
   };
 }
 

--- a/src/cli/commands/run-once/args.test.ts
+++ b/src/cli/commands/run-once/args.test.ts
@@ -39,7 +39,12 @@ test("parseArgs executes by default when no args are provided", () => {
   assert.deepEqual(config.projectPolicy, DEFAULT_PATCHMILL_POLICY);
   assert.equal(config.readyLabel, "agent-ready");
   assert.equal(config.issueLimit, 1);
-  assert.equal(config.requirePlanApproval, false);
+  assert.equal(config.approvalPolicy.specApproval.required, false);
+  assert.equal(config.approvalPolicy.planApproval.required, false);
+  assert.equal(
+    config.approvalPolicy.planApproval.approvedLabel,
+    "plan-approved",
+  );
 });
 
 test("parseArgs shows help for help flags", () => {
@@ -194,6 +199,31 @@ test("summarizeResult includes merged issue handoff fields", () => {
       reviewSummary: "reviewed",
       landingDecision: "direct squash-landed: simple localized bug fix",
       logPath: ".patchmill/runs/issue-42/run.jsonl",
+    },
+  );
+});
+
+test("summarizeResult includes approval-required details", () => {
+  assert.deepEqual(
+    summarizeResult({
+      status: "approval-required",
+      issue: {
+        number: 42,
+        title: "Needs spec approval",
+        body: "Body",
+        labels: ["agent-ready"],
+        state: "open",
+      },
+      approvalKind: "spec",
+      missingLabel: "spec-approved",
+      logPath: ".patchmill/runs/run.jsonl",
+    }),
+    {
+      status: "approval-required",
+      issueNumber: 42,
+      approvalKind: "spec",
+      missingLabel: "spec-approved",
+      logPath: ".patchmill/runs/run.jsonl",
     },
   );
 });
@@ -399,6 +429,30 @@ test("loadCliConfig passes configured skills and project policy through to run-o
     config.projectPolicy.visualEvidence.prEvidenceExample?.screenshotPath,
     ".tmp/issue-42-sentinel-after.png",
   );
+});
+
+test("loadCliConfig resolves workflow plan approval ahead of legacy project policy", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-run-once-approval-"),
+  );
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        specApproval: { required: true, approvedLabel: "spec-ok" },
+        planApproval: { required: false, approvedLabel: "plan-ok" },
+      },
+      projectPolicy: { planRequiresApproval: true },
+    }),
+    "utf8",
+  );
+
+  const config = await loadCliConfig(["--dry-run"], repoRoot, {});
+
+  assert.equal(config.approvalPolicy.specApproval.required, true);
+  assert.equal(config.approvalPolicy.specApproval.approvedLabel, "spec-ok");
+  assert.equal(config.approvalPolicy.planApproval.required, false);
+  assert.equal(config.approvalPolicy.planApproval.approvedLabel, "plan-ok");
 });
 
 test("loadCliConfig ignores removed legacy tea login when patchmill config only customizes paths", async () => {

--- a/src/cli/commands/run-once/args.ts
+++ b/src/cli/commands/run-once/args.ts
@@ -2,6 +2,7 @@ import { cwd } from "node:process";
 import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import type { PatchmillConfig } from "../../../config/types.ts";
 import type { AgentIssueConfig } from "./types.ts";
 
@@ -42,6 +43,10 @@ export function parseArgs(
   const patchmillConfig = normalizedConfig ?? DEFAULT_PATCHMILL_CONFIG;
   const host = hostConfig(env, patchmillConfig);
   const projectPolicy = patchmillConfig.projectPolicy;
+  const approvalPolicy = createWorkflowApprovalPolicy(
+    patchmillConfig.workflow,
+    projectPolicy,
+  );
   const config: AgentIssueConfig = {
     repoRoot,
     dryRun: false,
@@ -73,7 +78,7 @@ export function parseArgs(
     ),
     readyLabel: patchmillConfig.labels.ready,
     issueLimit: 1,
-    requirePlanApproval: projectPolicy.planRequiresApproval,
+    approvalPolicy,
     baseBranch: patchmillConfig.git.baseBranch,
     baseRef: patchmillConfig.git.baseRef,
     remote: patchmillConfig.git.remote,

--- a/src/cli/commands/run-once/args.ts
+++ b/src/cli/commands/run-once/args.ts
@@ -1,8 +1,7 @@
 import { cwd } from "node:process";
 import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
-import { createTriagePolicy } from "../../../policy/triage.ts";
-import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import type { PatchmillConfig } from "../../../config/types.ts";
 import type { AgentIssueConfig } from "./types.ts";
 
@@ -43,10 +42,7 @@ export function parseArgs(
   const patchmillConfig = normalizedConfig ?? DEFAULT_PATCHMILL_CONFIG;
   const host = hostConfig(env, patchmillConfig);
   const projectPolicy = patchmillConfig.projectPolicy;
-  const approvalPolicy = createWorkflowApprovalPolicy(
-    patchmillConfig.workflow,
-    projectPolicy,
-  );
+  const labelCatalog = createPatchmillLabelCatalog(patchmillConfig);
   const config: AgentIssueConfig = {
     repoRoot,
     dryRun: false,
@@ -72,13 +68,11 @@ export function parseArgs(
       : {}),
     projectPolicy,
     skills: patchmillConfig.skills,
-    triagePolicy: createTriagePolicy(
-      patchmillConfig.labels,
-      patchmillConfig.triage,
-    ),
+    triagePolicy: labelCatalog.triagePolicy,
     readyLabel: patchmillConfig.labels.ready,
     issueLimit: 1,
-    approvalPolicy,
+    labelCatalog,
+    approvalPolicy: labelCatalog.workflowApprovalPolicy,
     baseBranch: patchmillConfig.git.baseBranch,
     baseRef: patchmillConfig.git.baseRef,
     remote: patchmillConfig.git.remote,

--- a/src/cli/commands/run-once/main.ts
+++ b/src/cli/commands/run-once/main.ts
@@ -83,6 +83,12 @@ type JsonResult = JsonResultLog &
         landingDecision?: string;
       }
     | {
+        status: "approval-required";
+        issueNumber: number;
+        approvalKind: "spec" | "plan";
+        missingLabel: string;
+      }
+    | {
         status: "blocked";
         issueNumber: number;
         reason: string;
@@ -177,6 +183,14 @@ export function summarizeResult(result: AgentIssuePipelineResult): JsonResult {
         landingDecision: result.landingDecision,
         ...withLogPath,
       };
+    case "approval-required":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        approvalKind: result.approvalKind,
+        missingLabel: result.missingLabel,
+        ...withLogPath,
+      };
     case "blocked":
       return {
         status: result.status,
@@ -260,7 +274,9 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
     console.log(
       JSON.stringify(summarizeResult({ ...result, logPath: outputLogPath })),
     );
-    return result.status === "blocked" ? 1 : 0;
+    return result.status === "blocked" || result.status === "approval-required"
+      ? 1
+      : 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.log(JSON.stringify({ status: "error", error: message }));

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import {
   buildSkillPackMetadata,
   hashText,
@@ -312,7 +313,10 @@ async function makeConfig(
     projectPolicy: DEFAULT_PATCHMILL_POLICY,
     readyLabel: "agent-ready",
     issueLimit: 1,
-    requirePlanApproval: false,
+    approvalPolicy: createWorkflowApprovalPolicy(
+      DEFAULT_PATCHMILL_CONFIG.workflow,
+      DEFAULT_PATCHMILL_POLICY,
+    ),
     baseBranch: "main",
     baseRef: "HEAD",
     remote: "origin",
@@ -1211,7 +1215,16 @@ test("runOneIssue stops after finding an existing plan when plan approval is req
   const config = await makeConfig({
     dryRun: false,
     execute: true,
-    requirePlanApproval: true,
+    approvalPolicy: createWorkflowApprovalPolicy(
+      {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow,
+        planApproval: {
+          ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+          required: true,
+        },
+      },
+      DEFAULT_PATCHMILL_POLICY,
+    ),
   });
   const planPath = "docs/plans/2026-05-14-issue-47-approval-existing-plan.md";
   await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
@@ -1272,7 +1285,16 @@ test("runOneIssue stops after creating a plan when plan approval is required", a
   const config = await makeConfig({
     dryRun: false,
     execute: true,
-    requirePlanApproval: true,
+    approvalPolicy: createWorkflowApprovalPolicy(
+      {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow,
+        planApproval: {
+          ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+          required: true,
+        },
+      },
+      DEFAULT_PATCHMILL_POLICY,
+    ),
   });
   const selected = issue(48, ["agent-ready", "bug"], "Approval created plan");
   const expectedPlanPath =

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -1467,6 +1467,88 @@ test("runOneIssue stops after creating a plan when plan approval is required", a
   );
 });
 
+test("runOneIssue ignores stale plan approval when a new plan is created", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    approvalPolicy: approvalPolicy({ planRequired: true }),
+  });
+  const selected = issue(
+    50,
+    ["agent-ready", "plan-approved", "bug"],
+    "Stale plan approval",
+  );
+  const expectedPlanPath =
+    "docs/plans/2026-05-09-issue-50-stale-plan-approval.md";
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    )
+      return { code: 0, stdout: labelListPayload(), stderr: "" };
+    if (
+      call.command === "tea" &&
+      (call.args[0] === "issues" || call.args[0] === "comment")
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "pi") {
+      const prompt = await readFile(promptPath(call.args), "utf8");
+      assert.match(prompt, /Create an implementation plan/);
+      return {
+        code: 0,
+        stdout: `planning...\n{"status":"plan-created","planPath":"${expectedPlanPath}","commit":"abc123"}`,
+        stderr: "",
+      };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "plan-created");
+  assert.equal(result.planPath, expectedPlanPath);
+  assert.equal(runner.calls.filter((call) => call.command === "pi").length, 1);
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "worktree",
+    ),
+    false,
+  );
+  const editCalls = runner.calls.filter(
+    (call) =>
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit",
+  );
+  const restoreCall = editCalls.at(-1);
+  assert.ok(restoreCall);
+  assert.equal(
+    restoreCall.args[restoreCall.args.indexOf("--add-labels") + 1],
+    "agent-ready,plan-review",
+  );
+  assert.equal(
+    restoreCall.args[restoreCall.args.indexOf("--remove-labels") + 1],
+    "plan-approved,in-progress",
+  );
+});
+
 test("runOneIssue proceeds when plan approval label is present and clears plan-review", async () => {
   const config = await makeConfig({
     dryRun: false,

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -123,6 +123,10 @@ const DEFAULT_LABEL_NAMES = [
   "priority:medium",
   "priority:high",
   "priority:critical",
+  "spec-review",
+  "spec-approved",
+  "plan-review",
+  "plan-approved",
 ] as const;
 
 function labelListPayload(
@@ -292,6 +296,40 @@ async function writeTodo(
   );
 }
 
+function approvalPolicy(
+  overrides: {
+    specRequired?: boolean;
+    specApprovedLabel?: string;
+    planRequired?: boolean;
+    planReviewLabel?: string;
+    planApprovedLabel?: string;
+  } = {},
+) {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      specApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+        required: overrides.specRequired,
+        approvedLabel:
+          overrides.specApprovedLabel ??
+          DEFAULT_PATCHMILL_CONFIG.workflow.specApproval.approvedLabel,
+      },
+      planApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+        required: overrides.planRequired,
+        reviewLabel:
+          overrides.planReviewLabel ??
+          DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.reviewLabel,
+        approvedLabel:
+          overrides.planApprovedLabel ??
+          DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.approvedLabel,
+      },
+    },
+    DEFAULT_PATCHMILL_POLICY,
+  );
+}
+
 async function makeConfig(
   overrides: Partial<AgentIssueConfig> = {},
 ): Promise<AgentIssueConfig> {
@@ -376,6 +414,83 @@ test("runOneIssue dry-run lists open issues and returns the selected agent-ready
       (call) => `${call.command} ${call.args[0]} ${call.args[1]}`,
     ),
     ["tea issues list", "tea issues list"],
+  );
+});
+
+test("runOneIssue automatic selection skips spec-unapproved issues", async () => {
+  const config = await makeConfig({
+    approvalPolicy: approvalPolicy({ specRequired: true }),
+  });
+  const runner = createMockRunner((call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout:
+          page === "1"
+            ? issueListPayload([
+                issue(1, ["agent-ready", "priority:critical"], "Needs spec"),
+                issue(
+                  2,
+                  ["agent-ready", "priority:high", "spec-approved"],
+                  "Spec approved",
+                ),
+              ])
+            : "[]",
+        stderr: "",
+      };
+    }
+
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "dry-run");
+  assert.equal(result.issue.number, 2);
+});
+
+test("runOneIssue returns approval-required for explicit spec-unapproved issue", async () => {
+  const config = await makeConfig({
+    issueNumber: 7,
+    approvalPolicy: approvalPolicy({
+      specRequired: true,
+      specApprovedLabel: "spec-ok",
+    }),
+  });
+  const runner = createMockRunner((call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "7"
+    ) {
+      return {
+        code: 0,
+        stdout: issueViewPayload(issue(7, ["agent-ready"])),
+        stderr: "",
+      };
+    }
+
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "approval-required");
+  assert.equal(result.issue.number, 7);
+  assert.equal(result.approvalKind, "spec");
+  assert.equal(result.missingLabel, "spec-ok");
+  assert.equal(
+    runner.calls.some((call) => call.command === "git"),
+    false,
   );
 });
 
@@ -1215,16 +1330,7 @@ test("runOneIssue stops after finding an existing plan when plan approval is req
   const config = await makeConfig({
     dryRun: false,
     execute: true,
-    approvalPolicy: createWorkflowApprovalPolicy(
-      {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow,
-        planApproval: {
-          ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
-          required: true,
-        },
-      },
-      DEFAULT_PATCHMILL_POLICY,
-    ),
+    approvalPolicy: approvalPolicy({ planRequired: true }),
   });
   const planPath = "docs/plans/2026-05-14-issue-47-approval-existing-plan.md";
   await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
@@ -1279,22 +1385,25 @@ test("runOneIssue stops after finding an existing plan when plan approval is req
   );
   assert.equal(comments.length, 2);
   assert.match(commentBody(comments[1]), /Existing plan ready/);
+  const editCalls = runner.calls.filter(
+    (call) =>
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit",
+  );
+  const restoreCall = editCalls.at(-1);
+  assert.ok(restoreCall);
+  assert.equal(
+    restoreCall.args[restoreCall.args.indexOf("--add-labels") + 1],
+    "agent-ready,plan-review",
+  );
 });
 
 test("runOneIssue stops after creating a plan when plan approval is required", async () => {
   const config = await makeConfig({
     dryRun: false,
     execute: true,
-    approvalPolicy: createWorkflowApprovalPolicy(
-      {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow,
-        planApproval: {
-          ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
-          required: true,
-        },
-      },
-      DEFAULT_PATCHMILL_POLICY,
-    ),
+    approvalPolicy: approvalPolicy({ planRequired: true }),
   });
   const selected = issue(48, ["agent-ready", "bug"], "Approval created plan");
   const expectedPlanPath =
@@ -1355,6 +1464,113 @@ test("runOneIssue stops after creating a plan when plan approval is required", a
       (call) => call.command === "git" && call.args[0] === "show-ref",
     ),
     false,
+  );
+});
+
+test("runOneIssue proceeds when plan approval label is present and clears plan-review", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    approvalPolicy: approvalPolicy({ planRequired: true }),
+  });
+  const planPath = "docs/plans/2026-05-14-issue-49-approved-plan.md";
+  await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
+  const selected = issue(
+    49,
+    ["agent-ready", "plan-review", "plan-approved", "bug"],
+    "Approved plan",
+  );
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "list"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "git" && call.args[0] === "show-ref")
+      return { code: 1, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "add"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    )
+      return {
+        code: 0,
+        stdout: labelListPayload([
+          "agent-ready",
+          "in-progress",
+          "agent-done",
+          "plan-review",
+          "plan-approved",
+        ]),
+        stderr: "",
+      };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "tea" && call.args[0] === "comment")
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "pi") {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          status: "pr-created",
+          prUrl: "https://forgejo/pr/49",
+          branch: "agent/issue-49-approved-plan",
+          commits: ["abc123"],
+          validation: [
+            "node --test src/cli/commands/run-once/pipeline.test.ts",
+          ],
+        }),
+        stderr: "",
+      };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created");
+  const claimCall = runner.calls.find(
+    (call) =>
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit" &&
+      call.args.includes("--remove-labels"),
+  );
+  assert.ok(claimCall);
+  assert.equal(
+    claimCall.args[claimCall.args.indexOf("--remove-labels") + 1],
+    "agent-ready,plan-review",
+  );
+  assert.equal(
+    claimCall.args[claimCall.args.indexOf("--add-labels") + 1],
+    "in-progress",
   );
 });
 

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import {
   buildSkillPackMetadata,
@@ -305,29 +306,30 @@ function approvalPolicy(
     planApprovedLabel?: string;
   } = {},
 ) {
-  return createWorkflowApprovalPolicy(
-    {
-      ...DEFAULT_PATCHMILL_CONFIG.workflow,
-      specApproval: {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
-        required: overrides.specRequired,
-        approvedLabel:
-          overrides.specApprovedLabel ??
-          DEFAULT_PATCHMILL_CONFIG.workflow.specApproval.approvedLabel,
-      },
-      planApproval: {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
-        required: overrides.planRequired,
-        reviewLabel:
-          overrides.planReviewLabel ??
-          DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.reviewLabel,
-        approvedLabel:
-          overrides.planApprovedLabel ??
-          DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.approvedLabel,
-      },
+  return createWorkflowApprovalPolicy({
+    ...DEFAULT_PATCHMILL_CONFIG.workflow,
+    specApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+      required:
+        overrides.specRequired ??
+        DEFAULT_PATCHMILL_CONFIG.workflow.specApproval.required,
+      approvedLabel:
+        overrides.specApprovedLabel ??
+        DEFAULT_PATCHMILL_CONFIG.workflow.specApproval.approvedLabel,
     },
-    DEFAULT_PATCHMILL_POLICY,
-  );
+    planApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+      required:
+        overrides.planRequired ??
+        DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.required,
+      reviewLabel:
+        overrides.planReviewLabel ??
+        DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.reviewLabel,
+      approvedLabel:
+        overrides.planApprovedLabel ??
+        DEFAULT_PATCHMILL_CONFIG.workflow.planApproval.approvedLabel,
+    },
+  });
 }
 
 async function makeConfig(
@@ -337,6 +339,13 @@ async function makeConfig(
   const plansDir = join(repoRoot, "docs", "plans");
   const runStateDir = join(repoRoot, ".patchmill", "runs");
   await mkdir(plansDir, { recursive: true });
+  const labelCatalog = createPatchmillLabelCatalog({
+    ...DEFAULT_PATCHMILL_CONFIG,
+    labels: overrides.triagePolicy?.labels ?? DEFAULT_PATCHMILL_CONFIG.labels,
+    triage: overrides.triagePolicy
+      ? { stateMap: overrides.triagePolicy.stateMap }
+      : DEFAULT_PATCHMILL_CONFIG.triage,
+  });
 
   return {
     repoRoot,
@@ -351,9 +360,9 @@ async function makeConfig(
     projectPolicy: DEFAULT_PATCHMILL_POLICY,
     readyLabel: "agent-ready",
     issueLimit: 1,
+    labelCatalog,
     approvalPolicy: createWorkflowApprovalPolicy(
       DEFAULT_PATCHMILL_CONFIG.workflow,
-      DEFAULT_PATCHMILL_POLICY,
     ),
     baseBranch: "main",
     baseRef: "HEAD",

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -8,11 +8,7 @@ import {
 } from "../../../git/worktree-strategy.ts";
 import type { GitWorktreeStrategyConfig } from "../../../git/types.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
-import type {
-  IssueHostProvider,
-  LabelDefinition,
-} from "../../../host/types.ts";
-import type { PatchmillTriagePolicy } from "../../../policy/triage.ts";
+import type { IssueHostProvider } from "../../../host/types.ts";
 import { skillInvocationPaths } from "../../../workflow/skills.ts";
 import {
   DEFAULT_TRIAGE_POLICY,
@@ -550,14 +546,12 @@ function unexpectedFailureCommentKey(
 
 async function ensureAutomationLabel(
   host: IssueHostProvider,
-  triagePolicy: PatchmillTriagePolicy | undefined,
-  extraLabels: readonly LabelDefinition[],
+  config: Pick<AgentIssueConfig, "labelCatalog">,
   name: string,
 ): Promise<void> {
   const missing = missingLabelDefinitions(
     await host.listLabels(),
-    triagePolicy ?? DEFAULT_TRIAGE_POLICY,
-    extraLabels,
+    config.labelCatalog,
   );
   const label = missing.find((definition) => definition.name === name);
   if (!label) return;
@@ -672,7 +666,7 @@ async function blockIssue(
     issueNumber: issue.number,
   });
   const blockedLabels = nextLabels(labels, [inProgress], [needsInfo]);
-  await ensureAutomationLabel(host, config.triagePolicy, [], needsInfo);
+  await ensureAutomationLabel(host, config, needsInfo);
   await host.applyLabels(planLabelChange(issue.number, labels, blockedLabels));
   await writeRunState(
     config.runStateDir,
@@ -894,7 +888,7 @@ export async function runOneIssue(
         `ensuring ${inProgress} label exists`,
         { issueNumber: issue.number },
       );
-      await ensureAutomationLabel(host, config.triagePolicy, [], inProgress);
+      await ensureAutomationLabel(host, config, inProgress);
       await host.applyLabels(
         planLabelChange(issue.number, issue.labels, labels),
       );
@@ -1113,12 +1107,7 @@ export async function runOneIssue(
       }
       if (!checkpoints.readyLabelRestored) {
         if (planGate.action === "stop-for-plan-review") {
-          await ensureAutomationLabel(
-            host,
-            config.triagePolicy,
-            config.approvalPolicy.labelDefinitions,
-            planGate.reviewLabel,
-          );
+          await ensureAutomationLabel(host, config, planGate.reviewLabel);
         }
         await host.applyLabels(
           planLabelChange(issue.number, labels, finalLabels),
@@ -1596,7 +1585,7 @@ export async function runOneIssue(
       checkpoints.handoffCommentPosted = true;
     }
     if (!checkpoints.doneLabelEnsured) {
-      await ensureAutomationLabel(host, config.triagePolicy, [], done);
+      await ensureAutomationLabel(host, config, done);
       await writeRunState(
         config.runStateDir,
         {

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -8,7 +8,10 @@ import {
 } from "../../../git/worktree-strategy.ts";
 import type { GitWorktreeStrategyConfig } from "../../../git/types.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
-import type { IssueHostProvider } from "../../../host/types.ts";
+import type {
+  IssueHostProvider,
+  LabelDefinition,
+} from "../../../host/types.ts";
 import type { PatchmillTriagePolicy } from "../../../policy/triage.ts";
 import { skillInvocationPaths } from "../../../workflow/skills.ts";
 import {
@@ -27,6 +30,11 @@ import {
   readIssueTodoTasks,
 } from "./issue-todos.ts";
 import { runPiPrompt } from "./pi.ts";
+import {
+  ApprovalRequiredError,
+  approvedWorkflowReviewLabelsToRemove,
+  decidePlanApprovalGate,
+} from "./approval-gates.ts";
 import { readPlanTaskLabels } from "./plan-tasks.ts";
 import { buildPlanPath, findIssuePlan } from "./plans.ts";
 import {
@@ -458,6 +466,7 @@ async function selectResumableIssue(
       issueNumber: config.issueNumber,
       readyLabel: ready,
       triagePolicy: config.triagePolicy,
+      approvalPolicy: config.approvalPolicy,
     });
     if (!selected) return undefined;
     if (resumable.length === 1 && resumable[0]?.number !== selected.number) {
@@ -479,6 +488,7 @@ async function selectResumableIssue(
     issueNumber: config.issueNumber,
     readyLabel: ready,
     triagePolicy: config.triagePolicy,
+    approvalPolicy: config.approvalPolicy,
   });
   return selected ? { issue: selected, resumed: false } : undefined;
 }
@@ -541,11 +551,13 @@ function unexpectedFailureCommentKey(
 async function ensureAutomationLabel(
   host: IssueHostProvider,
   triagePolicy: PatchmillTriagePolicy | undefined,
+  extraLabels: readonly LabelDefinition[],
   name: string,
 ): Promise<void> {
   const missing = missingLabelDefinitions(
     await host.listLabels(),
     triagePolicy ?? DEFAULT_TRIAGE_POLICY,
+    extraLabels,
   );
   const label = missing.find((definition) => definition.name === name);
   if (!label) return;
@@ -660,7 +672,7 @@ async function blockIssue(
     issueNumber: issue.number,
   });
   const blockedLabels = nextLabels(labels, [inProgress], [needsInfo]);
-  await ensureAutomationLabel(host, config.triagePolicy, needsInfo);
+  await ensureAutomationLabel(host, config.triagePolicy, [], needsInfo);
   await host.applyLabels(planLabelChange(issue.number, labels, blockedLabels));
   await writeRunState(
     config.runStateDir,
@@ -696,7 +708,23 @@ export async function runOneIssue(
     host: config.host,
   });
   const issues = await loadSelectionIssues(host, config, options);
-  const selected = await selectResumableIssue(issues, config);
+  let selected: { issue: IssueSummary; resumed: boolean } | undefined;
+  try {
+    selected = await selectResumableIssue(issues, config);
+  } catch (error) {
+    if (error instanceof ApprovalRequiredError) {
+      return withLogPath(
+        {
+          status: "approval-required",
+          issue: error.issue,
+          approvalKind: error.approvalKind,
+          missingLabel: error.missingLabel,
+        },
+        options,
+      );
+    }
+    throw error;
+  }
   const issue = selected?.issue;
 
   if (!issue) {
@@ -840,11 +868,23 @@ export async function runOneIssue(
   const ignoredPaths = cleanStatusIgnoredPaths(config, options);
   await assertCleanWorktree(runner, config.repoRoot, ignoredPaths);
   const { ready, inProgress, done, needsInfo } = lifecycleLabels(config);
+  const workflowReviewLabelsToRemove = approvedWorkflowReviewLabelsToRemove(
+    issue.labels,
+    config.approvalPolicy,
+  );
   let labels = resumed
     ? issue.labels.includes(inProgress)
       ? issue.labels
-      : nextLabels(issue.labels, [ready], [inProgress])
-    : nextLabels(issue.labels, [ready], [inProgress]);
+      : nextLabels(
+          issue.labels,
+          [ready, ...workflowReviewLabelsToRemove],
+          [inProgress],
+        )
+    : nextLabels(
+        issue.labels,
+        [ready, ...workflowReviewLabelsToRemove],
+        [inProgress],
+      );
   if (!checkpoints.claimed) {
     await runStep("claim issue", async () => {
       await progress(
@@ -854,7 +894,7 @@ export async function runOneIssue(
         `ensuring ${inProgress} label exists`,
         { issueNumber: issue.number },
       );
-      await ensureAutomationLabel(host, config.triagePolicy, inProgress);
+      await ensureAutomationLabel(host, config.triagePolicy, [], inProgress);
       await host.applyLabels(
         planLabelChange(issue.number, issue.labels, labels),
       );
@@ -1030,8 +1070,18 @@ export async function runOneIssue(
       });
     }
 
-    if (config.planOnly || config.approvalPolicy.planApproval.required) {
-      const finalLabels = nextLabels(labels, [inProgress], [ready]);
+    const planGate = decidePlanApprovalGate({
+      labels,
+      planOnly: config.planOnly,
+      policy: config.approvalPolicy,
+    });
+
+    if (planGate.action !== "proceed") {
+      const labelsToAdd =
+        planGate.action === "stop-for-plan-review"
+          ? [ready, planGate.reviewLabel]
+          : [ready];
+      const finalLabels = nextLabels(labels, [inProgress], labelsToAdd);
       if (!checkpoints.planReadyCommentPosted) {
         await host.commentIssue(
           issue.number,
@@ -1051,6 +1101,14 @@ export async function runOneIssue(
         checkpoints.planReadyCommentPosted = true;
       }
       if (!checkpoints.readyLabelRestored) {
+        if (planGate.action === "stop-for-plan-review") {
+          await ensureAutomationLabel(
+            host,
+            config.triagePolicy,
+            config.approvalPolicy.labelDefinitions,
+            planGate.reviewLabel,
+          );
+        }
         await host.applyLabels(
           planLabelChange(issue.number, labels, finalLabels),
         );
@@ -1527,7 +1585,7 @@ export async function runOneIssue(
       checkpoints.handoffCommentPosted = true;
     }
     if (!checkpoints.doneLabelEnsured) {
-      await ensureAutomationLabel(host, config.triagePolicy, done);
+      await ensureAutomationLabel(host, config.triagePolicy, [], done);
       await writeRunState(
         config.runStateDir,
         {

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -924,6 +924,7 @@ export async function runOneIssue(
   let branch: string | undefined;
   let worktreePath: string | undefined;
   let planCreated = false;
+  let planCreatedThisRun = false;
 
   try {
     if (!checkpoints.startedCommentPosted) {
@@ -1045,6 +1046,7 @@ export async function runOneIssue(
       planPath = repoPath(config.repoRoot, planned.planPath).relative;
       planCommit = planned.commit;
       planCreated = true;
+      planCreatedThisRun = true;
       await writeRunState(
         config.runStateDir,
         {
@@ -1074,6 +1076,7 @@ export async function runOneIssue(
     const planGate = decidePlanApprovalGate({
       labels,
       planOnly: config.planOnly,
+      planCreatedThisRun,
       policy: config.approvalPolicy,
     });
 
@@ -1082,7 +1085,14 @@ export async function runOneIssue(
         planGate.action === "stop-for-plan-review"
           ? [ready, planGate.reviewLabel]
           : [ready];
-      const finalLabels = nextLabels(labels, [inProgress], labelsToAdd);
+      const labelsToRemove = [
+        inProgress,
+        ...(planGate.action === "stop-for-plan-review" &&
+        planGate.staleApprovedLabel
+          ? [planGate.staleApprovedLabel]
+          : []),
+      ];
+      const finalLabels = nextLabels(labels, labelsToRemove, labelsToAdd);
       if (!checkpoints.planReadyCommentPosted) {
         await host.commentIssue(
           issue.number,

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -1030,7 +1030,7 @@ export async function runOneIssue(
       });
     }
 
-    if (config.planOnly || config.requirePlanApproval) {
+    if (config.planOnly || config.approvalPolicy.planApproval.required) {
       const finalLabels = nextLabels(labels, [inProgress], [ready]);
       if (!checkpoints.planReadyCommentPosted) {
         await host.commentIssue(

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -1000,6 +1000,7 @@ export async function runOneIssue(
             issue,
             planPath,
             projectPolicy: config.projectPolicy,
+            planApprovalRequired: config.approvalPolicy.planApproval.required,
             skills: config.skills,
             triageLabels: { ready, needsInfo },
           }),

--- a/src/cli/commands/run-once/prompts.test.ts
+++ b/src/cli/commands/run-once/prompts.test.ts
@@ -156,6 +156,42 @@ test("buildPlanCreationPrompt includes issue context, workflow rules, and result
   assert.match(prompt, /"status": "plan-created"/);
 });
 
+test("buildPlanCreationPrompt uses normalized plan approval requirement when provided", () => {
+  const prompt = buildPlanCreationPrompt({
+    issue,
+    planPath,
+    projectPolicy: { ...examplePolicy, planRequiresApproval: false },
+    planApprovalRequired: true,
+  });
+
+  assert.match(
+    prompt,
+    /Stop after writing the plan and wait for explicit manual approval before implementation continues/,
+  );
+  assert.doesNotMatch(
+    prompt,
+    /Do not stop for an additional manual plan-approval gate/,
+  );
+});
+
+test("buildPlanCreationPrompt lets normalized plan approval disable legacy alias prompt text", () => {
+  const prompt = buildPlanCreationPrompt({
+    issue,
+    planPath,
+    projectPolicy: { ...examplePolicy, planRequiresApproval: true },
+    planApprovalRequired: false,
+  });
+
+  assert.match(
+    prompt,
+    /Do not stop for an additional manual plan-approval gate/,
+  );
+  assert.doesNotMatch(
+    prompt,
+    /Stop after writing the plan and wait for explicit manual approval before implementation continues/,
+  );
+});
+
 test("buildPlanCreationPrompt uses deterministic fallbacks for missing fields", () => {
   const prompt = buildPlanCreationPrompt({
     issue: {

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -25,6 +25,7 @@ export type PlanCreationPromptInput = {
   issue: IssueSummary;
   planPath: string;
   projectPolicy: PatchmillProjectPolicy;
+  planApprovalRequired?: boolean;
   skills?: PatchmillSkillsConfig;
   triageLabels?: Partial<PromptTriageLabels>;
 };
@@ -552,6 +553,8 @@ export function buildPlanCreationPrompt(
   input: PlanCreationPromptInput,
 ): string {
   const { issue, planPath, projectPolicy } = input;
+  const planApprovalRequired =
+    input.planApprovalRequired ?? projectPolicy.planRequiresApproval;
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
   const { ready, needsInfo } = resolvePromptTriageLabels(input.triageLabels);
   const workflow = numberedWorkflow([
@@ -559,7 +562,7 @@ export function buildPlanCreationPrompt(
     `Treat \`${ready}\` as meaning the issue is already clear and unambiguous enough to plan. Do not run a separate brainstorming/requirements-discovery process by default.`,
     renderPlanningSkillStep(skills),
     `Do not substitute an ad-hoc planning process for the configured planning skill. The plan must be saved to ${planPath} and use checkbox steps suitable for agent execution.`,
-    projectPolicy.planRequiresApproval
+    planApprovalRequired
       ? "Stop after writing the plan and wait for explicit manual approval before implementation continues."
       : "Do not stop for an additional manual plan-approval gate. Only use the blocker contract if the issue is unexpectedly not clear enough to plan safely.",
     renderTodoWorkflowStep(projectPolicy, "plan", issue.number),

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -553,8 +553,7 @@ export function buildPlanCreationPrompt(
   input: PlanCreationPromptInput,
 ): string {
   const { issue, planPath, projectPolicy } = input;
-  const planApprovalRequired =
-    input.planApprovalRequired ?? projectPolicy.planRequiresApproval;
+  const planApprovalRequired = input.planApprovalRequired ?? false;
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
   const { ready, needsInfo } = resolvePromptTriageLabels(input.triageLabels);
   const workflow = numberedWorkflow([

--- a/src/cli/commands/run-once/selection.test.ts
+++ b/src/cli/commands/run-once/selection.test.ts
@@ -27,17 +27,14 @@ function issue(number: number, labels: string[], state = "open"): IssueSummary {
 }
 
 function specApprovalPolicy(approvedLabel = "spec-approved") {
-  return createWorkflowApprovalPolicy(
-    {
-      ...DEFAULT_PATCHMILL_CONFIG.workflow,
-      specApproval: {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
-        required: true,
-        approvedLabel,
-      },
+  return createWorkflowApprovalPolicy({
+    ...DEFAULT_PATCHMILL_CONFIG.workflow,
+    specApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+      required: true,
+      approvedLabel,
     },
-    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
-  );
+  });
 }
 
 test("selectIssue chooses the highest-priority agent-ready issue", () => {

--- a/src/cli/commands/run-once/selection.test.ts
+++ b/src/cli/commands/run-once/selection.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import { createWorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
+import { ApprovalRequiredError } from "./approval-gates.ts";
 import { selectIssue } from "./selection.ts";
 import type { IssueSummary } from "./types.ts";
 
@@ -22,6 +24,20 @@ function issue(number: number, labels: string[], state = "open"): IssueSummary {
     labels,
     state,
   };
+}
+
+function specApprovalPolicy(approvedLabel = "spec-approved") {
+  return createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      specApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+        required: true,
+        approvedLabel,
+      },
+    },
+    DEFAULT_PATCHMILL_CONFIG.projectPolicy,
+  );
 }
 
 test("selectIssue chooses the highest-priority agent-ready issue", () => {
@@ -190,6 +206,31 @@ test("selectIssue blocks labels mapped to non-ready triage states", () => {
   );
 
   assert.equal(selected?.number, 5);
+});
+
+test("selectIssue skips spec-unapproved automatic candidates and can choose lower priority approved work", () => {
+  const selected = selectIssue(
+    [issue(1, [ready, critical]), issue(2, [ready, high, "spec-approved"])],
+    { readyLabel: ready, approvalPolicy: specApprovalPolicy() },
+  );
+
+  assert.equal(selected?.number, 2);
+});
+
+test("selectIssue rejects explicit issue missing required spec approval", () => {
+  assert.throws(
+    () =>
+      selectIssue([issue(5, [ready])], {
+        readyLabel: ready,
+        issueNumber: 5,
+        approvalPolicy: specApprovalPolicy("spec-ok"),
+      }),
+    (error: unknown) => {
+      assert(error instanceof ApprovalRequiredError);
+      assert.equal(error.missingLabel, "spec-ok");
+      return true;
+    },
+  );
 });
 
 test("selectIssue returns no issue when no open agent-ready issue exists", () => {

--- a/src/cli/commands/run-once/selection.ts
+++ b/src/cli/commands/run-once/selection.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
+import {
+  assertExplicitIssueApprovals,
+  issueMeetsAutomaticApprovals,
+} from "./approval-gates.ts";
 import type { IssueSelectionOptions, IssueSummary } from "./types.ts";
 
 const DEFAULT_TRIAGE_POLICY = createTriagePolicy(
@@ -9,6 +13,7 @@ const DEFAULT_TRIAGE_POLICY = createTriagePolicy(
 type ResolvedIssueSelectionOptions = {
   issueNumber?: number;
   readyLabel: IssueSelectionOptions["readyLabel"];
+  approvalPolicy: IssueSelectionOptions["approvalPolicy"];
   priorityLabels: readonly string[];
   excludedLabels: Set<string>;
 };
@@ -28,6 +33,7 @@ function resolveSelectionOptions(
   return {
     issueNumber: options.issueNumber,
     readyLabel: options.readyLabel,
+    approvalPolicy: options.approvalPolicy,
     priorityLabels:
       options.priorityLabels ?? triagePolicy.runOnceSelection.priorityOrder,
     excludedLabels: new Set([
@@ -62,7 +68,8 @@ function isEligible(
   return (
     issue.state === "open" &&
     issue.labels.includes(options.readyLabel) &&
-    blockingLabels(issue.labels, options.excludedLabels).length === 0
+    blockingLabels(issue.labels, options.excludedLabels).length === 0 &&
+    issueMeetsAutomaticApprovals(issue, options.approvalPolicy)
   );
 }
 
@@ -102,6 +109,8 @@ export function selectIssue(
         `Issue #${issue.number} is open but not eligible because it has ${blockedBy.join(", ")}`,
       );
     }
+
+    assertExplicitIssueApprovals(issue, resolved.approvalPolicy);
 
     return issue;
   }

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -1,6 +1,7 @@
 import type { PatchmillHostConfig } from "../../../config/types.ts";
 import type { PatchmillTriagePolicy } from "../../../policy/triage.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
+import type { PatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import type { WorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
 
@@ -34,6 +35,7 @@ export type AgentIssueConfig = {
   triagePolicy?: PatchmillTriagePolicy;
   readyLabel: string;
   issueLimit: 1;
+  labelCatalog: PatchmillLabelCatalog;
   approvalPolicy: WorkflowApprovalPolicy;
   baseBranch: string;
   baseRef: string;

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -48,6 +48,7 @@ export type IssueSelectionOptions = Pick<
   AgentIssueConfig,
   "issueNumber" | "readyLabel" | "triagePolicy"
 > & {
+  approvalPolicy?: AgentIssueConfig["approvalPolicy"];
   priorityLabels?: readonly string[];
   excludedLabels?: readonly string[];
 };

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -1,6 +1,7 @@
 import type { PatchmillHostConfig } from "../../../config/types.ts";
 import type { PatchmillTriagePolicy } from "../../../policy/triage.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
+import type { WorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
 
 export type {
@@ -33,7 +34,7 @@ export type AgentIssueConfig = {
   triagePolicy?: PatchmillTriagePolicy;
   readyLabel: string;
   issueLimit: 1;
-  requirePlanApproval: boolean;
+  approvalPolicy: WorkflowApprovalPolicy;
   baseBranch: string;
   baseRef: string;
   remote: string;
@@ -157,6 +158,13 @@ export type AgentIssuePlanCreatedResult = {
   commit?: string;
 };
 
+export type AgentIssueApprovalRequiredResult = {
+  status: "approval-required";
+  issue: IssueSummary;
+  approvalKind: "spec" | "plan";
+  missingLabel: string;
+};
+
 export type AgentIssueVisualEvidence = {
   screenshotPath: string;
   caption?: string;
@@ -202,6 +210,7 @@ export type AgentIssuePipelineResult = AgentIssuePipelineResultLog &
         issue: IssueSummary;
         planPath: string;
       }
+    | AgentIssueApprovalRequiredResult
     | ({
         issue: IssueSummary;
         planPath: string;

--- a/src/cli/commands/triage/labels.test.ts
+++ b/src/cli/commands/triage/labels.test.ts
@@ -39,25 +39,8 @@ test("missingLabelDefinitions returns labels absent from Forgejo", () => {
   );
 });
 
-test("missingLabelDefinitions can include workflow approval labels", () => {
-  const workflowLabels = [
-    {
-      name: "spec-review",
-      color: "#5319e7",
-      description: "Awaiting specification review",
-    },
-    {
-      name: "spec-approved",
-      color: "#0e8a16",
-      description: "Specification approved for automation",
-    },
-  ];
-
-  const missing = missingLabelDefinitions(
-    [ready, "bug"],
-    undefined,
-    workflowLabels,
-  );
+test("missingLabelDefinitions uses the default Patchmill label catalog", () => {
+  const missing = missingLabelDefinitions([ready, "bug"]);
 
   assert.ok(missing.some((label) => label.name === "needs-info"));
   assert.ok(missing.some((label) => label.name === "spec-review"));

--- a/src/cli/commands/triage/labels.test.ts
+++ b/src/cli/commands/triage/labels.test.ts
@@ -39,6 +39,31 @@ test("missingLabelDefinitions returns labels absent from Forgejo", () => {
   );
 });
 
+test("missingLabelDefinitions can include workflow approval labels", () => {
+  const workflowLabels = [
+    {
+      name: "spec-review",
+      color: "#5319e7",
+      description: "Awaiting specification review",
+    },
+    {
+      name: "spec-approved",
+      color: "#0e8a16",
+      description: "Specification approved for automation",
+    },
+  ];
+
+  const missing = missingLabelDefinitions(
+    [ready, "bug"],
+    undefined,
+    workflowLabels,
+  );
+
+  assert.ok(missing.some((label) => label.name === "needs-info"));
+  assert.ok(missing.some((label) => label.name === "spec-review"));
+  assert.ok(missing.some((label) => label.name === "spec-approved"));
+});
+
 test("planLabelChange computes additions and removals", () => {
   const change = planLabelChange(7, ["bug", "old", needsInfo], ["bug", ready]);
 

--- a/src/cli/commands/triage/labels.ts
+++ b/src/cli/commands/triage/labels.ts
@@ -1,11 +1,15 @@
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
-import { createTriagePolicy } from "../../../policy/triage.ts";
-import type { LabelChangePlan, LabelDefinition } from "./types.ts";
+import {
+  createPatchmillLabelCatalog,
+  type PatchmillLabelCatalog,
+} from "../../../policy/label-catalog.ts";
+import type { LabelChangePlan } from "./types.ts";
 
-export const DEFAULT_TRIAGE_POLICY = createTriagePolicy(
-  DEFAULT_PATCHMILL_CONFIG.labels,
-  DEFAULT_PATCHMILL_CONFIG.triage,
+export const DEFAULT_LABEL_CATALOG = createPatchmillLabelCatalog(
+  DEFAULT_PATCHMILL_CONFIG,
 );
+
+export const DEFAULT_TRIAGE_POLICY = DEFAULT_LABEL_CATALOG.triagePolicy;
 
 export function uniqueSorted(values: string[]): string[] {
   return [...new Set(values)].sort((a, b) => a.localeCompare(b));
@@ -15,25 +19,14 @@ function uniquePreserved(values: string[]): string[] {
   return [...new Set(values)];
 }
 
-function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
-  const seen = new Set<string>();
-  return labels.filter((label) => {
-    if (seen.has(label.name)) return false;
-    seen.add(label.name);
-    return true;
-  });
-}
-
 export function missingLabelDefinitions(
   existingNames: string[],
-  triagePolicy = DEFAULT_TRIAGE_POLICY,
-  extraLabels: readonly LabelDefinition[] = [],
-): LabelDefinition[] {
+  labelCatalog: PatchmillLabelCatalog = DEFAULT_LABEL_CATALOG,
+): PatchmillLabelCatalog["labelDefinitions"] {
   const existing = new Set(existingNames);
-  return dedupeLabelDefinitions([
-    ...triagePolicy.allowedLabels,
-    ...extraLabels,
-  ]).filter((label) => !existing.has(label.name));
+  return labelCatalog.labelDefinitions.filter(
+    (label) => !existing.has(label.name),
+  );
 }
 
 export function planLabelChange(

--- a/src/cli/commands/triage/labels.ts
+++ b/src/cli/commands/triage/labels.ts
@@ -15,14 +15,25 @@ function uniquePreserved(values: string[]): string[] {
   return [...new Set(values)];
 }
 
+function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
+  const seen = new Set<string>();
+  return labels.filter((label) => {
+    if (seen.has(label.name)) return false;
+    seen.add(label.name);
+    return true;
+  });
+}
+
 export function missingLabelDefinitions(
   existingNames: string[],
   triagePolicy = DEFAULT_TRIAGE_POLICY,
+  extraLabels: readonly LabelDefinition[] = [],
 ): LabelDefinition[] {
   const existing = new Set(existingNames);
-  return triagePolicy.allowedLabels.filter(
-    (label) => !existing.has(label.name),
-  );
+  return dedupeLabelDefinitions([
+    ...triagePolicy.allowedLabels,
+    ...extraLabels,
+  ]).filter((label) => !existing.has(label.name));
 }
 
 export function planLabelChange(

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -12,10 +12,12 @@ test("defaults match the current patchmill baseline configuration", () => {
   assert.equal(DEFAULT_PATCHMILL_CONFIG.skills, DEFAULT_PATCHMILL_SKILLS);
   assert.deepEqual(DEFAULT_PATCHMILL_CONFIG.workflow, {
     specApproval: {
+      required: false,
       reviewLabel: "spec-review",
       approvedLabel: "spec-approved",
     },
     planApproval: {
+      required: false,
       reviewLabel: "plan-review",
       approvedLabel: "plan-approved",
     },
@@ -53,10 +55,12 @@ test("defaults match the current patchmill baseline configuration", () => {
     },
     workflow: {
       specApproval: {
+        required: false,
         reviewLabel: "spec-review",
         approvedLabel: "spec-approved",
       },
       planApproval: {
+        required: false,
         reviewLabel: "plan-review",
         approvedLabel: "plan-approved",
       },

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -10,6 +10,16 @@ test("defaults match the current patchmill baseline configuration", () => {
     DEFAULT_PATCHMILL_POLICY,
   );
   assert.equal(DEFAULT_PATCHMILL_CONFIG.skills, DEFAULT_PATCHMILL_SKILLS);
+  assert.deepEqual(DEFAULT_PATCHMILL_CONFIG.workflow, {
+    specApproval: {
+      reviewLabel: "spec-review",
+      approvedLabel: "spec-approved",
+    },
+    planApproval: {
+      reviewLabel: "plan-review",
+      approvedLabel: "plan-approved",
+    },
+  });
   assert.deepEqual(DEFAULT_PATCHMILL_CONFIG, {
     host: {
       provider: "forgejo-tea",
@@ -39,6 +49,16 @@ test("defaults match the current patchmill baseline configuration", () => {
         "needs-info": "needs-info",
         "agent-unsuitable": "agent-unsuitable",
         blocked: "blocked",
+      },
+    },
+    workflow: {
+      specApproval: {
+        reviewLabel: "spec-review",
+        approvedLabel: "spec-approved",
+      },
+      planApproval: {
+        reviewLabel: "plan-review",
+        approvedLabel: "plan-approved",
       },
     },
     skills: DEFAULT_PATCHMILL_SKILLS,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -20,6 +20,17 @@ const DEFAULT_PATCHMILL_LABELS = {
   ],
 };
 
+const DEFAULT_PATCHMILL_WORKFLOW = {
+  specApproval: {
+    reviewLabel: "spec-review",
+    approvedLabel: "spec-approved",
+  },
+  planApproval: {
+    reviewLabel: "plan-review",
+    approvedLabel: "plan-approved",
+  },
+};
+
 export const DEFAULT_PATCHMILL_CONFIG: PatchmillConfig = {
   host: {
     provider: "forgejo-tea",
@@ -32,6 +43,7 @@ export const DEFAULT_PATCHMILL_CONFIG: PatchmillConfig = {
   triage: {
     stateMap: defaultTriageStateMap(DEFAULT_PATCHMILL_LABELS),
   },
+  workflow: DEFAULT_PATCHMILL_WORKFLOW,
   skills: DEFAULT_PATCHMILL_SKILLS,
   paths: {
     plansDir: "docs/plans",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -22,10 +22,12 @@ const DEFAULT_PATCHMILL_LABELS = {
 
 const DEFAULT_PATCHMILL_WORKFLOW = {
   specApproval: {
+    required: false,
     reviewLabel: "spec-review",
     approvedLabel: "spec-approved",
   },
   planApproval: {
+    required: false,
     reviewLabel: "plan-review",
     approvedLabel: "plan-approved",
   },

--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -383,10 +383,42 @@ test("loadPatchmillConfig parses workflow approval config and preserves default 
       approvedLabel: "spec-approved",
     },
     planApproval: {
+      required: false,
       reviewLabel: "awaiting-plan-review",
       approvedLabel: "plan-reviewed",
     },
   });
+});
+
+test("loadPatchmillConfig normalizes projectPolicy.planRequiresApproval into workflow plan approval", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-workflow-alias-"));
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({ projectPolicy: { planRequiresApproval: true } }),
+    "utf8",
+  );
+
+  const config = await loadPatchmillConfig(repoRoot, {}, []);
+
+  assert.equal(config.workflow.planApproval.required, true);
+});
+
+test("loadPatchmillConfig lets workflow plan approval override projectPolicy alias", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-workflow-alias-override-"),
+  );
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: { planApproval: { required: false } },
+      projectPolicy: { planRequiresApproval: true },
+    }),
+    "utf8",
+  );
+
+  const config = await loadPatchmillConfig(repoRoot, {}, []);
+
+  assert.equal(config.workflow.planApproval.required, false);
 });
 
 test("loadPatchmillConfig rejects invalid workflow approval config", async () => {
@@ -451,6 +483,65 @@ test("loadPatchmillConfig rejects identical plan approval review and approved la
     () => loadPatchmillConfig(repoRoot, {}, []),
     /workflow\.planApproval\.approvedLabel must differ from workflow\.planApproval\.reviewLabel/,
   );
+});
+
+test("loadPatchmillConfig rejects workflow approval labels that collide with owned labels", async () => {
+  const cases = [
+    {
+      name: "workflow label reuses lifecycle label",
+      config: { workflow: { planApproval: { approvedLabel: "agent-ready" } } },
+      pattern:
+        /workflow\.planApproval\.approvedLabel must not reuse labels\.ready/,
+    },
+    {
+      name: "lifecycle label reuses default workflow label",
+      config: { labels: { ready: "spec-approved" } },
+      pattern:
+        /workflow\.specApproval\.approvedLabel must not reuse labels\.ready/,
+    },
+    {
+      name: "type label",
+      config: { workflow: { specApproval: { approvedLabel: "bug" } } },
+      pattern:
+        /workflow\.specApproval\.approvedLabel must not reuse labels\.types\[0\]/,
+    },
+    {
+      name: "priority label",
+      config: {
+        workflow: {
+          specApproval: { reviewLabel: "priority:high" },
+        },
+      },
+      pattern:
+        /workflow\.specApproval\.reviewLabel must not reuse labels\.priorities\[1\]/,
+    },
+    {
+      name: "another workflow approval label",
+      config: {
+        workflow: {
+          specApproval: { approvedLabel: "plan-approved" },
+        },
+      },
+      pattern:
+        /workflow\.planApproval\.approvedLabel must differ from workflow\.specApproval\.approvedLabel/,
+    },
+  ] as const;
+
+  for (const entry of cases) {
+    const repoRoot = await mkdtemp(
+      join(tmpdir(), `patchmill-workflow-collision-${entry.name}-`),
+    );
+    await writeFile(
+      join(repoRoot, "patchmill.config.json"),
+      JSON.stringify(entry.config),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () => loadPatchmillConfig(repoRoot, {}, []),
+      entry.pattern,
+    );
+  }
 });
 
 test("loadPatchmillConfig rejects removed skill workflow settings", async () => {

--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -358,6 +358,55 @@ test("loadPatchmillConfig rejects blank skills", async () => {
   );
 });
 
+test("loadPatchmillConfig parses workflow approval config and preserves default labels", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-workflow-config-"));
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        specApproval: { required: true },
+        planApproval: {
+          reviewLabel: "awaiting-plan-review",
+          approvedLabel: "plan-reviewed",
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  const config = await loadPatchmillConfig(repoRoot, {}, []);
+
+  assert.deepEqual(config.workflow, {
+    specApproval: {
+      required: true,
+      reviewLabel: "spec-review",
+      approvedLabel: "spec-approved",
+    },
+    planApproval: {
+      reviewLabel: "awaiting-plan-review",
+      approvedLabel: "plan-reviewed",
+    },
+  });
+});
+
+test("loadPatchmillConfig rejects invalid workflow approval config", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-workflow-invalid-"));
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        planApproval: { required: "yes" },
+      },
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => loadPatchmillConfig(repoRoot, {}, []),
+    /workflow\.planApproval\.required must be a boolean/,
+  );
+});
+
 test("loadPatchmillConfig rejects removed skill workflow settings", async () => {
   const repoRoot = await mkdtemp(
     join(tmpdir(), "patchmill-removed-skill-settings-"),

--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -407,6 +407,52 @@ test("loadPatchmillConfig rejects invalid workflow approval config", async () =>
   );
 });
 
+test("loadPatchmillConfig rejects identical spec approval review and approved labels", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-workflow-spec-duplicate-"),
+  );
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        specApproval: {
+          reviewLabel: "spec-review",
+          approvedLabel: "spec-review",
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => loadPatchmillConfig(repoRoot, {}, []),
+    /workflow\.specApproval\.approvedLabel must differ from workflow\.specApproval\.reviewLabel/,
+  );
+});
+
+test("loadPatchmillConfig rejects identical plan approval review and approved labels", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-workflow-plan-duplicate-"),
+  );
+  await writeFile(
+    join(repoRoot, "patchmill.config.json"),
+    JSON.stringify({
+      workflow: {
+        planApproval: {
+          reviewLabel: "plan-review",
+          approvedLabel: "plan-review",
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => loadPatchmillConfig(repoRoot, {}, []),
+    /workflow\.planApproval\.approvedLabel must differ from workflow\.planApproval\.reviewLabel/,
+  );
+});
+
 test("loadPatchmillConfig rejects removed skill workflow settings", async () => {
   const repoRoot = await mkdtemp(
     join(tmpdir(), "patchmill-removed-skill-settings-"),

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -14,9 +14,25 @@ import {
   type PatchmillSkillKey,
 } from "../workflow/skills.ts";
 import { DEFAULT_PATCHMILL_CONFIG } from "./defaults.ts";
+import {
+  CONFIG_FILE_NAME,
+  configError,
+  hasEntries,
+  isRecord,
+  readOptionalBoolean,
+  readOptionalLiteral,
+  readOptionalPositiveInteger,
+  readOptionalSection,
+  readOptionalString,
+  readOptionalStringArray,
+} from "./parse-helpers.ts";
 import type { PatchmillConfig } from "./types.ts";
-
-const CONFIG_FILE_NAME = "patchmill.config.json";
+import {
+  cloneWorkflowConfig,
+  mergeWorkflowConfig,
+  readWorkflowConfig,
+  type PartialWorkflowConfig,
+} from "./workflow.ts";
 
 type Env = Record<string, string | undefined>;
 
@@ -41,15 +57,6 @@ type PartialProjectPolicy = Partial<
   visualEvidence?: Partial<PatchmillConfig["projectPolicy"]["visualEvidence"]>;
   pi?: PartialPiWorkflowPolicy;
 };
-
-type PartialWorkflowApprovalConfig = Partial<
-  PatchmillConfig["workflow"]["specApproval"]
->;
-
-type PartialWorkflowConfig = Partial<{
-  specApproval: PartialWorkflowApprovalConfig;
-  planApproval: PartialWorkflowApprovalConfig;
-}>;
 
 type PartialConfig = Partial<{
   host: Partial<PatchmillConfig["host"]>;
@@ -279,89 +286,35 @@ function mergeTriageConfig(
   };
 }
 
-function cloneWorkflowApprovalConfig(
-  approval: PatchmillConfig["workflow"]["specApproval"],
-): PatchmillConfig["workflow"]["specApproval"] {
-  return {
-    ...(approval.required !== undefined ? { required: approval.required } : {}),
-    reviewLabel: approval.reviewLabel,
-    approvedLabel: approval.approvedLabel,
-  };
-}
-
-function mergeWorkflowApprovalConfig(
-  base: PatchmillConfig["workflow"]["specApproval"],
-  update: PartialWorkflowApprovalConfig | undefined,
-): PatchmillConfig["workflow"]["specApproval"] {
-  return {
-    ...(update?.required !== undefined
-      ? { required: update.required }
-      : base.required !== undefined
-        ? { required: base.required }
-        : {}),
-    reviewLabel: update?.reviewLabel ?? base.reviewLabel,
-    approvedLabel: update?.approvedLabel ?? base.approvedLabel,
-  };
-}
-
-function cloneWorkflowConfig(
-  workflow: PatchmillConfig["workflow"],
-): PatchmillConfig["workflow"] {
-  return {
-    specApproval: cloneWorkflowApprovalConfig(workflow.specApproval),
-    planApproval: cloneWorkflowApprovalConfig(workflow.planApproval),
-  };
-}
-
-function assertDistinctWorkflowApprovalLabels(
-  key: "specApproval" | "planApproval",
-  approval: PatchmillConfig["workflow"]["specApproval"],
-): void {
-  if (approval.reviewLabel !== approval.approvedLabel) return;
-  throw new Error(
-    `Invalid ${CONFIG_FILE_NAME}: workflow.${key}.approvedLabel must differ from workflow.${key}.reviewLabel`,
-  );
-}
-
-function mergeWorkflowConfig(
-  base: PatchmillConfig["workflow"],
-  update: PartialWorkflowConfig | undefined,
-): PatchmillConfig["workflow"] {
-  const specApproval = mergeWorkflowApprovalConfig(
-    base.specApproval,
-    update?.specApproval,
-  );
-  const planApproval = mergeWorkflowApprovalConfig(
-    base.planApproval,
-    update?.planApproval,
-  );
-
-  assertDistinctWorkflowApprovalLabels("specApproval", specApproval);
-  assertDistinctWorkflowApprovalLabels("planApproval", planApproval);
-
-  return { specApproval, planApproval };
-}
-
 function mergeConfig(
   base: PatchmillConfig,
   update: PartialConfig,
 ): PatchmillConfig {
-  const labels = { ...base.labels, ...update.labels };
+  const labels = {
+    ...base.labels,
+    ...update.labels,
+    types: cloneStringArray(update.labels?.types ?? base.labels.types),
+    priorities: cloneStringArray(
+      update.labels?.priorities ?? base.labels.priorities,
+    ),
+  };
   const triage = mergeTriageConfig(base, labels, update);
   const paths = { ...base.paths, ...update.paths };
+  const projectPolicy = mergeProjectPolicy(
+    base.projectPolicy,
+    update.projectPolicy,
+  );
+  const workflow = mergeWorkflowConfig(base.workflow, update.workflow, {
+    labels,
+    planRequiresApprovalAlias: update.projectPolicy?.planRequiresApproval,
+  });
 
   return {
     host: { ...base.host, ...update.host },
     pi: { ...base.pi, ...update.pi },
-    labels: {
-      ...labels,
-      types: cloneStringArray(update.labels?.types ?? base.labels.types),
-      priorities: cloneStringArray(
-        update.labels?.priorities ?? base.labels.priorities,
-      ),
-    },
+    labels,
     triage,
-    workflow: mergeWorkflowConfig(base.workflow, update.workflow),
+    workflow,
     skills: mergeSkillsConfig(base.skills, update.skills),
     paths: {
       ...paths,
@@ -374,7 +327,7 @@ function mergeConfig(
     ...(update.cleanupHook !== undefined || base.cleanupHook !== undefined
       ? { cleanupHook: update.cleanupHook ?? base.cleanupHook }
       : {}),
-    projectPolicy: mergeProjectPolicy(base.projectPolicy, update.projectPolicy),
+    projectPolicy,
   };
 }
 
@@ -402,100 +355,6 @@ function absolutizePaths(
     },
     projectPolicy: cloneProjectPolicy(config.projectPolicy),
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function describeValue(value: unknown): string {
-  if (value === null) return "null";
-  if (typeof value === "string") return JSON.stringify(value);
-  if (Array.isArray(value)) return "an array";
-  if (typeof value === "object") return "an object";
-  return String(value);
-}
-
-function configError(path: string, expected: string, value: unknown): Error {
-  return new Error(
-    `Invalid ${CONFIG_FILE_NAME}: ${path} must be ${expected}; received ${describeValue(value)}`,
-  );
-}
-
-function readOptionalSection(
-  source: Record<string, unknown>,
-  key: string,
-): Record<string, unknown> | undefined {
-  const value = source[key];
-  if (value === undefined) return undefined;
-  if (!isRecord(value)) throw configError(key, "an object", value);
-  return value;
-}
-
-function readOptionalString(
-  source: Record<string, unknown>,
-  key: string,
-  path: string,
-): string | undefined {
-  const value = source[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== "string") throw configError(path, "a string", value);
-  return value;
-}
-
-function readOptionalBoolean(
-  source: Record<string, unknown>,
-  key: string,
-  path: string,
-): boolean | undefined {
-  const value = source[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== "boolean") throw configError(path, "a boolean", value);
-  return value;
-}
-
-function readOptionalPositiveInteger(
-  source: Record<string, unknown>,
-  key: string,
-  path: string,
-): number | undefined {
-  const value = source[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
-    throw configError(path, "a positive integer", value);
-  }
-  return value;
-}
-
-function readOptionalStringArray(
-  source: Record<string, unknown>,
-  key: string,
-  path: string,
-): string[] | undefined {
-  const value = source[key];
-  if (value === undefined) return undefined;
-  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-    throw configError(path, "an array of strings", value);
-  }
-  return cloneStringArray(value);
-}
-
-function readOptionalLiteral<T extends string>(
-  source: Record<string, unknown>,
-  key: string,
-  path: string,
-  allowed: readonly [T, ...T[]],
-): T | undefined {
-  const value = source[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== "string" || !allowed.includes(value as T)) {
-    const expected =
-      allowed.length === 1
-        ? `the literal ${JSON.stringify(allowed[0])}`
-        : `one of ${allowed.map((entry) => JSON.stringify(entry)).join(", ")}`;
-    throw configError(path, expected, value);
-  }
-  return value as T;
 }
 
 function readSkillsConfig(
@@ -553,73 +412,6 @@ function readTriageConfig(
         `triage.${key}`,
         "a supported triage setting",
         value[key],
-      );
-    }
-  }
-
-  return hasEntries(parsed) ? parsed : undefined;
-}
-
-function readWorkflowApprovalConfig(
-  source: Record<string, unknown>,
-  key: "specApproval" | "planApproval",
-): PartialWorkflowApprovalConfig | undefined {
-  const value = readOptionalSection(source, key);
-  if (!value) return undefined;
-
-  const parsed: PartialWorkflowApprovalConfig = {};
-  const required = readOptionalBoolean(
-    value,
-    "required",
-    `workflow.${key}.required`,
-  );
-  const reviewLabel = readOptionalString(
-    value,
-    "reviewLabel",
-    `workflow.${key}.reviewLabel`,
-  );
-  const approvedLabel = readOptionalString(
-    value,
-    "approvedLabel",
-    `workflow.${key}.approvedLabel`,
-  );
-
-  if (required !== undefined) parsed.required = required;
-  if (reviewLabel !== undefined) parsed.reviewLabel = reviewLabel;
-  if (approvedLabel !== undefined) parsed.approvedLabel = approvedLabel;
-
-  for (const entry of Object.keys(value)) {
-    if (!["required", "reviewLabel", "approvedLabel"].includes(entry)) {
-      throw configError(
-        `workflow.${key}.${entry}`,
-        "a supported workflow approval setting",
-        value[entry],
-      );
-    }
-  }
-
-  return hasEntries(parsed) ? parsed : undefined;
-}
-
-function readWorkflowConfig(
-  source: Record<string, unknown>,
-): PartialWorkflowConfig | undefined {
-  const value = source.workflow;
-  if (value === undefined) return undefined;
-  if (!isRecord(value)) throw configError("workflow", "an object", value);
-
-  const parsed: PartialWorkflowConfig = {};
-  const specApproval = readWorkflowApprovalConfig(value, "specApproval");
-  const planApproval = readWorkflowApprovalConfig(value, "planApproval");
-  if (specApproval !== undefined) parsed.specApproval = specApproval;
-  if (planApproval !== undefined) parsed.planApproval = planApproval;
-
-  for (const entry of Object.keys(value)) {
-    if (!["specApproval", "planApproval"].includes(entry)) {
-      throw configError(
-        `workflow.${entry}`,
-        "a supported workflow setting",
-        value[entry],
       );
     }
   }
@@ -721,10 +513,6 @@ function readOptionalVisualEvidenceExample(
     ...(caption !== undefined ? { caption } : {}),
     ...(referencePaths !== undefined ? { referencePaths } : {}),
   };
-}
-
-function hasEntries(value: object): boolean {
-  return Object.keys(value).length > 0;
 }
 
 function rejectRemovedWorkflowSettings(

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -313,20 +313,33 @@ function cloneWorkflowConfig(
   };
 }
 
+function assertDistinctWorkflowApprovalLabels(
+  key: "specApproval" | "planApproval",
+  approval: PatchmillConfig["workflow"]["specApproval"],
+): void {
+  if (approval.reviewLabel !== approval.approvedLabel) return;
+  throw new Error(
+    `Invalid ${CONFIG_FILE_NAME}: workflow.${key}.approvedLabel must differ from workflow.${key}.reviewLabel`,
+  );
+}
+
 function mergeWorkflowConfig(
   base: PatchmillConfig["workflow"],
   update: PartialWorkflowConfig | undefined,
 ): PatchmillConfig["workflow"] {
-  return {
-    specApproval: mergeWorkflowApprovalConfig(
-      base.specApproval,
-      update?.specApproval,
-    ),
-    planApproval: mergeWorkflowApprovalConfig(
-      base.planApproval,
-      update?.planApproval,
-    ),
-  };
+  const specApproval = mergeWorkflowApprovalConfig(
+    base.specApproval,
+    update?.specApproval,
+  );
+  const planApproval = mergeWorkflowApprovalConfig(
+    base.planApproval,
+    update?.planApproval,
+  );
+
+  assertDistinctWorkflowApprovalLabels("specApproval", specApproval);
+  assertDistinctWorkflowApprovalLabels("planApproval", planApproval);
+
+  return { specApproval, planApproval };
 }
 
 function mergeConfig(

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -42,12 +42,22 @@ type PartialProjectPolicy = Partial<
   pi?: PartialPiWorkflowPolicy;
 };
 
+type PartialWorkflowApprovalConfig = Partial<
+  PatchmillConfig["workflow"]["specApproval"]
+>;
+
+type PartialWorkflowConfig = Partial<{
+  specApproval: PartialWorkflowApprovalConfig;
+  planApproval: PartialWorkflowApprovalConfig;
+}>;
+
 type PartialConfig = Partial<{
   host: Partial<PatchmillConfig["host"]>;
   pi: Partial<PatchmillConfig["pi"]>;
   paths: Partial<PatchmillConfig["paths"]>;
   labels: Partial<PatchmillConfig["labels"]>;
   triage: Partial<PatchmillConfig["triage"]>;
+  workflow: PartialWorkflowConfig;
   skills: PartialPatchmillSkillsConfig;
   git: Partial<PatchmillConfig["git"]>;
   cleanupHook: string;
@@ -269,6 +279,56 @@ function mergeTriageConfig(
   };
 }
 
+function cloneWorkflowApprovalConfig(
+  approval: PatchmillConfig["workflow"]["specApproval"],
+): PatchmillConfig["workflow"]["specApproval"] {
+  return {
+    ...(approval.required !== undefined ? { required: approval.required } : {}),
+    reviewLabel: approval.reviewLabel,
+    approvedLabel: approval.approvedLabel,
+  };
+}
+
+function mergeWorkflowApprovalConfig(
+  base: PatchmillConfig["workflow"]["specApproval"],
+  update: PartialWorkflowApprovalConfig | undefined,
+): PatchmillConfig["workflow"]["specApproval"] {
+  return {
+    ...(update?.required !== undefined
+      ? { required: update.required }
+      : base.required !== undefined
+        ? { required: base.required }
+        : {}),
+    reviewLabel: update?.reviewLabel ?? base.reviewLabel,
+    approvedLabel: update?.approvedLabel ?? base.approvedLabel,
+  };
+}
+
+function cloneWorkflowConfig(
+  workflow: PatchmillConfig["workflow"],
+): PatchmillConfig["workflow"] {
+  return {
+    specApproval: cloneWorkflowApprovalConfig(workflow.specApproval),
+    planApproval: cloneWorkflowApprovalConfig(workflow.planApproval),
+  };
+}
+
+function mergeWorkflowConfig(
+  base: PatchmillConfig["workflow"],
+  update: PartialWorkflowConfig | undefined,
+): PatchmillConfig["workflow"] {
+  return {
+    specApproval: mergeWorkflowApprovalConfig(
+      base.specApproval,
+      update?.specApproval,
+    ),
+    planApproval: mergeWorkflowApprovalConfig(
+      base.planApproval,
+      update?.planApproval,
+    ),
+  };
+}
+
 function mergeConfig(
   base: PatchmillConfig,
   update: PartialConfig,
@@ -288,6 +348,7 @@ function mergeConfig(
       ),
     },
     triage,
+    workflow: mergeWorkflowConfig(base.workflow, update.workflow),
     skills: mergeSkillsConfig(base.skills, update.skills),
     paths: {
       ...paths,
@@ -315,6 +376,7 @@ function absolutizePaths(
   return {
     ...config,
     triage: cloneTriageConfig(config.triage),
+    workflow: cloneWorkflowConfig(config.workflow),
     skills: cloneSkillsConfig(config.skills),
     paths: {
       plansDir: absolutize(root, config.paths.plansDir),
@@ -478,6 +540,73 @@ function readTriageConfig(
         `triage.${key}`,
         "a supported triage setting",
         value[key],
+      );
+    }
+  }
+
+  return hasEntries(parsed) ? parsed : undefined;
+}
+
+function readWorkflowApprovalConfig(
+  source: Record<string, unknown>,
+  key: "specApproval" | "planApproval",
+): PartialWorkflowApprovalConfig | undefined {
+  const value = readOptionalSection(source, key);
+  if (!value) return undefined;
+
+  const parsed: PartialWorkflowApprovalConfig = {};
+  const required = readOptionalBoolean(
+    value,
+    "required",
+    `workflow.${key}.required`,
+  );
+  const reviewLabel = readOptionalString(
+    value,
+    "reviewLabel",
+    `workflow.${key}.reviewLabel`,
+  );
+  const approvedLabel = readOptionalString(
+    value,
+    "approvedLabel",
+    `workflow.${key}.approvedLabel`,
+  );
+
+  if (required !== undefined) parsed.required = required;
+  if (reviewLabel !== undefined) parsed.reviewLabel = reviewLabel;
+  if (approvedLabel !== undefined) parsed.approvedLabel = approvedLabel;
+
+  for (const entry of Object.keys(value)) {
+    if (!["required", "reviewLabel", "approvedLabel"].includes(entry)) {
+      throw configError(
+        `workflow.${key}.${entry}`,
+        "a supported workflow approval setting",
+        value[entry],
+      );
+    }
+  }
+
+  return hasEntries(parsed) ? parsed : undefined;
+}
+
+function readWorkflowConfig(
+  source: Record<string, unknown>,
+): PartialWorkflowConfig | undefined {
+  const value = source.workflow;
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw configError("workflow", "an object", value);
+
+  const parsed: PartialWorkflowConfig = {};
+  const specApproval = readWorkflowApprovalConfig(value, "specApproval");
+  const planApproval = readWorkflowApprovalConfig(value, "planApproval");
+  if (specApproval !== undefined) parsed.specApproval = specApproval;
+  if (planApproval !== undefined) parsed.planApproval = planApproval;
+
+  for (const entry of Object.keys(value)) {
+    if (!["specApproval", "planApproval"].includes(entry)) {
+      throw configError(
+        `workflow.${entry}`,
+        "a supported workflow setting",
+        value[entry],
       );
     }
   }
@@ -820,6 +949,11 @@ function parseConfigFile(data: unknown): PartialConfig {
   const triage = readTriageConfig(data);
   if (triage !== undefined) {
     config.triage = triage;
+  }
+
+  const workflow = readWorkflowConfig(data);
+  if (workflow !== undefined) {
+    config.workflow = workflow;
   }
 
   const projectPolicy = readOptionalSection(data, "projectPolicy");

--- a/src/config/parse-helpers.ts
+++ b/src/config/parse-helpers.ts
@@ -1,0 +1,103 @@
+export const CONFIG_FILE_NAME = "patchmill.config.json";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) return "an array";
+  if (typeof value === "object") return "an object";
+  return String(value);
+}
+
+export function configError(
+  path: string,
+  expected: string,
+  value: unknown,
+): Error {
+  return new Error(
+    `Invalid ${CONFIG_FILE_NAME}: ${path} must be ${expected}; received ${describeValue(value)}`,
+  );
+}
+
+export function readOptionalSection(
+  source: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw configError(key, "an object", value);
+  return value;
+}
+
+export function readOptionalString(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | undefined {
+  const value = source[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw configError(path, "a string", value);
+  return value;
+}
+
+export function readOptionalBoolean(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+): boolean | undefined {
+  const value = source[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") throw configError(path, "a boolean", value);
+  return value;
+}
+
+export function readOptionalPositiveInteger(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+): number | undefined {
+  const value = source[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw configError(path, "a positive integer", value);
+  }
+  return value;
+}
+
+export function readOptionalStringArray(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] | undefined {
+  const value = source[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw configError(path, "an array of strings", value);
+  }
+  return [...value];
+}
+
+export function readOptionalLiteral<T extends string>(
+  source: Record<string, unknown>,
+  key: string,
+  path: string,
+  allowed: readonly [T, ...T[]],
+): T | undefined {
+  const value = source[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    const expected =
+      allowed.length === 1
+        ? `the literal ${JSON.stringify(allowed[0])}`
+        : `one of ${allowed.map((entry) => JSON.stringify(entry)).join(", ")}`;
+    throw configError(path, expected, value);
+  }
+  return value as T;
+}
+
+export function hasEntries(value: object): boolean {
+  return Object.keys(value).length > 0;
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -30,7 +30,7 @@ export type PatchmillTriageConfig = {
 };
 
 export type PatchmillWorkflowApprovalConfig = {
-  required?: boolean;
+  required: boolean;
   reviewLabel: string;
   approvedLabel: string;
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -29,6 +29,17 @@ export type PatchmillTriageConfig = {
   stateMap: PatchmillTriageStateMap;
 };
 
+export type PatchmillWorkflowApprovalConfig = {
+  required?: boolean;
+  reviewLabel: string;
+  approvedLabel: string;
+};
+
+export type PatchmillWorkflowConfig = {
+  specApproval: PatchmillWorkflowApprovalConfig;
+  planApproval: PatchmillWorkflowApprovalConfig;
+};
+
 export type PatchmillPathsConfig = {
   plansDir: string;
   runStateDir: string;
@@ -46,6 +57,7 @@ export type PatchmillConfig = {
   pi: PatchmillPiConfig;
   labels: PatchmillLabelsConfig;
   triage: PatchmillTriageConfig;
+  workflow: PatchmillWorkflowConfig;
   skills: PatchmillSkillsConfig;
   paths: PatchmillPathsConfig;
   git: PatchmillGitConfig;

--- a/src/config/workflow.ts
+++ b/src/config/workflow.ts
@@ -1,0 +1,218 @@
+import type { PatchmillConfig } from "./types.ts";
+import {
+  configError,
+  hasEntries,
+  readOptionalBoolean,
+  readOptionalSection,
+  readOptionalString,
+} from "./parse-helpers.ts";
+
+const WORKFLOW_APPROVAL_KEYS = ["specApproval", "planApproval"] as const;
+const WORKFLOW_APPROVAL_LABEL_KEYS = ["reviewLabel", "approvedLabel"] as const;
+
+type WorkflowApprovalKey = (typeof WORKFLOW_APPROVAL_KEYS)[number];
+type WorkflowApprovalLabelKey = (typeof WORKFLOW_APPROVAL_LABEL_KEYS)[number];
+
+type WorkflowApprovalConfig = PatchmillConfig["workflow"][WorkflowApprovalKey];
+
+export type PartialWorkflowApprovalConfig = Partial<WorkflowApprovalConfig>;
+
+export type PartialWorkflowConfig = Partial<{
+  specApproval: PartialWorkflowApprovalConfig;
+  planApproval: PartialWorkflowApprovalConfig;
+}>;
+
+function workflowLabelEntries(workflow: PatchmillConfig["workflow"]): Array<{
+  path: `workflow.${WorkflowApprovalKey}.${WorkflowApprovalLabelKey}`;
+  value: string;
+}> {
+  return WORKFLOW_APPROVAL_KEYS.flatMap((approvalKey) =>
+    WORKFLOW_APPROVAL_LABEL_KEYS.map((labelKey) => ({
+      path: `workflow.${approvalKey}.${labelKey}` as const,
+      value: workflow[approvalKey][labelKey],
+    })),
+  );
+}
+
+function labelOwners(labels: PatchmillConfig["labels"]): Map<string, string> {
+  const owners = new Map<string, string>();
+  const add = (label: string, owner: string) => {
+    if (!owners.has(label)) owners.set(label, owner);
+  };
+
+  add(labels.ready, "labels.ready");
+  add(labels.needsInfo, "labels.needsInfo");
+  add(labels.unsuitable, "labels.unsuitable");
+  add(labels.inProgress, 'labels["in-progress"]');
+  add(labels.done, "labels.done");
+  add(labels.blocked, "labels.blocked");
+  labels.types.forEach((label, index) => add(label, `labels.types[${index}]`));
+  labels.priorities.forEach((label, index) =>
+    add(label, `labels.priorities[${index}]`),
+  );
+
+  return owners;
+}
+
+function assertDistinctWorkflowApprovalLabels(
+  workflow: PatchmillConfig["workflow"],
+): void {
+  const seen = new Map<string, string>();
+  for (const entry of workflowLabelEntries(workflow)) {
+    const existingPath = seen.get(entry.value);
+    if (existingPath) {
+      throw new Error(
+        `Invalid patchmill.config.json: ${entry.path} must differ from ${existingPath}`,
+      );
+    }
+    seen.set(entry.value, entry.path);
+  }
+}
+
+function assertWorkflowApprovalLabelsDoNotReuseOwnedLabels(
+  workflow: PatchmillConfig["workflow"],
+  labels: PatchmillConfig["labels"],
+): void {
+  const owners = labelOwners(labels);
+  for (const entry of workflowLabelEntries(workflow)) {
+    const owner = owners.get(entry.value);
+    if (!owner) continue;
+    throw new Error(
+      `Invalid patchmill.config.json: ${entry.path} must not reuse ${owner}`,
+    );
+  }
+}
+
+export function validateWorkflowConfig(
+  workflow: PatchmillConfig["workflow"],
+  labels: PatchmillConfig["labels"],
+): PatchmillConfig["workflow"] {
+  assertDistinctWorkflowApprovalLabels(workflow);
+  assertWorkflowApprovalLabelsDoNotReuseOwnedLabels(workflow, labels);
+  return workflow;
+}
+
+function cloneWorkflowApprovalConfig(
+  approval: WorkflowApprovalConfig,
+): WorkflowApprovalConfig {
+  return {
+    required: approval.required,
+    reviewLabel: approval.reviewLabel,
+    approvedLabel: approval.approvedLabel,
+  };
+}
+
+function mergeWorkflowApprovalConfig(
+  base: WorkflowApprovalConfig,
+  update: PartialWorkflowApprovalConfig | undefined,
+  requiredAlias?: boolean,
+): WorkflowApprovalConfig {
+  return {
+    required: update?.required ?? requiredAlias ?? base.required,
+    reviewLabel: update?.reviewLabel ?? base.reviewLabel,
+    approvedLabel: update?.approvedLabel ?? base.approvedLabel,
+  };
+}
+
+export function cloneWorkflowConfig(
+  workflow: PatchmillConfig["workflow"],
+): PatchmillConfig["workflow"] {
+  return {
+    specApproval: cloneWorkflowApprovalConfig(workflow.specApproval),
+    planApproval: cloneWorkflowApprovalConfig(workflow.planApproval),
+  };
+}
+
+export function mergeWorkflowConfig(
+  base: PatchmillConfig["workflow"],
+  update: PartialWorkflowConfig | undefined,
+  options: {
+    labels: PatchmillConfig["labels"];
+    planRequiresApprovalAlias?: boolean;
+  },
+): PatchmillConfig["workflow"] {
+  const workflow = {
+    specApproval: mergeWorkflowApprovalConfig(
+      base.specApproval,
+      update?.specApproval,
+    ),
+    planApproval: mergeWorkflowApprovalConfig(
+      base.planApproval,
+      update?.planApproval,
+      update?.planApproval?.required === undefined
+        ? options.planRequiresApprovalAlias
+        : undefined,
+    ),
+  };
+
+  return validateWorkflowConfig(workflow, options.labels);
+}
+
+function readWorkflowApprovalConfig(
+  source: Record<string, unknown>,
+  key: WorkflowApprovalKey,
+): PartialWorkflowApprovalConfig | undefined {
+  const value = readOptionalSection(source, key);
+  if (!value) return undefined;
+
+  const parsed: PartialWorkflowApprovalConfig = {};
+  const required = readOptionalBoolean(
+    value,
+    "required",
+    `workflow.${key}.required`,
+  );
+  const reviewLabel = readOptionalString(
+    value,
+    "reviewLabel",
+    `workflow.${key}.reviewLabel`,
+  );
+  const approvedLabel = readOptionalString(
+    value,
+    "approvedLabel",
+    `workflow.${key}.approvedLabel`,
+  );
+
+  if (required !== undefined) parsed.required = required;
+  if (reviewLabel !== undefined) parsed.reviewLabel = reviewLabel;
+  if (approvedLabel !== undefined) parsed.approvedLabel = approvedLabel;
+
+  for (const entry of Object.keys(value)) {
+    if (!["required", "reviewLabel", "approvedLabel"].includes(entry)) {
+      throw configError(
+        `workflow.${key}.${entry}`,
+        "a supported workflow approval setting",
+        value[entry],
+      );
+    }
+  }
+
+  return hasEntries(parsed) ? parsed : undefined;
+}
+
+export function readWorkflowConfig(
+  source: Record<string, unknown>,
+): PartialWorkflowConfig | undefined {
+  const value = source.workflow;
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw configError("workflow", "an object", value);
+  }
+
+  const parsed: PartialWorkflowConfig = {};
+  const specApproval = readWorkflowApprovalConfig(value, "specApproval");
+  const planApproval = readWorkflowApprovalConfig(value, "planApproval");
+  if (specApproval !== undefined) parsed.specApproval = specApproval;
+  if (planApproval !== undefined) parsed.planApproval = planApproval;
+
+  for (const entry of Object.keys(value)) {
+    if (!WORKFLOW_APPROVAL_KEYS.includes(entry as WorkflowApprovalKey)) {
+      throw configError(
+        `workflow.${entry}`,
+        "a supported workflow setting",
+        value[entry],
+      );
+    }
+  }
+
+  return hasEntries(parsed) ? parsed : undefined;
+}

--- a/src/pi/runner.ts
+++ b/src/pi/runner.ts
@@ -42,6 +42,7 @@ export class PiRunner implements PiPromptContracts {
         issue: input.issue,
         planPath: input.planPath,
         projectPolicy,
+        planApprovalRequired: input.planApprovalRequired,
         skills: input.skills,
         triageLabels: input.triageLabels,
       }),

--- a/src/pi/types.ts
+++ b/src/pi/types.ts
@@ -19,6 +19,7 @@ export type PlanPiInput = {
   issue: IssueSummary;
   planPath: string;
   projectPolicy?: PatchmillProjectPolicy;
+  planApprovalRequired?: boolean;
   skills?: PatchmillSkillsConfig;
   triageLabels?: Partial<PromptTriageLabels>;
   runOptions?: PiRunnerRunOptions;

--- a/src/policy/label-catalog.test.ts
+++ b/src/policy/label-catalog.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_PATCHMILL_CONFIG } from "../config/defaults.ts";
+import { createPatchmillLabelCatalog } from "./label-catalog.ts";
+
+test("createPatchmillLabelCatalog returns every Patchmill-owned label definition", () => {
+  const catalog = createPatchmillLabelCatalog({
+    ...DEFAULT_PATCHMILL_CONFIG,
+    labels: {
+      ...DEFAULT_PATCHMILL_CONFIG.labels,
+      ready: "ready-for-agent",
+      types: ["defect"],
+      priorities: ["priority:urgent"],
+    },
+    workflow: {
+      specApproval: {
+        required: true,
+        reviewLabel: "awaiting-spec-review",
+        approvedLabel: "spec-reviewed",
+      },
+      planApproval: {
+        required: true,
+        reviewLabel: "awaiting-plan-review",
+        approvedLabel: "plan-reviewed",
+      },
+    },
+  });
+
+  assert.deepEqual(
+    catalog.labelDefinitions.map((label) => label.name),
+    [
+      "ready-for-agent",
+      "needs-info",
+      "agent-unsuitable",
+      "in-progress",
+      "agent-done",
+      "blocked",
+      "defect",
+      "priority:urgent",
+      "awaiting-spec-review",
+      "spec-reviewed",
+      "awaiting-plan-review",
+      "plan-reviewed",
+    ],
+  );
+  assert.equal(catalog.triagePolicy.labels.ready, "ready-for-agent");
+  assert.equal(catalog.workflowApprovalPolicy.planApproval.required, true);
+});

--- a/src/policy/label-catalog.ts
+++ b/src/policy/label-catalog.ts
@@ -1,0 +1,38 @@
+import type { PatchmillConfig } from "../config/types.ts";
+import type { LabelDefinition } from "../host/types.ts";
+import {
+  createWorkflowApprovalPolicy,
+  type WorkflowApprovalPolicy,
+} from "../workflow/approval-policy.ts";
+import { createTriagePolicy, type PatchmillTriagePolicy } from "./triage.ts";
+
+export type PatchmillLabelCatalog = {
+  triagePolicy: PatchmillTriagePolicy;
+  workflowApprovalPolicy: WorkflowApprovalPolicy;
+  labelDefinitions: LabelDefinition[];
+};
+
+function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
+  const seen = new Set<string>();
+  return labels.filter((label) => {
+    if (seen.has(label.name)) return false;
+    seen.add(label.name);
+    return true;
+  });
+}
+
+export function createPatchmillLabelCatalog(
+  config: PatchmillConfig,
+): PatchmillLabelCatalog {
+  const triagePolicy = createTriagePolicy(config.labels, config.triage);
+  const workflowApprovalPolicy = createWorkflowApprovalPolicy(config.workflow);
+
+  return {
+    triagePolicy,
+    workflowApprovalPolicy,
+    labelDefinitions: dedupeLabelDefinitions([
+      ...triagePolicy.allowedLabels,
+      ...workflowApprovalPolicy.labelDefinitions,
+    ]),
+  };
+}

--- a/src/workflow/approval-policy.test.ts
+++ b/src/workflow/approval-policy.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_PATCHMILL_CONFIG } from "../config/defaults.ts";
+import { createTriagePolicy } from "../policy/triage.ts";
+import { createWorkflowApprovalPolicy } from "./approval-policy.ts";
+
+const projectPolicy = DEFAULT_PATCHMILL_CONFIG.projectPolicy;
+
+test("createWorkflowApprovalPolicy defaults both gates to not required", () => {
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    { ...projectPolicy, planRequiresApproval: false },
+  );
+
+  assert.equal(policy.specApproval.required, false);
+  assert.equal(policy.specApproval.reviewLabel, "spec-review");
+  assert.equal(policy.specApproval.approvedLabel, "spec-approved");
+  assert.equal(policy.planApproval.required, false);
+  assert.equal(policy.planApproval.reviewLabel, "plan-review");
+  assert.equal(policy.planApproval.approvedLabel, "plan-approved");
+});
+
+test("createWorkflowApprovalPolicy treats projectPolicy.planRequiresApproval as plan alias", () => {
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    { ...projectPolicy, planRequiresApproval: true },
+  );
+
+  assert.equal(policy.planApproval.required, true);
+});
+
+test("createWorkflowApprovalPolicy lets workflow.planApproval.required override the alias", () => {
+  const policy = createWorkflowApprovalPolicy(
+    {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow,
+      planApproval: {
+        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+        required: false,
+      },
+    },
+    { ...projectPolicy, planRequiresApproval: true },
+  );
+
+  assert.equal(policy.planApproval.required, false);
+});
+
+test("createWorkflowApprovalPolicy exposes workflow label definitions outside triage labels", () => {
+  const triagePolicy = createTriagePolicy(
+    DEFAULT_PATCHMILL_CONFIG.labels,
+    DEFAULT_PATCHMILL_CONFIG.triage,
+  );
+  const policy = createWorkflowApprovalPolicy(
+    DEFAULT_PATCHMILL_CONFIG.workflow,
+    projectPolicy,
+  );
+
+  assert.deepEqual(
+    policy.labelDefinitions.map((label) => label.name),
+    ["spec-review", "spec-approved", "plan-review", "plan-approved"],
+  );
+  assert.equal(
+    triagePolicy.allowedLabels.some((label) => label.name === "spec-review"),
+    false,
+  );
+});

--- a/src/workflow/approval-policy.test.ts
+++ b/src/workflow/approval-policy.test.ts
@@ -4,12 +4,9 @@ import { DEFAULT_PATCHMILL_CONFIG } from "../config/defaults.ts";
 import { createTriagePolicy } from "../policy/triage.ts";
 import { createWorkflowApprovalPolicy } from "./approval-policy.ts";
 
-const projectPolicy = DEFAULT_PATCHMILL_CONFIG.projectPolicy;
-
 test("createWorkflowApprovalPolicy defaults both gates to not required", () => {
   const policy = createWorkflowApprovalPolicy(
     DEFAULT_PATCHMILL_CONFIG.workflow,
-    { ...projectPolicy, planRequiresApproval: false },
   );
 
   assert.equal(policy.specApproval.required, false);
@@ -20,28 +17,21 @@ test("createWorkflowApprovalPolicy defaults both gates to not required", () => {
   assert.equal(policy.planApproval.approvedLabel, "plan-approved");
 });
 
-test("createWorkflowApprovalPolicy treats projectPolicy.planRequiresApproval as plan alias", () => {
-  const policy = createWorkflowApprovalPolicy(
-    DEFAULT_PATCHMILL_CONFIG.workflow,
-    { ...projectPolicy, planRequiresApproval: true },
-  );
-
-  assert.equal(policy.planApproval.required, true);
-});
-
-test("createWorkflowApprovalPolicy lets workflow.planApproval.required override the alias", () => {
-  const policy = createWorkflowApprovalPolicy(
-    {
-      ...DEFAULT_PATCHMILL_CONFIG.workflow,
-      planApproval: {
-        ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
-        required: false,
-      },
+test("createWorkflowApprovalPolicy uses normalized workflow required flags", () => {
+  const policy = createWorkflowApprovalPolicy({
+    ...DEFAULT_PATCHMILL_CONFIG.workflow,
+    specApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.specApproval,
+      required: true,
     },
-    { ...projectPolicy, planRequiresApproval: true },
-  );
+    planApproval: {
+      ...DEFAULT_PATCHMILL_CONFIG.workflow.planApproval,
+      required: true,
+    },
+  });
 
-  assert.equal(policy.planApproval.required, false);
+  assert.equal(policy.specApproval.required, true);
+  assert.equal(policy.planApproval.required, true);
 });
 
 test("createWorkflowApprovalPolicy exposes workflow label definitions outside triage labels", () => {
@@ -51,7 +41,6 @@ test("createWorkflowApprovalPolicy exposes workflow label definitions outside tr
   );
   const policy = createWorkflowApprovalPolicy(
     DEFAULT_PATCHMILL_CONFIG.workflow,
-    projectPolicy,
   );
 
   assert.deepEqual(

--- a/src/workflow/approval-policy.ts
+++ b/src/workflow/approval-policy.ts
@@ -1,6 +1,5 @@
 import type { PatchmillWorkflowConfig } from "../config/types.ts";
 import type { LabelDefinition } from "../host/types.ts";
-import type { PatchmillProjectPolicy } from "../policy/types.ts";
 
 export type WorkflowApprovalKind = "spec" | "plan";
 
@@ -36,18 +35,16 @@ function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
 
 export function createWorkflowApprovalPolicy(
   workflow: PatchmillWorkflowConfig,
-  projectPolicy: Pick<PatchmillProjectPolicy, "planRequiresApproval">,
 ): WorkflowApprovalPolicy {
   const specApproval: WorkflowApprovalStagePolicy = {
     kind: "spec",
-    required: workflow.specApproval.required ?? false,
+    required: workflow.specApproval.required,
     reviewLabel: workflow.specApproval.reviewLabel,
     approvedLabel: workflow.specApproval.approvedLabel,
   };
   const planApproval: WorkflowApprovalStagePolicy = {
     kind: "plan",
-    required:
-      workflow.planApproval.required ?? projectPolicy.planRequiresApproval,
+    required: workflow.planApproval.required,
     reviewLabel: workflow.planApproval.reviewLabel,
     approvedLabel: workflow.planApproval.approvedLabel,
   };

--- a/src/workflow/approval-policy.ts
+++ b/src/workflow/approval-policy.ts
@@ -1,0 +1,81 @@
+import type { PatchmillWorkflowConfig } from "../config/types.ts";
+import type { LabelDefinition } from "../host/types.ts";
+import type { PatchmillProjectPolicy } from "../policy/types.ts";
+
+export type WorkflowApprovalKind = "spec" | "plan";
+
+export type WorkflowApprovalStagePolicy = {
+  kind: WorkflowApprovalKind;
+  required: boolean;
+  reviewLabel: string;
+  approvedLabel: string;
+};
+
+export type WorkflowApprovalPolicy = {
+  specApproval: WorkflowApprovalStagePolicy;
+  planApproval: WorkflowApprovalStagePolicy;
+  labelDefinitions: LabelDefinition[];
+};
+
+function workflowLabelDefinition(
+  name: string,
+  color: string,
+  description: string,
+): LabelDefinition {
+  return { name, color, description };
+}
+
+function dedupeLabelDefinitions(labels: LabelDefinition[]): LabelDefinition[] {
+  const seen = new Set<string>();
+  return labels.filter((label) => {
+    if (seen.has(label.name)) return false;
+    seen.add(label.name);
+    return true;
+  });
+}
+
+export function createWorkflowApprovalPolicy(
+  workflow: PatchmillWorkflowConfig,
+  projectPolicy: Pick<PatchmillProjectPolicy, "planRequiresApproval">,
+): WorkflowApprovalPolicy {
+  const specApproval: WorkflowApprovalStagePolicy = {
+    kind: "spec",
+    required: workflow.specApproval.required ?? false,
+    reviewLabel: workflow.specApproval.reviewLabel,
+    approvedLabel: workflow.specApproval.approvedLabel,
+  };
+  const planApproval: WorkflowApprovalStagePolicy = {
+    kind: "plan",
+    required:
+      workflow.planApproval.required ?? projectPolicy.planRequiresApproval,
+    reviewLabel: workflow.planApproval.reviewLabel,
+    approvedLabel: workflow.planApproval.approvedLabel,
+  };
+
+  return {
+    specApproval,
+    planApproval,
+    labelDefinitions: dedupeLabelDefinitions([
+      workflowLabelDefinition(
+        specApproval.reviewLabel,
+        "#5319e7",
+        "Awaiting specification review",
+      ),
+      workflowLabelDefinition(
+        specApproval.approvedLabel,
+        "#0e8a16",
+        "Specification approved for automation",
+      ),
+      workflowLabelDefinition(
+        planApproval.reviewLabel,
+        "#5319e7",
+        "Awaiting implementation plan review",
+      ),
+      workflowLabelDefinition(
+        planApproval.approvedLabel,
+        "#0e8a16",
+        "Implementation plan approved for automation",
+      ),
+    ]),
+  };
+}


### PR DESCRIPTION
## Summary
- Add configurable `workflow.specApproval` and `workflow.planApproval` gates with normalized policy/label definitions.
- Wire approval policy through run-once selection, pipeline stops, JSON summaries, init/doctor label setup, and planning prompts.
- Document workflow approval configuration and run-once approval states.

## Test Plan
- [x] `node --test src/config/defaults.test.ts src/config/load.test.ts src/workflow/approval-policy.test.ts src/cli/commands/triage/labels.test.ts src/cli/commands/labels/setup.test.ts src/cli/commands/run-once/approval-gates.test.ts src/cli/commands/run-once/selection.test.ts src/cli/commands/run-once/args.test.ts src/cli/commands/run-once/prompts.test.ts src/cli/commands/run-once/pipeline.test.ts src/cli/commands/init/main.test.ts src/cli/commands/doctor/main.test.ts src/cli/commands/doctor/checks.test.ts`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`

## Review
- Fresh-context reviewer found one important prompt-policy mismatch; fixed in `f059e00`.
