### PR TITLE
feat: add patchmill auth command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Current command status:
 Functional:
 
 - `patchmill init` initializes local configuration and recommended skills.
+- `patchmill auth` configures or repairs repo-local Pi provider authentication
+  under `.patchmill/pi-agent`.
+- `patchmill doctor` runs read-only readiness checks.
 - `patchmill version` prints the installed Patchmill CLI version.
 - `patchmill triage` is the intake/sorting station. It classifies open issues
   and can apply readiness labels or comments.
@@ -69,6 +72,7 @@ Install the Patchmill CLI globally, then start with the onboarding flow:
 npm install -g patchmill
 
 patchmill init
+patchmill auth
 patchmill doctor
 patchmill triage --dry-run
 ```
@@ -77,6 +81,7 @@ If you prefer not to install Patchmill globally, use `npx`:
 
 ```sh
 npx patchmill init
+npx patchmill auth
 npx patchmill doctor
 npx patchmill triage --dry-run
 ```
@@ -150,6 +155,11 @@ patchmill init --skills global
 patchmill init --skills none
 patchmill init --skills path:project-skills
 ```
+
+`patchmill auth` reruns the repo-local Pi provider/model setup used by init. It
+stores Patchmill-owned Pi authentication state under `.patchmill/pi-agent`, so
+it is the canonical repair command when provider auth or model selection
+changes.
 
 `patchmill doctor` is read-only: it checks git, host access, labels, configured
 skills, runtime access, and local paths, verifying bundled/path-like skills and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,13 @@ smoke test. When the smoke test passes, continue with:
 patchmill triage --dry-run
 ```
 
-If the smoke test fails, complete Pi setup with `pi` and `/login`, then run
-`patchmill doctor`.
+If the smoke test fails, repair repo-local Pi provider/model setup, then run the
+read-only checks:
+
+```sh
+patchmill auth
+patchmill doctor
+```
 
 By default, init writes host fields and project-local skill mappings for
 required stages (`triage`, `planning`, and `implementation`); Patchmill fills

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -42,6 +42,22 @@ set the host provider explicitly:
 The first `github-gh` version uses the active `gh` authentication context. It
 does not support named logins or GitHub visual-evidence upload.
 
+## Runtime Pi authentication
+
+Patchmill uses Pi as its runtime harness and keeps Patchmill-owned Pi provider
+authentication in the repository-local `.patchmill/pi-agent` directory. Run the
+guided auth command to configure or repair provider login and default model
+selection:
+
+```sh
+patchmill auth
+patchmill doctor
+```
+
+Issue-host authentication remains separate: use `gh auth login` for GitHub and
+`tea` login configuration for Forgejo/Gitea access. `patchmill auth` only
+manages Patchmill's repo-local Pi provider state.
+
 ## Configuration surface
 
 Patchmill reads provider and workflow settings from `patchmill.config.json` and

--- a/src/cli/commands/auth/main.test.ts
+++ b/src/cli/commands/auth/main.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { test } from "node:test";
+import { HELP_TEXT, main, runAuth } from "./main.ts";
+import type { PiInitSetupResult } from "../init/pi-init-setup.ts";
+import type { PiModelChoice, PiReadiness } from "../init/pi-preflight.ts";
+
+function model(): PiModelChoice {
+  return {
+    provider: "anthropic",
+    providerName: "Anthropic",
+    id: "claude-sonnet-4-5",
+    label: "Anthropic / Claude Sonnet 4.5",
+    value: "anthropic/claude-sonnet-4-5",
+    authSource: "stored",
+    reasoning: true,
+    input: ["text"],
+  };
+}
+
+function readyReadiness(): PiReadiness {
+  return {
+    status: "ready",
+    message: "Pi reported 1 provider/model option with configured auth.",
+    models: [model()],
+  };
+}
+
+function missingReadiness(): PiReadiness {
+  return {
+    status: "missing",
+    message: "Pi did not report any provider/model with configured auth.",
+    models: [],
+  };
+}
+
+function readySetup(): PiInitSetupResult {
+  return {
+    status: "ready",
+    readiness: readyReadiness(),
+    selection: {
+      status: "selected",
+      model: "anthropic/claude-sonnet-4-5",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      message: "Using Pi model Anthropic / Claude Sonnet 4.5.",
+    },
+    smoke: {
+      status: "pass",
+      message:
+        "Pi completed the provider smoke test with anthropic/claude-sonnet-4-5.",
+      command: "pi smoke",
+      details: "ok",
+    },
+  };
+}
+
+test("patchmill auth --help prints help", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runAuth(["--help"], "/repo", {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    }),
+    0,
+  );
+  assert.deepEqual(stdout, [HELP_TEXT]);
+  assert.deepEqual(stderr, []);
+});
+
+test("patchmill auth rejects unknown options", async () => {
+  await assert.rejects(
+    runAuth(["--unknown"], "/repo", {
+      stdout: () => undefined,
+      stderr: () => undefined,
+    }),
+    /Unknown option: --unknown/,
+  );
+});
+
+test("main returns numeric exit code", async () => {
+  assert.equal(typeof (await main(["--help"])), "number");
+});
+
+test("successful interactive auth prints repo-local summary and next commands", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const repoRoot = "/repo";
+  let forceInteractiveSetup: boolean | undefined;
+
+  const exitCode = await runAuth(
+    [],
+    repoRoot,
+    {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    },
+    {
+      isInteractive: true,
+      detectPiReadiness: () => readyReadiness(),
+      readLocalPiDefaultModel: async () => undefined,
+      persistDefaultModel: async () => undefined,
+      resolvePiInitSetup: async (options) => {
+        forceInteractiveSetup = options.forceInteractiveSetup;
+        assert.equal(
+          options.piAgentDir,
+          join(repoRoot, ".patchmill", "pi-agent"),
+        );
+        return readySetup();
+      },
+    },
+  );
+
+  assert.equal(exitCode, 0);
+  assert.equal(forceInteractiveSetup, true);
+  assert.deepEqual(stderr, []);
+  assert.match(
+    stdout[0] ?? "",
+    /Pi agent directory: \/repo\/\.patchmill\/pi-agent/,
+  );
+  assert.match(stdout[0] ?? "", /Pi reported 1 provider\/model option/);
+  assert.match(stdout[0] ?? "", /Selected model: anthropic\/claude-sonnet-4-5/);
+  assert.match(stdout[0] ?? "", /Pi completed the provider smoke test/);
+  assert.match(stdout[0] ?? "", /Details:\nok/);
+  assert.match(
+    stdout[0] ?? "",
+    /Next:\n {2}patchmill doctor\n {2}patchmill triage/,
+  );
+});
+
+test("incomplete non-interactive setup exits before prompt-capable setup", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let setupCalled = false;
+
+  const exitCode = await runAuth(
+    [],
+    "/repo",
+    {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    },
+    {
+      isInteractive: false,
+      detectPiReadiness: () => missingReadiness(),
+      resolvePiInitSetup: async () => {
+        setupCalled = true;
+        throw new Error("setup should not run");
+      },
+    },
+  );
+
+  assert.equal(exitCode, 1);
+  assert.equal(setupCalled, false);
+  assert.deepEqual(stdout, []);
+  assert.deepEqual(stderr, [
+    "Pi provider/model setup is incomplete.\nRerun `patchmill auth` in an interactive terminal to configure provider auth and select a model.",
+  ]);
+});
+
+test("ready state still forces interactive setup", async () => {
+  let forceInteractiveSetup: boolean | undefined;
+
+  await runAuth(
+    [],
+    "/repo",
+    {
+      stdout: () => undefined,
+      stderr: () => undefined,
+    },
+    {
+      isInteractive: true,
+      detectPiReadiness: () => readyReadiness(),
+      readLocalPiDefaultModel: async () => undefined,
+      persistDefaultModel: async () => undefined,
+      resolvePiInitSetup: async (options) => {
+        forceInteractiveSetup = options.forceInteractiveSetup;
+        return readySetup();
+      },
+    },
+  );
+
+  assert.equal(forceInteractiveSetup, true);
+});
+
+test("cancelled setup exits 1 without workflow commands", async () => {
+  const stdout: string[] = [];
+
+  const exitCode = await runAuth(
+    [],
+    "/repo",
+    {
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined,
+    },
+    {
+      isInteractive: true,
+      detectPiReadiness: () => readyReadiness(),
+      readLocalPiDefaultModel: async () => undefined,
+      persistDefaultModel: async () => undefined,
+      resolvePiInitSetup: async () => ({
+        status: "cancelled",
+        readiness: readyReadiness(),
+        selection: {
+          status: "unavailable",
+          reason: "cancelled",
+          message: "Pi model selection was cancelled.",
+        },
+      }),
+    },
+  );
+
+  assert.equal(exitCode, 1);
+  assert.doesNotMatch(stdout[0] ?? "", /patchmill triage/);
+});

--- a/src/cli/commands/auth/main.test.ts
+++ b/src/cli/commands/auth/main.test.ts
@@ -160,6 +160,30 @@ test("incomplete non-interactive setup exits before prompt-capable setup", async
   ]);
 });
 
+test("local Pi default model read failures are surfaced", async () => {
+  await assert.rejects(
+    runAuth(
+      [],
+      "/repo",
+      {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      },
+      {
+        isInteractive: true,
+        detectPiReadiness: () => readyReadiness(),
+        readLocalPiDefaultModel: async () => {
+          throw new Error("settings are malformed");
+        },
+        resolvePiInitSetup: async () => {
+          throw new Error("setup should not run");
+        },
+      },
+    ),
+    /settings are malformed/,
+  );
+});
+
 test("ready state still forces interactive setup", async () => {
   let forceInteractiveSetup: boolean | undefined;
 

--- a/src/cli/commands/auth/main.ts
+++ b/src/cli/commands/auth/main.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { cwd } from "node:process";
+import { pathToFileURL } from "node:url";
+import {
+  localPiAgentDir,
+  readLocalPiDefaultModel,
+  writeLocalPiDefaultModel,
+} from "../init/pi-agent-settings.ts";
+import {
+  resolvePiInitSetup as defaultResolvePiInitSetup,
+  type PiInitSetupResolver,
+  type PiInitSetupResult,
+} from "../init/pi-init-setup.ts";
+import { selectModelInteractively as defaultSelectModelInteractively } from "../init/pi-model-selector.ts";
+import type { SelectInteractiveModel } from "../init/pi-model-selection.ts";
+import { detectPiReadiness, type PiReadiness } from "../init/pi-preflight.ts";
+import { runPiSmokeTest } from "../init/pi-smoke-test.ts";
+
+export const HELP_TEXT = `Usage:
+  patchmill auth [options]
+
+Configure or repair repo-local Pi provider authentication.
+
+Options:
+  --help, -h  Show this help and exit.
+`;
+
+export type AuthOutput = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+};
+
+export type PiReadinessDetector = (options: {
+  agentDir: string;
+}) => PiReadiness;
+export type PiSmokeTestRunner = typeof runPiSmokeTest;
+
+const DEFAULT_OUTPUT: AuthOutput = {
+  stdout: (line) => console.log(line),
+  stderr: (line) => console.error(line),
+};
+
+function selectedModel(setup: PiInitSetupResult): string | undefined {
+  return setup.selection.status === "selected"
+    ? `${setup.selection.provider}/${setup.selection.modelId}`
+    : undefined;
+}
+
+function formatSummary(piAgentDir: string, setup: PiInitSetupResult): string {
+  const messages = [
+    `Pi agent directory: ${piAgentDir}`,
+    setup.readiness.message,
+    setup.readiness.status === "ready" ? setup.readiness.warning : undefined,
+    setup.selection.message !== setup.readiness.message
+      ? setup.selection.message
+      : undefined,
+    selectedModel(setup)
+      ? `Selected model: ${selectedModel(setup)}`
+      : undefined,
+    "smoke" in setup ? setup.smoke.message : undefined,
+    "smoke" in setup && setup.smoke.details
+      ? `Details:\n${setup.smoke.details}`
+      : undefined,
+    setup.status === "ready"
+      ? "Next:\n  patchmill doctor\n  patchmill triage"
+      : undefined,
+  ];
+  return messages.filter(Boolean).join("\n\n");
+}
+
+export async function runAuth(
+  args: string[],
+  repoRoot = cwd(),
+  output: AuthOutput = DEFAULT_OUTPUT,
+  options: {
+    detectPiReadiness?: PiReadinessDetector;
+    runPiSmokeTest?: PiSmokeTestRunner;
+    isInteractive?: boolean;
+    selectModelInteractively?: SelectInteractiveModel;
+    resolvePiInitSetup?: PiInitSetupResolver;
+    readLocalPiDefaultModel?: typeof readLocalPiDefaultModel;
+    persistDefaultModel?: typeof writeLocalPiDefaultModel;
+  } = {},
+): Promise<number> {
+  if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
+    output.stdout(HELP_TEXT);
+    return 0;
+  }
+  if (args.length > 0) {
+    throw new Error(`Unknown option: ${args[0]}`);
+  }
+
+  const resolvedRepoRoot = repoRoot;
+  const piAgentDir = localPiAgentDir(resolvedRepoRoot);
+  const readiness = (options.detectPiReadiness ?? detectPiReadiness)({
+    agentDir: piAgentDir,
+  });
+  const isInteractive = options.isInteractive ?? Boolean(process.stdin.isTTY);
+
+  if (!isInteractive && readiness.status !== "ready") {
+    output.stderr(
+      "Pi provider/model setup is incomplete.\nRerun `patchmill auth` in an interactive terminal to configure provider auth and select a model.",
+    );
+    return 1;
+  }
+
+  let currentDefault: Awaited<ReturnType<typeof readLocalPiDefaultModel>>;
+  try {
+    currentDefault = await (
+      options.readLocalPiDefaultModel ?? readLocalPiDefaultModel
+    )(piAgentDir);
+  } catch {
+    currentDefault = undefined;
+  }
+
+  const persistDefaultModel = async (
+    model: Parameters<typeof writeLocalPiDefaultModel>[1],
+  ) => {
+    await (options.persistDefaultModel ?? writeLocalPiDefaultModel)(
+      piAgentDir,
+      model,
+    );
+  };
+
+  const setup = await (options.resolvePiInitSetup ?? defaultResolvePiInitSetup)(
+    {
+      repoRoot: resolvedRepoRoot,
+      piAgentDir,
+      readiness,
+      isInteractive,
+      currentDefault,
+      selectModelInteractively:
+        options.selectModelInteractively ?? defaultSelectModelInteractively,
+      persistDefaultModel,
+      runPiSmokeTest: options.runPiSmokeTest,
+      forceInteractiveSetup: true,
+    },
+  );
+
+  output.stdout(formatSummary(piAgentDir, setup));
+  return setup.status === "ready" ? 0 : 1;
+}
+
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  try {
+    return await runAuth(args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isMain) {
+  process.exitCode = await main();
+}

--- a/src/cli/commands/auth/main.ts
+++ b/src/cli/commands/auth/main.ts
@@ -104,14 +104,9 @@ export async function runAuth(
     return 1;
   }
 
-  let currentDefault: Awaited<ReturnType<typeof readLocalPiDefaultModel>>;
-  try {
-    currentDefault = await (
-      options.readLocalPiDefaultModel ?? readLocalPiDefaultModel
-    )(piAgentDir);
-  } catch {
-    currentDefault = undefined;
-  }
+  const currentDefault = await (
+    options.readLocalPiDefaultModel ?? readLocalPiDefaultModel
+  )(piAgentDir);
 
   const persistDefaultModel = async (
     model: Parameters<typeof writeLocalPiDefaultModel>[1],

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -118,12 +118,22 @@ function projectLocalPiSmokeCommand(paths: string[]): string {
   ].join(" ");
 }
 
+function normalizePiCommandKey(command: string, args: string[]): string {
+  if (
+    command === process.execPath &&
+    args[0]?.includes("@earendil-works/pi-coding-agent")
+  ) {
+    return ["pi", ...args.slice(1)].join(" ");
+  }
+  return [command, ...args].join(" ");
+}
+
 function runnerFrom(
   map: Record<string, { code: number; stdout?: string; stderr?: string }>,
 ): CommandRunner {
   return {
     async run(command, args) {
-      const key = [command, ...args].join(" ");
+      const key = normalizePiCommandKey(command, args);
       const result = map[key] ?? {
         code: 127,
         stderr: `missing mock for ${key}`,
@@ -253,7 +263,11 @@ test("runDoctorChecks points Pi provider failures to guided setup", async () => 
   const piProvider = results.find((result) => result.name === "pi provider");
 
   assert.equal(piProvider?.status, "fail");
-  assert.match((piProvider?.remediation ?? []).join("\n"), /patchmill init/);
+  assert.match((piProvider?.remediation ?? []).join("\n"), /patchmill auth/);
+  assert.doesNotMatch(
+    (piProvider?.remediation ?? []).join("\n"),
+    /patchmill init/,
+  );
   assert.match((piProvider?.remediation ?? []).join("\n"), /missing key/);
 });
 
@@ -272,7 +286,7 @@ test("runDoctorChecks scopes Pi provider smoke test to local agent dir", async (
   const runner: CommandRunner = {
     async run(command, args, options = {}) {
       calls.push({ command, args: [...args], env: options.env });
-      const key = [command, ...args].join(" ");
+      const key = normalizePiCommandKey(command, args);
       const result = successMocks()[key] ?? {
         code: 127,
         stdout: "",
@@ -295,10 +309,8 @@ test("runDoctorChecks scopes Pi provider smoke test to local agent dir", async (
     results.find((result) => result.name === "pi provider")?.status,
     "pass",
   );
-  const smokeCall = calls.find(
-    (call) =>
-      call.command === "pi" &&
-      call.args.includes("Reply with PATCHMILL_PI_OK and nothing else."),
+  const smokeCall = calls.find((call) =>
+    call.args.includes("Reply with PATCHMILL_PI_OK and nothing else."),
   );
   assert.equal(
     smokeCall?.env?.PI_CODING_AGENT_DIR,
@@ -647,7 +659,7 @@ test("runDoctorChecks passes for fresh configured project-local skills", async (
   const calls: string[] = [];
   const runner: CommandRunner = {
     async run(command, args) {
-      const key = [command, ...args].join(" ");
+      const key = normalizePiCommandKey(command, args);
       calls.push(key);
       return (
         successMocks(REQUIRED_LABELS, {
@@ -734,7 +746,7 @@ test("runDoctorChecks ignores unused .patchmill skills when config uses global/n
   const calls: string[] = [];
   const runner: CommandRunner = {
     async run(command, args) {
-      const key = [command, ...args].join(" ");
+      const key = normalizePiCommandKey(command, args);
       calls.push(key);
       return (
         successMocks(REQUIRED_LABELS)[key] ?? {
@@ -803,7 +815,7 @@ test("runDoctorChecks smoke-tests the exact shared resolver paths when metadata 
   const calls: string[] = [];
   const runner: CommandRunner = {
     async run(command, args) {
-      const key = [command, ...args].join(" ");
+      const key = normalizePiCommandKey(command, args);
       calls.push(key);
       return (
         successMocks(REQUIRED_LABELS, {
@@ -882,7 +894,7 @@ test("runDoctorChecks rejects metadata paths outside project-local skills", asyn
     const calls: string[] = [];
     const runner: CommandRunner = {
       async run(command, args) {
-        const key = [command, ...args].join(" ");
+        const key = normalizePiCommandKey(command, args);
         calls.push(key);
         return (
           successMocks(REQUIRED_LABELS, {
@@ -1017,7 +1029,7 @@ test("runDoctorChecks allows project-local skills to be ignored by git", async (
   const calls: string[] = [];
   const runner: CommandRunner = {
     async run(command, args) {
-      const key = [command, ...args].join(" ");
+      const key = normalizePiCommandKey(command, args);
       calls.push(key);
       return (
         successMocks(REQUIRED_LABELS, {

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -1,8 +1,13 @@
 import { constants } from "node:fs";
 import { access, readFile, stat } from "node:fs/promises";
 import { dirname } from "node:path";
-import { localPiAgentDir, piAgentEnv } from "../init/pi-agent-settings.ts";
+import { localPiAgentDir } from "../init/pi-agent-settings.ts";
 import { runPiSmokeTest } from "../init/pi-smoke-test.ts";
+import {
+  piAgentCommandEnv,
+  piCommandArgs,
+  resolveBundledPiCommand,
+} from "../../pi-cli.ts";
 import { loadPatchmillConfigState } from "../../../config/load.ts";
 import { createIssueHostProvider } from "../../../host/factory.ts";
 import { createPatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
@@ -151,12 +156,17 @@ async function checkPiBinary(
   runner: CommandRunner,
   repoRoot: string,
 ): Promise<DoctorCheckResult> {
-  const result = await runner.run("pi", ["--help"], { cwd: repoRoot });
+  const piCommand = resolveBundledPiCommand();
+  const result = await runner.run(
+    piCommand.command,
+    piCommandArgs(piCommand, ["--help"]),
+    { cwd: repoRoot },
+  );
   return result.code === 0
     ? pass("pi", "binary available")
     : fail("pi", `binary unavailable: ${commandOutput(result)}`, [
-        "Install Pi, then rerun:",
-        "  npm install -g @earendil-works/pi-coding-agent",
+        "Patchmill could not run its bundled Pi dependency. Reinstall dependencies, then rerun:",
+        "  npm install",
         "  patchmill doctor",
       ]);
 }
@@ -177,13 +187,8 @@ async function checkPiProvider(
       "Patchmill doctor did not change the repository or issue host.",
       "The Pi check made no Patchmill workflow changes, but it could not reach a configured model provider.",
       "",
-      "Run Patchmill's guided setup, then rerun doctor:",
-      "  patchmill init",
-      "  patchmill doctor",
-      "",
-      "Manual Pi setup is also supported:",
-      "  pi",
-      "  /login",
+      "Run Patchmill's guided auth repair, then rerun doctor:",
+      "  patchmill auth",
       "  patchmill doctor",
       "",
       result.details ? `Details: ${result.details}` : "",
@@ -313,17 +318,19 @@ async function smokeTestProjectLocalSkills(
   skillPaths: string[],
   piAgentDir: string,
 ): Promise<SkillCheckEntry> {
+  const piCommand = resolveBundledPiCommand();
+  const args = [
+    "--no-session",
+    "--no-context-files",
+    "--no-prompt-templates",
+    ...skillPaths.flatMap((path) => ["--skill", path]),
+    "-p",
+    PROJECT_LOCAL_SKILLS_PROMPT,
+  ];
   const result = await runner.run(
-    "pi",
-    [
-      "--no-session",
-      "--no-context-files",
-      "--no-prompt-templates",
-      ...skillPaths.flatMap((path) => ["--skill", path]),
-      "-p",
-      PROJECT_LOCAL_SKILLS_PROMPT,
-    ],
-    { cwd: repoRoot, env: piAgentEnv(piAgentDir) },
+    piCommand.command,
+    piCommandArgs(piCommand, args),
+    { cwd: repoRoot, env: piAgentCommandEnv(piAgentDir) },
   );
 
   if (result.code === 0 && result.stdout.includes("PATCHMILL_SKILLS_OK")) {

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -147,7 +147,7 @@ test("runInit installs project-local skills by default", async () => {
   assert.doesNotMatch(stdout.join("\n"), /Commit \.patchmill\/skills\//);
   assert.match(
     stdout.join("\n"),
-    /Run `patchmill doctor` after completing Pi setup/,
+    /Run `patchmill auth` in an interactive terminal/,
   );
 });
 
@@ -331,7 +331,7 @@ test("runInit creates config and prints next step", async () => {
   assert.match(stdout.join("\n"), /PATCHMILL_HOST_LOGIN/);
   assert.match(
     stdout.join("\n"),
-    /Run `patchmill doctor` after completing Pi setup/,
+    /Run `patchmill auth` in an interactive terminal/,
   );
   assert.match(stdout.join("\n"), /patchmill doctor/);
 });
@@ -447,4 +447,6 @@ test("runInit refuses existing config without installing skills", async () => {
   assert.equal(installCalled, false);
   assert.match(stdout.join("\n"), /already exists/);
   assert.match(stdout.join("\n"), /did not overwrite/);
+  assert.match(stdout.join("\n"), /patchmill auth/);
+  assert.match(stdout.join("\n"), /patchmill doctor/);
 });

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -102,12 +102,12 @@ function stageableSkillRoots(
 }
 
 const EXISTING_CONFIG_MESSAGE =
-  "patchmill.config.json already exists.\n\nPatchmill did not overwrite it.\n\nNext:\n  patchmill doctor";
+  "patchmill.config.json already exists.\n\nPatchmill did not overwrite it.\n\nNext:\n  patchmill auth\n  patchmill doctor";
 
 function nextSteps(piReady: boolean) {
   return piReady
     ? "Run `patchmill triage` to triage issues.\n\nNext:\n  patchmill triage"
-    : "Run `patchmill doctor` after completing Pi setup.\n\nNext:\n  patchmill doctor";
+    : "Run `patchmill auth` in an interactive terminal, then run `patchmill doctor`.\n\nNext:\n  patchmill auth\n  patchmill doctor";
 }
 
 function formatPiSetupMessage(setup: PiInitSetupResult): string {
@@ -129,7 +129,7 @@ function formatPiSetupMessage(setup: PiInitSetupResult): string {
     "Pi provider/model setup is incomplete.",
     setup.smoke.message,
     setup.smoke.details ? `Details:\n${setup.smoke.details}` : undefined,
-    "Run `patchmill init` in an interactive terminal to configure provider auth and select a model.",
+    "Run `patchmill auth` in an interactive terminal to configure provider auth and select a model.",
     "After setup, run `patchmill doctor`.",
   ]
     .filter(Boolean)

--- a/src/cli/commands/init/pi-init-flow.test.ts
+++ b/src/cli/commands/init/pi-init-flow.test.ts
@@ -211,9 +211,12 @@ test("runInit reports Patchmill setup guidance when Pi readiness remains missing
   assert.match(stdout.join("\n"), /Pi provider\/model setup is incomplete/);
   assert.match(
     stdout.join("\n"),
-    /Run `patchmill init` in an interactive terminal to configure provider auth and select a model/,
+    /Run `patchmill auth` in an interactive terminal to configure provider auth and select a model/,
   );
-  assert.match(stdout.join("\n"), /Next:\n {2}patchmill doctor/);
+  assert.match(
+    stdout.join("\n"),
+    /Next:\n {2}patchmill auth\n {2}patchmill doctor/,
+  );
 });
 
 test("runInit persists selected model to local Pi settings and smoke-tests it", async () => {
@@ -530,11 +533,11 @@ test("runInit keeps config but reports incomplete Pi setup when smoke test fails
   assert.match(output, /After setup, run `patchmill doctor`/);
   assert.match(
     output,
-    /Run `patchmill init` in an interactive terminal to configure provider auth and select a model/,
+    /Run `patchmill auth` in an interactive terminal to configure provider auth and select a model/,
   );
   assert.doesNotMatch(output, /Run `pi`, then `\/login`/);
   assert.doesNotMatch(output, /rerun `patchmill init`/);
-  assert.match(output, /Next:\n {2}patchmill doctor/);
+  assert.match(output, /Next:\n {2}patchmill auth\n {2}patchmill doctor/);
   assert.doesNotMatch(
     await readFile(join(repoRoot, "patchmill.config.json"), "utf8"),
     /missing key|sk-/u,
@@ -606,5 +609,8 @@ test("runInit aborts when the required interactive model selector is cancelled",
   assert.equal(smokeCalled, false);
   assertOnlyGitPolicyPrompt(prompts);
   assert.match(stdout.join("\n"), /Pi model selection was cancelled/);
-  assert.match(stdout.join("\n"), /Next:\n {2}patchmill doctor/);
+  assert.match(
+    stdout.join("\n"),
+    /Next:\n {2}patchmill auth\n {2}patchmill doctor/,
+  );
 });

--- a/src/cli/commands/init/pi-init-setup.test.ts
+++ b/src/cli/commands/init/pi-init-setup.test.ts
@@ -79,6 +79,77 @@ test("resolvePiInitSetup returns invalid without running a fake smoke test", asy
   assert.equal(smokeCalled, false);
 });
 
+test("resolvePiInitSetup selects model without interactive setup when ready and force is false", async () => {
+  let setupCalled = false;
+  let selected = false;
+
+  const result = await resolvePiInitSetup({
+    repoRoot: "/repo",
+    piAgentDir: "/repo/.patchmill/pi-agent",
+    readiness: readyReadiness(),
+    isInteractive: false,
+    setupPiInteractively: async () => {
+      setupCalled = true;
+      throw new Error("setup should not run");
+    },
+    selectModelInteractively: async () => {
+      selected = true;
+      return model();
+    },
+    runPiSmokeTest: async (_runner, options) => ({
+      status: "pass",
+      message: `smoke ${options.model}`,
+      command: "pi smoke",
+    }),
+  });
+
+  assert.equal(result.status, "ready");
+  assert.equal(setupCalled, false);
+  assert.equal(selected, false);
+  assert.equal(result.selection.status, "selected");
+});
+
+test("resolvePiInitSetup forces interactive setup when readiness is already ready", async () => {
+  let setupCalled = false;
+  let smokeModel: string | undefined;
+
+  const result = await resolvePiInitSetup({
+    repoRoot: "/repo",
+    piAgentDir: "/repo/.patchmill/pi-agent",
+    readiness: readyReadiness(),
+    isInteractive: true,
+    forceInteractiveSetup: true,
+    setupPiInteractively: async ({ agentDir, initialReadiness }) => {
+      setupCalled = true;
+      assert.equal(agentDir, "/repo/.patchmill/pi-agent");
+      assert.equal(initialReadiness.status, "ready");
+      return {
+        readiness: readyReadiness(),
+        selection: {
+          status: "selected",
+          model: "anthropic/claude-sonnet-4-5",
+          provider: "anthropic",
+          modelId: "claude-sonnet-4-5",
+          message: "Using Pi model Anthropic / Claude Sonnet 4.5.",
+        },
+      };
+    },
+    runPiSmokeTest: async (_runner, options) => {
+      smokeModel = options.model;
+      return {
+        status: "pass",
+        message:
+          "Pi completed the provider smoke test with anthropic/claude-sonnet-4-5.",
+        command: "pi smoke",
+      };
+    },
+  });
+
+  assert.equal(result.status, "ready");
+  assert.equal(setupCalled, true);
+  assert.equal(smokeModel, "anthropic/claude-sonnet-4-5");
+});
+
 test("resolvePiInitSetup uses canonical interactive setup when readiness is missing", async () => {
   let setupAgentDir: string | undefined;
   let smokeModel: string | undefined;

--- a/src/cli/commands/init/pi-init-setup.ts
+++ b/src/cli/commands/init/pi-init-setup.ts
@@ -76,12 +76,16 @@ export async function resolvePiInitSetup(options: {
   persistDefaultModel?: PersistDefaultModel;
   setupPiInteractively?: InteractivePiSetup;
   runPiSmokeTest?: PiSmokeTestRunner;
+  forceInteractiveSetup?: boolean;
 }): Promise<PiInitSetupResult> {
   const interactiveSetup = options.setupPiInteractively ?? setupPiInteractively;
   let readiness = options.readiness;
   let selection: PiModelSelection;
 
-  if (readiness.status !== "ready" && options.isInteractive) {
+  if (
+    options.isInteractive &&
+    (readiness.status !== "ready" || options.forceInteractiveSetup === true)
+  ) {
     const setup = await interactiveSetup({
       repoRoot: options.repoRoot,
       agentDir: options.piAgentDir,

--- a/src/cli/commands/init/pi-smoke-test.test.ts
+++ b/src/cli/commands/init/pi-smoke-test.test.ts
@@ -3,6 +3,8 @@ import { test } from "node:test";
 import type { CommandRunner } from "../triage/types.ts";
 import { runPiSmokeTest } from "./pi-smoke-test.ts";
 
+const FAKE_PI_COMMAND = { command: "pi", argsPrefix: [] };
+
 function runner(result: {
   code: number;
   stdout?: string;
@@ -36,6 +38,7 @@ test("runPiSmokeTest succeeds when Pi prints sentinel", async () => {
   const result = await runPiSmokeTest(fake, {
     repoRoot: "/repo",
     model: "anthropic/claude-sonnet-4-5",
+    piCommand: FAKE_PI_COMMAND,
   });
 
   assert.deepEqual(result, {
@@ -63,6 +66,21 @@ test("runPiSmokeTest succeeds when Pi prints sentinel", async () => {
   ]);
 });
 
+test("runPiSmokeTest uses injectable bundled command spec without spawning real Pi", async () => {
+  const fake = runner({ code: 0, stdout: "PATCHMILL_PI_OK\n" });
+
+  await runPiSmokeTest(fake, {
+    repoRoot: "/repo",
+    piCommand: { command: "node", argsPrefix: ["/pkg/dist/cli.js"] },
+  });
+
+  assert.equal(fake.calls[0]?.command, "node");
+  assert.deepEqual(fake.calls[0]?.args.slice(0, 2), [
+    "/pkg/dist/cli.js",
+    "--no-session",
+  ]);
+});
+
 test("runPiSmokeTest scopes Pi to the provided local agent dir", async () => {
   const fake = runner({ code: 0, stdout: "PATCHMILL_PI_OK\n" });
 
@@ -70,6 +88,7 @@ test("runPiSmokeTest scopes Pi to the provided local agent dir", async () => {
     repoRoot: "/repo",
     model: "openai-codex/gpt-5.5",
     piAgentDir: "/repo/.patchmill/pi-agent",
+    piCommand: FAKE_PI_COMMAND,
   });
 
   assert.equal(
@@ -81,7 +100,7 @@ test("runPiSmokeTest scopes Pi to the provided local agent dir", async () => {
 test("runPiSmokeTest omits model when no model is selected", async () => {
   const fake = runner({ code: 0, stdout: "PATCHMILL_PI_OK\n" });
 
-  await runPiSmokeTest(fake, { repoRoot: "/repo" });
+  await runPiSmokeTest(fake, { repoRoot: "/repo", piCommand: FAKE_PI_COMMAND });
 
   assert.deepEqual(fake.calls[0]?.args, [
     "--no-session",
@@ -95,7 +114,10 @@ test("runPiSmokeTest omits model when no model is selected", async () => {
 test("runPiSmokeTest fails when Pi exits non-zero", async () => {
   const fake = runner({ code: 1, stderr: "missing key" });
 
-  const result = await runPiSmokeTest(fake, { repoRoot: "/repo" });
+  const result = await runPiSmokeTest(fake, {
+    repoRoot: "/repo",
+    piCommand: FAKE_PI_COMMAND,
+  });
 
   assert.equal(result.status, "fail");
   assert.match(result.message, /Pi could not complete the provider smoke test/);
@@ -105,7 +127,10 @@ test("runPiSmokeTest fails when Pi exits non-zero", async () => {
 test("runPiSmokeTest fails when sentinel is absent", async () => {
   const fake = runner({ code: 0, stdout: "hello\n" });
 
-  const result = await runPiSmokeTest(fake, { repoRoot: "/repo" });
+  const result = await runPiSmokeTest(fake, {
+    repoRoot: "/repo",
+    piCommand: FAKE_PI_COMMAND,
+  });
 
   assert.equal(result.status, "fail");
   assert.match(result.details ?? "", /hello/);

--- a/src/cli/commands/init/pi-smoke-test.ts
+++ b/src/cli/commands/init/pi-smoke-test.ts
@@ -1,5 +1,10 @@
 import type { CommandRunner } from "../triage/types.ts";
-import { piAgentEnv } from "./pi-agent-settings.ts";
+import {
+  piAgentCommandEnv,
+  piCommandArgs,
+  resolveBundledPiCommand,
+  type PiCommandSpec,
+} from "../../pi-cli.ts";
 
 const PI_SMOKE_PROMPT = "Reply with PATCHMILL_PI_OK and nothing else.";
 const PI_SMOKE_SENTINEL = "PATCHMILL_PI_OK";
@@ -15,8 +20,8 @@ function shellQuote(value: string): string {
   return /\s/u.test(value) ? value : value;
 }
 
-function formatCommand(args: string[]): string {
-  return ["pi", ...args.map(shellQuote)].join(" ");
+function formatCommand(spec: PiCommandSpec, args: string[]): string {
+  return [spec.command, ...piCommandArgs(spec, args).map(shellQuote)].join(" ");
 }
 
 function commandOutput(stdout: string, stderr: string): string {
@@ -25,17 +30,29 @@ function commandOutput(stdout: string, stderr: string): string {
 
 export async function runPiSmokeTest(
   runner: CommandRunner,
-  options: { repoRoot: string; model?: string; piAgentDir?: string },
+  options: {
+    repoRoot: string;
+    model?: string;
+    piAgentDir?: string;
+    piCommand?: PiCommandSpec;
+  },
 ): Promise<PiSmokeTestResult> {
   const args = ["--no-session", "--no-context-files", "--no-prompt-templates"];
   if (options.model) args.push("--model", options.model);
   args.push("-p", PI_SMOKE_PROMPT);
 
-  const result = await runner.run("pi", args, {
-    cwd: options.repoRoot,
-    ...(options.piAgentDir ? { env: piAgentEnv(options.piAgentDir) } : {}),
-  });
-  const command = formatCommand(args);
+  const piCommand = options.piCommand ?? resolveBundledPiCommand();
+  const result = await runner.run(
+    piCommand.command,
+    piCommandArgs(piCommand, args),
+    {
+      cwd: options.repoRoot,
+      ...(options.piAgentDir
+        ? { env: piAgentCommandEnv(options.piAgentDir) }
+        : {}),
+    },
+  );
+  const command = formatCommand(piCommand, args);
   if (result.code === 0 && result.stdout.includes(PI_SMOKE_SENTINEL)) {
     return {
       status: "pass",

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -51,6 +51,15 @@ function createStaticCommandRunner(results: CommandResult[]): CommandRunner {
   });
 }
 
+function assertBundledPiCall(call: Call): string[] {
+  assert.equal(call.command, process.execPath);
+  assert.match(
+    call.args[0] ?? "",
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/,
+  );
+  return call.args.slice(1);
+}
+
 function promptPath(args: string[]): string {
   const promptArg = args.find((arg) => arg.startsWith("@"));
   assert.ok(promptArg, `expected prompt path in ${args.join(" ")}`);
@@ -74,18 +83,12 @@ async function writeTodo(
 
 test("runPiPrompt writes the prompt to a temp file and surfaces nonzero pi failures", async () => {
   const runner = createMockRunner(async (call) => {
-    assert.equal(call.command, "pi");
+    const args = assertBundledPiCall(call);
     assert.equal(call.cwd, "/repo/worktree");
-    assert.deepEqual(call.args.slice(0, 5), [
-      "-e",
-      call.args[1],
-      "-e",
-      call.args[3],
-      "-p",
-    ]);
-    assert.match(call.args[1] ?? "", /node_modules\/pi-subagents$/);
-    assert.match(call.args[3] ?? "", /extensions\/todos\.ts$/);
-    const prompt = await readFile(promptPath(call.args), "utf8");
+    assert.deepEqual(args.slice(0, 5), ["-e", args[1], "-e", args[3], "-p"]);
+    assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
+    assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
+    const prompt = await readFile(promptPath(args), "utf8");
     assert.equal(prompt, "prompt body");
     return { code: 9, stdout: "", stderr: "pi exploded" };
   });
@@ -98,17 +101,11 @@ test("runPiPrompt writes the prompt to a temp file and surfaces nonzero pi failu
 
 test("runPiPrompt loads bundled Pi extensions before the prompt argument", async () => {
   const runner = createMockRunner(async (call) => {
-    assert.equal(call.command, "pi");
-    assert.deepEqual(call.args.slice(0, 5), [
-      "-e",
-      call.args[1],
-      "-e",
-      call.args[3],
-      "-p",
-    ]);
-    assert.match(call.args[1] ?? "", /node_modules\/pi-subagents$/);
-    assert.match(call.args[3] ?? "", /extensions\/todos\.ts$/);
-    assert.equal(call.args[5]?.startsWith("@"), true);
+    const args = assertBundledPiCall(call);
+    assert.deepEqual(args.slice(0, 5), ["-e", args[1], "-e", args[3], "-p"]);
+    assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
+    assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
+    assert.equal(args[5]?.startsWith("@"), true);
     return {
       code: 0,
       stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
@@ -145,21 +142,21 @@ test("runPiPrompt can parse development environment results", async () => {
 
 test("runPiPrompt passes configured skill files before the prompt argument", async () => {
   const runner = createMockRunner(async (call) => {
-    assert.equal(call.command, "pi");
-    assert.deepEqual(call.args.slice(0, 9), [
+    const args = assertBundledPiCall(call);
+    assert.deepEqual(args.slice(0, 9), [
       "-e",
-      call.args[1],
+      args[1],
       "-e",
-      call.args[3],
+      args[3],
       "--skill",
       "/repo/.patchmill/skills/writing-plans/SKILL.md",
       "--skill",
       "/repo/.patchmill/skills/review/SKILL.md",
       "-p",
     ]);
-    assert.match(call.args[1] ?? "", /node_modules\/pi-subagents$/);
-    assert.match(call.args[3] ?? "", /extensions\/todos\.ts$/);
-    assert.equal(call.args[9]?.startsWith("@"), true);
+    assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
+    assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
+    assert.equal(args[9]?.startsWith("@"), true);
     return {
       code: 0,
       stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
@@ -246,22 +243,17 @@ test("runPiPrompt logs pi stdout and stderr chunks", async () => {
 test("runPiPrompt streams messages appended to the prompted pi session JSONL", async () => {
   const streamed: string[] = [];
   const runner = createMockRunner(async (call) => {
-    assert.deepEqual(call.args.slice(0, 5), [
-      "-e",
-      call.args[1],
-      "-e",
-      call.args[3],
-      "-p",
-    ]);
-    assert.match(call.args[1] ?? "", /node_modules\/pi-subagents$/);
-    assert.match(call.args[3] ?? "", /extensions\/todos\.ts$/);
-    assert.equal(call.args.includes("--mode"), false);
-    const sessionDirIndex = call.args.indexOf("--session-dir");
+    const args = assertBundledPiCall(call);
+    assert.deepEqual(args.slice(0, 5), ["-e", args[1], "-e", args[3], "-p"]);
+    assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
+    assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
+    assert.equal(args.includes("--mode"), false);
+    const sessionDirIndex = args.indexOf("--session-dir");
     assert.ok(
       sessionDirIndex >= 0,
-      `expected --session-dir in ${call.args.join(" ")}`,
+      `expected --session-dir in ${args.join(" ")}`,
     );
-    const sessionDir = call.args[sessionDirIndex + 1];
+    const sessionDir = args[sessionDirIndex + 1];
     assert.ok(sessionDir);
 
     const sessionPath = join(sessionDir, "--repo--", "session.jsonl");

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -208,7 +208,6 @@ test("runPiPrompt passes the local Pi agent dir to Pi", async () => {
 
   await runPiPrompt(runner, "/repo", "prompt", {
     stage: "pi-plan",
-    piAgentDir: "/repo/.patchmill/pi-agent",
   });
 });
 

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -7,7 +7,8 @@ import {
   DEFAULT_PI_TASK_CONTRACT,
   type PatchmillPiTaskContract,
 } from "../../../policy/task-contract.ts";
-import { piAgentEnv } from "../init/pi-agent-settings.ts";
+import { localPiAgentDir } from "../init/pi-agent-settings.ts";
+import { piAgentCommandEnv } from "../../pi-cli.ts";
 import { issueTodoProgress } from "./issue-todos.ts";
 import {
   createPiSessionMessageStreamer,
@@ -494,12 +495,11 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
         piPromptArgs(promptPath, sessionDir, options?.skillPaths),
         {
           cwd,
-          env: {
-            ...(options?.piAgentDir ? piAgentEnv(options.piAgentDir) : {}),
+          env: piAgentCommandEnv(options?.piAgentDir ?? localPiAgentDir(cwd), {
             PI_TODO_PATH:
               options?.taskContract?.todoRoot ??
               DEFAULT_PI_TASK_CONTRACT.todoRoot,
-          },
+          }),
         },
       );
     } finally {

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -8,7 +8,12 @@ import {
   type PatchmillPiTaskContract,
 } from "../../../policy/task-contract.ts";
 import { localPiAgentDir } from "../init/pi-agent-settings.ts";
-import { piAgentCommandEnv } from "../../pi-cli.ts";
+import {
+  piAgentCommandEnv,
+  piCommandArgs,
+  resolveBundledPiCommand,
+  type PiCommandSpec,
+} from "../../pi-cli.ts";
 import { issueTodoProgress } from "./issue-todos.ts";
 import {
   createPiSessionMessageStreamer,
@@ -332,6 +337,7 @@ export type RunPiPromptOptions<Result = AgentIssuePiResult> = {
   verbosePiOutput?: boolean;
   taskContract?: PatchmillPiTaskContract;
   piAgentDir?: string;
+  piCommand?: PiCommandSpec;
 };
 
 function stageStatus(stage: RunPiPromptStage): string {
@@ -490,9 +496,13 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
     sessionStreamer?.start();
     let result: CommandResult;
     try {
+      const piCommand = options?.piCommand ?? resolveBundledPiCommand();
       result = await runner.run(
-        "pi",
-        piPromptArgs(promptPath, sessionDir, options?.skillPaths),
+        piCommand.command,
+        piCommandArgs(
+          piCommand,
+          piPromptArgs(promptPath, sessionDir, options?.skillPaths),
+        ),
         {
           cwd,
           env: piAgentCommandEnv(options?.piAgentDir ?? localPiAgentDir(cwd), {

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -152,6 +152,18 @@ function collectProgressEvents(): {
   };
 }
 
+function normalizeRecordedPiCall(call: Call): Call {
+  if (
+    call.command === process.execPath &&
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/.test(
+      call.args[0] ?? "",
+    )
+  ) {
+    return { ...call, command: "pi", args: call.args.slice(1) };
+  }
+  return call;
+}
+
 function createMockRunner(
   handler: (call: Call) => Promise<CommandResult> | CommandResult,
 ): MockRunner {
@@ -159,16 +171,16 @@ function createMockRunner(
   return {
     calls,
     async run(command, args, options = {}) {
-      const call = {
+      const call = normalizeRecordedPiCall({
         command,
         args: [...args],
         cwd: options.cwd,
         ...(options.env ? { env: options.env } : {}),
         onStdout: options.onStdout,
         onStderr: options.onStderr,
-      };
+      });
       calls.push(call);
-      if (command === "pi") {
+      if (call.command === "pi") {
         try {
           return await normalizePiResult(call, await handler(call));
         } catch (error) {

--- a/src/cli/commands/triage/dry-run-agent.test.ts
+++ b/src/cli/commands/triage/dry-run-agent.test.ts
@@ -18,7 +18,11 @@ import {
   runTriageDryRunAgent,
   validateTriagePreviewDocument,
 } from "./dry-run-agent.ts";
-import type { CommandRunner, IssueSummary } from "./types.ts";
+import type {
+  CommandRunOptions,
+  CommandRunner,
+  IssueSummary,
+} from "./types.ts";
 
 const issues: IssueSummary[] = [
   {
@@ -80,10 +84,20 @@ async function createProjectLocalTriageRepo(): Promise<{
 }
 
 class RecordingRunner implements CommandRunner {
-  readonly calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
+  readonly calls: Array<{
+    command: string;
+    args: string[];
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+  }> = [];
 
-  async run(command: string, args: string[], options = {}) {
-    this.calls.push({ command, args: [...args], cwd: options.cwd });
+  async run(command: string, args: string[], options: CommandRunOptions = {}) {
+    this.calls.push({
+      command,
+      args: [...args],
+      cwd: options.cwd,
+      env: options.env,
+    });
     const promptPath = args[args.indexOf("-p") + 1]?.slice(1);
     assert.ok(promptPath);
     const prompt = await readFile(promptPath, "utf8");
@@ -380,6 +394,7 @@ test("runTriageDryRunAgent invokes Pi with read-only tools", async () => {
   assert.equal(previews[0]?.canonicalBucket, "agent-ready");
   const call = runner.calls[0]!;
   assert.equal(call.command, "pi");
+  assert.equal(call.env?.PI_CODING_AGENT_DIR, "/repo/.patchmill/pi-agent");
   assert.deepEqual(call.args.slice(0, 4), [
     "--tools",
     "read,grep,find,ls",

--- a/src/cli/commands/triage/dry-run-agent.test.ts
+++ b/src/cli/commands/triage/dry-run-agent.test.ts
@@ -393,9 +393,15 @@ test("runTriageDryRunAgent invokes Pi with read-only tools", async () => {
 
   assert.equal(previews[0]?.canonicalBucket, "agent-ready");
   const call = runner.calls[0]!;
-  assert.equal(call.command, "pi");
+  assert.equal(call.command, process.execPath);
+  assert.match(
+    call.args[0] ?? "",
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/,
+  );
   assert.equal(call.env?.PI_CODING_AGENT_DIR, "/repo/.patchmill/pi-agent");
-  assert.deepEqual(call.args.slice(0, 4), [
+  const toolsIndex = call.args.indexOf("--tools");
+  assert.notEqual(toolsIndex, -1);
+  assert.deepEqual(call.args.slice(toolsIndex, toolsIndex + 4), [
     "--tools",
     "read,grep,find,ls",
     "--no-context-files",

--- a/src/cli/commands/triage/dry-run-agent.ts
+++ b/src/cli/commands/triage/dry-run-agent.ts
@@ -1,5 +1,10 @@
 import { localPiAgentDir } from "../init/pi-agent-settings.ts";
-import { piAgentCommandEnv } from "../../pi-cli.ts";
+import {
+  piAgentCommandEnv,
+  piCommandArgs,
+  resolveBundledPiCommand,
+  type PiCommandSpec,
+} from "../../pi-cli.ts";
 import { withPromptFile } from "./prompt-file.ts";
 import { runWithToolCallObservation } from "./tool-call-observer.ts";
 import type { PatchmillTriageStateMap } from "../../../policy/triage-state.ts";
@@ -27,6 +32,7 @@ export type TriageDryRunPromptInput = {
   thinking?: string;
   onToolCall?: TriageToolCallHandler;
   piAgentDir?: string;
+  piCommand?: PiCommandSpec;
 };
 
 function issuePayload(issues: IssueSummary[]): string {
@@ -279,9 +285,10 @@ export async function runTriageDryRunAgent(
       const sessionArgs = sessionDir
         ? ["--session-dir", sessionDir]
         : ["--no-session"];
+      const piCommand = input.piCommand ?? resolveBundledPiCommand();
       const result = await runner.run(
-        "pi",
-        [
+        piCommand.command,
+        piCommandArgs(piCommand, [
           "--tools",
           "read,grep,find,ls",
           "--no-context-files",
@@ -291,7 +298,7 @@ export async function runTriageDryRunAgent(
           thinking,
           "-p",
           `@${promptPath}`,
-        ],
+        ]),
         {
           cwd: repoRoot,
           env: piAgentCommandEnv(input.piAgentDir ?? localPiAgentDir(repoRoot)),

--- a/src/cli/commands/triage/dry-run-agent.ts
+++ b/src/cli/commands/triage/dry-run-agent.ts
@@ -1,3 +1,5 @@
+import { localPiAgentDir } from "../init/pi-agent-settings.ts";
+import { piAgentCommandEnv } from "../../pi-cli.ts";
 import { withPromptFile } from "./prompt-file.ts";
 import { runWithToolCallObservation } from "./tool-call-observer.ts";
 import type { PatchmillTriageStateMap } from "../../../policy/triage-state.ts";
@@ -24,6 +26,7 @@ export type TriageDryRunPromptInput = {
   stateMap: PatchmillTriageStateMap;
   thinking?: string;
   onToolCall?: TriageToolCallHandler;
+  piAgentDir?: string;
 };
 
 function issuePayload(issues: IssueSummary[]): string {
@@ -289,7 +292,10 @@ export async function runTriageDryRunAgent(
           "-p",
           `@${promptPath}`,
         ],
-        { cwd: repoRoot },
+        {
+          cwd: repoRoot,
+          env: piAgentCommandEnv(input.piAgentDir ?? localPiAgentDir(repoRoot)),
+        },
       );
 
       if (result.code !== 0) {

--- a/src/cli/commands/triage/execute-agent.test.ts
+++ b/src/cli/commands/triage/execute-agent.test.ts
@@ -16,7 +16,11 @@ import {
   buildTriageExecutePrompt,
   runTriageExecuteAgent,
 } from "./execute-agent.ts";
-import type { CommandRunner, IssueSummary } from "./types.ts";
+import type {
+  CommandRunOptions,
+  CommandRunner,
+  IssueSummary,
+} from "./types.ts";
 
 const issues: IssueSummary[] = [
   {
@@ -78,10 +82,20 @@ async function createProjectLocalTriageRepo(): Promise<{
 }
 
 class RecordingRunner implements CommandRunner {
-  readonly calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
+  readonly calls: Array<{
+    command: string;
+    args: string[];
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+  }> = [];
 
-  async run(command: string, args: string[], options = {}) {
-    this.calls.push({ command, args: [...args], cwd: options.cwd });
+  async run(command: string, args: string[], options: CommandRunOptions = {}) {
+    this.calls.push({
+      command,
+      args: [...args],
+      cwd: options.cwd,
+      env: options.env,
+    });
     const promptPath = args[args.indexOf("-p") + 1]?.slice(1);
     assert.ok(promptPath);
     const prompt = await readFile(promptPath, "utf8");
@@ -180,6 +194,7 @@ test("runTriageExecuteAgent invokes Pi without read-only tool restriction", asyn
 
   const call = runner.calls[0]!;
   assert.equal(call.command, "pi");
+  assert.equal(call.env?.PI_CODING_AGENT_DIR, "/repo/.patchmill/pi-agent");
   assert.equal(call.args.includes("--tools"), false);
   assert.equal(call.args.includes("--no-context-files"), true);
   assert.equal(call.args.includes("--no-session"), true);

--- a/src/cli/commands/triage/execute-agent.test.ts
+++ b/src/cli/commands/triage/execute-agent.test.ts
@@ -193,7 +193,11 @@ test("runTriageExecuteAgent invokes Pi without read-only tool restriction", asyn
   });
 
   const call = runner.calls[0]!;
-  assert.equal(call.command, "pi");
+  assert.equal(call.command, process.execPath);
+  assert.match(
+    call.args[0] ?? "",
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/,
+  );
   assert.equal(call.env?.PI_CODING_AGENT_DIR, "/repo/.patchmill/pi-agent");
   assert.equal(call.args.includes("--tools"), false);
   assert.equal(call.args.includes("--no-context-files"), true);

--- a/src/cli/commands/triage/execute-agent.ts
+++ b/src/cli/commands/triage/execute-agent.ts
@@ -1,3 +1,5 @@
+import { localPiAgentDir } from "../init/pi-agent-settings.ts";
+import { piAgentCommandEnv } from "../../pi-cli.ts";
 import { withPromptFile } from "./prompt-file.ts";
 import { runWithToolCallObservation } from "./tool-call-observer.ts";
 import type { PatchmillHostConfig } from "../../../config/types.ts";
@@ -22,6 +24,7 @@ export type TriageExecutePromptInput = {
   skills?: PatchmillSkillsConfig;
   thinking?: string;
   onToolCall?: TriageToolCallHandler;
+  piAgentDir?: string;
 };
 
 function issuePayload(issues: IssueSummary[]): string {
@@ -124,7 +127,10 @@ export async function runTriageExecuteAgent(
           "-p",
           `@${promptPath}`,
         ],
-        { cwd: repoRoot },
+        {
+          cwd: repoRoot,
+          env: piAgentCommandEnv(input.piAgentDir ?? localPiAgentDir(repoRoot)),
+        },
       );
 
       if (result.code !== 0) {

--- a/src/cli/commands/triage/execute-agent.ts
+++ b/src/cli/commands/triage/execute-agent.ts
@@ -1,5 +1,10 @@
 import { localPiAgentDir } from "../init/pi-agent-settings.ts";
-import { piAgentCommandEnv } from "../../pi-cli.ts";
+import {
+  piAgentCommandEnv,
+  piCommandArgs,
+  resolveBundledPiCommand,
+  type PiCommandSpec,
+} from "../../pi-cli.ts";
 import { withPromptFile } from "./prompt-file.ts";
 import { runWithToolCallObservation } from "./tool-call-observer.ts";
 import type { PatchmillHostConfig } from "../../../config/types.ts";
@@ -25,6 +30,7 @@ export type TriageExecutePromptInput = {
   thinking?: string;
   onToolCall?: TriageToolCallHandler;
   piAgentDir?: string;
+  piCommand?: PiCommandSpec;
 };
 
 function issuePayload(issues: IssueSummary[]): string {
@@ -116,9 +122,10 @@ export async function runTriageExecuteAgent(
       const sessionArgs = sessionDir
         ? ["--session-dir", sessionDir]
         : ["--no-session"];
+      const piCommand = input.piCommand ?? resolveBundledPiCommand();
       const result = await runner.run(
-        "pi",
-        [
+        piCommand.command,
+        piCommandArgs(piCommand, [
           "--no-context-files",
           ...sessionArgs,
           ...skillArgs,
@@ -126,7 +133,7 @@ export async function runTriageExecuteAgent(
           thinking,
           "-p",
           `@${promptPath}`,
-        ],
+        ]),
         {
           cwd: repoRoot,
           env: piAgentCommandEnv(input.piAgentDir ?? localPiAgentDir(repoRoot)),

--- a/src/cli/commands/triage/pipeline-blocked.test.ts
+++ b/src/cli/commands/triage/pipeline-blocked.test.ts
@@ -4,7 +4,10 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
-import { createStaticCommandRunner } from "../../../../test-support/command-runner.ts";
+import {
+  createStaticCommandRunner,
+  normalizeRecordedPiCall,
+} from "../../../../test-support/command-runner.ts";
 import { runTriage } from "./pipeline.ts";
 
 function previewJson(previews: unknown[]): string {
@@ -25,7 +28,10 @@ test("runTriage dry-run trusts active GitHub user for blocked metadata when conf
   const runner = {
     calls,
     async run(command: string, args: string[], options = {}) {
-      calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (command === "gh" && args.slice(0, 2).join(" ") === "issue list") {
         return {
@@ -246,7 +252,10 @@ test("runTriage execute removes blocked and adds agent-ready when blockers are c
   const runner = {
     calls: [] as Array<{ command: string; args: string[]; cwd?: string }>,
     async run(command: string, args: string[], options = {}) {
-      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      runner.calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (command === "gh" && args.slice(0, 2).join(" ") === "issue list") {
         return {

--- a/src/cli/commands/triage/pipeline.test.ts
+++ b/src/cli/commands/triage/pipeline.test.ts
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_PATCHMILL_CONFIG } from "../../../config/defaults.ts";
 import { createTriagePolicy } from "../../../policy/triage.ts";
-import { createStaticCommandRunner } from "../../../../test-support/command-runner.ts";
+import {
+  createStaticCommandRunner,
+  normalizeRecordedPiCall,
+} from "../../../../test-support/command-runner.ts";
 import { runTriage } from "./pipeline.ts";
 
 const issueJson = JSON.stringify([
@@ -210,7 +213,10 @@ test("runTriage targeted GitHub issue reads issue by number", async () => {
   const runner = {
     calls: [] as Array<{ command: string; args: string[]; cwd?: string }>,
     async run(command: string, args: string[], options = {}) {
-      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      runner.calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (command === "gh" && args[0] === "issue" && args[1] === "view") {
         return {
@@ -345,7 +351,10 @@ test("runTriage execute emits each issue after its own snapshot", async () => {
   const runner = {
     calls: [] as Array<{ command: string; args: string[]; cwd?: string }>,
     async run(command: string, args: string[], options = {}) {
-      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      runner.calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (command === "gh" && args.slice(0, 2).join(" ") === "issue list") {
         return {
@@ -451,7 +460,10 @@ test("runTriage execute snapshots Forgejo issues without repeated all-issue scan
   const runner = {
     calls: [] as Array<{ command: string; args: string[]; cwd?: string }>,
     async run(command: string, args: string[], options = {}) {
-      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      runner.calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (command === "tea" && args.slice(0, 2).join(" ") === "issues list") {
         const state = args[args.indexOf("--state") + 1];
@@ -636,7 +648,10 @@ test("runTriage passes configured custom skills through to the triage agent", as
   const runner = {
     calls: [] as Array<{ command: string; args: string[]; cwd?: string }>,
     async run(command: string, args: string[], options = {}) {
-      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      runner.calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (
         command === "tea" &&
@@ -711,7 +726,10 @@ test("runTriage execute passes configured state map to the Pi prompt", async () 
   const runner = {
     calls: [] as Array<{ command: string; args: string[]; cwd?: string }>,
     async run(command: string, args: string[], options = {}) {
-      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const recordedCall = normalizeRecordedPiCall(command, args, options.cwd);
+      runner.calls.push(recordedCall);
+      command = recordedCall.command;
+      args = recordedCall.args;
 
       if (
         command === "tea" &&
@@ -818,6 +836,10 @@ test("runTriage execute failure log keeps completed issue entries", async () => 
   let piCalls = 0;
   const runner = {
     async run(command: string, args: string[]) {
+      const recordedCall = normalizeRecordedPiCall(command, args);
+      command = recordedCall.command;
+      args = recordedCall.args;
+
       if (command === "gh" && args.slice(0, 2).join(" ") === "issue list") {
         return {
           code: 0,

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -46,6 +46,13 @@ test("resolveCommand maps init to the public command name", () => {
   });
 });
 
+test("resolveCommand maps auth to the public command name", () => {
+  assert.deepEqual(resolveCommand(["auth", "--help"], ["auth"]), {
+    command: "auth",
+    args: ["--help"],
+  });
+});
+
 test("resolveCommand maps doctor to the public command name", () => {
   assert.deepEqual(resolveCommand(["doctor", "--quiet"], ["doctor"]), {
     command: "doctor",
@@ -102,6 +109,10 @@ test("createCliMain prints top-level help", async () => {
 
   assert.equal(await main(["--help"]), 0);
   assert.match(HELP_TEXT, /init\s+Create a minimal patchmill\.config\.json\./);
+  assert.match(
+    HELP_TEXT,
+    /auth\s+Configure or repair repo-local Pi provider authentication\./,
+  );
   assert.match(HELP_TEXT, /doctor\s+Run read-only readiness checks\./);
   assert.match(HELP_TEXT, /version\s+Print the Patchmill CLI version\./);
   assert.match(
@@ -157,6 +168,24 @@ test("createCliMain dispatches setup-test-repo command", async () => {
   assert.deepEqual(calls, [
     ["--provider", "github-gh", "--repo", "OWNER/REPO"],
   ]);
+});
+
+test("createCliMain dispatches auth command", async () => {
+  const calls: string[][] = [];
+  const main = createCliMain(
+    new Map([
+      [
+        "auth",
+        async (args) => {
+          calls.push(args);
+          return 0;
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(await main(["auth", "--help"]), 0);
+  assert.deepEqual(calls, [["--help"]]);
 });
 
 test("createCliMain dispatches init and doctor commands", async () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,3 +1,4 @@
+import { main as authMain } from "./commands/auth/main.ts";
 import { main as doctorMain } from "./commands/doctor/main.ts";
 import { main as initMain } from "./commands/init/main.ts";
 import { main as runOnceMain } from "./commands/run-once/main.ts";
@@ -10,6 +11,7 @@ export const HELP_TEXT = `Usage:
 
 Commands:
   init        Create a minimal patchmill.config.json.
+  auth        Configure or repair repo-local Pi provider authentication.
   doctor      Run read-only readiness checks.
   triage      Classify repository issues for agent readiness.
   run-once    Claim and process one agent-ready issue.
@@ -92,6 +94,7 @@ export function createCliMain(
 
 const COMMANDS = new Map<string, CommandHandler>([
   ["init", initMain],
+  ["auth", authMain],
   ["doctor", doctorMain],
   ["triage", triageMain],
   ["run-once", runOnceMain],

--- a/src/cli/pi-cli.test.ts
+++ b/src/cli/pi-cli.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { test } from "node:test";
 import {
   piAgentCommandEnv,
   piCommandArgs,
   resolveBundledPiCommand,
+  resolveBundledPiCommandFrom,
 } from "./pi-cli.ts";
 
 test("resolveBundledPiCommand returns node and installed Pi CLI script", () => {
@@ -17,6 +22,30 @@ test("resolveBundledPiCommand returns node and installed Pi CLI script", () => {
     /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/,
   );
   assert.equal(existsSync(spec.argsPrefix[0] ?? ""), true);
+});
+
+test("resolveBundledPiCommand works from compiled dist module locations", async () => {
+  const packageRoot = await mkdtemp(join(tmpdir(), "patchmill-pi-cli-dist-"));
+  const distCliDir = join(packageRoot, "dist", "src", "cli");
+  const piPackageDir = join(
+    packageRoot,
+    "node_modules",
+    "@earendil-works",
+    "pi-coding-agent",
+  );
+  await mkdir(join(piPackageDir, "bin"), { recursive: true });
+  await mkdir(distCliDir, { recursive: true });
+  await writeFile(
+    join(piPackageDir, "package.json"),
+    JSON.stringify({ bin: { pi: "bin/pi.js" } }),
+  );
+
+  const spec = resolveBundledPiCommandFrom(
+    pathToFileURL(join(distCliDir, "pi-cli.js")).href,
+  );
+
+  assert.equal(spec.command, process.execPath);
+  assert.equal(spec.argsPrefix[0], resolve(piPackageDir, "bin", "pi.js"));
 });
 
 test("piAgentCommandEnv includes repo-local Pi agent dir and preserves extra env", () => {

--- a/src/cli/pi-cli.test.ts
+++ b/src/cli/pi-cli.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { test } from "node:test";
+import {
+  piAgentCommandEnv,
+  piCommandArgs,
+  resolveBundledPiCommand,
+} from "./pi-cli.ts";
+
+test("resolveBundledPiCommand returns node and installed Pi CLI script", () => {
+  const spec = resolveBundledPiCommand();
+
+  assert.equal(spec.command, process.execPath);
+  assert.equal(spec.argsPrefix.length, 1);
+  assert.match(
+    spec.argsPrefix[0] ?? "",
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/,
+  );
+  assert.equal(existsSync(spec.argsPrefix[0] ?? ""), true);
+});
+
+test("piAgentCommandEnv includes repo-local Pi agent dir and preserves extra env", () => {
+  assert.deepEqual(
+    piAgentCommandEnv("/repo/.patchmill/pi-agent", {
+      OTHER: "value",
+      UNSET: undefined,
+    }),
+    {
+      OTHER: "value",
+      UNSET: undefined,
+      PI_CODING_AGENT_DIR: "/repo/.patchmill/pi-agent",
+    },
+  );
+});
+
+test("piCommandArgs prefixes caller args without spawning Pi", () => {
+  const spec = { command: "node", argsPrefix: ["/pi/dist/cli.js"] };
+
+  assert.deepEqual(piCommandArgs(spec, ["--help"]), [
+    "/pi/dist/cli.js",
+    "--help",
+  ]);
+});

--- a/src/cli/pi-cli.ts
+++ b/src/cli/pi-cli.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type PiCommandSpec = { command: string; argsPrefix: string[] };
+
+type PackageJson = { bin?: unknown };
+
+const require = createRequire(import.meta.url);
+
+function resolvePackageJsonPath(): string {
+  try {
+    return require.resolve("@earendil-works/pi-coding-agent/package.json");
+  } catch (error) {
+    if (
+      typeof error !== "object" ||
+      error === null ||
+      !("code" in error) ||
+      error.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED"
+    ) {
+      throw error;
+    }
+  }
+
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(
+      moduleDir,
+      "..",
+      "..",
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "package.json",
+    ),
+    join(
+      process.cwd(),
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "package.json",
+    ),
+  ];
+  const packageJsonPath = candidates.find((candidate) => existsSync(candidate));
+  if (packageJsonPath) return packageJsonPath;
+
+  throw new Error("Could not locate bundled Pi package.json");
+}
+
+function piBinFromPackage(packageJsonPath: string): string {
+  const packageJson = JSON.parse(
+    readFileSync(packageJsonPath, "utf8"),
+  ) as PackageJson;
+  const bin = packageJson.bin;
+  if (typeof bin === "string") return bin;
+  if (bin && typeof bin === "object" && !Array.isArray(bin)) {
+    const piBin = (bin as Record<string, unknown>).pi;
+    if (typeof piBin === "string") return piBin;
+  }
+  return "dist/cli.js";
+}
+
+export function resolveBundledPiCommand(): PiCommandSpec {
+  const packageJsonPath = resolvePackageJsonPath();
+  return {
+    command: process.execPath,
+    argsPrefix: [
+      join(dirname(packageJsonPath), piBinFromPackage(packageJsonPath)),
+    ],
+  };
+}
+
+export function piAgentCommandEnv(
+  agentDir: string,
+  extra: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return { ...extra, PI_CODING_AGENT_DIR: agentDir };
+}
+
+export function piCommandArgs(spec: PiCommandSpec, args: string[]): string[] {
+  return [...spec.argsPrefix, ...args];
+}

--- a/src/cli/pi-cli.ts
+++ b/src/cli/pi-cli.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, parse } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export type PiCommandSpec = { command: string; argsPrefix: string[] };
@@ -9,7 +9,22 @@ type PackageJson = { bin?: unknown };
 
 const require = createRequire(import.meta.url);
 
-function resolvePackageJsonPath(): string {
+function bundledPiPackageJsonPathFrom(startDir: string): string | undefined {
+  const root = parse(startDir).root;
+  for (let dir = startDir; ; dir = dirname(dir)) {
+    const candidate = join(
+      dir,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "package.json",
+    );
+    if (existsSync(candidate)) return candidate;
+    if (dir === root) return undefined;
+  }
+}
+
+function resolvePackageJsonPath(moduleUrl = import.meta.url): string {
   try {
     return require.resolve("@earendil-works/pi-coding-agent/package.json");
   } catch (error) {
@@ -23,26 +38,9 @@ function resolvePackageJsonPath(): string {
     }
   }
 
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(
-      moduleDir,
-      "..",
-      "..",
-      "node_modules",
-      "@earendil-works",
-      "pi-coding-agent",
-      "package.json",
-    ),
-    join(
-      process.cwd(),
-      "node_modules",
-      "@earendil-works",
-      "pi-coding-agent",
-      "package.json",
-    ),
-  ];
-  const packageJsonPath = candidates.find((candidate) => existsSync(candidate));
+  const packageJsonPath = bundledPiPackageJsonPathFrom(
+    dirname(fileURLToPath(moduleUrl)),
+  );
   if (packageJsonPath) return packageJsonPath;
 
   throw new Error("Could not locate bundled Pi package.json");
@@ -61,14 +59,18 @@ function piBinFromPackage(packageJsonPath: string): string {
   return "dist/cli.js";
 }
 
-export function resolveBundledPiCommand(): PiCommandSpec {
-  const packageJsonPath = resolvePackageJsonPath();
+export function resolveBundledPiCommandFrom(moduleUrl: string): PiCommandSpec {
+  const packageJsonPath = resolvePackageJsonPath(moduleUrl);
   return {
     command: process.execPath,
     argsPrefix: [
       join(dirname(packageJsonPath), piBinFromPackage(packageJsonPath)),
     ],
   };
+}
+
+export function resolveBundledPiCommand(): PiCommandSpec {
+  return resolveBundledPiCommandFrom(import.meta.url);
 }
 
 export function piAgentCommandEnv(

--- a/src/pi/runner.test.ts
+++ b/src/pi/runner.test.ts
@@ -61,6 +61,15 @@ function createFakeRunner(
   };
 }
 
+function assertBundledPiCall(call: RecordedCall): string[] {
+  assert.equal(call.command, process.execPath);
+  assert.match(
+    call.args[0] ?? "",
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/,
+  );
+  return call.args.slice(1);
+}
+
 function createProgressRecorder(): {
   events: AgentIssueProgressEvent[];
   reporter: ProgressReporter;
@@ -106,7 +115,7 @@ test("PiRunner plan forwards runOptions into runPiPrompt", async () => {
   const planPath = "docs/plans/2026-05-23-pi-runner.md";
   const { events, reporter } = createProgressRecorder();
   const runner = createFakeRunner((call) => {
-    assert.equal(call.command, "pi");
+    assertBundledPiCall(call);
     assert.equal(call.cwd, repoRoot);
     assert.ok(call.args.includes("-p"));
     assert.ok(call.args.includes("--session-dir"));
@@ -154,7 +163,7 @@ test("PiRunner plan passes configured ready and needs-info labels into the promp
   const repoRoot = "/repo";
   const planPath = "docs/plans/2026-05-23-pi-runner-custom-labels.md";
   const runner = createFakeRunner((call) => {
-    assert.equal(call.command, "pi");
+    assertBundledPiCall(call);
     assert.match(
       call.prompt,
       /Treat `ready-for-bots` as meaning the issue is already clear and unambiguous enough to plan/,
@@ -260,7 +269,7 @@ test("PiRunner implementation uses the worktree root, derives the default landin
 
   const { events, reporter } = createProgressRecorder();
   const runner = createFakeRunner(async (call) => {
-    assert.equal(call.command, "pi");
+    assertBundledPiCall(call);
     assert.equal(call.cwd, worktreeRoot);
     assert.ok(call.args.includes("--session-dir"));
     assert.match(call.prompt, /Resume context:/);

--- a/test-support/command-runner.ts
+++ b/test-support/command-runner.ts
@@ -3,17 +3,39 @@ import type {
   CommandRunner,
 } from "../src/cli/commands/triage/types.ts";
 
+export type RecordedCommandCall = {
+  command: string;
+  args: string[];
+  cwd?: string;
+};
+
+export function normalizeRecordedPiCall(
+  command: string,
+  args: string[],
+  cwd?: string,
+): RecordedCommandCall {
+  if (
+    command === process.execPath &&
+    /@earendil-works[/\\]pi-coding-agent[/\\]dist[/\\]cli\.js$/.test(
+      args[0] ?? "",
+    )
+  ) {
+    return { command: "pi", args: args.slice(1), cwd };
+  }
+  return { command, args: [...args], cwd };
+}
+
 export function createStaticCommandRunner(
   results: CommandResult[],
 ): CommandRunner & {
-  calls: Array<{ command: string; args: string[]; cwd?: string }>;
+  calls: RecordedCommandCall[];
 } {
-  const calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
+  const calls: RecordedCommandCall[] = [];
   let index = 0;
   return {
     calls,
     async run(command, args, options = {}) {
-      calls.push({ command, args: [...args], cwd: options.cwd });
+      calls.push(normalizeRecordedPiCall(command, args, options.cwd));
       const result = results[index];
       index += 1;
       return result ?? { code: 0, stdout: "", stderr: "" };


### PR DESCRIPTION
## Summary
- add `patchmill auth` for repo-local Pi provider auth repair/setup
- centralize bundled Pi invocation and repo-local `PI_CODING_AGENT_DIR` for Patchmill-owned Pi calls
- update init/doctor guidance and docs

## Validation
- node --test src/cli/main.test.ts src/cli/commands/auth/main.test.ts src/cli/pi-cli.test.ts src/cli/commands/init/pi-init-setup.test.ts src/cli/commands/init/main.test.ts src/cli/commands/doctor/checks.test.ts src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/execute-agent.test.ts src/cli/commands/run-once/pi.test.ts
- npm test
- npm run lint
- npm run build
- node bin/patchmill.ts --help
- node bin/patchmill.ts auth --help

## Reviews
- Final Codex full-worktree review: pass after fixing bundled Pi/install, workflow invocation, and settings error handling findings
- Final thermo-nuclear full-worktree review: pass

Human review is required because this repository has no configured direct landing skill, so Patchmill must use PR fallback.