### PR TITLE
Recover blocked run workspaces

### DIFF
--- a/docs/plans/2026-06-20-issue-35-recover-blocked-runs-with-saved-branch-worktree-state.md
+++ b/docs/plans/2026-06-20-issue-35-recover-blocked-runs-with-saved-branch-worktree-state.md
@@ -1,0 +1,723 @@
+# Recover Blocked Runs with Saved Branch/Worktree State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `patchmill run-once --issue <n>` safely recover blocked
+implementation runs that preserved useful branch/worktree state, and replace the
+stale-state dead end with actionable recovery reports.
+
+**Architecture:** Keep ordinary resumability in `run-state.ts` unchanged, and
+add a focused blocked-run recovery module under `src/cli/commands/run-once/`.
+The pipeline inspects blocked saved workspaces before the existing stale
+branch/worktree guard; only a clean, unmerged, non-diverged saved workspace
+enters the existing resume path.
+
+**Tech Stack:** TypeScript ESM, Node.js `node:test`, mocked `CommandRunner` Git
+commands, existing Patchmill run-once pipeline and run-state JSON files.
+
+---
+
+## Context and Constraints
+
+- Approved spec:
+  `docs/specs/2026-06-20-issue-35-recover-blocked-runs-with-saved-branch-worktree-state-design.md`.
+- No `AGENTS.md` was present at the repository root when this plan was written;
+  validation commands are selected from `package.json` scripts.
+- Do not implement a new `patchmill recover` command in this issue. The primary
+  supported recovery path is `patchmill run-once --issue <n>`.
+- Do not broaden `isResumableRunState()` to return true for all blocked states.
+  Blocked state is resumable only after Git inspection returns
+  `recoverable-clean`.
+- Never delete, reset, overwrite, or auto-clean saved branches/worktrees.
+
+## File Structure
+
+- Create: `src/cli/commands/run-once/recovery.ts`
+  - Owns blocked-run recovery types, Git inspection helpers, classification, and
+    human-readable report formatting.
+- Create: `src/cli/commands/run-once/recovery.test.ts`
+  - Focused unit tests for classification and report formatting using a mocked
+    `CommandRunner`.
+- Modify: `src/cli/commands/run-once/pipeline.ts`
+  - Calls recovery inspection before the non-resumable stale branch/worktree
+    guard.
+  - Allows only `recoverable-clean` blocked state to reuse saved
+    checkpoints/workspace.
+  - Throws `AgentIssueSafetyError` with formatted recovery reports for
+    non-recoverable blocked states.
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+  - Adds end-to-end run-once tests for clean blocked retry and non-recoverable
+    blocked reports.
+  - Keeps existing finished-state stale branch/worktree tests intact.
+- Modify only if needed: `src/cli/commands/run-once/git.ts`
+  - Export reusable Git helper behavior only if keeping those helpers in
+    `recovery.ts` would duplicate existing code excessively.
+- Modify only if needed: `src/cli/commands/run-once/run-state.test.ts`
+  - Keep the existing assertion that
+    `isResumableRunState({ status: "blocked" })` is false.
+
+## Implementation Tasks
+
+### Task 1: Add blocked recovery inspection types and Git command tests
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/recovery.ts`
+- Create: `src/cli/commands/run-once/recovery.test.ts`
+
+- [ ] **Step 1: Write failing tests for clean, dirty, missing, merged, and
+      diverged classifications**
+
+  Add `recovery.test.ts` with mocked command responses for these scenarios:
+
+  ```ts
+  import test from "node:test";
+  import assert from "node:assert/strict";
+  import { inspectBlockedRunRecovery } from "./recovery.ts";
+  import type { CommandResult, CommandRunner } from "./types.ts";
+
+  type Call = { command: string; args: string[]; cwd?: string };
+
+  function runnerFor(
+    handler: (call: Call) => CommandResult,
+  ): CommandRunner & { calls: Call[] } {
+    const calls: Call[] = [];
+    return {
+      calls,
+      async run(command, args, options = {}) {
+        const call = { command, args: [...args], cwd: options.cwd };
+        calls.push(call);
+        return handler(call);
+      },
+    };
+  }
+
+  const baseState = {
+    issueNumber: 45,
+    title: "Recover blocked run",
+    status: "blocked" as const,
+    branch: "agent/issue-45-recover-blocked-run",
+    worktreePath: ".worktrees/patchmill-issue-45-recover-blocked-run",
+    commits: ["abc123", "def456"],
+    lastError: "Required verification environment is unavailable.",
+    createdAt: "2026-06-20T08:00:00.000Z",
+    updatedAt: "2026-06-20T08:10:00.000Z",
+  };
+
+  test("inspectBlockedRunRecovery classifies clean unmerged saved workspace as recoverable", async () => {
+    const runner = runnerFor((call) => {
+      if (call.args[0] === "show-ref")
+        return { code: 0, stdout: "", stderr: "" };
+      if (call.args.join(" ") === "worktree list --porcelain") {
+        return {
+          code: 0,
+          stdout:
+            "worktree /repo/.worktrees/patchmill-issue-45-recover-blocked-run\nbranch refs/heads/agent/issue-45-recover-blocked-run\n",
+          stderr: "",
+        };
+      }
+      if (call.args[0] === "-C" && call.args[2] === "status")
+        return { code: 0, stdout: "", stderr: "" };
+      if (call.args[0] === "merge-base")
+        return { code: 1, stdout: "", stderr: "" };
+      if (call.args[0] === "rev-list")
+        return { code: 0, stdout: "0\t2\n", stderr: "" };
+      if (call.args[0] === "log")
+        return {
+          code: 0,
+          stdout: "def456 add verification\nabc123 implement feature\n",
+          stderr: "",
+        };
+      throw new Error(`unexpected command: git ${call.args.join(" ")}`);
+    });
+
+    const report = await inspectBlockedRunRecovery({
+      runner,
+      repoRoot: "/repo",
+      runStatePath: ".patchmill/runs/issue-45.json",
+      state: baseState,
+      baseRef: "main",
+    });
+
+    assert.equal(report.kind, "recoverable-clean");
+    assert.equal(report.branch.exists, true);
+    assert.equal(report.worktree.exists, true);
+    assert.equal(report.worktree.clean, true);
+    assert.deepEqual(report.divergence, { ahead: 2, behind: 0 });
+  });
+  ```
+
+  Also add tests named:
+  - `inspectBlockedRunRecovery classifies dirty saved worktree`
+  - `inspectBlockedRunRecovery classifies already merged branch`
+  - `inspectBlockedRunRecovery classifies diverged branch`
+  - `inspectBlockedRunRecovery classifies missing worktree with existing branch`
+  - `inspectBlockedRunRecovery classifies missing branch and worktree`
+
+- [ ] **Step 2: Run the new test file and confirm it fails because the module
+      does not exist**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/recovery.test.ts
+  ```
+
+  Expected: FAIL with an import/module-not-found error for `./recovery.ts`.
+
+- [ ] **Step 3: Implement `recovery.ts` types and inspection helper**
+
+  Implement these exported types and function signatures:
+
+  ```ts
+  import { resolve } from "node:path";
+  import type { AgentIssueRunState, CommandRunner } from "./types.ts";
+
+  export type BlockedRunRecoveryKind =
+    | "recoverable-clean"
+    | "dirty-worktree"
+    | "already-merged"
+    | "diverged"
+    | "missing-worktree-existing-branch"
+    | "missing-branch-or-worktree"
+    | "not-blocked-recovery";
+
+  export type BlockedRunRecoveryReport = {
+    kind: BlockedRunRecoveryKind;
+    runStatePath: string;
+    issueNumber: number;
+    title: string;
+    status: AgentIssueRunState["status"];
+    blockerReason?: string;
+    branch: { name?: string; exists: boolean; merged: boolean };
+    worktree: {
+      path?: string;
+      exists: boolean;
+      registered: boolean;
+      clean?: boolean;
+      dirtyStatus?: string;
+    };
+    divergence?: { ahead: number; behind: number };
+    commits: string[];
+    recommendedActions: string[];
+  };
+
+  export async function inspectBlockedRunRecovery(input: {
+    runner: CommandRunner;
+    repoRoot: string;
+    runStatePath: string;
+    state: AgentIssueRunState;
+    baseRef: string;
+  }): Promise<BlockedRunRecoveryReport>;
+  ```
+
+  Classification rules:
+  - Return `not-blocked-recovery` when `state.status !== "blocked"` or neither
+    `state.branch` nor `state.worktreePath` is saved.
+  - Run `git show-ref --verify --quiet refs/heads/<branch>` when a branch is
+    saved.
+  - Run `git worktree list --porcelain` and match resolved worktree paths
+    against `resolve(repoRoot, state.worktreePath)`.
+  - Run `git -C <worktreePath> status --porcelain=v1 --untracked-files=all` only
+    when the saved worktree is registered.
+  - Run `git merge-base --is-ancestor <branch> <baseRef>` to detect
+    already-merged branches; exit code `0` means merged, `1` means unmerged.
+  - Run `git rev-list --left-right --count <baseRef>...<branch>` and parse
+    `<behind>\t<ahead>`.
+  - Run `git log --oneline <baseRef>..<branch>` and prefer its lines over
+    `state.commits` when available.
+
+- [ ] **Step 4: Run focused recovery tests**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/recovery.test.ts
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+  ```bash
+  git add src/cli/commands/run-once/recovery.ts src/cli/commands/run-once/recovery.test.ts
+  git commit -m "feat: inspect blocked run recovery state"
+  ```
+
+### Task 2: Format operator-facing recovery reports
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/recovery.ts`
+- Modify: `src/cli/commands/run-once/recovery.test.ts`
+
+- [ ] **Step 1: Add failing formatting tests**
+
+  Add assertions for an exported `formatBlockedRunRecoveryReport(report)`
+  helper. The clean report must include:
+
+  ```ts
+  assert.match(
+    message,
+    /Issue #45 has a blocked run with preserved workspace state\./,
+  );
+  assert.match(message, /Run state: \.patchmill\/runs\/issue-45\.json/);
+  assert.match(
+    message,
+    /Blocked reason: Required verification environment is unavailable\./,
+  );
+  assert.match(
+    message,
+    /Saved branch: agent\/issue-45-recover-blocked-run \(exists, unmerged, ahead 2, behind 0\)/,
+  );
+  assert.match(
+    message,
+    /Saved worktree: \.worktrees\/patchmill-issue-45-recover-blocked-run \(registered, clean\)/,
+  );
+  assert.match(message, /def456 add verification/);
+  assert.match(message, /patchmill run-once --issue 45/);
+  ```
+
+  Add separate assertions for dirty, merged, diverged, missing-worktree, and
+  missing-branch reports. Each message must avoid `delete` as the first
+  recommended action for unmerged work.
+
+- [ ] **Step 2: Run formatting tests and confirm they fail**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/recovery.test.ts
+  ```
+
+  Expected: FAIL because `formatBlockedRunRecoveryReport` is not exported.
+
+- [ ] **Step 3: Implement report formatting and recommendations**
+
+  Export:
+
+  ```ts
+  export function formatBlockedRunRecoveryReport(
+    report: BlockedRunRecoveryReport,
+  ): string;
+  ```
+
+  Required recommendations:
+  - `recoverable-clean`: retry with `patchmill run-once --issue <n>` after
+    fixing the external prerequisite.
+  - `dirty-worktree`: commit, stash, or clean local modifications in the saved
+    worktree before retrying.
+  - `already-merged`: clean/finalize stale run state after confirming the work
+    is landed.
+  - `diverged`: rebase or cherry-pick saved work onto the current base, then
+    retry.
+  - `missing-worktree-existing-branch`: reattach with
+    `git worktree add <savedPath> <branch>` when the saved path is absent.
+  - `missing-branch-or-worktree`: archive or remove stale run state only after
+    confirming no branch/worktree needs preservation.
+
+- [ ] **Step 4: Run focused recovery tests**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/recovery.test.ts
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+  ```bash
+  git add src/cli/commands/run-once/recovery.ts src/cli/commands/run-once/recovery.test.ts
+  git commit -m "feat: format blocked run recovery reports"
+  ```
+
+### Task 3: Let the pipeline resume recoverable clean blocked runs
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.ts`
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+
+- [ ] **Step 1: Add a failing pipeline test for external prerequisite recovery**
+
+  Add a test near existing stale-state tests named
+  `runOneIssue resumes clean blocked implementation workspace after external prerequisite is fixed`.
+
+  Test setup:
+  - Write blocked run state for issue 45 with saved `planPath`, `branch`,
+    `worktreePath`, `commits`, `validation`, `lastError`, `failureCommentKeys`,
+    and checkpoints through `worktreeReady`.
+  - Mock Git recovery commands to return branch exists, worktree registered,
+    clean status, unmerged branch, `0\t2` divergence, and two
+    `git log --oneline` lines.
+  - Mock Pi implementation to return a successful direct-land or PR result
+    already used by nearby pipeline tests.
+  - Assert no stale branch/worktree error is thrown.
+  - Assert the Pi implementation prompt receives resume context with
+    `resumed: true`, `worktreeCreated: false`, and existing commit lines.
+  - Assert final run state preserves saved branch/worktree and clears/advances
+    blocked status.
+
+- [ ] **Step 2: Run the targeted pipeline test and confirm it fails with the
+      current stale-state error**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "resumes clean blocked implementation workspace"
+  ```
+
+  Expected: FAIL with
+  `Non-resumable run state for issue #45 has stale branch/worktree`.
+
+- [ ] **Step 3: Integrate recovery inspection before the stale guard**
+
+  In `pipeline.ts`:
+  - Import `inspectBlockedRunRecovery` and `formatBlockedRunRecoveryReport`.
+  - Compute a `blockedRecoveryReport` after `existingState`, `resumed`, and
+    `resumableState` are known, but before `resetStaleCheckpoints` is used to
+    throw.
+  - Use `runStatePath(config.runStateDir, issue.number)` for the report path.
+  - Treat `blockedRecoveryReport.kind === "recoverable-clean"` as resumable for
+    this run.
+  - Keep `isResumableRunState(existingState)` unchanged for
+    claimed/planning/implementing.
+
+  The intended control-flow shape is:
+
+  ```ts
+  const ordinaryResumableState =
+    resumed && !!existingState && isResumableRunState(existingState);
+  const blockedRecoveryReport =
+    resumed &&
+    existingState?.status === "blocked" &&
+    (existingState.branch || existingState.worktreePath)
+      ? await inspectBlockedRunRecovery({
+          runner,
+          repoRoot: config.repoRoot,
+          runStatePath: runStatePath(config.runStateDir, issue.number),
+          state: existingState,
+          baseRef: config.baseRef,
+        })
+      : undefined;
+  const blockedRecoveryResumable =
+    blockedRecoveryReport?.kind === "recoverable-clean";
+  const resumableState = ordinaryResumableState || blockedRecoveryResumable;
+  const resetStaleCheckpoints = !!existingState && !resumableState;
+  ```
+
+  If `blockedRecoveryReport` exists and is not `recoverable-clean`, throw:
+
+  ```ts
+  throw new AgentIssueSafetyError(
+    formatBlockedRunRecoveryReport(blockedRecoveryReport),
+  );
+  ```
+
+  before the generic stale branch/worktree guard.
+
+- [ ] **Step 4: Ensure existing workspace reuse sees blocked recovery as
+      resumed**
+
+  When building `implemented`, validating saved branch/worktree, assigning
+  `branch` and `worktreePath`, and constructing
+  `AgentIssueImplementationResumeContext`, use the new `resumableState` boolean.
+  Do not reset checkpoints for clean blocked recovery.
+
+- [ ] **Step 5: Run the targeted pipeline test**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "resumes clean blocked implementation workspace"
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+  ```bash
+  git add src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts
+  git commit -m "feat: resume clean blocked run workspaces"
+  ```
+
+### Task 4: Stop with recovery reports for unsafe blocked states
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+- Modify if needed: `src/cli/commands/run-once/pipeline.ts`
+
+- [ ] **Step 1: Add failing pipeline tests for non-recoverable blocked states**
+
+  Add tests for:
+  - dirty saved worktree
+  - already merged branch
+  - diverged branch
+  - missing worktree with existing branch
+  - missing branch and missing worktree
+
+  Each test should:
+  - Write blocked run state with saved branch/worktree metadata.
+  - Mock only selection, repository clean check, and recovery Git commands.
+  - Assert `runOneIssue` rejects with a message containing
+    `Issue #45 has a blocked run with preserved workspace state.` plus the
+    scenario-specific recommendation.
+  - Assert no Pi command runs.
+  - Assert no labels or comments are changed before the operator resolves
+    recovery.
+  - Assert the run state JSON remains `status: "blocked"` and retains
+    `branch`/`worktreePath` when they were saved.
+
+- [ ] **Step 2: Run the non-recoverable blocked tests and confirm failures**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "blocked.*recovery|recovery.*blocked"
+  ```
+
+  Expected before final fixes: FAIL for any missing pipeline behavior or message
+  text.
+
+- [ ] **Step 3: Fix pipeline ordering and messages**
+
+  Ensure recovery inspection runs before any label, comment, checkpoint reset,
+  worktree creation, or Pi execution for blocked saved workspace states.
+  Finished or otherwise non-blocked stale states must still use the existing
+  generic stale-state guard.
+
+- [ ] **Step 4: Run targeted non-recoverable blocked tests**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "blocked.*recovery|recovery.*blocked"
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+  ```bash
+  git add src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts
+  git commit -m "feat: report blocked run recovery guidance"
+  ```
+
+### Task 5: Preserve blocked-run metadata during successful recovery
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+- Modify if needed: `src/cli/commands/run-once/pipeline.ts`
+- Modify if needed: `src/cli/commands/run-once/run-state.ts`
+
+- [ ] **Step 1: Add regression assertions for metadata preservation**
+
+  Extend the clean recovery test or add a focused test to assert:
+  - `specPath`, `specCommit`, `planPath`, and `planCommit` are preserved.
+  - `branch` and `worktreePath` are preserved exactly from the saved blocked
+    state.
+  - Existing `failureCommentKeys` remain present and no duplicate blocker
+    comment is posted during retry.
+  - Existing `commits`/`validation` remain available until replaced by the new
+    implementation result.
+  - `resetCheckpoints` is not applied for clean blocked recovery.
+
+- [ ] **Step 2: Run the regression test and confirm any failure**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "metadata.*blocked|blocked.*metadata|resumes clean blocked"
+  ```
+
+  Expected: FAIL only if metadata is accidentally dropped.
+
+- [ ] **Step 3: Fix metadata handling minimally**
+
+  If needed, adjust the `resumableState`, `resetStaleCheckpoints`, and
+  `effectiveCheckpoints()` inputs so clean blocked recovery follows the same
+  state-preservation path as ordinary resumed `implementing` runs.
+
+- [ ] **Step 4: Run metadata tests**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "metadata.*blocked|blocked.*metadata|resumes clean blocked"
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit Task 5**
+
+  ```bash
+  git add src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts src/cli/commands/run-once/run-state.ts
+  git commit -m "fix: preserve blocked recovery run metadata"
+  ```
+
+### Task 6: Protect existing stale-state behavior and run-state semantics
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+- Modify if needed: `src/cli/commands/run-once/run-state.test.ts`
+
+- [ ] **Step 1: Run existing stale finished-state tests**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "stale finished"
+  ```
+
+  Expected: PASS. These tests should still reject stale finished branch/worktree
+  state before resetting or mutating anything.
+
+- [ ] **Step 2: Run run-state resumability tests**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/run-once/run-state.test.ts --test-name-pattern "isResumableRunState"
+  ```
+
+  Expected: PASS, including `blocked` remaining false.
+
+- [ ] **Step 3: Fix regressions without broadening blocked resumability**
+
+  If either command fails, fix only the pipeline recovery integration. Do not
+  change `isResumableRunState()` to accept blocked globally.
+
+- [ ] **Step 4: Commit Task 6 if fixes were needed**
+
+  If files changed:
+
+  ```bash
+  git add src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/run-state.test.ts
+  git commit -m "test: preserve stale run-state safeguards"
+  ```
+
+  If no files changed, record the passing command output in the task handoff
+  instead of creating an empty commit.
+
+### Task 7: Run the full run-once validation set
+
+**Files:**
+
+- No source edits expected unless validation reveals defects.
+
+- [ ] **Step 1: Run focused run-once tests**
+
+  Run:
+
+  ```bash
+  npm run test:run-once
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 2: Run TypeScript and formatting/lint checks**
+
+  Run:
+
+  ```bash
+  npm run lint
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+  Run:
+
+  ```bash
+  npm test
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 4: Fix any validation failures and commit**
+
+  If validation required source/test edits:
+
+  ```bash
+  git add src/cli/commands/run-once/recovery.ts src/cli/commands/run-once/recovery.test.ts src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts src/cli/commands/run-once/run-state.test.ts
+  git commit -m "fix: stabilize blocked run recovery validation"
+  ```
+
+  If no edits were needed, do not create an empty commit.
+
+### Task 8: Final acceptance review
+
+**Files:**
+
+- No source edits expected unless acceptance review reveals a missed
+  requirement.
+
+- [ ] **Step 1: Verify acceptance criteria manually against the implementation**
+
+  Check that:
+  - Clean blocked branch/worktree state can be retried through
+    `patchmill run-once --issue <n>`.
+  - Generic stale branch/worktree output is not used for blocked saved workspace
+    states.
+  - Recovery output includes blocker reason, run-state path, saved branch, saved
+    worktree, and commits.
+  - Dirty, merged, diverged, missing-worktree/existing-branch, and
+    missing-branch/worktree cases are tested.
+  - Finished stale states still refuse to reset or overwrite unmerged saved
+    work.
+
+- [ ] **Step 2: Review destructive-action language**
+
+  Search recovery output tests and implementation:
+
+  ```bash
+  rg -n "delete|remove|reset|clean up|archive|worktree add|cherry-pick|rebase" src/cli/commands/run-once/recovery.ts src/cli/commands/run-once/recovery.test.ts src/cli/commands/run-once/pipeline.test.ts
+  ```
+
+  Expected: Any destructive wording is guarded by preserve/archive language and
+  is not the first recommendation for unmerged saved work.
+
+- [ ] **Step 3: Commit any final acceptance fixes**
+
+  If files changed:
+
+  ```bash
+  git add src/cli/commands/run-once/recovery.ts src/cli/commands/run-once/recovery.test.ts src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts
+  git commit -m "fix: complete blocked run recovery acceptance cases"
+  ```
+
+  If no files changed, record acceptance review notes in the handoff.
+
+## Validation Commands
+
+Use these commands before final handoff:
+
+```bash
+node --test src/cli/commands/run-once/recovery.test.ts
+node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "blocked.*recovery|recovery.*blocked|resumes clean blocked|stale finished"
+node --test src/cli/commands/run-once/run-state.test.ts --test-name-pattern "isResumableRunState"
+npm run test:run-once
+npm run lint
+npm test
+```
+
+## Self-Review Notes
+
+- Spec coverage: The tasks cover recovery inspection, classifications, safe
+  clean retry through `run-once`, formatted reports, metadata preservation, and
+  tests for every required workspace state.
+- Placeholder scan: No task uses TBD-style placeholders; implementation
+  signatures, command names, and expected test behavior are explicit.
+- Type consistency: The plan uses `BlockedRunRecoveryKind`,
+  `BlockedRunRecoveryReport`, `inspectBlockedRunRecovery`, and
+  `formatBlockedRunRecoveryReport` consistently across tests, implementation,
+  and pipeline integration.

--- a/docs/specs/2026-06-20-issue-35-recover-blocked-runs-with-saved-branch-worktree-state-design.md
+++ b/docs/specs/2026-06-20-issue-35-recover-blocked-runs-with-saved-branch-worktree-state-design.md
@@ -1,0 +1,257 @@
+# Recover Blocked Runs with Saved Branch/Worktree State Design
+
+## Summary
+
+Patchmill should provide a safe, guided recovery path when a `run-once`
+execution stops with `status: "blocked"` after creating useful work on a saved
+branch/worktree. A later `patchmill run-once --issue <n>` should not dead-end
+with the generic stale branch/worktree safety error. Instead, Patchmill should
+inspect the saved state and Git repository, explain what was preserved, and
+either resume a safe blocked run or report exact non-destructive recovery
+options.
+
+## Goals
+
+- Preserve the existing safety invariant: never delete or overwrite unmerged or
+  dirty work automatically.
+- Treat blocked implementation runs with saved branch/worktree state as
+  recoverable when the saved workspace is still usable.
+- Make `run-once --issue <n>` the primary retry path after an external
+  prerequisite is fixed.
+- Replace the generic stale-state error for blocked runs with a recovery report
+  that includes the blocker reason, saved branch, saved worktree, and safe next
+  actions.
+- Distinguish clean, dirty, merged, diverged, partially missing, and fully
+  missing saved workspace states.
+- Cover recovery behavior with tests for an external verification prerequisite
+  blocker.
+
+## Non-goals
+
+- Do not implement destructive cleanup as an implicit side effect of `run-once`.
+- Do not require a new primary command before `run-once` can recover the common
+  clean blocked case.
+- Do not infer that all blocked runs are automatically safe to continue.
+  Recovery is limited to blocked states with saved implementation workspace
+  metadata and a safe Git inspection result.
+- Do not change triage-level blocked issue semantics; this design applies to
+  `run-once` run state where an automation run returned `status: "blocked"`.
+
+## Current behavior
+
+`src/cli/commands/run-once/run-state.ts` currently marks only `claimed`,
+`planning`, and `implementing` states as resumable.
+`src/cli/commands/run-once/pipeline.ts` then treats every non-resumable state
+that still records a `branch` or `worktreePath` as stale and throws:
+
+```text
+Non-resumable run state for issue #<n> has stale branch/worktree; clean up before starting a fresh run
+```
+
+That guard is safe for terminal or obsolete states, but it is too blunt for
+blocked implementation runs. A blocked implementation can contain unmerged
+commits recorded in `commits` and preserved on `branch`, with validation paused
+only because an external prerequisite was unavailable.
+
+## Proposed behavior
+
+### 1. Add a blocked-run recovery inspection
+
+Introduce a focused recovery inspection helper in the `run-once` command area,
+for example `src/cli/commands/run-once/recovery.ts`. It should accept the saved
+`AgentIssueRunState`, repository root, configured base ref/branch/worktree
+strategy, and command runner, then return a typed recovery report.
+
+The report should include:
+
+- run state path,
+- issue number and title,
+- saved status,
+- blocker reason from `lastError`,
+- saved branch and whether it exists,
+- saved worktree and whether it exists/registered,
+- worktree clean/dirty status when present,
+- branch merged/unmerged status relative to the configured base branch,
+- branch divergence from the configured base ref,
+- saved commits from run state and/or `git log <baseRef>..<branch>`, and
+- recommended safe actions.
+
+Use Git commands behind small helpers so tests can simulate each case:
+
+- `git show-ref --verify --quiet refs/heads/<branch>` for branch existence,
+- `git worktree list --porcelain` for registered worktrees,
+- `git -C <worktree> status --porcelain` for dirtiness,
+- `git merge-base --is-ancestor <branch> <baseRef>` or equivalent to detect
+  already-merged work,
+- `git rev-list --left-right --count <baseRef>...<branch>` for ahead/behind
+  divergence,
+- `git log --oneline <baseRef>..<branch>` for visible unmerged commits.
+
+### 2. Classify blocked recovery states
+
+Add a classification type such as:
+
+```ts
+type BlockedRunRecoveryKind =
+  | "recoverable-clean"
+  | "dirty-worktree"
+  | "already-merged"
+  | "diverged"
+  | "missing-worktree-existing-branch"
+  | "missing-branch-or-worktree"
+  | "not-blocked-recovery";
+```
+
+Required classifications:
+
+- **clean unmerged branch/worktree**: saved branch and registered worktree
+  exist, worktree is clean, branch is unmerged, and branch is not
+  behind/diverged in a way that requires user intervention.
+  `run-once --issue <n>` may continue using the existing branch/worktree.
+- **dirty worktree**: stop before running agents; report dirty status and
+  instruct the operator to commit, stash, or clean changes before retrying.
+- **branch already merged**: do not retry implementation; report that work
+  appears merged and suggest run-state cleanup/state finalization in a follow-up
+  command or manual cleanup path.
+- **branch diverged from current base**: warn before continuing. The default
+  `run-once` path should stop with a clear message unless the implementation
+  adds an explicit opt-in flag later; suggest rebase/cherry-pick onto current
+  base.
+- **missing worktree but existing branch**: report that the branch can be
+  reattached with `git worktree add <path> <branch>` or recovered by a future
+  explicit recover command. Do not recreate automatically unless the target path
+  is absent and the branch matches the saved state exactly.
+- **missing branch/worktree with stale run state**: report that the saved
+  workspace is gone and suggest archiving/removing stale run state before
+  starting fresh.
+
+### 3. Make safe blocked states resumable by `run-once`
+
+Update the resumability decision so blocked states are considered resumable only
+after recovery inspection confirms `recoverable-clean`. This should not be a
+broad change to `isResumableRunState(state)` alone unless that function can also
+account for the Git recovery report. The safer design is:
+
+1. Keep basic state resumability for ordinary in-flight states.
+2. Before the stale branch/worktree guard, detect
+   `existingState.status === "blocked"` with saved `branch` or `worktreePath`.
+3. Build the blocked recovery report.
+4. If the report is `recoverable-clean`, set the pipeline's resumed/resumable
+   path for this issue and continue from the saved workspace.
+5. Otherwise throw an `AgentIssueSafetyError` whose message is the formatted
+   recovery report, not the generic stale-state error.
+
+When continuing a clean blocked implementation run, preserve existing
+checkpoints, branch, worktree path, spec/plan metadata, commits, validation, and
+failure comment keys. The next run may re-enter the
+implementation/development-environment verification stages as appropriate and
+must not duplicate already-posted comments or recreate the branch.
+
+### 4. Improve recovery output
+
+Format non-recoverable blocked reports as operator-facing text, for example:
+
+```text
+Issue #45 has a blocked run with preserved workspace state.
+Run state: .patchmill/runs/issue-45.json
+Blocked reason: Required verification environment is unavailable.
+Saved branch: agent/issue-45-example (exists, unmerged, ahead 4, behind 0)
+Saved worktree: .worktrees/patchmill-issue-45-example (registered, clean)
+Commits:
+- abc1234 implement feature
+- def5678 add tests
+
+Recommended action: retry after the external prerequisite is fixed with:
+  patchmill run-once --issue 45
+```
+
+For dirty, merged, diverged, or missing cases, replace the recommendation with
+safe instructions. The message must never tell users to delete an unmerged
+branch/worktree as the first option. Prefer archiving or preserving commands
+when a fresh start is necessary.
+
+### 5. Optional future `recover` command
+
+This design does not require a new command for the first implementation. The
+recovery report and clean blocked retry through `run-once --issue <n>` satisfy
+the immediate issue. A later `patchmill recover --issue <n>` command can reuse
+the same recovery inspection and formatting helpers to add explicit flags such
+as `--retry`, `--retry-verification`, `--rebase-current-main`,
+`--archive-and-rerun`, and `--abandon`.
+
+## Affected components
+
+- `src/cli/commands/run-once/pipeline.ts`
+  - Detect blocked saved workspace state before the stale branch/worktree guard.
+  - Use recovery inspection to decide whether to resume or throw a recovery
+    report.
+  - Ensure clean blocked retries preserve saved branch/worktree metadata.
+
+- `src/cli/commands/run-once/run-state.ts`
+  - Keep ordinary resumability clear, or add a separate helper name for blocked
+    recovery so `blocked` is not blindly treated like `implementing`.
+
+- `src/cli/commands/run-once/git.ts`
+  - Reuse existing branch/worktree helpers where possible.
+  - Add small Git status/divergence helpers if they are shared by worktree
+    creation and recovery.
+
+- `src/cli/commands/run-once/recovery.ts` (new)
+  - Own blocked recovery inspection, classification, and human-readable report
+    formatting.
+
+- `src/cli/commands/run-once/pipeline.test.ts`
+  - Add end-to-end pipeline tests for blocked retry and safety report behavior.
+
+- `src/cli/commands/run-once/run-state.test.ts` or new `recovery.test.ts`
+  - Add focused unit tests for classification and formatting.
+
+## Safety requirements
+
+- Never auto-delete saved branches or worktrees.
+- Never overwrite dirty worktree changes.
+- Never start a fresh branch when saved blocked state points at an existing
+  unmerged branch/worktree.
+- Stop with a warning when the saved branch is behind/diverged from configured
+  base.
+- Treat already-merged branches as cleanup/finalization candidates, not
+  implementation retry candidates.
+- Include exact saved paths in recovery output so operators can inspect the
+  state manually.
+
+## Verification strategy
+
+Add tests that cover:
+
+1. A blocked run caused by an external verification prerequisite writes blocked
+   state with branch/worktree and, after the prerequisite is fixed,
+   `runOneIssue` resumes the saved clean workspace instead of throwing the
+   stale-state error.
+2. A blocked run with a dirty saved worktree stops before Pi execution and
+   prints dirty worktree recovery guidance.
+3. A blocked run whose branch is already merged reports cleanup/finalization
+   guidance instead of retrying implementation.
+4. A blocked run whose branch is behind/diverged from base reports a
+   rebase/cherry-pick warning.
+5. A blocked run with a missing worktree but existing branch reports
+   reattachment/recovery guidance.
+6. A blocked run with missing branch and missing worktree reports stale
+   run-state guidance.
+7. Existing finished-state stale branch/worktree tests continue to reject fresh
+   starts without destructive cleanup.
+
+Run the relevant targeted tests, then the existing full test command used by the
+project.
+
+## Acceptance criteria
+
+- A blocked run with a saved clean unmerged branch/worktree can be retried with
+  `patchmill run-once --issue <n>` without manual deletion.
+- `run-once` no longer emits only the generic stale branch/worktree error for
+  blocked saved workspace states.
+- Recovery output includes blocker reason, run-state path, saved branch, saved
+  worktree, and commit information when available.
+- Recovery distinguishes clean unmerged, dirty, already merged, diverged,
+  missing-worktree/existing-branch, and missing-branch/worktree cases.
+- Tests prove an external verification prerequisite blocker suggests
+  retry/recover behavior rather than destructive cleanup.

--- a/src/cli/commands/run-once/git.ts
+++ b/src/cli/commands/run-once/git.ts
@@ -116,7 +116,7 @@ function isIgnoredStatusPath(path: string, ignoredPrefixes: string[]): boolean {
   );
 }
 
-function blockingStatusOutput(
+export function blockingStatusOutput(
   stdout: string,
   repoRoot: string,
   ignoredPaths: string[] = [],

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -1050,6 +1050,87 @@ test("runOneIssue rejects multiple resumable in-progress issues", async () => {
   );
 });
 
+test("runOneIssue does not count blocked saved workspace as resumable before recovery inspection", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    planOnly: true,
+  });
+  await writeRunState(
+    config.runStateDir,
+    {
+      issueNumber: 45,
+      title: "Blocked saved workspace",
+      status: "blocked",
+      branch: "agent/issue-45-blocked-saved-workspace",
+      worktreePath: ".worktrees/patchmill-issue-45-blocked-saved-workspace",
+    },
+    NOW.toISOString(),
+  );
+  const planPath = "docs/plans/2026-05-14-issue-46-resumable-plan.md";
+  await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
+  await writeRunState(
+    config.runStateDir,
+    {
+      issueNumber: 46,
+      title: "Resumable plan",
+      status: "planning",
+      planPath,
+      checkpoints: {
+        claimed: true,
+        startedCommentPosted: true,
+      },
+    },
+    NOW.toISOString(),
+  );
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout:
+          page === "1"
+            ? issueListPayload([
+                issue(45, ["in-progress"], "Blocked saved workspace"),
+                issue(46, ["in-progress"], "Resumable plan"),
+              ])
+            : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit"
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "tea" && call.args[0] === "comment")
+      return { code: 0, stdout: "", stderr: "" };
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "plan-found");
+  assert.equal(result.issue.number, 46);
+  assert.equal(
+    runner.calls.some(
+      (call) =>
+        call.command === "git" &&
+        (call.args[0] === "show-ref" || call.args[0] === "worktree"),
+    ),
+    false,
+  );
+});
+
 test("runOneIssue rejects an explicit open issue that is not agent-ready with a clear message", async () => {
   const config = await makeConfig({
     dryRun: false,

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -2842,6 +2842,342 @@ test("runOneIssue reuses existing implementation worktree on resume", async () =
   assert.ok(runner.calls.find((call) => call.command === "pi"));
 });
 
+async function writeBlockedRecoveryRunState(
+  config: AgentIssueConfig,
+  overrides: Parameters<typeof writeRunState>[1] = {
+    issueNumber: 45,
+    status: "blocked",
+  },
+): Promise<void> {
+  const planPath =
+    overrides.planPath ??
+    "docs/plans/2026-06-20-issue-45-recover-blocked-run.md";
+  await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
+  await writeRunState(
+    config.runStateDir,
+    {
+      issueNumber: 45,
+      title: "Recover blocked run",
+      status: "blocked",
+      specPath: "docs/specs/2026-06-20-issue-45-recover-blocked-run.md",
+      specCommit: "spec123",
+      planPath,
+      planCommit: "plan123",
+      branch: "agent/issue-45-recover-blocked-run",
+      worktreePath: ".worktrees/patchmill-issue-45-recover-blocked-run",
+      commits: ["abc123", "def456"],
+      validation: ["formatting passed", "verification environment unavailable"],
+      failureCommentKeys: ["blocked:verification"],
+      lastError: "Required verification environment is unavailable.",
+      checkpoints: {
+        claimed: true,
+        startedCommentPosted: true,
+        specPathResolved: true,
+        planPathResolved: true,
+        worktreeReady: true,
+      },
+      ...overrides,
+    },
+    NOW.toISOString(),
+  );
+}
+
+function blockedRecoveryRunner(
+  config: AgentIssueConfig,
+  options: {
+    selectedLabels?: string[];
+    branchExists?: boolean;
+    worktreeRegistered?: boolean;
+    dirtyStatus?: string;
+    merged?: boolean;
+    revList?: string;
+    log?: string;
+    onPi?: (prompt: string) => CommandResult;
+  } = {},
+): MockRunner {
+  return createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout:
+          page === "1"
+            ? issueListPayload([
+                issue(
+                  45,
+                  options.selectedLabels ?? ["needs-info"],
+                  "Recover blocked run",
+                ),
+              ])
+            : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "show-ref") {
+      return {
+        code: options.branchExists === false ? 1 : 0,
+        stdout: "",
+        stderr: "",
+      };
+    }
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "list"
+    ) {
+      return {
+        code: 0,
+        stdout:
+          options.worktreeRegistered === false
+            ? ""
+            : `worktree ${join(config.repoRoot, ".worktrees/patchmill-issue-45-recover-blocked-run")}\n`,
+        stderr: "",
+      };
+    }
+    if (
+      call.command === "git" &&
+      call.args[0] === "-C" &&
+      call.args[2] === "status"
+    ) {
+      return { code: 0, stdout: options.dirtyStatus ?? "", stderr: "" };
+    }
+    if (
+      call.command === "git" &&
+      call.args[0] === "-C" &&
+      call.args[2] === "branch"
+    ) {
+      return {
+        code: 0,
+        stdout: "agent/issue-45-recover-blocked-run\n",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "merge-base") {
+      return { code: options.merged ? 0 : 1, stdout: "", stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "rev-list") {
+      return { code: 0, stdout: options.revList ?? "0\t2\n", stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "status") {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "log") {
+      return {
+        code: 0,
+        stdout:
+          options.log ?? "def456 add verification\nabc123 implement feature\n",
+        stderr: "",
+      };
+    }
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    )
+      return { code: 0, stdout: labelListPayload(), stderr: "" };
+    if (
+      call.command === "tea" &&
+      (call.args[0] === "issues" || call.args[0] === "comment")
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "pi") {
+      const prompt = await readFile(promptPath(call.args), "utf8");
+      return options.onPi
+        ? options.onPi(prompt)
+        : {
+            code: 0,
+            stdout: JSON.stringify({
+              status: "pr-created",
+              prUrl: "https://forgejo/pr/45",
+              branch: "agent/issue-45-recover-blocked-run",
+              commits: ["abc123", "def456", "789abc"],
+              validation: ["npm test passed"],
+              reviewSummary: "reviewed",
+            }),
+            stderr: "",
+          };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+}
+
+test("runOneIssue resumes clean blocked implementation workspace after external prerequisite is fixed", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  let implementationPrompt = "";
+  const runner = blockedRecoveryRunner(config, {
+    onPi(prompt) {
+      implementationPrompt = prompt;
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          status: "pr-created",
+          prUrl: "https://forgejo/pr/45",
+          branch: "agent/issue-45-recover-blocked-run",
+          commits: ["789abc"],
+          validation: ["verification passed"],
+          reviewSummary: "reviewed",
+        }),
+        stderr: "",
+      };
+    },
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created", JSON.stringify(result));
+  assert.match(implementationPrompt, /Resume context:/);
+  assert.match(implementationPrompt, /def456 add verification/);
+  assert.match(implementationPrompt, /Continue from current branch state/);
+  assert.match(implementationPrompt, /was reused from the prior run/);
+  assert.equal(
+    runner.calls.some(
+      (call) =>
+        call.command === "git" &&
+        call.args[0] === "worktree" &&
+        call.args[1] === "add",
+    ),
+    false,
+  );
+  const state = JSON.parse(
+    await readFile(runStatePath(config.runStateDir, 45), "utf8"),
+  );
+  assert.equal(state.status, "finished");
+  assert.equal(state.branch, "agent/issue-45-recover-blocked-run");
+  assert.equal(
+    state.worktreePath,
+    ".worktrees/patchmill-issue-45-recover-blocked-run",
+  );
+  assert.equal(
+    state.specPath,
+    "docs/specs/2026-06-20-issue-45-recover-blocked-run.md",
+  );
+  assert.equal(state.specCommit, "spec123");
+  assert.equal(state.planCommit, "plan123");
+  assert.deepEqual(state.failureCommentKeys, ["blocked:verification"]);
+});
+
+test("runOneIssue reports dirty blocked recovery before mutations", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  const runner = blockedRecoveryRunner(config, {
+    dirtyStatus: " M src/index.ts\n",
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Commit, stash, or clean local modifications/,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args[0] !== "issues",
+    ),
+    false,
+  );
+  const state = JSON.parse(
+    await readFile(runStatePath(config.runStateDir, 45), "utf8"),
+  );
+  assert.equal(state.status, "blocked");
+  assert.equal(state.branch, "agent/issue-45-recover-blocked-run");
+});
+
+test("runOneIssue reports already merged blocked recovery before mutations", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  const runner = blockedRecoveryRunner(config, { merged: true, log: "" });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Confirm the work is landed/,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+});
+
+test("runOneIssue reports diverged blocked recovery before mutations", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  const runner = blockedRecoveryRunner(config, { revList: "3\t2\n" });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Rebase or cherry-pick/,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+});
+
+test("runOneIssue reports missing worktree with existing branch blocked recovery before mutations", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  const runner = blockedRecoveryRunner(config, { worktreeRegistered: false });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /git worktree add \.worktrees\/patchmill-issue-45-recover-blocked-run agent\/issue-45-recover-blocked-run/,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+});
+
+test("runOneIssue reports missing branch and worktree blocked recovery before mutations", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  const runner = blockedRecoveryRunner(config, {
+    branchExists: false,
+    worktreeRegistered: false,
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Archive or remove stale run state/,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+});
+
 test("runOneIssue reuses existing implementation result on resume without rerunning pi", async () => {
   const config = await makeConfig({
     dryRun: false,

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -636,6 +636,42 @@ test("runOneIssue dry-run lists open issues and returns the selected agent-ready
   );
 });
 
+test("runOneIssue dry-run for blocked saved workspace skips recovery inspection", async () => {
+  const config = await makeConfig({ issueNumber: 45 });
+  await writeBlockedRecoveryRunState(config);
+  const runner = createMockRunner((call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list" &&
+      call.args[call.args.indexOf("--state") + 1] === "all" &&
+      call.args[call.args.indexOf("--keyword") + 1] === "45"
+    ) {
+      return {
+        code: 0,
+        stdout: issueListPayload([
+          issue(45, ["agent-ready"], "Recover blocked run"),
+        ]),
+        stderr: "",
+      };
+    }
+
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "dry-run");
+  assert.equal(result.issue.number, 45);
+  assert.equal(result.transition, "agent-ready -> agent-done");
+  assert.equal(
+    runner.calls.some((call) => call.command === "git"),
+    false,
+  );
+});
+
 test("runOneIssue automatic selection includes agent-ready when spec approval is required", async () => {
   const config = await makeConfig({
     approvalPolicy: approvalPolicy({ specRequired: true }),

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -1231,6 +1231,81 @@ test("runOneIssue rejects a different explicit issue when a resumable run exists
   );
 });
 
+test("runOneIssue rejects a different explicit blocked recovery issue when a resumable run exists", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeRunState(
+    config.runStateDir,
+    {
+      issueNumber: 45,
+      title: "Blocked saved workspace",
+      status: "blocked",
+      branch: "agent/issue-45-blocked-saved-workspace",
+      worktreePath: ".worktrees/patchmill-issue-45-blocked-saved-workspace",
+    },
+    NOW.toISOString(),
+  );
+  await writeRunState(
+    config.runStateDir,
+    { issueNumber: 46, title: "Resume first", status: "planning" },
+    NOW.toISOString(),
+  );
+  const runner = createMockRunner((call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "45"
+    ) {
+      return {
+        code: 0,
+        stdout: issueViewPayload(
+          issue(45, ["in-progress", "bug"], "Blocked saved workspace"),
+        ),
+        stderr: "",
+      };
+    }
+
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout:
+          page === "1"
+            ? issueListPayload([
+                issue(45, ["in-progress", "bug"], "Blocked saved workspace"),
+                issue(46, ["in-progress", "bug"], "Resume first"),
+              ])
+            : "[]",
+        stderr: "",
+      };
+    }
+
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Resumable in-progress automation run #46 exists; resume it before processing #45/,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) =>
+        call.command === "git" &&
+        (call.args[0] === "show-ref" || call.args[0] === "worktree"),
+    ),
+    false,
+  );
+});
+
 test("runOneIssue allows an explicit resumable issue", async () => {
   const config = await makeConfig({
     dryRun: false,
@@ -3175,6 +3250,7 @@ test("runOneIssue resumes clean blocked implementation workspace after external 
   );
   assert.equal(state.specCommit, "spec123");
   assert.equal(state.planCommit, "plan123");
+  assert.equal(state.lastError, undefined);
   assert.deepEqual(state.failureCommentKeys, ["blocked:verification"]);
 });
 

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -2848,11 +2848,22 @@ async function writeBlockedRecoveryRunState(
     issueNumber: 45,
     status: "blocked",
   },
+  options: { createWorktreePath?: boolean } = {},
 ): Promise<void> {
   const planPath =
     overrides.planPath ??
     "docs/plans/2026-06-20-issue-45-recover-blocked-run.md";
   await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
+  if (options.createWorktreePath !== false) {
+    await mkdir(
+      join(
+        config.repoRoot,
+        overrides.worktreePath ??
+          ".worktrees/patchmill-issue-45-recover-blocked-run",
+      ),
+      { recursive: true },
+    );
+  }
   await writeRunState(
     config.runStateDir,
     {
@@ -3049,6 +3060,25 @@ test("runOneIssue resumes clean blocked implementation workspace after external 
     ),
     false,
   );
+  const finalLabelCall = runner.calls.find(
+    (call) =>
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "edit" &&
+      call.args.includes("--add-labels") &&
+      call.args.includes("agent-done"),
+  );
+  assert.ok(finalLabelCall, "expected final done label update");
+  assert.equal(
+    finalLabelCall.args.includes("--remove-labels"),
+    true,
+    "expected final label update to remove stale labels",
+  );
+  assert.match(
+    finalLabelCall.args[finalLabelCall.args.indexOf("--remove-labels") + 1] ??
+      "",
+    /needs-info/,
+  );
   const state = JSON.parse(
     await readFile(runStatePath(config.runStateDir, 45), "utf8"),
   );
@@ -3143,7 +3173,9 @@ test("runOneIssue reports missing worktree with existing branch blocked recovery
     execute: true,
     issueNumber: 45,
   });
-  await writeBlockedRecoveryRunState(config);
+  await writeBlockedRecoveryRunState(config, undefined, {
+    createWorktreePath: false,
+  });
   const runner = blockedRecoveryRunner(config, { worktreeRegistered: false });
 
   await assert.rejects(
@@ -3162,7 +3194,9 @@ test("runOneIssue reports missing branch and worktree blocked recovery before mu
     execute: true,
     issueNumber: 45,
   });
-  await writeBlockedRecoveryRunState(config);
+  await writeBlockedRecoveryRunState(config, undefined, {
+    createWorktreePath: false,
+  });
   const runner = blockedRecoveryRunner(config, {
     branchExists: false,
     worktreeRegistered: false,

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -3254,6 +3254,26 @@ test("runOneIssue resumes clean blocked implementation workspace after external 
   assert.deepEqual(state.failureCommentKeys, ["blocked:verification"]);
 });
 
+test("runOneIssue treats configured ignored dirty paths as clean blocked recovery", async () => {
+  const config = await makeConfig({
+    dryRun: false,
+    execute: true,
+    issueNumber: 45,
+  });
+  await writeBlockedRecoveryRunState(config);
+  const runner = blockedRecoveryRunner(config, {
+    dirtyStatus: "?? .patchmill/runs/issue-45.json\n",
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created", JSON.stringify(result));
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    true,
+  );
+});
+
 test("runOneIssue reports dirty blocked recovery before mutations", async () => {
   const config = await makeConfig({
     dryRun: false,

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -767,6 +767,7 @@ export async function runOneIssue(
   const resumed = selected?.resumed ?? false;
   const ordinaryResumableState =
     resumed && !!existingState && isResumableRunState(existingState);
+  const ignoredPaths = cleanStatusIgnoredPaths(config, options);
   const blockedRecoveryReport =
     existingState?.status === "blocked" &&
     (existingState.branch || existingState.worktreePath)
@@ -776,6 +777,7 @@ export async function runOneIssue(
           runStatePath: runStatePath(config.runStateDir, issue.number),
           state: existingState,
           baseRef: config.baseRef,
+          ignoredPaths,
         })
       : undefined;
   const blockedRecoveryResumable =
@@ -929,7 +931,6 @@ export async function runOneIssue(
   await progress(options, "info", "git", "checking repository status", {
     issueNumber: issue.number,
   });
-  const ignoredPaths = cleanStatusIgnoredPaths(config, options);
   await assertCleanWorktree(runner, config.repoRoot, ignoredPaths);
   const { ready, inProgress, done, needsInfo } = lifecycleLabels(config);
   let labels = resumed

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -456,11 +456,7 @@ async function selectResumableIssue(
     for (const issue of issues) {
       if (!issue.labels.includes(inProgress)) continue;
       const state = await readRunState(config.runStateDir, issue.number);
-      if (
-        state &&
-        (isResumableRunState(state) || hasBlockedSavedWorkspaceState(state))
-      )
-        resumable.push(issue);
+      if (state && isResumableRunState(state)) resumable.push(issue);
     }
   }
 

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -767,26 +767,6 @@ export async function runOneIssue(
   const resumed = selected?.resumed ?? false;
   const ordinaryResumableState =
     resumed && !!existingState && isResumableRunState(existingState);
-  const ignoredPaths = cleanStatusIgnoredPaths(config, options);
-  const blockedRecoveryReport =
-    existingState?.status === "blocked" &&
-    (existingState.branch || existingState.worktreePath)
-      ? await inspectBlockedRunRecovery({
-          runner,
-          repoRoot: config.repoRoot,
-          runStatePath: runStatePath(config.runStateDir, issue.number),
-          state: existingState,
-          baseRef: config.baseRef,
-          ignoredPaths,
-        })
-      : undefined;
-  const blockedRecoveryResumable =
-    blockedRecoveryReport?.kind === "recoverable-clean";
-  const resumableState = ordinaryResumableState || blockedRecoveryResumable;
-  const resetStaleCheckpoints = !!existingState && !resumableState;
-  const checkpoints = {
-    ...(effectiveCheckpoints(existingState?.checkpoints, resumableState) ?? {}),
-  };
 
   await progress(
     options,
@@ -810,6 +790,27 @@ export async function runOneIssue(
       options,
     );
   }
+
+  const ignoredPaths = cleanStatusIgnoredPaths(config, options);
+  const blockedRecoveryReport =
+    existingState?.status === "blocked" &&
+    (existingState.branch || existingState.worktreePath)
+      ? await inspectBlockedRunRecovery({
+          runner,
+          repoRoot: config.repoRoot,
+          runStatePath: runStatePath(config.runStateDir, issue.number),
+          state: existingState,
+          baseRef: config.baseRef,
+          ignoredPaths,
+        })
+      : undefined;
+  const blockedRecoveryResumable =
+    blockedRecoveryReport?.kind === "recoverable-clean";
+  const resumableState = ordinaryResumableState || blockedRecoveryResumable;
+  const resetStaleCheckpoints = !!existingState && !resumableState;
+  const checkpoints = {
+    ...(effectiveCheckpoints(existingState?.checkpoints, resumableState) ?? {}),
+  };
 
   if (blockedRecoveryReport && !blockedRecoveryResumable) {
     throw new AgentIssueSafetyError(

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -37,8 +37,13 @@ import type { VisualEvidenceUploader } from "../../../host/visual-evidence.ts";
 import {
   isResumableRunState,
   readRunState,
+  runStatePath,
   writeRunState,
 } from "./run-state.ts";
+import {
+  formatBlockedRunRecoveryReport,
+  inspectBlockedRunRecovery,
+} from "./recovery.ts";
 import { selectIssue } from "./selection.ts";
 import {
   defaultVisualEvidenceUploader,
@@ -203,6 +208,15 @@ function workflowTransition(
   }
 
   return `${state.kind} -> no-issue`;
+}
+
+function hasBlockedSavedWorkspaceState(
+  state: Awaited<ReturnType<typeof readRunState>>,
+): boolean {
+  return (
+    state?.status === "blocked" &&
+    (state.branch !== undefined || state.worktreePath !== undefined)
+  );
 }
 
 function lifecycleLabels(
@@ -442,7 +456,11 @@ async function selectResumableIssue(
     for (const issue of issues) {
       if (!issue.labels.includes(inProgress)) continue;
       const state = await readRunState(config.runStateDir, issue.number);
-      if (state && isResumableRunState(state)) resumable.push(issue);
+      if (
+        state &&
+        (isResumableRunState(state) || hasBlockedSavedWorkspaceState(state))
+      )
+        resumable.push(issue);
     }
   }
 
@@ -458,6 +476,18 @@ async function selectResumableIssue(
     );
     if (resumableSelected) {
       return { issue: resumableSelected, resumed: true };
+    }
+    if (shouldResume) {
+      const explicitIssue = issues.find(
+        (candidate) =>
+          candidate.number === config.issueNumber && candidate.state === "open",
+      );
+      const explicitState = explicitIssue
+        ? await readRunState(config.runStateDir, explicitIssue.number)
+        : undefined;
+      if (explicitIssue && hasBlockedSavedWorkspaceState(explicitState)) {
+        return { issue: explicitIssue, resumed: true };
+      }
     }
     const selected = selectIssue(issues, {
       issueNumber: config.issueNumber,
@@ -731,8 +761,22 @@ export async function runOneIssue(
   const existingState = await readRunState(config.runStateDir, issue.number);
   const piAgentDir = localPiAgentDir(config.repoRoot);
   const resumed = selected?.resumed ?? false;
-  const resumableState =
+  const ordinaryResumableState =
     resumed && !!existingState && isResumableRunState(existingState);
+  const blockedRecoveryReport =
+    existingState?.status === "blocked" &&
+    (existingState.branch || existingState.worktreePath)
+      ? await inspectBlockedRunRecovery({
+          runner,
+          repoRoot: config.repoRoot,
+          runStatePath: runStatePath(config.runStateDir, issue.number),
+          state: existingState,
+          baseRef: config.baseRef,
+        })
+      : undefined;
+  const blockedRecoveryResumable =
+    blockedRecoveryReport?.kind === "recoverable-clean";
+  const resumableState = ordinaryResumableState || blockedRecoveryResumable;
   const resetStaleCheckpoints = !!existingState && !resumableState;
   const checkpoints = {
     ...(effectiveCheckpoints(existingState?.checkpoints, resumableState) ?? {}),
@@ -758,6 +802,12 @@ export async function runOneIssue(
         transition: workflowTransition(state, config),
       },
       options,
+    );
+  }
+
+  if (blockedRecoveryReport && !blockedRecoveryResumable) {
+    throw new AgentIssueSafetyError(
+      formatBlockedRunRecoveryReport(blockedRecoveryReport),
     );
   }
 

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -482,6 +482,14 @@ async function selectResumableIssue(
         ? await readRunState(config.runStateDir, explicitIssue.number)
         : undefined;
       if (explicitIssue && hasBlockedSavedWorkspaceState(explicitState)) {
+        if (
+          resumable.length === 1 &&
+          resumable[0]?.number !== explicitIssue.number
+        ) {
+          throw new Error(
+            `Resumable ${inProgress} automation run #${resumable[0]?.number} exists; resume it before processing #${explicitIssue.number}`,
+          );
+        }
         return { issue: explicitIssue, resumed: true };
       }
     }
@@ -1595,6 +1603,7 @@ export async function runOneIssue(
         planCommit,
         branch,
         worktreePath,
+        clearLastError: true,
       },
       timestamp,
     );

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -1556,7 +1556,7 @@ export async function runOneIssue(
         readyLabel: ready,
         policy: config.approvalPolicy,
       }),
-      [inProgress],
+      [inProgress, needsInfo],
       [done],
     );
     if (!checkpoints.doneLabelApplied) {

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   formatBlockedRunRecoveryReport,
   inspectBlockedRunRecovery,
@@ -35,6 +38,14 @@ const baseState = {
   updatedAt: "2026-06-20T08:10:00.000Z",
 };
 
+async function tempRepo(options: { worktreeExists?: boolean } = {}) {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-recovery-"));
+  if (options.worktreeExists !== false) {
+    await mkdir(join(repoRoot, baseState.worktreePath), { recursive: true });
+  }
+  return repoRoot;
+}
+
 function cleanRunner(
   overrides: Partial<{
     branchExists: boolean;
@@ -59,7 +70,7 @@ function cleanRunner(
         stdout:
           overrides.worktreeRegistered === false
             ? ""
-            : "worktree /repo/.worktrees/patchmill-issue-45-recover-blocked-run\nbranch refs/heads/agent/issue-45-recover-blocked-run\n",
+            : `worktree ${join(call.cwd ?? "/repo", baseState.worktreePath)}\nbranch refs/heads/agent/issue-45-recover-blocked-run\n`,
         stderr: "",
       };
     }
@@ -85,10 +96,13 @@ function cleanRunner(
   });
 }
 
-async function inspect(overrides?: Parameters<typeof cleanRunner>[0]) {
+async function inspect(
+  overrides?: Parameters<typeof cleanRunner>[0],
+  options?: { worktreeExists?: boolean },
+) {
   return inspectBlockedRunRecovery({
     runner: cleanRunner(overrides),
-    repoRoot: "/repo",
+    repoRoot: await tempRepo(options),
     runStatePath: ".patchmill/runs/issue-45.json",
     state: baseState,
     baseRef: "main",
@@ -130,10 +144,14 @@ test("inspectBlockedRunRecovery classifies diverged branch", async () => {
 });
 
 test("inspectBlockedRunRecovery classifies missing worktree with existing branch", async () => {
-  const report = await inspect({ worktreeRegistered: false });
+  const report = await inspect(
+    { worktreeRegistered: false },
+    { worktreeExists: false },
+  );
 
   assert.equal(report.kind, "missing-worktree-existing-branch");
   assert.equal(report.branch.exists, true);
+  assert.equal(report.worktree.exists, false);
   assert.equal(report.worktree.registered, false);
 });
 
@@ -144,7 +162,7 @@ test("inspectBlockedRunRecovery classifies missing branch and worktree", async (
   });
   const report = await inspectBlockedRunRecovery({
     runner,
-    repoRoot: "/repo",
+    repoRoot: await tempRepo({ worktreeExists: false }),
     runStatePath: ".patchmill/runs/issue-45.json",
     state: baseState,
     baseRef: "main",
@@ -153,6 +171,26 @@ test("inspectBlockedRunRecovery classifies missing branch and worktree", async (
   assert.equal(report.kind, "missing-branch-or-worktree");
   assert.equal(report.branch.exists, false);
   assert.equal(report.worktree.registered, false);
+  assert.equal(report.worktree.exists, false);
+});
+
+test("inspectBlockedRunRecovery distinguishes unregistered existing saved path", async () => {
+  const report = await inspect({ worktreeRegistered: false });
+
+  assert.equal(report.kind, "missing-worktree-existing-branch");
+  assert.equal(report.worktree.exists, true);
+  assert.equal(report.worktree.registered, false);
+  assert.match(
+    report.recommendedActions[0] ?? "",
+    /exists but is not registered/,
+  );
+});
+
+test("inspectBlockedRunRecovery fails fast on unparseable divergence", async () => {
+  await assert.rejects(
+    () => inspect({ revList: "unexpected output\n" }),
+    /unparseable divergence/,
+  );
 });
 
 function report(
@@ -224,7 +262,7 @@ test("formatBlockedRunRecoveryReport includes clean recovery details", () => {
   );
   assert.match(
     message,
-    /Saved worktree: \.worktrees\/patchmill-issue-45-recover-blocked-run \(registered, clean\)/,
+    /Saved worktree: \.worktrees\/patchmill-issue-45-recover-blocked-run \(path exists, registered, clean\)/,
   );
   assert.match(message, /def456 add verification/);
   assert.match(message, /patchmill run-once --issue 45/);
@@ -269,7 +307,7 @@ test("formatBlockedRunRecoveryReport includes missing worktree recovery guidance
   delete missing.worktree.clean;
   const message = formatBlockedRunRecoveryReport(missing);
 
-  assert.match(message, /missing/);
+  assert.match(message, /path missing, not registered/);
   assert.match(message, /git worktree add/);
 });
 

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -169,6 +169,12 @@ test("inspectBlockedRunRecovery classifies registered but missing worktree path 
   assert.equal(report.branch.exists, true);
   assert.equal(report.worktree.exists, false);
   assert.equal(report.worktree.registered, true);
+  assert.match(report.recommendedActions[0] ?? "", /still registered with Git/);
+  assert.match(
+    report.recommendedActions[1] ?? "",
+    /prune or remove the stale worktree registration/,
+  );
+  assert.doesNotMatch(report.recommendedActions[0] ?? "", /git worktree add/);
   assert.equal(
     runner.calls.some(
       (call) => call.args[0] === "-C" && call.args[2] === "status",
@@ -331,6 +337,27 @@ test("formatBlockedRunRecoveryReport includes missing worktree recovery guidance
 
   assert.match(message, /path missing, not registered/);
   assert.match(message, /git worktree add/);
+});
+
+test("formatBlockedRunRecoveryReport distinguishes registered missing worktree guidance", () => {
+  const missing = report("missing-worktree-existing-branch");
+  missing.worktree.exists = false;
+  missing.worktree.registered = true;
+  delete missing.worktree.clean;
+  missing.recommendedActions = [
+    "The saved worktree path .worktrees/patchmill-issue-45-recover-blocked-run is still registered with Git but the path is missing; repair or restore the missing path if local files need preservation.",
+    "If no local files need preservation at that path, prune or remove the stale worktree registration, then reattach the saved branch.",
+    "After repair, retry with: patchmill run-once --issue 45",
+  ];
+  const message = formatBlockedRunRecoveryReport(missing);
+
+  assert.match(message, /path missing, registered/);
+  assert.match(message, /still registered with Git but the path is missing/);
+  assert.match(message, /prune or remove the stale worktree registration/);
+  assert.doesNotMatch(
+    message.split("Recommended actions:")[1]?.split("\n")[1] ?? "",
+    /git worktree add/,
+  );
 });
 
 test("formatBlockedRunRecoveryReport includes missing branch and worktree recovery guidance", () => {

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -98,7 +98,7 @@ function cleanRunner(
 
 async function inspect(
   overrides?: Parameters<typeof cleanRunner>[0],
-  options?: { worktreeExists?: boolean },
+  options?: { worktreeExists?: boolean; ignoredPaths?: string[] },
 ) {
   return inspectBlockedRunRecovery({
     runner: cleanRunner(overrides),
@@ -106,6 +106,7 @@ async function inspect(
     runStatePath: ".patchmill/runs/issue-45.json",
     state: baseState,
     baseRef: "main",
+    ignoredPaths: options?.ignoredPaths,
   });
 }
 
@@ -127,6 +128,28 @@ test("inspectBlockedRunRecovery classifies dirty saved worktree", async () => {
   assert.equal(report.kind, "dirty-worktree");
   assert.equal(report.worktree.clean, false);
   assert.match(report.worktree.dirtyStatus ?? "", /src\/index\.ts/);
+});
+
+test("inspectBlockedRunRecovery ignores configured clean-status paths in saved worktree", async () => {
+  const report = await inspect(
+    { dirtyStatus: "?? .patchmill/runs/issue-45.json\n" },
+    { ignoredPaths: [".patchmill/runs/"] },
+  );
+
+  assert.equal(report.kind, "recoverable-clean");
+  assert.equal(report.worktree.clean, true);
+  assert.equal(report.worktree.dirtyStatus, undefined);
+});
+
+test("inspectBlockedRunRecovery still blocks non-ignored dirty status with ignored paths configured", async () => {
+  const report = await inspect(
+    { dirtyStatus: "?? .patchmill/runs/issue-45.json\n M src/index.ts\n" },
+    { ignoredPaths: [".patchmill/runs/"] },
+  );
+
+  assert.equal(report.kind, "dirty-worktree");
+  assert.equal(report.worktree.clean, false);
+  assert.equal(report.worktree.dirtyStatus, "M src/index.ts");
 });
 
 test("inspectBlockedRunRecovery classifies already merged branch", async () => {

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -155,6 +155,28 @@ test("inspectBlockedRunRecovery classifies missing worktree with existing branch
   assert.equal(report.worktree.registered, false);
 });
 
+test("inspectBlockedRunRecovery classifies registered but missing worktree path without status", async () => {
+  const runner = cleanRunner();
+  const report = await inspectBlockedRunRecovery({
+    runner,
+    repoRoot: await tempRepo({ worktreeExists: false }),
+    runStatePath: ".patchmill/runs/issue-45.json",
+    state: baseState,
+    baseRef: "main",
+  });
+
+  assert.equal(report.kind, "missing-worktree-existing-branch");
+  assert.equal(report.branch.exists, true);
+  assert.equal(report.worktree.exists, false);
+  assert.equal(report.worktree.registered, true);
+  assert.equal(
+    runner.calls.some(
+      (call) => call.args[0] === "-C" && call.args[2] === "status",
+    ),
+    false,
+  );
+});
+
 test("inspectBlockedRunRecovery classifies missing branch and worktree", async () => {
   const runner = cleanRunner({
     branchExists: false,

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -1,0 +1,286 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatBlockedRunRecoveryReport,
+  inspectBlockedRunRecovery,
+  type BlockedRunRecoveryReport,
+} from "./recovery.ts";
+import type { CommandResult, CommandRunner } from "./types.ts";
+
+type Call = { command: string; args: string[]; cwd?: string };
+
+function runnerFor(
+  handler: (call: Call) => CommandResult,
+): CommandRunner & { calls: Call[] } {
+  const calls: Call[] = [];
+  return {
+    calls,
+    async run(command, args, options = {}) {
+      const call = { command, args: [...args], cwd: options.cwd };
+      calls.push(call);
+      return handler(call);
+    },
+  };
+}
+
+const baseState = {
+  issueNumber: 45,
+  title: "Recover blocked run",
+  status: "blocked" as const,
+  branch: "agent/issue-45-recover-blocked-run",
+  worktreePath: ".worktrees/patchmill-issue-45-recover-blocked-run",
+  commits: ["abc123", "def456"],
+  lastError: "Required verification environment is unavailable.",
+  createdAt: "2026-06-20T08:00:00.000Z",
+  updatedAt: "2026-06-20T08:10:00.000Z",
+};
+
+function cleanRunner(
+  overrides: Partial<{
+    branchExists: boolean;
+    worktreeRegistered: boolean;
+    dirtyStatus: string;
+    merged: boolean;
+    revList: string;
+    log: string;
+  }> = {},
+) {
+  return runnerFor((call) => {
+    if (call.args[0] === "show-ref") {
+      return {
+        code: overrides.branchExists === false ? 1 : 0,
+        stdout: "",
+        stderr: "",
+      };
+    }
+    if (call.args.join(" ") === "worktree list --porcelain") {
+      return {
+        code: 0,
+        stdout:
+          overrides.worktreeRegistered === false
+            ? ""
+            : "worktree /repo/.worktrees/patchmill-issue-45-recover-blocked-run\nbranch refs/heads/agent/issue-45-recover-blocked-run\n",
+        stderr: "",
+      };
+    }
+    if (call.args[0] === "-C" && call.args[2] === "status") {
+      return { code: 0, stdout: overrides.dirtyStatus ?? "", stderr: "" };
+    }
+    if (call.args[0] === "merge-base") {
+      return { code: overrides.merged ? 0 : 1, stdout: "", stderr: "" };
+    }
+    if (call.args[0] === "rev-list") {
+      return { code: 0, stdout: overrides.revList ?? "0\t2\n", stderr: "" };
+    }
+    if (call.args[0] === "log") {
+      return {
+        code: 0,
+        stdout:
+          overrides.log ??
+          "def456 add verification\nabc123 implement feature\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: git ${call.args.join(" ")}`);
+  });
+}
+
+async function inspect(overrides?: Parameters<typeof cleanRunner>[0]) {
+  return inspectBlockedRunRecovery({
+    runner: cleanRunner(overrides),
+    repoRoot: "/repo",
+    runStatePath: ".patchmill/runs/issue-45.json",
+    state: baseState,
+    baseRef: "main",
+  });
+}
+
+test("inspectBlockedRunRecovery classifies clean unmerged saved workspace as recoverable", async () => {
+  const report = await inspect();
+
+  assert.equal(report.kind, "recoverable-clean");
+  assert.equal(report.branch.exists, true);
+  assert.equal(report.worktree.exists, true);
+  assert.equal(report.worktree.clean, true);
+  assert.deepEqual(report.divergence, { ahead: 2, behind: 0 });
+});
+
+test("inspectBlockedRunRecovery classifies dirty saved worktree", async () => {
+  const report = await inspect({
+    dirtyStatus: " M src/index.ts\n?? tmp.txt\n",
+  });
+
+  assert.equal(report.kind, "dirty-worktree");
+  assert.equal(report.worktree.clean, false);
+  assert.match(report.worktree.dirtyStatus ?? "", /src\/index\.ts/);
+});
+
+test("inspectBlockedRunRecovery classifies already merged branch", async () => {
+  const report = await inspect({ merged: true, log: "" });
+
+  assert.equal(report.kind, "already-merged");
+  assert.equal(report.branch.merged, true);
+});
+
+test("inspectBlockedRunRecovery classifies diverged branch", async () => {
+  const report = await inspect({ revList: "3\t2\n" });
+
+  assert.equal(report.kind, "diverged");
+  assert.deepEqual(report.divergence, { ahead: 2, behind: 3 });
+});
+
+test("inspectBlockedRunRecovery classifies missing worktree with existing branch", async () => {
+  const report = await inspect({ worktreeRegistered: false });
+
+  assert.equal(report.kind, "missing-worktree-existing-branch");
+  assert.equal(report.branch.exists, true);
+  assert.equal(report.worktree.registered, false);
+});
+
+test("inspectBlockedRunRecovery classifies missing branch and worktree", async () => {
+  const runner = cleanRunner({
+    branchExists: false,
+    worktreeRegistered: false,
+  });
+  const report = await inspectBlockedRunRecovery({
+    runner,
+    repoRoot: "/repo",
+    runStatePath: ".patchmill/runs/issue-45.json",
+    state: baseState,
+    baseRef: "main",
+  });
+
+  assert.equal(report.kind, "missing-branch-or-worktree");
+  assert.equal(report.branch.exists, false);
+  assert.equal(report.worktree.registered, false);
+});
+
+function report(
+  kind: BlockedRunRecoveryReport["kind"],
+): BlockedRunRecoveryReport {
+  const common: BlockedRunRecoveryReport = {
+    kind,
+    runStatePath: ".patchmill/runs/issue-45.json",
+    issueNumber: 45,
+    title: "Recover blocked run",
+    status: "blocked",
+    blockerReason: "Required verification environment is unavailable.",
+    branch: {
+      name: "agent/issue-45-recover-blocked-run",
+      exists: true,
+      merged: false,
+    },
+    worktree: {
+      path: ".worktrees/patchmill-issue-45-recover-blocked-run",
+      exists: true,
+      registered: true,
+      clean: true,
+    },
+    divergence: { ahead: 2, behind: 0 },
+    commits: ["def456 add verification", "abc123 implement feature"],
+    recommendedActions: [],
+  };
+  const actions: Record<BlockedRunRecoveryReport["kind"], string[]> = {
+    "recoverable-clean": [
+      "Retry after the external prerequisite is fixed with: patchmill run-once --issue 45",
+    ],
+    "dirty-worktree": [
+      "Commit, stash, or clean local modifications in the saved worktree before retrying.",
+    ],
+    "already-merged": [
+      "Confirm the work is landed, then clean/finalize stale run state.",
+    ],
+    diverged: [
+      "Rebase or cherry-pick the saved work onto the current base, then retry.",
+    ],
+    "missing-worktree-existing-branch": [
+      "Reattach the saved branch with: git worktree add .worktrees/patchmill-issue-45-recover-blocked-run agent/issue-45-recover-blocked-run",
+    ],
+    "missing-branch-or-worktree": [
+      "Archive or remove stale run state only after confirming no saved branch or worktree needs preservation.",
+    ],
+    "not-blocked-recovery": [
+      "No blocked run workspace recovery is available for this state.",
+    ],
+  };
+  return { ...common, recommendedActions: actions[kind] };
+}
+
+test("formatBlockedRunRecoveryReport includes clean recovery details", () => {
+  const message = formatBlockedRunRecoveryReport(report("recoverable-clean"));
+
+  assert.match(
+    message,
+    /Issue #45 has a blocked run with preserved workspace state\./,
+  );
+  assert.match(message, /Run state: \.patchmill\/runs\/issue-45\.json/);
+  assert.match(
+    message,
+    /Blocked reason: Required verification environment is unavailable\./,
+  );
+  assert.match(
+    message,
+    /Saved branch: agent\/issue-45-recover-blocked-run \(exists, unmerged, ahead 2, behind 0\)/,
+  );
+  assert.match(
+    message,
+    /Saved worktree: \.worktrees\/patchmill-issue-45-recover-blocked-run \(registered, clean\)/,
+  );
+  assert.match(message, /def456 add verification/);
+  assert.match(message, /patchmill run-once --issue 45/);
+});
+
+test("formatBlockedRunRecoveryReport includes dirty recovery guidance", () => {
+  const dirty = report("dirty-worktree");
+  dirty.worktree.clean = false;
+  dirty.worktree.dirtyStatus = " M src/index.ts";
+  const message = formatBlockedRunRecoveryReport(dirty);
+
+  assert.match(message, /dirty/i);
+  assert.match(message, /Commit, stash, or clean local modifications/);
+  assert.doesNotMatch(
+    message.split("Recommended actions:")[1] ?? "",
+    /^- delete/i,
+  );
+});
+
+test("formatBlockedRunRecoveryReport includes merged recovery guidance", () => {
+  const merged = report("already-merged");
+  merged.branch.merged = true;
+  const message = formatBlockedRunRecoveryReport(merged);
+
+  assert.match(message, /exists, merged/);
+  assert.match(message, /Confirm the work is landed/);
+});
+
+test("formatBlockedRunRecoveryReport includes diverged recovery guidance", () => {
+  const diverged = report("diverged");
+  diverged.divergence = { ahead: 2, behind: 3 };
+  const message = formatBlockedRunRecoveryReport(diverged);
+
+  assert.match(message, /ahead 2, behind 3/);
+  assert.match(message, /Rebase or cherry-pick/);
+});
+
+test("formatBlockedRunRecoveryReport includes missing worktree recovery guidance", () => {
+  const missing = report("missing-worktree-existing-branch");
+  missing.worktree.exists = false;
+  missing.worktree.registered = false;
+  delete missing.worktree.clean;
+  const message = formatBlockedRunRecoveryReport(missing);
+
+  assert.match(message, /missing/);
+  assert.match(message, /git worktree add/);
+});
+
+test("formatBlockedRunRecoveryReport includes missing branch and worktree recovery guidance", () => {
+  const missing = report("missing-branch-or-worktree");
+  missing.branch.exists = false;
+  missing.worktree.exists = false;
+  missing.worktree.registered = false;
+  delete missing.worktree.clean;
+  const message = formatBlockedRunRecoveryReport(missing);
+
+  assert.match(message, /Saved branch: .*\(missing/);
+  assert.match(message, /Archive or remove stale run state/);
+});

--- a/src/cli/commands/run-once/recovery.ts
+++ b/src/cli/commands/run-once/recovery.ts
@@ -1,0 +1,343 @@
+import { resolve } from "node:path";
+import type {
+  AgentIssueRunState,
+  CommandResult,
+  CommandRunner,
+} from "./types.ts";
+
+export type BlockedRunRecoveryKind =
+  | "recoverable-clean"
+  | "dirty-worktree"
+  | "already-merged"
+  | "diverged"
+  | "missing-worktree-existing-branch"
+  | "missing-branch-or-worktree"
+  | "not-blocked-recovery";
+
+export type BlockedRunRecoveryReport = {
+  kind: BlockedRunRecoveryKind;
+  runStatePath: string;
+  issueNumber: number;
+  title: string;
+  status: AgentIssueRunState["status"];
+  blockerReason?: string;
+  branch: { name?: string; exists: boolean; merged: boolean };
+  worktree: {
+    path?: string;
+    exists: boolean;
+    registered: boolean;
+    clean?: boolean;
+    dirtyStatus?: string;
+  };
+  divergence?: { ahead: number; behind: number };
+  commits: string[];
+  recommendedActions: string[];
+};
+
+function commandFailure(message: string, result: CommandResult): Error {
+  const output =
+    [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n") ||
+    "(no output)";
+  return new Error(`${message} with exit code ${result.code}: ${output}`);
+}
+
+async function branchExists(
+  runner: CommandRunner,
+  repoRoot: string,
+  branch: string | undefined,
+): Promise<boolean> {
+  if (!branch) return false;
+  const result = await runner.run(
+    "git",
+    ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+    { cwd: repoRoot },
+  );
+  if (result.code === 0) return true;
+  if (result.code === 1) return false;
+  throw commandFailure(`git show-ref failed for ${branch}`, result);
+}
+
+function worktreePaths(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => resolve(line.slice("worktree ".length).trim()));
+}
+
+async function registeredWorktreeExists(
+  runner: CommandRunner,
+  repoRoot: string,
+  worktreePath: string | undefined,
+): Promise<boolean> {
+  if (!worktreePath) return false;
+  const result = await runner.run("git", ["worktree", "list", "--porcelain"], {
+    cwd: repoRoot,
+  });
+  if (result.code !== 0)
+    throw commandFailure("git worktree list failed", result);
+  return worktreePaths(result.stdout).includes(resolve(repoRoot, worktreePath));
+}
+
+async function worktreeStatus(input: {
+  runner: CommandRunner;
+  repoRoot: string;
+  worktreePath: string;
+}): Promise<{ clean: boolean; dirtyStatus?: string }> {
+  const result = await input.runner.run(
+    "git",
+    [
+      "-C",
+      input.worktreePath,
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+    ],
+    { cwd: input.repoRoot },
+  );
+  if (result.code !== 0)
+    throw commandFailure(`git status failed for ${input.worktreePath}`, result);
+  const dirtyStatus = result.stdout.trim();
+  return dirtyStatus === "" ? { clean: true } : { clean: false, dirtyStatus };
+}
+
+async function branchMerged(input: {
+  runner: CommandRunner;
+  repoRoot: string;
+  branch: string;
+  baseRef: string;
+}): Promise<boolean> {
+  const result = await input.runner.run(
+    "git",
+    ["merge-base", "--is-ancestor", input.branch, input.baseRef],
+    { cwd: input.repoRoot },
+  );
+  if (result.code === 0) return true;
+  if (result.code === 1) return false;
+  throw commandFailure(`git merge-base failed for ${input.branch}`, result);
+}
+
+async function branchDivergence(input: {
+  runner: CommandRunner;
+  repoRoot: string;
+  branch: string;
+  baseRef: string;
+}): Promise<{ ahead: number; behind: number } | undefined> {
+  const result = await input.runner.run(
+    "git",
+    [
+      "rev-list",
+      "--left-right",
+      "--count",
+      `${input.baseRef}...${input.branch}`,
+    ],
+    { cwd: input.repoRoot },
+  );
+  if (result.code !== 0)
+    throw commandFailure(`git rev-list failed for ${input.branch}`, result);
+  const [behindText, aheadText] = result.stdout.trim().split(/\s+/u);
+  const behind = Number.parseInt(behindText ?? "0", 10);
+  const ahead = Number.parseInt(aheadText ?? "0", 10);
+  return Number.isFinite(behind) && Number.isFinite(ahead)
+    ? { ahead, behind }
+    : undefined;
+}
+
+async function unmergedCommitLines(input: {
+  runner: CommandRunner;
+  repoRoot: string;
+  branch: string;
+  baseRef: string;
+}): Promise<string[]> {
+  const result = await input.runner.run(
+    "git",
+    ["log", "--oneline", `${input.baseRef}..${input.branch}`],
+    { cwd: input.repoRoot },
+  );
+  if (result.code !== 0)
+    throw commandFailure(`git log failed for ${input.branch}`, result);
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function recommendations(
+  kind: BlockedRunRecoveryKind,
+  report: Pick<BlockedRunRecoveryReport, "issueNumber" | "branch" | "worktree">,
+): string[] {
+  switch (kind) {
+    case "recoverable-clean":
+      return [
+        `Retry after the external prerequisite is fixed with: patchmill run-once --issue ${report.issueNumber}`,
+      ];
+    case "dirty-worktree":
+      return [
+        "Commit, stash, or clean local modifications in the saved worktree before retrying.",
+        `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
+      ];
+    case "already-merged":
+      return [
+        "Confirm the work is landed, then clean/finalize the stale run state while preserving any branch or worktree you still need.",
+      ];
+    case "diverged":
+      return [
+        "Rebase or cherry-pick the saved work onto the current base, then retry the run.",
+        `After recovery, retry with: patchmill run-once --issue ${report.issueNumber}`,
+      ];
+    case "missing-worktree-existing-branch":
+      return [
+        `Reattach the saved branch with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
+        `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
+      ];
+    case "missing-branch-or-worktree":
+      return [
+        "Archive or remove stale run state only after confirming no saved branch or worktree needs preservation.",
+      ];
+    case "not-blocked-recovery":
+      return ["No blocked run workspace recovery is available for this state."];
+  }
+}
+
+export async function inspectBlockedRunRecovery(input: {
+  runner: CommandRunner;
+  repoRoot: string;
+  runStatePath: string;
+  state: AgentIssueRunState;
+  baseRef: string;
+}): Promise<BlockedRunRecoveryReport> {
+  const baseReport = {
+    runStatePath: input.runStatePath,
+    issueNumber: input.state.issueNumber,
+    title: input.state.title,
+    status: input.state.status,
+    blockerReason: input.state.lastError,
+    branch: { name: input.state.branch, exists: false, merged: false },
+    worktree: {
+      path: input.state.worktreePath,
+      exists: false,
+      registered: false,
+    },
+    commits: input.state.commits ?? [],
+  } satisfies Omit<BlockedRunRecoveryReport, "kind" | "recommendedActions">;
+
+  if (
+    input.state.status !== "blocked" ||
+    (!input.state.branch && !input.state.worktreePath)
+  ) {
+    const kind = "not-blocked-recovery";
+    return {
+      ...baseReport,
+      kind,
+      recommendedActions: recommendations(kind, baseReport),
+    };
+  }
+
+  const exists = await branchExists(
+    input.runner,
+    input.repoRoot,
+    input.state.branch,
+  );
+  const registered = await registeredWorktreeExists(
+    input.runner,
+    input.repoRoot,
+    input.state.worktreePath,
+  );
+  const worktree = { ...baseReport.worktree, exists: registered, registered };
+  if (registered && input.state.worktreePath) {
+    Object.assign(
+      worktree,
+      await worktreeStatus({
+        runner: input.runner,
+        repoRoot: input.repoRoot,
+        worktreePath: input.state.worktreePath,
+      }),
+    );
+  }
+
+  let merged = false;
+  let divergence: { ahead: number; behind: number } | undefined;
+  let commits = baseReport.commits;
+  if (exists && input.state.branch) {
+    merged = await branchMerged({
+      runner: input.runner,
+      repoRoot: input.repoRoot,
+      branch: input.state.branch,
+      baseRef: input.baseRef,
+    });
+    divergence = await branchDivergence({
+      runner: input.runner,
+      repoRoot: input.repoRoot,
+      branch: input.state.branch,
+      baseRef: input.baseRef,
+    });
+    const gitCommits = await unmergedCommitLines({
+      runner: input.runner,
+      repoRoot: input.repoRoot,
+      branch: input.state.branch,
+      baseRef: input.baseRef,
+    });
+    if (gitCommits.length > 0) commits = gitCommits;
+  }
+
+  let kind: BlockedRunRecoveryKind;
+  if (!exists) kind = "missing-branch-or-worktree";
+  else if (!registered) kind = "missing-worktree-existing-branch";
+  else if (worktree.clean === false) kind = "dirty-worktree";
+  else if (merged) kind = "already-merged";
+  else if ((divergence?.behind ?? 0) > 0) kind = "diverged";
+  else kind = "recoverable-clean";
+
+  const report: Omit<BlockedRunRecoveryReport, "recommendedActions"> = {
+    ...baseReport,
+    kind,
+    branch: { name: input.state.branch, exists, merged },
+    worktree,
+    divergence,
+    commits,
+  };
+  return { ...report, recommendedActions: recommendations(kind, report) };
+}
+
+function branchStatus(report: BlockedRunRecoveryReport): string {
+  const parts = [report.branch.exists ? "exists" : "missing"];
+  if (report.branch.exists)
+    parts.push(report.branch.merged ? "merged" : "unmerged");
+  if (report.divergence) {
+    parts.push(`ahead ${report.divergence.ahead}`);
+    parts.push(`behind ${report.divergence.behind}`);
+  }
+  return parts.join(", ");
+}
+
+function worktreeStatusText(report: BlockedRunRecoveryReport): string {
+  const parts = [report.worktree.registered ? "registered" : "missing"];
+  if (report.worktree.clean === true) parts.push("clean");
+  if (report.worktree.clean === false) parts.push("dirty");
+  return parts.join(", ");
+}
+
+export function formatBlockedRunRecoveryReport(
+  report: BlockedRunRecoveryReport,
+): string {
+  const lines = [
+    `Issue #${report.issueNumber} has a blocked run with preserved workspace state.`,
+    `Run state: ${report.runStatePath}`,
+  ];
+  if (report.blockerReason)
+    lines.push(`Blocked reason: ${report.blockerReason}`);
+  lines.push(
+    `Saved branch: ${report.branch.name ?? "(none)"} (${branchStatus(report)})`,
+    `Saved worktree: ${report.worktree.path ?? "(none)"} (${worktreeStatusText(report)})`,
+  );
+  if (report.worktree.dirtyStatus) {
+    lines.push("Dirty status:", report.worktree.dirtyStatus);
+  }
+  if (report.commits.length > 0) {
+    lines.push("Commits:", ...report.commits.map((commit) => `- ${commit}`));
+  }
+  lines.push(
+    "Recommended actions:",
+    ...report.recommendedActions.map((action) => `- ${action}`),
+  );
+  return lines.join("\n");
+}

--- a/src/cli/commands/run-once/recovery.ts
+++ b/src/cli/commands/run-once/recovery.ts
@@ -216,16 +216,24 @@ function recommendations(
         `After recovery, retry with: patchmill run-once --issue ${report.issueNumber}`,
       ];
     case "missing-worktree-existing-branch":
-      return report.worktree.exists
-        ? [
-            `The saved path ${report.worktree.path ?? "<savedPath>"} exists but is not registered as a git worktree; inspect and move or archive it before reattaching the branch.`,
-            `After preserving that path, reattach with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
-            `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
-          ]
-        : [
-            `Reattach the saved branch with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
-            `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
-          ];
+      if (report.worktree.exists) {
+        return [
+          `The saved path ${report.worktree.path ?? "<savedPath>"} exists but is not registered as a git worktree; inspect and move or archive it before reattaching the branch.`,
+          `After preserving that path, reattach with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
+          `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
+        ];
+      }
+      if (report.worktree.registered) {
+        return [
+          `The saved worktree path ${report.worktree.path ?? "<savedPath>"} is still registered with Git but the path is missing; repair or restore the missing path if local files need preservation.`,
+          "If no local files need preservation at that path, prune or remove the stale worktree registration, then reattach the saved branch.",
+          `After repair, retry with: patchmill run-once --issue ${report.issueNumber}`,
+        ];
+      }
+      return [
+        `Reattach the saved branch with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
+        `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
+      ];
     case "missing-branch-or-worktree":
       return [
         "Archive or remove stale run state only after confirming no saved branch or worktree needs preservation.",

--- a/src/cli/commands/run-once/recovery.ts
+++ b/src/cli/commands/run-once/recovery.ts
@@ -287,7 +287,7 @@ export async function inspectBlockedRunRecovery(input: {
     exists: physicalExists,
     registered,
   };
-  if (registered && input.state.worktreePath) {
+  if (registered && physicalExists && input.state.worktreePath) {
     Object.assign(
       worktree,
       await worktreeStatus({
@@ -325,7 +325,8 @@ export async function inspectBlockedRunRecovery(input: {
 
   let kind: BlockedRunRecoveryKind;
   if (!exists) kind = "missing-branch-or-worktree";
-  else if (!registered) kind = "missing-worktree-existing-branch";
+  else if (!registered || !worktree.exists)
+    kind = "missing-worktree-existing-branch";
   else if (worktree.clean === false) kind = "dirty-worktree";
   else if (merged) kind = "already-merged";
   else if ((divergence?.behind ?? 0) > 0) kind = "diverged";

--- a/src/cli/commands/run-once/recovery.ts
+++ b/src/cli/commands/run-once/recovery.ts
@@ -1,3 +1,4 @@
+import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import type {
   AgentIssueRunState,
@@ -64,6 +65,27 @@ function worktreePaths(stdout: string): string[] {
     .map((line) => resolve(line.slice("worktree ".length).trim()));
 }
 
+async function physicalWorktreeExists(
+  repoRoot: string,
+  worktreePath: string | undefined,
+): Promise<boolean> {
+  if (!worktreePath) return false;
+  try {
+    await stat(resolve(repoRoot, worktreePath));
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error.code === "ENOENT" || error.code === "ENOTDIR")
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function registeredWorktreeExists(
   runner: CommandRunner,
   repoRoot: string,
@@ -121,7 +143,7 @@ async function branchDivergence(input: {
   repoRoot: string;
   branch: string;
   baseRef: string;
-}): Promise<{ ahead: number; behind: number } | undefined> {
+}): Promise<{ ahead: number; behind: number }> {
   const result = await input.runner.run(
     "git",
     [
@@ -134,12 +156,21 @@ async function branchDivergence(input: {
   );
   if (result.code !== 0)
     throw commandFailure(`git rev-list failed for ${input.branch}`, result);
-  const [behindText, aheadText] = result.stdout.trim().split(/\s+/u);
-  const behind = Number.parseInt(behindText ?? "0", 10);
-  const ahead = Number.parseInt(aheadText ?? "0", 10);
-  return Number.isFinite(behind) && Number.isFinite(ahead)
-    ? { ahead, behind }
-    : undefined;
+  const fields = result.stdout.trim().split(/\s+/u);
+  if (fields.length !== 2) {
+    throw new Error(
+      `git rev-list returned unparseable divergence for ${input.branch}: ${result.stdout.trim() || "(empty output)"}`,
+    );
+  }
+  const [behindText, aheadText] = fields;
+  if (!/^\d+$/u.test(behindText) || !/^\d+$/u.test(aheadText)) {
+    throw new Error(
+      `git rev-list returned unparseable divergence for ${input.branch}: ${result.stdout.trim()}`,
+    );
+  }
+  const behind = Number.parseInt(behindText, 10);
+  const ahead = Number.parseInt(aheadText, 10);
+  return { ahead, behind };
 }
 
 async function unmergedCommitLines(input: {
@@ -185,10 +216,16 @@ function recommendations(
         `After recovery, retry with: patchmill run-once --issue ${report.issueNumber}`,
       ];
     case "missing-worktree-existing-branch":
-      return [
-        `Reattach the saved branch with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
-        `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
-      ];
+      return report.worktree.exists
+        ? [
+            `The saved path ${report.worktree.path ?? "<savedPath>"} exists but is not registered as a git worktree; inspect and move or archive it before reattaching the branch.`,
+            `After preserving that path, reattach with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
+            `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
+          ]
+        : [
+            `Reattach the saved branch with: git worktree add ${report.worktree.path ?? "<savedPath>"} ${report.branch.name ?? "<branch>"}`,
+            `Then retry with: patchmill run-once --issue ${report.issueNumber}`,
+          ];
     case "missing-branch-or-worktree":
       return [
         "Archive or remove stale run state only after confirming no saved branch or worktree needs preservation.",
@@ -237,12 +274,19 @@ export async function inspectBlockedRunRecovery(input: {
     input.repoRoot,
     input.state.branch,
   );
-  const registered = await registeredWorktreeExists(
-    input.runner,
-    input.repoRoot,
-    input.state.worktreePath,
-  );
-  const worktree = { ...baseReport.worktree, exists: registered, registered };
+  const [physicalExists, registered] = await Promise.all([
+    physicalWorktreeExists(input.repoRoot, input.state.worktreePath),
+    registeredWorktreeExists(
+      input.runner,
+      input.repoRoot,
+      input.state.worktreePath,
+    ),
+  ]);
+  const worktree = {
+    ...baseReport.worktree,
+    exists: physicalExists,
+    registered,
+  };
   if (registered && input.state.worktreePath) {
     Object.assign(
       worktree,
@@ -310,7 +354,8 @@ function branchStatus(report: BlockedRunRecoveryReport): string {
 }
 
 function worktreeStatusText(report: BlockedRunRecoveryReport): string {
-  const parts = [report.worktree.registered ? "registered" : "missing"];
+  const parts = [report.worktree.exists ? "path exists" : "path missing"];
+  parts.push(report.worktree.registered ? "registered" : "not registered");
   if (report.worktree.clean === true) parts.push("clean");
   if (report.worktree.clean === false) parts.push("dirty");
   return parts.join(", ");

--- a/src/cli/commands/run-once/recovery.ts
+++ b/src/cli/commands/run-once/recovery.ts
@@ -1,5 +1,6 @@
 import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
+import { blockingStatusOutput } from "./git.ts";
 import type {
   AgentIssueRunState,
   CommandResult,
@@ -104,6 +105,7 @@ async function worktreeStatus(input: {
   runner: CommandRunner;
   repoRoot: string;
   worktreePath: string;
+  ignoredPaths: string[];
 }): Promise<{ clean: boolean; dirtyStatus?: string }> {
   const result = await input.runner.run(
     "git",
@@ -118,7 +120,11 @@ async function worktreeStatus(input: {
   );
   if (result.code !== 0)
     throw commandFailure(`git status failed for ${input.worktreePath}`, result);
-  const dirtyStatus = result.stdout.trim();
+  const dirtyStatus = blockingStatusOutput(
+    result.stdout,
+    resolve(input.repoRoot, input.worktreePath),
+    input.ignoredPaths,
+  ).trim();
   return dirtyStatus === "" ? { clean: true } : { clean: false, dirtyStatus };
 }
 
@@ -249,6 +255,7 @@ export async function inspectBlockedRunRecovery(input: {
   runStatePath: string;
   state: AgentIssueRunState;
   baseRef: string;
+  ignoredPaths?: string[];
 }): Promise<BlockedRunRecoveryReport> {
   const baseReport = {
     runStatePath: input.runStatePath,
@@ -302,6 +309,7 @@ export async function inspectBlockedRunRecovery(input: {
         runner: input.runner,
         repoRoot: input.repoRoot,
         worktreePath: input.state.worktreePath,
+        ignoredPaths: input.ignoredPaths ?? [],
       }),
     );
   }

--- a/src/cli/commands/run-once/run-state.ts
+++ b/src/cli/commands/run-once/run-state.ts
@@ -170,7 +170,9 @@ function mergeRunState(
     failureCommentKeys,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
-    lastError: update.lastError ?? existing?.lastError,
+    lastError: update.clearLastError
+      ? undefined
+      : (update.lastError ?? existing?.lastError),
   };
 
   if (checkpoints === undefined) {
@@ -217,6 +219,9 @@ function mergeRunState(
   }
   if (failureCommentKeys === undefined) {
     delete next.failureCommentKeys;
+  }
+  if (next.lastError === undefined) {
+    delete next.lastError;
   }
 
   const timestampField = STATUS_TIMESTAMPS[update.status];

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -143,6 +143,7 @@ export type AgentIssueRunStateUpdate = {
   handoffCommentPosted?: boolean;
   failureCommentKeys?: string[];
   lastError?: string;
+  clearLastError?: boolean;
 };
 
 export type AgentIssueImplementationResumeContext = {


### PR DESCRIPTION
## Summary
- add blocked-run recovery inspection and formatted operator guidance for saved branch/worktree state
- let run-once resume only clean, unmerged, non-diverged blocked workspaces while reporting unsafe states before mutation
- preserve safeguards, dry-run behavior, labels, metadata, and run-state semantics with focused regression coverage

## Validation
- node --test src/cli/commands/run-once/recovery.test.ts
- node --test src/cli/commands/run-once/pipeline.test.ts --test-name-pattern "blocked.*recovery|recovery.*blocked|resumes clean blocked|stale finished"
- node --test src/cli/commands/run-once/run-state.test.ts --test-name-pattern "isResumableRunState"
- npm run test:run-once
- npm run lint
- npm test

## Reviews
- Final Codex full-worktree review: passed after fixes
- Final thermo-nuclear full-worktree review: passed after fixes