### PR TITLE
fix: improve init git hygiene

### DIFF
--- a/docs/plans/2026-06-23-issue-39-improve-patchmill-init-git-hygiene.md
+++ b/docs/plans/2026-06-23-issue-39-improve-patchmill-init-git-hygiene.md
@@ -1,0 +1,694 @@
+# Improve Patchmill Init Git Hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `patchmill init` consistently protects `.worktrees/` and
+`.pi/todos/` and creates best-effort commits for interactive tracked git hygiene
+choices.
+
+**Architecture:** Keep init orchestration in `src/cli/commands/init/main.ts`
+unchanged and concentrate git ignore/exclude mutation, staging, commit behavior,
+and warning text in `src/cli/commands/init/git-policy.ts`. Add focused tests
+around `applyInitGitPolicy` first, then update `runInit` integration tests for
+the new committed-output flow.
+
+**Tech Stack:** TypeScript ESM, Node.js `node:test`, injected `CommandRunner`,
+npm scripts from `package.json`.
+
+---
+
+## Context and Constraints
+
+- No repository-root `AGENTS.md` was present when this plan was written
+  (`find /home/roche/projects/patchmill -maxdepth 4 -name AGENTS.md -print` only
+  found one under `.worktrees/patchmill-auth/`, which is outside this worktree).
+  Use the validation commands below from `package.json`.
+- Approved spec:
+  `docs/specs/2026-06-23-issue-39-improve-patchmill-init-git-hygiene-design.md`.
+- Keep issue scope limited to `patchmill init` git hygiene; do not change prompt
+  choices, Pi setup, label setup, or non-interactive default policy.
+- Do not commit `.pi/todos` or any `.worktrees` contents; those are local
+  operator state.
+
+## File Structure
+
+- Modify: `src/cli/commands/init/git-policy.ts`
+  - Extend existing entry constants.
+  - Add a small best-effort commit helper near `applyInitGitPolicy`.
+  - Route `add` and `ignore` policies through the helper while keeping `exclude`
+    local-only.
+  - Keep `normalEntry`, `hasEntry`, `appendEntries`, `safeRelativePath`, and
+    `existingPaths` as the shared idempotent/safety layer.
+- Modify: `src/cli/commands/init/git-policy.test.ts`
+  - Update direct policy unit tests for new entries, commit call sequences,
+    duplicate variants, no-op behavior, and non-fatal warnings.
+- Modify: `src/cli/commands/init/main-git-policy.test.ts`
+  - Update init-level command call expectations and output assertions from
+    staged-only wording to committed/no-op wording.
+- Expected no logic changes: `src/cli/commands/init/main.ts`
+  - It should continue to call `selectInitGitPolicy` and `applyInitGitPolicy`
+    and print the returned message.
+
+## Validation Commands
+
+Run targeted tests after each task that changes behavior:
+
+```bash
+node --test src/cli/commands/init/git-policy.test.ts src/cli/commands/init/main-git-policy.test.ts
+```
+
+Run the full repository suite before the final implementation commit:
+
+```bash
+npm test
+```
+
+Optional style checks before opening a PR:
+
+```bash
+npm run lint
+```
+
+---
+
+### Task 1: Extend policy tests for new ignore entries and committed add flow
+
+**Files:**
+
+- Modify: `src/cli/commands/init/git-policy.test.ts`
+
+- [ ] **Step 1: Update the recording runner if a test needs per-command
+      failures**
+
+  Add a helper alongside the existing `recordingRunner` only if later assertions
+  need command-specific exit codes:
+
+  ```ts
+  function scriptedRunner(
+    calls: string[][] = [],
+    results: Array<{ code: number; stdout?: string; stderr?: string }> = [],
+  ): CommandRunner {
+    return {
+      async run(command, args, options) {
+        calls.push([command, ...args, `cwd=${options?.cwd ?? ""}`]);
+        const result = results.shift() ?? { code: 0, stdout: "", stderr: "" };
+        return {
+          code: result.code,
+          stdout: result.stdout ?? "",
+          stderr: result.stderr ?? "",
+        };
+      },
+    };
+  }
+  ```
+
+- [ ] **Step 2: Change the `add` policy test to expect local artifact entries
+      and a commit**
+
+  Update
+  `applyInitGitPolicy add stages config, skills, and runtime ignore entries` so
+  `.gitignore` is exactly:
+
+  ```text
+  .patchmill/pi-agent
+  .patchmill/runs
+  .patchmill/triage-runs
+  .worktrees/
+  .pi/todos/
+  ```
+
+  Assert calls in this order:
+
+  ```ts
+  assert.deepEqual(calls, [
+    [
+      "git",
+      "add",
+      "-f",
+      "patchmill.config.json",
+      ".patchmill/skills",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      ".patchmill/skills",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+  ]);
+  assert.match(
+    result.message,
+    /Patchmill config, skills, and local artifact ignore rules were committed/u,
+  );
+  ```
+
+- [ ] **Step 3: Update missing-skill and custom-skill `add` tests to include
+      commit calls**
+
+  For `applyInitGitPolicy add omits missing skills directory`, assert the call
+  sequence stages and commits only `patchmill.config.json` and `.gitignore`:
+
+  ```ts
+  assert.deepEqual(calls, [
+    [
+      "git",
+      "add",
+      "-f",
+      "patchmill.config.json",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+  ]);
+  ```
+
+  For `applyInitGitPolicy add stages provided repo-local skill roots`, assert
+  the commit path list is `patchmill.config.json`, `custom-skills`,
+  `.gitignore`.
+
+- [ ] **Step 4: Add a focused assertion that force-staging still applies when
+      `.patchmill/` is ignored**
+
+  Keep `applyInitGitPolicy add force-stages skills when .patchmill is ignored`,
+  but extend it so `calls[0]` begins with `git add -f` and `calls[1]` begins
+  with `git commit -m chore: initialize Patchmill --`. The commit call does not
+  use `-f`; only `git add` does.
+
+- [ ] **Step 5: Run targeted tests and verify they fail for the expected
+      reason**
+
+  ```bash
+  node --test src/cli/commands/init/git-policy.test.ts
+  ```
+
+  Expected before implementation: failures showing missing `.worktrees/` /
+  `.pi/todos/`, missing `git commit` calls, and staged-only output.
+
+---
+
+### Task 2: Add direct tests for ignore, exclude, duplicate variants, no-op, and warnings
+
+**Files:**
+
+- Modify: `src/cli/commands/init/git-policy.test.ts`
+
+- [ ] **Step 1: Update `ignore` policy test to expect all four entries and a
+      `.gitignore`-only commit**
+
+  Change
+  `applyInitGitPolicy ignore writes patchmill.config.json and .patchmill to .gitignore`
+  to expect:
+
+  ```text
+  patchmill.config.json
+  .patchmill/
+  .worktrees/
+  .pi/todos/
+  ```
+
+  Capture `calls` and assert:
+
+  ```ts
+  assert.deepEqual(calls, [
+    ["git", "add", ".gitignore", `cwd=${repoRoot}`],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill git hygiene",
+      "--",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+  ]);
+  assert.match(result.message, /.gitignore git hygiene rules were committed/u);
+  ```
+
+- [ ] **Step 2: Update `exclude` policy test to expect all four entries and no
+      git commands**
+
+  Capture `calls` and assert the exclude file contains the same four entries as
+  the `ignore` policy, then assert:
+
+  ```ts
+  assert.deepEqual(calls, []);
+  assert.match(result.message, /Added Patchmill files to .git\/info\/exclude/u);
+  ```
+
+- [ ] **Step 3: Add an `ignore` no-op test**
+
+  Add a new test that prewrites `.gitignore` with all required entries and
+  verifies no command runner calls happen:
+
+  ```ts
+  test("applyInitGitPolicy ignore skips commit when entries already exist", async () => {
+    const repoRoot = await tempRepo();
+    const calls: string[][] = [];
+    await writeFile(
+      join(repoRoot, ".gitignore"),
+      "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
+    );
+
+    const result = await applyInitGitPolicy({
+      repoRoot,
+      policy: "ignore",
+      runner: recordingRunner(calls),
+    });
+
+    assert.deepEqual(calls, []);
+    assert.match(result.message, /No git hygiene commit was needed/u);
+  });
+  ```
+
+- [ ] **Step 4: Extend duplicate tests for slash and root-anchored variants**
+
+  Update or add tests so these existing lines are treated as duplicates:
+
+  ```text
+  /.worktrees/
+  .worktrees
+  /.pi/todos/
+  .pi/todos
+  ```
+
+  Verify that `appendEntries` does not append `.worktrees/` or `.pi/todos/`
+  again for `add`, `ignore`, or `exclude` policy paths.
+
+- [ ] **Step 5: Add staging and commit failure tests**
+
+  Add a test where `scriptedRunner` returns
+  `{ code: 1, stderr: "index locked" }` for `git add`. Assert that the result
+  message contains `Warning`, `git add failed`, `index locked`, and that there
+  is no `git commit` call.
+
+  Add a second test where `git add` succeeds and `git commit` returns
+  `{ code: 1, stderr: "author identity unknown" }`. Assert that the result
+  message contains `Warning`, `git commit failed`, and
+  `author identity unknown`.
+
+- [ ] **Step 6: Run targeted tests and verify new failures identify missing
+      implementation**
+
+  ```bash
+  node --test src/cli/commands/init/git-policy.test.ts
+  ```
+
+  Expected before implementation: failures for new entries, commit behavior,
+  no-op message, duplicate handling, and warning text.
+
+---
+
+### Task 3: Implement entry constants and the best-effort commit helper
+
+**Files:**
+
+- Modify: `src/cli/commands/init/git-policy.ts`
+
+- [ ] **Step 1: Extend existing constants**
+
+  Change constants to:
+
+  ```ts
+  export const PATCHMILL_GIT_IGNORE_ENTRIES = [
+    "patchmill.config.json",
+    ".patchmill/",
+    ".worktrees/",
+    ".pi/todos/",
+  ] as const;
+
+  export const PATCHMILL_ADD_TO_GIT_IGNORE_ENTRIES = [
+    ".patchmill/pi-agent",
+    ".patchmill/runs",
+    ".patchmill/triage-runs",
+    ".worktrees/",
+    ".pi/todos/",
+  ] as const;
+  ```
+
+- [ ] **Step 2: Add commit result types near helper functions**
+
+  Add near `existingPaths`:
+
+  ```ts
+  type GitCommitOutcome =
+    | { status: "committed"; paths: string[] }
+    | { status: "nothing"; paths: string[] }
+    | { status: "missing"; paths: string[] }
+    | { status: "stage-warning"; warning: string; paths: string[] }
+    | { status: "commit-warning"; warning: string; paths: string[] };
+  ```
+
+- [ ] **Step 3: Add helper functions for git output and no-op detection**
+
+  Add these focused helpers:
+
+  ```ts
+  function gitOutput(result: { stdout: string; stderr: string }): string {
+    return result.stderr || result.stdout || "unknown error";
+  }
+
+  function isNothingToCommit(output: string): boolean {
+    return /nothing to commit|no changes added to commit|nothing added to commit|no changes/u.test(
+      output.toLowerCase(),
+    );
+  }
+  ```
+
+- [ ] **Step 4: Add the path-limited commit helper**
+
+  Add this helper near `applyInitGitPolicy`:
+
+  ```ts
+  async function commitInitGitHygiene(options: {
+    repoRoot: string;
+    runner: CommandRunner;
+    paths: readonly string[];
+    message: string;
+    forceAdd?: boolean;
+  }): Promise<GitCommitOutcome> {
+    const paths = await existingPaths(options.repoRoot, options.paths);
+    if (paths.length === 0) return { status: "missing", paths };
+
+    const addArgs = options.forceAdd
+      ? ["add", "-f", ...paths]
+      : ["add", ...paths];
+    const addResult = await options.runner.run("git", addArgs, {
+      cwd: options.repoRoot,
+    });
+    if (addResult.code !== 0) {
+      return {
+        status: "stage-warning",
+        warning: `Warning: git add failed while preparing init git hygiene commit; continuing without committing. ${gitOutput(addResult)}`,
+        paths,
+      };
+    }
+
+    const commitResult = await options.runner.run(
+      "git",
+      ["commit", "-m", options.message, "--", ...paths],
+      { cwd: options.repoRoot },
+    );
+    if (commitResult.code === 0) return { status: "committed", paths };
+
+    const output = gitOutput(commitResult);
+    if (isNothingToCommit(output)) return { status: "nothing", paths };
+    return {
+      status: "commit-warning",
+      warning: `Warning: git commit failed while finalizing init git hygiene; continuing. ${output}`,
+      paths,
+    };
+  }
+  ```
+
+- [ ] **Step 5: Run policy tests and confirm only routing/message failures
+      remain**
+
+  ```bash
+  node --test src/cli/commands/init/git-policy.test.ts
+  ```
+
+---
+
+### Task 4: Route `add` and `ignore` policies through the commit helper
+
+**Files:**
+
+- Modify: `src/cli/commands/init/git-policy.ts`
+
+- [ ] **Step 1: Replace the `add` branch staging-only logic**
+
+  In the `options.policy === "add"` branch, after appending runtime entries and
+  computing `skillRoots`, replace direct `git add` logic with:
+
+  ```ts
+  const commit = await commitInitGitHygiene({
+    repoRoot: options.repoRoot,
+    runner: options.runner,
+    paths: ["patchmill.config.json", ...skillRoots, ".gitignore"],
+    message: "chore: initialize Patchmill",
+    forceAdd: true,
+  });
+  ```
+
+- [ ] **Step 2: Format the `add` result message**
+
+  Use the commit outcome to produce these public messages:
+
+  ```ts
+  const stagedSkills = commit.paths.some((path) => skillRoots.includes(path));
+  const addSummary =
+    commit.status === "committed"
+      ? stagedSkills
+        ? "Patchmill config, skills, and local artifact ignore rules were committed."
+        : "Patchmill config and local artifact ignore rules were committed."
+      : commit.status === "nothing"
+        ? "No Patchmill git hygiene commit was needed."
+        : commit.status === "missing"
+          ? "No Patchmill files were available to commit."
+          : commit.warning;
+  ```
+
+  Keep the existing ignore-entry message, updated by constants, so users can see
+  whether entries were added or already present.
+
+- [ ] **Step 3: Replace the `ignore` branch no-stage logic**
+
+  In the `options.policy === "ignore"` branch, call the helper only when
+  `added.length > 0`:
+
+  ```ts
+  if (added.length === 0) {
+    return {
+      policy: options.policy,
+      message:
+        "No git hygiene commit was needed; Patchmill files were already listed in .gitignore.",
+    };
+  }
+
+  const commit = await commitInitGitHygiene({
+    repoRoot: options.repoRoot,
+    runner: options.runner,
+    paths: [".gitignore"],
+    message: "chore: initialize Patchmill git hygiene",
+  });
+  ```
+
+- [ ] **Step 4: Format the `ignore` result message**
+
+  Return one of these messages:
+
+  ```ts
+  const commitMessage =
+    commit.status === "committed"
+      ? ".gitignore git hygiene rules were committed."
+      : commit.status === "nothing"
+        ? "No git hygiene commit was needed."
+        : commit.status === "missing"
+          ? "Warning: .gitignore was not available to commit after init updated git hygiene rules."
+          : commit.warning;
+  return {
+    policy: options.policy,
+    message: [
+      commitMessage,
+      `Added Patchmill files to .gitignore:\n${formatEntries(added)}`,
+    ].join("\n"),
+  };
+  ```
+
+- [ ] **Step 5: Verify `exclude` remains local-only**
+
+  Do not call `commitInitGitHygiene` from the `exclude` branch. Confirm
+  `manualExcludeWarning` now includes `.worktrees/` and `.pi/todos/`
+  automatically through `PATCHMILL_GIT_IGNORE_ENTRIES`.
+
+- [ ] **Step 6: Run direct policy tests**
+
+  ```bash
+  node --test src/cli/commands/init/git-policy.test.ts
+  ```
+
+  Expected: all tests in `git-policy.test.ts` pass.
+
+---
+
+### Task 5: Update init-level git policy tests and verify non-fatal flow
+
+**Files:**
+
+- Modify: `src/cli/commands/init/main-git-policy.test.ts`
+- Read-only check: `src/cli/commands/init/main.ts`
+
+- [ ] **Step 1: Update add-to-git init tests to expect commit calls**
+
+  For `interactive init add-to-git stages config, skills, and gitignore`, rename
+  the test to mention commits and assert both `git add -f` and `git commit`
+  calls. Update `.gitignore` to include:
+
+  ```text
+  .patchmill/pi-agent
+  .patchmill/runs
+  .patchmill/triage-runs
+  .worktrees/
+  .pi/todos/
+  ```
+
+  Assert output matches:
+
+  ```ts
+  assert.match(
+    output,
+    /Patchmill config, skills, and local artifact ignore rules were committed/u,
+  );
+  ```
+
+- [ ] **Step 2: Update no-skills and path-skills init tests**
+
+  In the no-skills test, expect commit paths `patchmill.config.json` and
+  `.gitignore`, and output
+  `Patchmill config and local artifact ignore rules were committed`.
+
+  In the path-skills test, expect commit paths `patchmill.config.json`,
+  `custom-skills`, and `.gitignore`, and output
+  `Patchmill config, skills, and local artifact ignore rules were committed`.
+
+- [ ] **Step 3: Update git-ignore init test**
+
+  Rename it to mention committing `.gitignore`. Capture `calls`, assert
+  `git add .gitignore` and
+  `git commit -m chore: initialize Patchmill git hygiene -- .gitignore`, and
+  update `.gitignore` content to:
+
+  ```text
+  patchmill.config.json
+  .patchmill/
+  .worktrees/
+  .pi/todos/
+  ```
+
+  Assert output matches `.gitignore git hygiene rules were committed`.
+
+- [ ] **Step 4: Update git-exclude and non-interactive tests**
+
+  Update expected exclude file content in both tests to include `.worktrees/`
+  and `.pi/todos/`. Assert no command runner calls are made for the `exclude`
+  policy if the test already captures calls; otherwise add a calls array for one
+  exclude case.
+
+- [ ] **Step 5: Add an init-level non-fatal commit failure test**
+
+  Add a runner that returns success for `git add` and failure for `git commit`:
+
+  ```ts
+  const failingCommitRunner: CommandRunner = {
+    async run(command, args, options) {
+      calls.push([command, ...args, `cwd=${options?.cwd ?? ""}`]);
+      if (args[0] === "commit") {
+        return { code: 1, stdout: "", stderr: "author identity unknown" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  };
+  ```
+
+  Run `runInit` with prompt answer `1`. Assert exit code is still the Pi setup
+  result from the test fixture, output includes `Warning: git commit failed`,
+  output includes `author identity unknown`, and output still includes
+  `Label setup skipped.` plus the Pi setup message.
+
+- [ ] **Step 6: Run init git policy tests**
+
+  ```bash
+  node --test src/cli/commands/init/main-git-policy.test.ts
+  ```
+
+  Expected: all tests in `main-git-policy.test.ts` pass without changing
+  `main.ts` orchestration.
+
+---
+
+### Task 6: Final validation and implementation commit
+
+**Files:**
+
+- Modify: `src/cli/commands/init/git-policy.ts`
+- Modify: `src/cli/commands/init/git-policy.test.ts`
+- Modify: `src/cli/commands/init/main-git-policy.test.ts`
+
+- [ ] **Step 1: Run targeted tests**
+
+  ```bash
+  node --test src/cli/commands/init/git-policy.test.ts src/cli/commands/init/main-git-policy.test.ts
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 2: Run the full test suite**
+
+  ```bash
+  npm test
+  ```
+
+  Expected: all repository tests pass.
+
+- [ ] **Step 3: Run lint if time permits before handoff**
+
+  ```bash
+  npm run lint
+  ```
+
+  Expected: format, TypeScript lint, and markdown lint pass. If markdown lint
+  flags this plan or another unrelated file, fix only files in this issue scope
+  unless the unrelated failure blocks CI.
+
+- [ ] **Step 4: Review the final diff for scope**
+
+  ```bash
+  git diff -- src/cli/commands/init/git-policy.ts src/cli/commands/init/git-policy.test.ts src/cli/commands/init/main-git-policy.test.ts
+  git status --short
+  ```
+
+  Expected: only the three implementation/test files are modified for the
+  implementation. `.pi/todos` and `.worktrees` must not be staged.
+
+- [ ] **Step 5: Commit the implementation**
+
+  ```bash
+  git add src/cli/commands/init/git-policy.ts src/cli/commands/init/git-policy.test.ts src/cli/commands/init/main-git-policy.test.ts
+  git commit -m "fix: improve init git hygiene"
+  ```
+
+  Expected: a Conventional Commit containing only this issue's implementation
+  and tests.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: tasks cover new `.worktrees/` and `.pi/todos/` constants,
+  duplicate normalization via existing helpers, `add` commit, `ignore`
+  commit/no-op, `exclude` local-only behavior, non-fatal staging/commit
+  warnings, injected `CommandRunner`, and init-level output changes.
+- Placeholder scan: the plan contains no `TBD`, no deferred requirements, and
+  every code-oriented step includes exact snippets or commands.
+- Type consistency: helper snippets use the existing `CommandRunner`,
+  `CommandResult` shape (`code`, `stdout`, `stderr`), repo-relative path
+  filtering through `existingPaths`, and current `InitGitPolicyResult` message
+  contract.

--- a/docs/specs/2026-06-23-issue-39-improve-patchmill-init-git-hygiene-design.md
+++ b/docs/specs/2026-06-23-issue-39-improve-patchmill-init-git-hygiene-design.md
@@ -1,0 +1,225 @@
+# Improve Patchmill Init Git Hygiene Design
+
+## Goal
+
+Make `patchmill init` consistently protect local implementation artifacts and
+finish interactive git-hygiene setup with an appropriate best-effort commit.
+
+## Current behavior
+
+- `src/cli/commands/init/git-policy.ts` owns the init git policy prompt and
+  policy application.
+- `PATCHMILL_GIT_IGNORE_ENTRIES` is used for the `ignore` and `exclude` policy
+  entry lists and currently contains only `patchmill.config.json` and
+  `.patchmill/`.
+- `PATCHMILL_ADD_TO_GIT_IGNORE_ENTRIES` is used by the `add` policy to keep
+  local Patchmill runtime state out of tracked config and currently contains
+  `.patchmill/pi-agent`, `.patchmill/runs`, and `.patchmill/triage-runs`.
+- The `add` policy appends runtime entries to `.gitignore`, stages existing
+  `patchmill.config.json`, skill roots, and `.gitignore` with `git add -f`, and
+  reports staged files. It does not commit.
+- The `ignore` policy appends entries to `.gitignore` and does not stage or
+  commit `.gitignore`.
+- The `exclude` policy appends entries to `.git/info/exclude` and reports
+  non-fatal warnings if git metadata cannot be resolved or written.
+- `src/cli/commands/init/main.ts` orchestrates config writing, skill install,
+  git policy application, label setup, and Pi setup; git mutation details are
+  already isolated in `git-policy.ts`.
+
+## Desired behavior
+
+### Shared local artifact protection
+
+`patchmill init` must treat these directories as local implementation artifacts
+that should never become project configuration:
+
+- `.worktrees/`
+- `.pi/todos/`
+
+The artifact entries must be appended idempotently and recognized as duplicates
+when users already have slash or root-anchored variants such as `.worktrees`,
+`.worktrees/`, `/.worktrees/`, `.pi/todos`, or `/.pi/todos/`.
+
+### Add config and skills to git
+
+When the selected policy is `add`:
+
+1. Append these entries to `.gitignore` if missing:
+   - `.patchmill/pi-agent`
+   - `.patchmill/runs`
+   - `.patchmill/triage-runs`
+   - `.worktrees/`
+   - `.pi/todos/`
+2. Stage only existing repo-relative Patchmill config, configured skill roots,
+   and `.gitignore`.
+3. Preserve existing force-add behavior for skill roots that may live below
+   ignored parents.
+4. If staging succeeds and there is something to commit, create a commit with a
+   Conventional Commit message such as:
+
+   ```text
+   chore: initialize Patchmill
+   ```
+
+5. Report that Patchmill config, skills, and local artifact ignore rules were
+   committed when the commit succeeds.
+6. If staging or committing fails, complete init and include an actionable
+   warning containing git stdout/stderr.
+
+### Add Patchmill files to `.gitignore`
+
+When the selected policy is `ignore`:
+
+1. Append these entries to `.gitignore` if missing:
+   - `patchmill.config.json`
+   - `.patchmill/`
+   - `.worktrees/`
+   - `.pi/todos/`
+2. If `.gitignore` changed, stage and commit `.gitignore` only.
+3. Do not stage or commit `patchmill.config.json` or `.patchmill/`, because the
+   user selected local-only Patchmill config.
+4. If all required `.gitignore` entries already existed, report that no git
+   hygiene commit was needed and do not run `git add` or `git commit`.
+5. Treat staging or commit failures as non-fatal warnings.
+
+### Add Patchmill files to `.git/info/exclude`
+
+When the selected policy is `exclude`:
+
+1. Append these entries to `.git/info/exclude` if missing:
+   - `patchmill.config.json`
+   - `.patchmill/`
+   - `.worktrees/`
+   - `.pi/todos/`
+2. Never stage or commit files for this policy.
+3. Keep missing or unwritable git metadata non-fatal and include the full manual
+   entry list in warning output.
+
+## Proposed design
+
+### Entry constants
+
+Extend the existing constants in `src/cli/commands/init/git-policy.ts` rather
+than adding a parallel policy path:
+
+- Add `.worktrees/` and `.pi/todos/` to `PATCHMILL_GIT_IGNORE_ENTRIES` so both
+  `ignore` and `exclude` policies share the same complete local-only list.
+- Add `.worktrees/` and `.pi/todos/` to `PATCHMILL_ADD_TO_GIT_IGNORE_ENTRIES` so
+  the `add` policy tracks config and skills while ignoring local implementation
+  state.
+
+The current `normalEntry` and `hasEntry` helpers already strip a leading slash
+and trailing slashes. Keep using them for idempotent append behavior.
+
+### Commit helper
+
+Add a focused helper near `applyInitGitPolicy` in `git-policy.ts` so `main.ts`
+remains orchestration-only. The helper should:
+
+- accept `repoRoot`, injected `CommandRunner`, exact repo-relative paths to
+  commit, commit message, a force-add flag, and text used for result messages;
+- filter paths through the existing safe relative path and existence checks
+  before staging;
+- run `git add` with only those paths, using `-f` when the `add` policy stages
+  skill roots;
+- run a path-limited commit flow for the same paths, for example:
+
+  ```bash
+  git commit -m "chore: initialize Patchmill" -- <paths...>
+  ```
+
+- treat git output indicating nothing to commit/no changes as a non-error;
+- return a small result object or message fragment that distinguishes committed,
+  no-op, staging warning, and commit warning outcomes;
+- include git stderr or stdout in warnings so users can act on failures.
+
+For the `ignore` policy, call this helper only when `appendEntries` reports that
+`.gitignore` changed, and pass only `.gitignore` as the commit path. For the
+`add` policy, call it after appending runtime artifact entries and pass existing
+`patchmill.config.json`, skill roots, and `.gitignore`.
+
+### Init output
+
+Keep the public prompt choices unchanged. Update success text from staged-only
+language to committed-language:
+
+- `add`: Patchmill config, skills, and local artifact ignore rules were
+  committed.
+- `ignore`: `.gitignore` git hygiene rules were committed, or no git hygiene
+  commit was needed when entries already existed.
+- `exclude`: local-only exclude messages remain unchanged apart from the larger
+  entry list.
+
+Warning text should make clear that init is continuing despite git staging or
+commit failures. Label setup and Pi setup must still run after git warnings.
+
+## Affected components
+
+- `src/cli/commands/init/git-policy.ts`
+  - Extend policy entry constants.
+  - Add the best-effort, path-limited git commit helper.
+  - Update `add`, `ignore`, and `exclude` policy messages.
+  - Keep append and duplicate normalization behavior centralized.
+- `src/cli/commands/init/git-policy.test.ts`
+  - Update direct policy tests for new entries, staging, commits, no-op commit
+    behavior, duplicate variants, and non-fatal commit failures.
+- `src/cli/commands/init/main-git-policy.test.ts`
+  - Update integration-style init output and command-call expectations from
+    staged-only to committed behavior.
+- `src/cli/commands/init/main.ts`
+  - No git logic changes expected beyond consuming the updated policy result
+    message if necessary.
+
+## Verification strategy
+
+Add focused automated tests covering:
+
+- `add` appends `.worktrees/` and `.pi/todos/` to `.gitignore`, force-stages
+  config, skills, and `.gitignore`, then commits those paths.
+- `add` still force-stages skill roots when `.patchmill/` is ignored.
+- `ignore` appends `patchmill.config.json`, `.patchmill/`, `.worktrees/`, and
+  `.pi/todos/` to `.gitignore`, then stages and commits `.gitignore` only.
+- `ignore` does not call `git add` or `git commit` when all required entries
+  already exist.
+- `exclude` appends all four local-only entries to `.git/info/exclude` and never
+  calls `git add` or `git commit`.
+- `.worktrees`, `.worktrees/`, `/.worktrees/`, `.pi/todos`, and `/.pi/todos/`
+  are treated as duplicate entries.
+- Staging and commit failures are reported as warnings and `runInit` still
+  returns the Pi setup result rather than failing because of git hygiene.
+- Existing `main` git policy tests assert committed output and the expected
+  `CommandRunner` call sequence.
+
+Run targeted tests:
+
+```bash
+node --test src/cli/commands/init/git-policy.test.ts src/cli/commands/init/main-git-policy.test.ts
+```
+
+Run the full suite before merge:
+
+```bash
+npm test
+```
+
+## Acceptance criteria
+
+- `.worktrees/` and `.pi/todos/` are protected for `add`, `ignore`, and
+  `exclude` policies.
+- Interactive `add` creates a best-effort commit for Patchmill config, skills,
+  and `.gitignore` changes.
+- Interactive `ignore` creates a best-effort commit for `.gitignore` only when
+  init changed `.gitignore`.
+- `exclude`, non-interactive default behavior, and `--yes` default behavior stay
+  local-only and do not commit.
+- Git staging/commit failures produce warnings but do not prevent label setup,
+  Pi setup, or init completion.
+- Tests verify command invocations through the injected `CommandRunner`.
+
+## Out of scope
+
+- Changing init prompt choices or adding a commit confirmation prompt.
+- Committing anything for the `exclude` policy.
+- Committing local Patchmill config for users who choose the `ignore` policy.
+- Managing, deleting, or migrating existing `.worktrees/` or `.pi/todos/`
+  contents.

--- a/src/cli/commands/init/git-policy.test.ts
+++ b/src/cli/commands/init/git-policy.test.ts
@@ -23,6 +23,23 @@ function recordingRunner(calls: string[][] = []): CommandRunner {
   };
 }
 
+function scriptedRunner(
+  calls: string[][] = [],
+  results: Array<{ code: number; stdout?: string; stderr?: string }> = [],
+): CommandRunner {
+  return {
+    async run(command, args, options) {
+      calls.push([command, ...args, `cwd=${options?.cwd ?? ""}`]);
+      const result = results.shift() ?? { code: 0, stdout: "", stderr: "" };
+      return {
+        code: result.code,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+      };
+    },
+  };
+}
+
 test("selectInitGitPolicy defaults to git-exclude for non-interactive runs", async () => {
   assert.equal(
     await selectInitGitPolicy({ isInteractive: false, assumeYes: false }),
@@ -75,7 +92,7 @@ test("applyInitGitPolicy add stages config, skills, and runtime ignore entries",
 
   assert.equal(
     await readFile(join(repoRoot, ".gitignore"), "utf8"),
-    ".patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n",
+    ".patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n.worktrees/\n.pi/todos/\n",
   );
   assert.deepEqual(calls, [
     [
@@ -87,8 +104,22 @@ test("applyInitGitPolicy add stages config, skills, and runtime ignore entries",
       ".gitignore",
       `cwd=${repoRoot}`,
     ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      ".patchmill/skills",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
   ]);
-  assert.match(result.message, /Added Patchmill config and skills to git/u);
+  assert.match(
+    result.message,
+    /Patchmill config, skills, and local artifact ignore rules were committed/u,
+  );
 });
 
 test("applyInitGitPolicy add omits missing skills directory", async () => {
@@ -111,8 +142,21 @@ test("applyInitGitPolicy add omits missing skills directory", async () => {
       ".gitignore",
       `cwd=${repoRoot}`,
     ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
   ]);
-  assert.match(result.message, /Staged patchmill.config.json and .gitignore/u);
+  assert.match(
+    result.message,
+    /Patchmill config and local artifact ignore rules were committed/u,
+  );
   assert.doesNotMatch(result.message, /.patchmill\/skills/u);
 });
 
@@ -139,8 +183,22 @@ test("applyInitGitPolicy add stages provided repo-local skill roots", async () =
       ".gitignore",
       `cwd=${repoRoot}`,
     ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      "custom-skills",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
   ]);
-  assert.match(result.message, /Added Patchmill config and skills to git/u);
+  assert.match(
+    result.message,
+    /Patchmill config, skills, and local artifact ignore rules were committed/u,
+  );
 });
 
 test("applyInitGitPolicy add force-stages skills when .patchmill is ignored", async () => {
@@ -163,49 +221,90 @@ test("applyInitGitPolicy add force-stages skills when .patchmill is ignored", as
     "patchmill.config.json",
   ]);
   assert.ok(calls[0]?.includes(".patchmill/skills"));
+  assert.deepEqual(calls[1]?.slice(0, 6), [
+    "git",
+    "commit",
+    "-m",
+    "chore: initialize Patchmill",
+    "--",
+    "patchmill.config.json",
+  ]);
 });
 
-test("applyInitGitPolicy ignore writes patchmill.config.json and .patchmill to .gitignore", async () => {
+test("applyInitGitPolicy ignore writes patchmill entries to .gitignore and commits .gitignore", async () => {
   const repoRoot = await tempRepo();
+  const calls: string[][] = [];
 
   const result = await applyInitGitPolicy({
     repoRoot,
     policy: "ignore",
-    runner: recordingRunner(),
+    runner: recordingRunner(calls),
   });
 
   assert.equal(
     await readFile(join(repoRoot, ".gitignore"), "utf8"),
-    "patchmill.config.json\n.patchmill/\n",
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
   );
-  assert.match(result.message, /Added Patchmill files to .gitignore/u);
+  assert.deepEqual(calls, [
+    ["git", "add", ".gitignore", `cwd=${repoRoot}`],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill git hygiene",
+      "--",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+  ]);
+  assert.match(result.message, /.gitignore git hygiene rules were committed/u);
 });
 
-test("applyInitGitPolicy exclude writes patchmill.config.json and .patchmill to local exclude", async () => {
+test("applyInitGitPolicy exclude writes patchmill entries to local exclude without git commands", async () => {
   const repoRoot = await tempRepo();
+  const calls: string[][] = [];
 
   const result = await applyInitGitPolicy({
     repoRoot,
     policy: "exclude",
-    runner: recordingRunner(),
+    runner: recordingRunner(calls),
   });
 
   assert.equal(
     await readFile(join(repoRoot, ".git", "info", "exclude"), "utf8"),
-    "patchmill.config.json\n.patchmill/\n",
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
   );
+  assert.deepEqual(calls, []);
   assert.match(result.message, /Added Patchmill files to .git\/info\/exclude/u);
+});
+
+test("applyInitGitPolicy ignore skips commit when entries already exist", async () => {
+  const repoRoot = await tempRepo();
+  const calls: string[][] = [];
+  await writeFile(
+    join(repoRoot, ".gitignore"),
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
+  );
+
+  const result = await applyInitGitPolicy({
+    repoRoot,
+    policy: "ignore",
+    runner: recordingRunner(calls),
+  });
+
+  assert.deepEqual(calls, []);
+  assert.match(result.message, /No git hygiene commit was needed/u);
 });
 
 test("applyInitGitPolicy does not duplicate existing ignore or exclude entries", async () => {
   const repoRoot = await tempRepo();
   await writeFile(
     join(repoRoot, ".gitignore"),
-    "node_modules\n.patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n",
+    "node_modules\n.patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n/.worktrees/\n.pi/todos\n",
   );
   await writeFile(
     join(repoRoot, ".git", "info", "exclude"),
-    "node_modules\n.patchmill\npatchmill.config.json\n",
+    "node_modules\n.patchmill\npatchmill.config.json\n.worktrees\n/.pi/todos/\n",
   );
 
   await applyInitGitPolicy({
@@ -221,31 +320,71 @@ test("applyInitGitPolicy does not duplicate existing ignore or exclude entries",
 
   assert.equal(
     await readFile(join(repoRoot, ".gitignore"), "utf8"),
-    "node_modules\n.patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n",
+    "node_modules\n.patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n/.worktrees/\n.pi/todos\n",
   );
   assert.equal(
     await readFile(join(repoRoot, ".git", "info", "exclude"), "utf8"),
-    "node_modules\n.patchmill\npatchmill.config.json\n",
+    "node_modules\n.patchmill\npatchmill.config.json\n.worktrees\n/.pi/todos/\n",
   );
 });
 
-test("applyInitGitPolicy treats root-anchored exclude entries as duplicates", async () => {
+test("applyInitGitPolicy treats root-anchored ignore entries as duplicates", async () => {
   const repoRoot = await tempRepo();
   await writeFile(
-    join(repoRoot, ".git", "info", "exclude"),
-    "node_modules\n/.patchmill/\n/patchmill.config.json\n",
+    join(repoRoot, ".gitignore"),
+    "/patchmill.config.json\n/.patchmill/\n/.worktrees/\n/.pi/todos/\n",
   );
+  const calls: string[][] = [];
 
-  await applyInitGitPolicy({
+  const result = await applyInitGitPolicy({
     repoRoot,
-    policy: "exclude",
-    runner: recordingRunner(),
+    policy: "ignore",
+    runner: recordingRunner(calls),
   });
 
+  assert.deepEqual(calls, []);
   assert.equal(
-    await readFile(join(repoRoot, ".git", "info", "exclude"), "utf8"),
-    "node_modules\n/.patchmill/\n/patchmill.config.json\n",
+    await readFile(join(repoRoot, ".gitignore"), "utf8"),
+    "/patchmill.config.json\n/.patchmill/\n/.worktrees/\n/.pi/todos/\n",
   );
+  assert.match(result.message, /No git hygiene commit was needed/u);
+});
+
+test("applyInitGitPolicy reports git add failures as non-fatal warnings", async () => {
+  const repoRoot = await tempRepo();
+  const calls: string[][] = [];
+  await writeFile(join(repoRoot, "patchmill.config.json"), "{}\n");
+
+  const result = await applyInitGitPolicy({
+    repoRoot,
+    policy: "add",
+    runner: scriptedRunner(calls, [{ code: 1, stderr: "index locked" }]),
+  });
+
+  assert.equal(calls.filter((call) => call[1] === "commit").length, 0);
+  assert.match(result.message, /Warning/u);
+  assert.match(result.message, /git add failed/u);
+  assert.match(result.message, /index locked/u);
+});
+
+test("applyInitGitPolicy reports git commit failures as non-fatal warnings", async () => {
+  const repoRoot = await tempRepo();
+  const calls: string[][] = [];
+  await writeFile(join(repoRoot, "patchmill.config.json"), "{}\n");
+
+  const result = await applyInitGitPolicy({
+    repoRoot,
+    policy: "add",
+    runner: scriptedRunner(calls, [
+      { code: 0 },
+      { code: 1, stderr: "author identity unknown" },
+    ]),
+  });
+
+  assert.equal(calls.filter((call) => call[1] === "commit").length, 1);
+  assert.match(result.message, /Warning/u);
+  assert.match(result.message, /git commit failed/u);
+  assert.match(result.message, /author identity unknown/u);
 });
 
 test("applyInitGitPolicy reports missing git metadata without failing init", async () => {
@@ -263,6 +402,8 @@ test("applyInitGitPolicy reports missing git metadata without failing init", asy
   );
   assert.match(result.message, /patchmill.config.json/u);
   assert.match(result.message, /.patchmill\//u);
+  assert.match(result.message, /.worktrees\//u);
+  assert.match(result.message, /.pi\/todos\//u);
 });
 
 test("applyInitGitPolicy reports local exclude write failures without failing init", async () => {
@@ -283,4 +424,6 @@ test("applyInitGitPolicy reports local exclude write failures without failing in
   assert.match(result.message, /not a directory|EEXIST/u);
   assert.match(result.message, /patchmill.config.json/u);
   assert.match(result.message, /.patchmill\//u);
+  assert.match(result.message, /.worktrees\//u);
+  assert.match(result.message, /.pi\/todos\//u);
 });

--- a/src/cli/commands/init/git-policy.ts
+++ b/src/cli/commands/init/git-policy.ts
@@ -7,12 +7,16 @@ export type InitGitPolicy = "add" | "ignore" | "exclude";
 export const PATCHMILL_GIT_IGNORE_ENTRIES = [
   "patchmill.config.json",
   ".patchmill/",
+  ".worktrees/",
+  ".pi/todos/",
 ] as const;
 
 export const PATCHMILL_ADD_TO_GIT_IGNORE_ENTRIES = [
   ".patchmill/pi-agent",
   ".patchmill/runs",
   ".patchmill/triage-runs",
+  ".worktrees/",
+  ".pi/todos/",
 ] as const;
 
 export type InitGitPolicyResult = {
@@ -21,6 +25,13 @@ export type InitGitPolicyResult = {
 };
 
 export type InitGitPolicyPrompt = (question: string) => Promise<string>;
+
+type GitCommitOutcome =
+  | { status: "committed"; paths: string[] }
+  | { status: "nothing"; paths: string[] }
+  | { status: "missing"; paths: string[] }
+  | { status: "stage-warning"; warning: string; paths: string[] }
+  | { status: "commit-warning"; warning: string; paths: string[] };
 
 function normalEntry(entry: string): string {
   return entry.trim().replace(/^\//u, "").replace(/\/+$/u, "");
@@ -76,10 +87,14 @@ function formatEntries(entries: readonly string[]): string {
   return entries.map((entry) => `  ${entry}`).join("\n");
 }
 
-function formatPathList(paths: readonly string[]): string {
-  if (paths.length <= 1) return paths[0] ?? "nothing";
-  if (paths.length === 2) return `${paths[0]} and ${paths[1]}`;
-  return `${paths.slice(0, -1).join(", ")}, and ${paths.at(-1)}`;
+function gitOutput(result: { stdout: string; stderr: string }): string {
+  return result.stderr || result.stdout || "unknown error";
+}
+
+function isNothingToCommit(output: string): boolean {
+  return /nothing to commit|no changes added to commit|nothing added to commit|no changes/u.test(
+    output.toLowerCase(),
+  );
 }
 
 function safeRelativePath(path: string): boolean {
@@ -114,6 +129,46 @@ function manualExcludeWarning(reason: string): string {
     "Add these entries manually to keep Patchmill files local:",
     formatEntries(PATCHMILL_GIT_IGNORE_ENTRIES),
   ].join("\n");
+}
+
+async function commitInitGitHygiene(options: {
+  repoRoot: string;
+  runner: CommandRunner;
+  paths: readonly string[];
+  message: string;
+  forceAdd?: boolean;
+}): Promise<GitCommitOutcome> {
+  const paths = await existingPaths(options.repoRoot, options.paths);
+  if (paths.length === 0) return { status: "missing", paths };
+
+  const addArgs = options.forceAdd
+    ? ["add", "-f", ...paths]
+    : ["add", ...paths];
+  const addResult = await options.runner.run("git", addArgs, {
+    cwd: options.repoRoot,
+  });
+  if (addResult.code !== 0) {
+    return {
+      status: "stage-warning",
+      warning: `Warning: git add failed while preparing init git hygiene commit; continuing without committing. ${gitOutput(addResult)}`,
+      paths,
+    };
+  }
+
+  const commitResult = await options.runner.run(
+    "git",
+    ["commit", "-m", options.message, "--", ...paths],
+    { cwd: options.repoRoot },
+  );
+  if (commitResult.code === 0) return { status: "committed", paths };
+
+  const output = gitOutput(commitResult);
+  if (isNothingToCommit(output)) return { status: "nothing", paths };
+  return {
+    status: "commit-warning",
+    warning: `Warning: git commit failed while finalizing init git hygiene; continuing. ${output}`,
+    paths,
+  };
 }
 
 export async function selectInitGitPolicy(options: {
@@ -159,36 +214,31 @@ export async function applyInitGitPolicy(options: {
       PATCHMILL_ADD_TO_GIT_IGNORE_ENTRIES,
     );
     const skillRoots = options.skillRoots ?? [".patchmill/skills"];
-    const pathsToStage = await existingPaths(options.repoRoot, [
-      "patchmill.config.json",
-      ...skillRoots,
-      ".gitignore",
-    ]);
-    const gitAdd =
-      pathsToStage.length > 0
-        ? await options.runner.run("git", ["add", "-f", ...pathsToStage], {
-            cwd: options.repoRoot,
-          })
-        : undefined;
-    const gitAddMessage = !gitAdd
-      ? "No Patchmill files were available to stage."
-      : gitAdd.code === 0
-        ? `Staged ${formatPathList(pathsToStage)}.`
-        : `Warning: git add failed: ${gitAdd.stderr || gitAdd.stdout || "unknown error"}`;
+    const commit = await commitInitGitHygiene({
+      repoRoot: options.repoRoot,
+      runner: options.runner,
+      paths: ["patchmill.config.json", ...skillRoots, ".gitignore"],
+      message: "chore: initialize Patchmill",
+      forceAdd: true,
+    });
     const ignoreMessage =
       added.length > 0
         ? `Added local Patchmill runtime directories to .gitignore:\n${formatEntries(added)}`
         : "Local Patchmill runtime directories were already listed in .gitignore.";
-    const stagedSkills = pathsToStage.some((path) => skillRoots.includes(path));
+    const stagedSkills = commit.paths.some((path) => skillRoots.includes(path));
     const addSummary =
-      gitAdd?.code === 0
+      commit.status === "committed"
         ? stagedSkills
-          ? "Added Patchmill config and skills to git."
-          : "Added Patchmill config to git."
-        : "Warning: Patchmill could not add files to git.";
+          ? "Patchmill config, skills, and local artifact ignore rules were committed."
+          : "Patchmill config and local artifact ignore rules were committed."
+        : commit.status === "nothing"
+          ? "No Patchmill git hygiene commit was needed."
+          : commit.status === "missing"
+            ? "No Patchmill files were available to commit."
+            : commit.warning;
     return {
       policy: options.policy,
-      message: [addSummary, gitAddMessage, ignoreMessage].join("\n"),
+      message: [addSummary, ignoreMessage].join("\n"),
     };
   }
 
@@ -197,12 +247,34 @@ export async function applyInitGitPolicy(options: {
       join(options.repoRoot, ".gitignore"),
       PATCHMILL_GIT_IGNORE_ENTRIES,
     );
+    if (added.length === 0) {
+      return {
+        policy: options.policy,
+        message:
+          "No git hygiene commit was needed; Patchmill files were already listed in .gitignore.",
+      };
+    }
+
+    const commit = await commitInitGitHygiene({
+      repoRoot: options.repoRoot,
+      runner: options.runner,
+      paths: [".gitignore"],
+      message: "chore: initialize Patchmill git hygiene",
+    });
+    const commitMessage =
+      commit.status === "committed"
+        ? ".gitignore git hygiene rules were committed."
+        : commit.status === "nothing"
+          ? "No git hygiene commit was needed."
+          : commit.status === "missing"
+            ? "Warning: .gitignore was not available to commit after init updated git hygiene rules."
+            : commit.warning;
     return {
       policy: options.policy,
-      message:
-        added.length > 0
-          ? `Added Patchmill files to .gitignore:\n${formatEntries(added)}`
-          : "Patchmill files were already listed in .gitignore.",
+      message: [
+        commitMessage,
+        `Added Patchmill files to .gitignore:\n${formatEntries(added)}`,
+      ].join("\n"),
     };
   }
 

--- a/src/cli/commands/init/main-git-policy.test.ts
+++ b/src/cli/commands/init/main-git-policy.test.ts
@@ -68,10 +68,11 @@ async function runInitForGitPolicy(
     isInteractive: boolean;
     promptAnswer?: string;
     calls?: string[][];
+    commandRunner?: CommandRunner;
   },
 ) {
   const stdout: string[] = [];
-  await runInit(
+  const exitCode = await runInit(
     options.args ?? [],
     repoRoot,
     {
@@ -84,21 +85,21 @@ async function runInitForGitPolicy(
       resolvePiInitSetup: incompletePiSetup,
       isInteractive: options.isInteractive,
       prompt: async () => options.promptAnswer ?? "",
-      commandRunner: runner(options.calls ?? []),
+      commandRunner: options.commandRunner ?? runner(options.calls ?? []),
       setupLabels: async () => ({
         status: "skipped",
         message: "Label setup skipped.",
       }),
     },
   );
-  return stdout.join("\n");
+  return { exitCode, output: stdout.join("\n") };
 }
 
-test("interactive init add-to-git stages config, skills, and gitignore", async () => {
+test("interactive init add-to-git commits config, skills, and gitignore", async () => {
   const repoRoot = await tempRepo();
   const calls: string[][] = [];
 
-  const output = await runInitForGitPolicy(repoRoot, {
+  const { output } = await runInitForGitPolicy(repoRoot, {
     isInteractive: true,
     promptAnswer: "1",
     calls,
@@ -114,20 +115,34 @@ test("interactive init add-to-git stages config, skills, and gitignore", async (
       ".gitignore",
       `cwd=${repoRoot}`,
     ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      ".patchmill/skills",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
   ]);
   assert.equal(
     await readFile(join(repoRoot, ".gitignore"), "utf8"),
-    ".patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n",
+    ".patchmill/pi-agent\n.patchmill/runs\n.patchmill/triage-runs\n.worktrees/\n.pi/todos/\n",
   );
-  assert.match(output, /Added Patchmill config and skills to git/u);
+  assert.match(
+    output,
+    /Patchmill config, skills, and local artifact ignore rules were committed/u,
+  );
   assert.doesNotMatch(output, /local-only by default/u);
 });
 
-test("interactive init add-to-git with no skills stages config and gitignore only", async () => {
+test("interactive init add-to-git with no skills commits config and gitignore only", async () => {
   const repoRoot = await tempRepo();
   const calls: string[][] = [];
 
-  const output = await runInitForGitPolicy(repoRoot, {
+  const { output } = await runInitForGitPolicy(repoRoot, {
     args: ["--skills", "none"],
     isInteractive: true,
     promptAnswer: "1",
@@ -143,19 +158,32 @@ test("interactive init add-to-git with no skills stages config and gitignore onl
       ".gitignore",
       `cwd=${repoRoot}`,
     ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
   ]);
-  assert.match(output, /Added Patchmill config to git/u);
+  assert.match(
+    output,
+    /Patchmill config and local artifact ignore rules were committed/u,
+  );
   assert.doesNotMatch(output, /.patchmill\/skills/u);
 });
 
-test("interactive init add-to-git with path skills stages the provided skill root", async () => {
+test("interactive init add-to-git with path skills commits the provided skill root", async () => {
   const repoRoot = await tempRepo();
   const calls: string[][] = [];
   await writeSkill(repoRoot, "custom-skills", "patchmill-issue-triage");
   await writeSkill(repoRoot, "custom-skills", "writing-plans");
   await writeSkill(repoRoot, "custom-skills", "subagent-driven-development");
 
-  const output = await runInitForGitPolicy(repoRoot, {
+  const { output } = await runInitForGitPolicy(repoRoot, {
     args: ["--skills", "path:custom-skills"],
     isInteractive: true,
     promptAnswer: "1",
@@ -172,39 +200,70 @@ test("interactive init add-to-git with path skills stages the provided skill roo
       ".gitignore",
       `cwd=${repoRoot}`,
     ],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill",
+      "--",
+      "patchmill.config.json",
+      "custom-skills",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
   ]);
-  assert.match(output, /Added Patchmill config and skills to git/u);
+  assert.match(
+    output,
+    /Patchmill config, skills, and local artifact ignore rules were committed/u,
+  );
   assert.doesNotMatch(output, /.patchmill\/skills/u);
 });
 
-test("interactive init git-ignore writes config and .patchmill to .gitignore", async () => {
+test("interactive init git-ignore commits .gitignore hygiene rules", async () => {
   const repoRoot = await tempRepo();
+  const calls: string[][] = [];
 
-  const output = await runInitForGitPolicy(repoRoot, {
+  const { output } = await runInitForGitPolicy(repoRoot, {
     isInteractive: true,
     promptAnswer: "2",
+    calls,
   });
 
+  assert.deepEqual(calls, [
+    ["git", "add", ".gitignore", `cwd=${repoRoot}`],
+    [
+      "git",
+      "commit",
+      "-m",
+      "chore: initialize Patchmill git hygiene",
+      "--",
+      ".gitignore",
+      `cwd=${repoRoot}`,
+    ],
+  ]);
   assert.equal(
     await readFile(join(repoRoot, ".gitignore"), "utf8"),
-    "patchmill.config.json\n.patchmill/\n",
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
   );
-  assert.match(output, /Added Patchmill files to .gitignore/u);
+  assert.match(output, /.gitignore git hygiene rules were committed/u);
   assert.doesNotMatch(output, /local-only by default/u);
 });
 
 test("interactive init git-exclude writes config and .patchmill to local exclude", async () => {
   const repoRoot = await tempRepo();
+  const calls: string[][] = [];
 
-  const output = await runInitForGitPolicy(repoRoot, {
+  const { output } = await runInitForGitPolicy(repoRoot, {
     isInteractive: true,
     promptAnswer: "3",
+    calls,
   });
 
   assert.equal(
     await readFile(join(repoRoot, ".git", "info", "exclude"), "utf8"),
-    "patchmill.config.json\n.patchmill/\n",
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
   );
+  assert.deepEqual(calls, []);
   assert.match(output, /Added Patchmill files to .git\/info\/exclude/u);
 });
 
@@ -244,10 +303,37 @@ test("non-interactive and --yes init choose git-exclude without prompting", asyn
   assert.equal(prompted, false);
   assert.equal(
     await readFile(join(nonInteractiveRoot, ".git", "info", "exclude"), "utf8"),
-    "patchmill.config.json\n.patchmill/\n",
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
   );
   assert.equal(
     await readFile(join(yesRoot, ".git", "info", "exclude"), "utf8"),
-    "patchmill.config.json\n.patchmill/\n",
+    "patchmill.config.json\n.patchmill/\n.worktrees/\n.pi/todos/\n",
   );
+});
+
+test("interactive init reports commit failures without aborting label or Pi setup", async () => {
+  const repoRoot = await tempRepo();
+  const calls: string[][] = [];
+  const failingCommitRunner: CommandRunner = {
+    async run(command, args, options) {
+      calls.push([command, ...args, `cwd=${options?.cwd ?? ""}`]);
+      if (args[0] === "commit") {
+        return { code: 1, stdout: "", stderr: "author identity unknown" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  };
+
+  const { exitCode, output } = await runInitForGitPolicy(repoRoot, {
+    isInteractive: true,
+    promptAnswer: "1",
+    commandRunner: failingCommitRunner,
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(calls.filter((call) => call[1] === "commit").length, 1);
+  assert.match(output, /Warning: git commit failed/u);
+  assert.match(output, /author identity unknown/u);
+  assert.match(output, /Label setup skipped\./u);
+  assert.match(output, /Pi provider\/model setup is incomplete/u);
 });

--- a/src/cli/commands/init/main.test.ts
+++ b/src/cli/commands/init/main.test.ts
@@ -185,7 +185,7 @@ test("runInit preserves existing local exclude entries and does not touch gitign
   );
   assert.equal(
     await readFile(join(repoRoot, ".git", "info", "exclude"), "utf8"),
-    "node_modules\n.patchmill\npatchmill.config.json\n",
+    "node_modules\n.patchmill\npatchmill.config.json\n.worktrees/\n.pi/todos/\n",
   );
 });
 


### PR DESCRIPTION
## Summary
- protect .worktrees/ and .pi/todos/ across patchmill init git policies
- best-effort commit generated hygiene changes for interactive add/ignore choices
- keep git exclude local-only and warnings non-fatal

## Validation
- node --test src/cli/commands/init/git-policy.test.ts src/cli/commands/init/main-git-policy.test.ts src/cli/commands/init/main.test.ts
- npm test
- npm run lint

## Reviews
- Final Codex full-worktree review: pass, no findings
- Final thermo-nuclear full-worktree review: pass, no findings

Human review required because this repository has no configured direct landing skill, so Patchmill policy requires PR fallback.