### PR TITLE
fix(npm): normalize package bin path

### DIFF
--- a/bin/package-files.test.ts
+++ b/bin/package-files.test.ts
@@ -26,7 +26,7 @@ test("package metadata identifies Patchmill as Apache-2.0", () => {
   );
 
   assert.equal(packageJson.license, "Apache-2.0");
-  assert.equal(packageJson.bin?.patchmill, "./dist/bin/patchmill.js");
+  assert.equal(packageJson.bin?.patchmill, "dist/bin/patchmill.js");
   assert.equal(packageJson.scripts?.prepack, "npm run build");
   assert.match(license, /^Copyright 2026 Roché Compaan\n/u);
   assert.match(license, /Apache License\n\s+Version 2\.0, January 2004/u);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "description": "An agent-driven software factory where humans and agents collaborate to preserve software craftsmanship.",
   "type": "module",
   "bin": {
-    "patchmill": "./dist/bin/patchmill.js"
+    "patchmill": "dist/bin/patchmill.js"
   },
   "scripts": {
     "patchmill": "node bin/patchmill.ts",


### PR DESCRIPTION
## Summary
- normalize the npm `bin.patchmill` path from `./dist/bin/patchmill.js` to `dist/bin/patchmill.js`
- update the package metadata test to lock that value

## Verification
- `npm test` — 862 pass, 0 fail
- `npm run lint` — 0 errors
- `npm publish --dry-run --access public` — exit 0; tarball includes `dist/bin/patchmill.js`
