### PR TITLE
feat(skill-pack): bump Superpowers to v6.0.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Patchmill agent instructions
+
+## Verification
+
+- When updating any skill pack or skill-pack dependency, verify both sides of
+  the integration:
+  - installed upstream skill files exist at the paths Patchmill resolves; and
+  - Patchmill skill-pack config, metadata, tests, and live dependency references
+    point at the same upstream version.
+- When npm dependencies change (`package.json`, `package-lock.json`, or
+  `npm-shrinkwrap.json`), rerun the Nix build as part of verification.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ record what happened. The goal is not a black box that writes code for you; it
 is a factory floor where every station is visible, configurable, and designed to
 preserve software craftsmanship while making iterative engineering scalable.
 
+## Superpowers
+
+> A key ingredient is the **[Superpowers](https://github.com/obra/superpowers)**
+> skills pack. Patchmill relies heavily on Superpowers for planning,
+> implementation, debugging, review, and workflow discipline. In the metaphor I
+> keep coming back to, Patchmill provides the factory floor, while Superpowers
+> provides much of the expertise that moves work through the factory.
+
 ## What Patchmill does
 
 Patchmill connects an issue host, repository policy, git worktrees, and

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -25,7 +25,7 @@ buildNpmPackageNode24 rec {
         || baseName == "result");
   };
 
-  npmDepsHash = "sha256-qhKJ0XDj+0DfYkCZI3TMjnkNSAA3V5ptcU3LkGXF1Cg=";
+  npmDepsHash = "sha256-k28NK006PRHjR9jxGSlrKh26lw4mVdXf2MSods8m0Wg=";
   npmDepsFetcherVersion = 2;
 
   dontNpmBuild = true;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@earendil-works/pi-coding-agent": "^0.77.0",
         "@earendil-works/pi-tui": "^0.77.0",
         "pi-subagents": "^0.25.0",
-        "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz"
+        "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
         "patchmill": "dist/bin/patchmill.js"
@@ -4599,9 +4599,9 @@
       }
     },
     "node_modules/superpowers": {
-      "version": "5.0.7",
-      "resolved": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
-      "integrity": "sha512-xGb/ZAZjyimxdRzR26KLzMz4IwIzsVSg9appLnbpCuZlVbtiu2YUBZiaxuB9G8oqGamkY71Zbxut2L2mf/RVNw=="
+      "version": "6.0.3",
+      "resolved": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz",
+      "integrity": "sha512-Vr0Zf1OW0k1agb0u6pnW34BppBtVFeiYfpwse+ywTC9xlQjgDgwhn9gg9NkPPcbBnEIpSC+IfBb4CeKQNkjjvg=="
     },
     "node_modules/tinyexec": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@earendil-works/pi-coding-agent": "^0.77.0",
         "@earendil-works/pi-tui": "^0.77.0",
         "pi-subagents": "^0.25.0",
-        "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz"
+        "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
         "patchmill": "dist/bin/patchmill.js"
@@ -4647,9 +4647,9 @@
       }
     },
     "node_modules/superpowers": {
-      "version": "5.0.7",
-      "resolved": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
-      "integrity": "sha512-xGb/ZAZjyimxdRzR26KLzMz4IwIzsVSg9appLnbpCuZlVbtiu2YUBZiaxuB9G8oqGamkY71Zbxut2L2mf/RVNw=="
+      "version": "6.0.3",
+      "resolved": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz",
+      "integrity": "sha512-Vr0Zf1OW0k1agb0u6pnW34BppBtVFeiYfpwse+ywTC9xlQjgDgwhn9gg9NkPPcbBnEIpSC+IfBb4CeKQNkjjvg=="
     },
     "node_modules/tinyexec": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "@earendil-works/pi-coding-agent": "^0.77.0",
     "@earendil-works/pi-tui": "^0.77.0",
     "pi-subagents": "^0.25.0",
-    "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz"
+    "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
   }
 }

--- a/src/workflow/skill-pack.test.ts
+++ b/src/workflow/skill-pack.test.ts
@@ -40,9 +40,9 @@ test("default pack records pinned external source", () => {
   assert.deepEqual(PATCHMILL_RECOMMENDED_SKILL_PACK.source, {
     type: "github-release",
     repository: "obra/superpowers",
-    tag: "v5.0.7",
+    tag: "v6.0.3",
     tarballUrl:
-      "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+      "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz",
   });
   assert.deepEqual(PATCHMILL_RECOMMENDED_SKILL_PACK.skills, [
     { name: "patchmill-issue-triage", source: "patchmill" },
@@ -111,9 +111,9 @@ test("buildSkillPackMetadata records installed file hashes", () => {
       source: {
         type: "github-release",
         repository: "obra/superpowers",
-        tag: "v5.0.7",
+        tag: "v6.0.3",
         tarballUrl:
-          "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+          "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz",
       },
     },
     installedAt: "<generated-by-init>",

--- a/src/workflow/skill-pack.ts
+++ b/src/workflow/skill-pack.ts
@@ -11,8 +11,8 @@ export const SINGLE_SUBAGENT_DEV_WITH_CODEX_AND_THERMO_REVIEWS_SKILL =
 export type SkillPackSource = {
   type: "github-release";
   repository: "obra/superpowers";
-  tag: "v5.0.7";
-  tarballUrl: "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz";
+  tag: "v6.0.3";
+  tarballUrl: "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz";
 };
 
 export type SkillPackSkill = {
@@ -45,9 +45,9 @@ export const PATCHMILL_RECOMMENDED_SKILL_PACK: SkillPack = {
   source: {
     type: "github-release",
     repository: "obra/superpowers",
-    tag: "v5.0.7",
+    tag: "v6.0.3",
     tarballUrl:
-      "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+      "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz",
   },
   skills: [
     { name: "patchmill-issue-triage", source: "patchmill" },


### PR DESCRIPTION
## Summary
- bump Superpowers package and Patchmill recommended skill-pack metadata to v6.0.3
- add README Superpowers section linking to the upstream repo
- add Patchmill-specific AGENTS.md verification rules
- refresh Nix npm dependency hash

## Verification
- upstream skill-pack path check: 14 Superpowers skills found under node_modules/superpowers/skills
- npm run lint
- npm test
- nix build .
