### PR TITLE
Hard-block run-once for unsafe branch bases

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,37 @@ pieces your repository needs.
 }
 ```
 
+## Git branch-base safety
+
+`patchmill run-once` creates issue branches from `git.baseRef`. The default is
+`"HEAD"`, which is convenient after a normal clone but can be unsafe just after
+initializing Patchmill: if you commit generated config locally and do not push
+or merge that commit to the PR target branch, every issue branch created from
+local `HEAD` would include that setup commit.
+
+Before claiming an issue, commenting, writing run state, creating a worktree, or
+running Pi, `run-once` checks that `git.baseRef` is contained in the configured
+PR target base. The target base is derived from:
+
+```text
+refs/remotes/<git.remote>/<git.baseBranch>
+```
+
+With the defaults, that is `refs/remotes/origin/main`.
+
+If `git.baseRef` has commits that are not in the target base, `run-once` exits
+non-zero and lists the commits that would leak into the issue PR. There is no
+CLI or config override for this guardrail. Fix the repository state by doing one
+of the following:
+
+- push or merge the local setup commits into `<git.remote>/<git.baseBranch>`;
+- run `git fetch <git.remote>` if the remote-tracking ref is stale;
+- set `git.baseRef` to an upstream ref that is already contained in the target
+  base, such as `refs/remotes/origin/main`.
+
+`--dry-run` performs the same check because it previews whether a real
+`run-once` can safely start.
+
 ## Host providers
 
 `host.provider` must be one of:

--- a/docs/issue-agent-workflows.md
+++ b/docs/issue-agent-workflows.md
@@ -222,9 +222,25 @@ labels determine ordering, then lower issue number wins. Explicit `--issue`
 selection validates the requested issue and returns `approval-required` for a
 waiting review state with the missing approved label.
 
-Before mutating, it checks the repository worktree is clean, ignoring configured
-local state paths such as the run-state directory and issue todo root. It
-records checkpoints so retries can skip already-completed side effects safely.
+After selecting an eligible issue and before any mutation, `run-once` verifies
+that the configured issue branch base (`git.baseRef`) is already contained in
+the configured PR target base. The target base is derived from `git.remote` and
+`git.baseBranch` as `refs/remotes/<remote>/<baseBranch>`, for example
+`refs/remotes/origin/main`. If `git.baseRef` has commits not present in that
+remote-tracking ref, Patchmill exits non-zero before claiming the issue,
+commenting, writing run state, creating a worktree, or invoking Pi. The error
+lists the commits that would leak into the issue PR and tells the operator to
+push or merge setup commits, fetch a stale remote-tracking ref, or configure
+`git.baseRef` to an upstream ref already contained in the PR base.
+
+Dry runs perform the same branch-base safety check because they preview whether
+`run-once` is safe to start. When no eligible issue exists, `run-once` returns
+`no-issue` without running this check because no issue branch would be created.
+
+After the branch-base check passes in execute mode, `run-once` checks the
+repository worktree is clean, ignoring configured local state paths such as the
+run-state directory and issue todo root. It records checkpoints so retries can
+skip already-completed side effects safely.
 
 ### Plan-creation Pi prompt
 

--- a/docs/plans/2026-06-27-issue-40-hard-block-run-once-when-branch-base-has-unpushed-commits.md
+++ b/docs/plans/2026-06-27-issue-40-hard-block-run-once-when-branch-base-has-unpushed-commits.md
@@ -1,0 +1,883 @@
+# Hard-Block Run-Once Unsafe Branch Base Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `patchmill run-once` fail before any mutation when the configured
+issue branch base contains commits not present in the configured PR target base.
+
+**Architecture:** Add one focused git safety helper in the existing run-once git
+module, then call it immediately after issue selection and before dry-run
+success or mutating safety gates. Keep the existing top-level error JSON shape
+by throwing actionable `Error`s from the preflight helper.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner (`node:test`), existing
+`CommandRunner` abstraction, git CLI, Markdown docs.
+
+---
+
+## File Structure
+
+- Modify `src/cli/commands/run-once/git.ts`
+  - Export
+    `assertIssueBaseContainedInPrBase(runner, repoRoot, baseRef, remote, baseBranch)`.
+  - Resolve both refs with `git rev-parse --verify <ref>^{commit}`.
+  - Detect leaking commits with `git log --oneline <targetRef>..<baseRef>`.
+  - Reuse the local `formatCommandFailure()` style for failed git commands.
+- Modify `src/cli/commands/run-once/git.test.ts`
+  - Add unit coverage for command sequencing, clean containment, leaked commits,
+    missing target refs, bad local base refs, and non-default target refs.
+- Modify `src/cli/commands/run-once/pipeline.ts`
+  - Import and invoke the helper after an issue is selected and progress has
+    recorded selection, before the dry-run return, before
+    `assertCleanWorktree()`, before claims/comments/run-state/worktree/Pi.
+- Modify `src/cli/commands/run-once/pipeline.test.ts`
+  - Add orchestration tests proving the preflight runs in clean execute and
+    dry-run paths, unsafe bases throw before any mutation, no eligible issue
+    skips the preflight, and configured remote/base branch are honored.
+- Modify `docs/issue-agent-workflows.md`
+  - Document run-once preflight ordering and why it blocks before claiming an
+    issue.
+- Modify `docs/configuration.md`
+  - Document target base derivation, why `git.baseRef: "HEAD"` can be unsafe,
+    and how operators fix failures.
+
+---
+
+## Task 1: Add git-helper unit tests for branch-base containment
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/git.test.ts`
+
+- [ ] **Step 1: Import the new helper in the git test file**
+
+Update the import from `./git.ts` so this symbol is included:
+
+```ts
+import {
+  assertCleanWorktree,
+  assertIssueBaseContainedInPrBase,
+  buildIssueBranchName,
+  buildIssueWorktreePath,
+  createIssueWorktree,
+  ensureIssueWorktree,
+  pushBranch,
+} from "./git.ts";
+```
+
+- [ ] **Step 2: Add the clean containment test before the existing
+      `assertCleanWorktree` tests**
+
+```ts
+test("assertIssueBaseContainedInPrBase accepts a base contained in the target remote ref", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    { code: 0, stdout: "target-sha\n", stderr: "" },
+    { code: 0, stdout: "\n", stderr: "" },
+  ]);
+
+  await assertIssueBaseContainedInPrBase(
+    runner,
+    "/repo",
+    "HEAD",
+    "origin",
+    "main",
+  );
+
+  assert.deepEqual(runner.calls, [
+    {
+      command: "git",
+      args: ["rev-parse", "--verify", "HEAD^{commit}"],
+      cwd: "/repo",
+    },
+    {
+      command: "git",
+      args: ["rev-parse", "--verify", "refs/remotes/origin/main^{commit}"],
+      cwd: "/repo",
+    },
+    {
+      command: "git",
+      args: ["log", "--oneline", "refs/remotes/origin/main..HEAD"],
+      cwd: "/repo",
+    },
+  ]);
+});
+```
+
+- [ ] **Step 3: Add the leaked commits failure test**
+
+```ts
+test("assertIssueBaseContainedInPrBase rejects commits that are not in the target remote ref", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    { code: 0, stdout: "target-sha\n", stderr: "" },
+    {
+      code: 0,
+      stdout:
+        "abc1234 chore: initialize Patchmill\ndef5678 docs: local setup\n",
+      stderr: "",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      assertIssueBaseContainedInPrBase(
+        runner,
+        "/repo",
+        "HEAD",
+        "origin",
+        "main",
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /Configured git\.baseRef HEAD is not contained in refs\/remotes\/origin\/main\./,
+      );
+      assert.match(error.message, /abc1234 chore: initialize Patchmill/);
+      assert.match(error.message, /def5678 docs: local setup/);
+      assert.match(
+        error.message,
+        /Push or merge these commits into origin\/main/,
+      );
+      assert.match(
+        error.message,
+        /configure git\.baseRef to a ref already contained/,
+      );
+      return true;
+    },
+  );
+});
+```
+
+- [ ] **Step 4: Add failure tests for bad base refs and missing remote-tracking
+      refs**
+
+```ts
+test("assertIssueBaseContainedInPrBase reports an unresolvable configured base ref", async () => {
+  const runner = createStaticCommandRunner([
+    {
+      code: 128,
+      stdout: "",
+      stderr: "fatal: Needed a single revision",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      assertIssueBaseContainedInPrBase(
+        runner,
+        "/repo",
+        "not-a-ref",
+        "origin",
+        "main",
+      ),
+    /Configured git\.baseRef not-a-ref could not be resolved to a commit with exit code 128: fatal: Needed a single revision/,
+  );
+});
+
+test("assertIssueBaseContainedInPrBase reports a missing target remote ref with remediation", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    {
+      code: 128,
+      stdout: "",
+      stderr: "fatal: Needed a single revision",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      assertIssueBaseContainedInPrBase(
+        runner,
+        "/repo",
+        "HEAD",
+        "origin",
+        "main",
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /Configured PR target base refs\/remotes\/origin\/main could not be resolved to a commit/,
+      );
+      assert.match(error.message, /Run git fetch origin/);
+      assert.match(error.message, /git\.remote/);
+      assert.match(error.message, /git\.baseBranch/);
+      return true;
+    },
+  );
+});
+```
+
+- [ ] **Step 5: Add a configured target ref test**
+
+```ts
+test("assertIssueBaseContainedInPrBase uses configured remote and base branch", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    { code: 0, stdout: "target-sha\n", stderr: "" },
+    { code: 0, stdout: "\n", stderr: "" },
+  ]);
+
+  await assertIssueBaseContainedInPrBase(
+    runner,
+    "/repo",
+    "refs/remotes/upstream/release/1.2",
+    "upstream",
+    "release/1.2",
+  );
+
+  assert.deepEqual(
+    runner.calls.map((call) => call.args),
+    [
+      ["rev-parse", "--verify", "refs/remotes/upstream/release/1.2^{commit}"],
+      ["rev-parse", "--verify", "refs/remotes/upstream/release/1.2^{commit}"],
+      [
+        "log",
+        "--oneline",
+        "refs/remotes/upstream/release/1.2..refs/remotes/upstream/release/1.2",
+      ],
+    ],
+  );
+});
+```
+
+- [ ] **Step 6: Run the focused git tests and confirm they fail because the
+      helper is not implemented yet**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/git.test.ts
+```
+
+Expected: FAIL with a TypeScript/module error or assertion failure indicating
+`assertIssueBaseContainedInPrBase` is missing.
+
+---
+
+## Task 2: Implement the git safety helper
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/git.ts`
+
+- [ ] **Step 1: Add small helper functions near `formatCommandFailure()`**
+
+```ts
+function issueBaseTargetRef(remote: string, baseBranch: string): string {
+  return `refs/remotes/${remote}/${baseBranch}`;
+}
+
+async function verifyCommitRef(
+  runner: CommandRunner,
+  repoRoot: string,
+  ref: string,
+  failure: string,
+): Promise<void> {
+  const result = await runner.run(
+    "git",
+    ["rev-parse", "--verify", `${ref}^{commit}`],
+    { cwd: repoRoot },
+  );
+  if (result.code !== 0) {
+    throw new Error(formatCommandFailure(failure, result));
+  }
+}
+```
+
+- [ ] **Step 2: Add and export `assertIssueBaseContainedInPrBase()` after
+      `assertCleanWorktree()`**
+
+```ts
+export async function assertIssueBaseContainedInPrBase(
+  runner: CommandRunner,
+  repoRoot: string,
+  baseRef: string,
+  remote: string,
+  baseBranch: string,
+): Promise<void> {
+  const targetRef = issueBaseTargetRef(remote, baseBranch);
+
+  await verifyCommitRef(
+    runner,
+    repoRoot,
+    baseRef,
+    `Configured git.baseRef ${baseRef} could not be resolved to a commit`,
+  );
+  await verifyCommitRef(
+    runner,
+    repoRoot,
+    targetRef,
+    `Configured PR target base ${targetRef} could not be resolved to a commit. Run git fetch ${remote}, or fix git.remote/git.baseBranch`,
+  );
+
+  const result = await runner.run(
+    "git",
+    ["log", "--oneline", `${targetRef}..${baseRef}`],
+    { cwd: repoRoot },
+  );
+  if (result.code !== 0) {
+    throw new Error(
+      formatCommandFailure(
+        `git log failed while checking whether git.baseRef ${baseRef} is contained in ${targetRef}`,
+        result,
+      ),
+    );
+  }
+
+  const leakedCommits = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (leakedCommits.length === 0) return;
+
+  throw new Error(
+    [
+      `Configured git.baseRef ${baseRef} is not contained in ${targetRef}.`,
+      `These commits would be included in the issue PR:`,
+      ...leakedCommits,
+      ``,
+      `Push or merge these commits into ${remote}/${baseBranch}, run git fetch if the remote ref is stale, or configure git.baseRef to a ref already contained in ${targetRef}.`,
+    ].join("\n"),
+  );
+}
+```
+
+- [ ] **Step 3: Run the focused git tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/git.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the git helper and unit tests**
+
+```sh
+git add src/cli/commands/run-once/git.ts src/cli/commands/run-once/git.test.ts
+git commit -m "feat: guard run-once issue base containment"
+```
+
+---
+
+## Task 3: Add run-once pipeline preflight orchestration tests
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+
+- [ ] **Step 1: Add a reusable git preflight responder near the existing test
+      helpers**
+
+```ts
+function gitBaseContainmentResult(call: Call): CommandResult | undefined {
+  if (call.command !== "git") return undefined;
+  if (call.args[0] === "rev-parse" && call.args[1] === "--verify") {
+    return { code: 0, stdout: "commit-sha\n", stderr: "" };
+  }
+  if (call.args[0] === "log" && call.args[1] === "--oneline") {
+    return { code: 0, stdout: "", stderr: "" };
+  }
+  return undefined;
+}
+
+function gitBaseContainmentFailure(call: Call): CommandResult | undefined {
+  if (call.command !== "git") return undefined;
+  if (call.args[0] === "rev-parse" && call.args[1] === "--verify") {
+    return { code: 0, stdout: "commit-sha\n", stderr: "" };
+  }
+  if (call.args[0] === "log" && call.args[1] === "--oneline") {
+    return {
+      code: 0,
+      stdout: "abc1234 chore: initialize Patchmill\n",
+      stderr: "",
+    };
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 2: Update new tests to return `gitBaseContainmentResult(call)`
+      before other git defaults**
+
+When adding tests in this task, put this at the top of each mock handler after
+issue-host command handling as appropriate:
+
+```ts
+const preflight = gitBaseContainmentResult(call);
+if (preflight) return preflight;
+```
+
+For unsafe-base tests, use:
+
+```ts
+const preflight = gitBaseContainmentFailure(call);
+if (preflight) return preflight;
+```
+
+- [ ] **Step 3: Add a dry-run safety failure test near existing dry-run tests**
+
+```ts
+test("runOneIssue dry-run blocks when the configured issue base is ahead of the target PR base", async () => {
+  const config = await makeConfig();
+  const selected = issue(45, ["agent-ready"], "Unsafe base");
+  const runner = createMockRunner((call) => {
+    if (call.command === "tea" && call.args.includes("issues")) {
+      return { code: 0, stdout: issueListPayload([selected]), stderr: "" };
+    }
+    const preflight = gitBaseContainmentFailure(call);
+    if (preflight) return preflight;
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Configured git\.baseRef HEAD is not contained in refs\/remotes\/origin\/main/,
+  );
+
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "status",
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args.includes("labels"),
+    ),
+    false,
+  );
+});
+```
+
+- [ ] **Step 4: Add an execute-mode unsafe-base test proving no mutation
+      occurs**
+
+```ts
+test("runOneIssue execute blocks unsafe issue base before claim, comments, run state, worktree, or Pi", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const selected = issue(45, ["agent-ready"], "Unsafe base");
+  const runner = createMockRunner((call) => {
+    if (call.command === "tea" && call.args.includes("issues")) {
+      return { code: 0, stdout: issueListPayload([selected]), stderr: "" };
+    }
+    const preflight = gitBaseContainmentFailure(call);
+    if (preflight) return preflight;
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /abc1234 chore: initialize Patchmill/);
+      return true;
+    },
+  );
+
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "status",
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "worktree",
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args.includes("comment"),
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args.includes("labels"),
+    ),
+    false,
+  );
+  await assert.rejects(
+    () => readFile(runStatePath(config.runStateDir, selected.number), "utf8"),
+    /ENOENT/,
+  );
+});
+```
+
+- [ ] **Step 5: Add a no-issue skip test**
+
+```ts
+test("runOneIssue skips base containment preflight when no eligible issue exists", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const runner = createMockRunner((call) => {
+    if (call.command === "tea" && call.args.includes("issues")) {
+      return { code: 0, stdout: issueListPayload([]), stderr: "" };
+    }
+    throw new Error(
+      `unexpected command ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.deepEqual(result, { status: "no-issue" });
+  assert.equal(
+    runner.calls.some((call) => call.command === "git"),
+    false,
+  );
+});
+```
+
+- [ ] **Step 6: Add a configured remote/base branch pipeline assertion to an
+      existing custom-strategy test**
+
+In
+`runOneIssue uses the configured worktree strategy for workspace names and prompt instructions`,
+ensure the mock handles the preflight and add an assertion that the target ref
+is built from the custom config:
+
+```ts
+assert.ok(
+  runner.calls.some(
+    (call) =>
+      call.command === "git" &&
+      call.args.join(" ") ===
+        "rev-parse --verify refs/remotes/upstream/release/1.2^{commit}",
+  ),
+);
+assert.ok(
+  runner.calls.some(
+    (call) =>
+      call.command === "git" &&
+      call.args.join(" ") ===
+        "log --oneline refs/remotes/upstream/release/1.2..refs/remotes/upstream/release/1.2",
+  ),
+);
+```
+
+- [ ] **Step 7: Run the focused pipeline tests and confirm they fail before
+      wiring the helper**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pipeline.test.ts
+```
+
+Expected: FAIL because the new preflight is not called yet or existing tests
+need their mock git handlers updated for the new preflight commands.
+
+---
+
+## Task 4: Wire the preflight into `runOneIssue()` and update affected test mocks
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline.ts`
+- Modify: `src/cli/commands/run-once/pipeline.test.ts`
+
+- [ ] **Step 1: Import the helper in `pipeline.ts`**
+
+```ts
+import {
+  assertCleanWorktree,
+  assertIssueBaseContainedInPrBase,
+  cleanStatusIgnoredPaths as buildCleanStatusIgnoredPaths,
+  ensureIssueWorktree,
+} from "./git.ts";
+```
+
+- [ ] **Step 2: Call the helper after selected-issue progress and before the
+      dry-run return**
+
+Insert this block immediately after the existing
+`await progress(... "selected" ...)` call and before `if (config.dryRun) {`:
+
+```ts
+await progress(
+  options,
+  "info",
+  "git",
+  "checking issue branch base containment",
+  { issueNumber: issue.number },
+);
+await assertIssueBaseContainedInPrBase(
+  runner,
+  config.repoRoot,
+  config.baseRef,
+  config.remote,
+  config.baseBranch,
+);
+```
+
+- [ ] **Step 3: Keep the existing clean-worktree check after dry-run**
+
+Do not remove this existing execute-mode gate:
+
+```ts
+await progress(options, "info", "git", "checking repository status", {
+  issueNumber: issue.number,
+});
+await assertCleanWorktree(runner, config.repoRoot, ignoredPaths);
+```
+
+The new containment check must run before it; `--dry-run` must run containment
+but must not run worktree cleanliness.
+
+- [ ] **Step 4: Update existing pipeline test mock handlers for the new git
+      commands**
+
+For tests that currently return special results for `git status`,
+`git worktree`, `git log`, `git show-ref`, or `git branch`, make sure the
+handler checks containment commands before broader `git log` handlers. Use this
+pattern:
+
+```ts
+const preflight = gitBaseContainmentResult(call);
+if (preflight) return preflight;
+```
+
+Place it before branches like:
+
+```ts
+if (call.command === "git" && call.args[0] === "log") {
+  return { code: 0, stdout: "existing work\n", stderr: "" };
+}
+```
+
+That prevents the new `git log --oneline refs/remotes/origin/main..HEAD`
+preflight from being mistaken for existing-worktree commit detection.
+
+- [ ] **Step 5: Run the focused pipeline tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pipeline.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run both focused suites together**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/git.test.ts src/cli/commands/run-once/pipeline.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the pipeline wiring and orchestration tests**
+
+```sh
+git add src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/pipeline.test.ts
+git commit -m "feat: block run-once before unsafe issue bases"
+```
+
+---
+
+## Task 5: Document the run-once branch-base safety block
+
+**Files:**
+
+- Modify: `docs/issue-agent-workflows.md`
+- Modify: `docs/configuration.md`
+
+- [ ] **Step 1: Update run-once safety-gate docs**
+
+In `docs/issue-agent-workflows.md`, in `### Issue selection and safety gates`,
+replace the paragraph beginning
+`Before mutating, it checks the repository worktree is clean` with:
+
+```md
+After selecting an eligible issue and before any mutation, `run-once` verifies
+that the configured issue branch base (`git.baseRef`) is already contained in
+the configured PR target base. The target base is derived from `git.remote` and
+`git.baseBranch` as `refs/remotes/<remote>/<baseBranch>`, for example
+`refs/remotes/origin/main`. If `git.baseRef` has commits not present in that
+remote-tracking ref, Patchmill exits non-zero before claiming the issue,
+commenting, writing run state, creating a worktree, or invoking Pi. The error
+lists the commits that would leak into the issue PR and tells the operator to
+push or merge setup commits, fetch a stale remote-tracking ref, or configure
+`git.baseRef` to an upstream ref already contained in the PR base.
+
+Dry runs perform the same branch-base safety check because they preview whether
+`run-once` is safe to start. When no eligible issue exists, `run-once` returns
+`no-issue` without running this check because no issue branch would be created.
+
+After the branch-base check passes in execute mode, `run-once` checks the
+repository worktree is clean, ignoring configured local state paths such as the
+run-state directory and issue todo root. It records checkpoints so retries can
+skip already-completed side effects safely.
+```
+
+- [ ] **Step 2: Add a git configuration subsection after the complete example**
+
+In `docs/configuration.md`, after the complete example JSON and before
+`## Host providers`, add:
+
+````md
+## Git branch-base safety
+
+`patchmill run-once` creates issue branches from `git.baseRef`. The default is
+`"HEAD"`, which is convenient after a normal clone but can be unsafe just after
+initializing Patchmill: if you commit generated config locally and do not push
+or merge that commit to the PR target branch, every issue branch created from
+local `HEAD` would include that setup commit.
+
+Before claiming an issue, commenting, writing run state, creating a worktree, or
+running Pi, `run-once` checks that `git.baseRef` is contained in the configured
+PR target base. The target base is derived from:
+
+```text
+refs/remotes/<git.remote>/<git.baseBranch>
+```
+
+With the defaults, that is `refs/remotes/origin/main`.
+
+If `git.baseRef` has commits that are not in the target base, `run-once` exits
+non-zero and lists the commits that would leak into the issue PR. There is no
+CLI or config override for this guardrail. Fix the repository state by doing one
+of the following:
+
+- push or merge the local setup commits into `<git.remote>/<git.baseBranch>`;
+- run `git fetch <git.remote>` if the remote-tracking ref is stale;
+- set `git.baseRef` to an upstream ref that is already contained in the target
+  base, such as `refs/remotes/origin/main`.
+
+`--dry-run` performs the same check because it previews whether a real
+`run-once` can safely start.
+````
+
+- [ ] **Step 3: Run a docs grep for the new terms**
+
+Run:
+
+```sh
+rg "branch-base|refs/remotes/<git.remote>/<git.baseBranch>|git.baseRef" docs/issue-agent-workflows.md docs/configuration.md
+```
+
+Expected: output includes the new safety-gate and configuration text.
+
+- [ ] **Step 4: Commit the docs**
+
+```sh
+git add docs/issue-agent-workflows.md docs/configuration.md
+git commit -m "docs: explain run-once branch base safety"
+```
+
+---
+
+## Task 6: Final verification and cleanup
+
+**Files:**
+
+- Verify only; no source changes expected unless a previous task missed a
+  requirement.
+
+- [ ] **Step 1: Run targeted tests required by the spec**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/git.test.ts src/cli/commands/run-once/pipeline.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+
+```sh
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Confirm no Nix build is required**
+
+Run:
+
+```sh
+git diff --name-only HEAD~3..HEAD | rg '(^|/)(package.json|package-lock.json|npm-shrinkwrap.json)$' || true
+```
+
+Expected: no output. Per `AGENTS.md`, no Nix build is required unless npm
+dependency metadata changed.
+
+- [ ] **Step 4: Review the final diff for scope**
+
+Run:
+
+```sh
+git diff --stat HEAD~3..HEAD
+git diff --check HEAD~3..HEAD
+```
+
+Expected: only the planned TypeScript tests/implementation and docs changed;
+`git diff --check` reports no whitespace errors.
+
+- [ ] **Step 5: Confirm final commits are present**
+
+Run:
+
+```sh
+git log --oneline -3
+```
+
+Expected: the last three commits are:
+
+```text
+<sha> docs: explain run-once branch base safety
+<sha> feat: block run-once before unsafe issue bases
+<sha> feat: guard run-once issue base containment
+```
+
+---
+
+## Validation Commands
+
+Use these exact commands during implementation:
+
+```sh
+node --test src/cli/commands/run-once/git.test.ts
+node --test src/cli/commands/run-once/pipeline.test.ts
+node --test src/cli/commands/run-once/git.test.ts src/cli/commands/run-once/pipeline.test.ts
+npm test
+rg "branch-base|refs/remotes/<git.remote>/<git.baseBranch>|git.baseRef" docs/issue-agent-workflows.md docs/configuration.md
+git diff --check HEAD~3..HEAD
+git diff --name-only HEAD~3..HEAD | rg '(^|/)(package.json|package-lock.json|npm-shrinkwrap.json)$' || true
+```
+
+No npm dependency changes are planned, so `AGENTS.md` does not require a Nix
+build for this issue unless implementation later edits `package.json`,
+`package-lock.json`, or `npm-shrinkwrap.json`.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: The plan covers the git helper, pre-mutation pipeline
+  placement, dry-run behavior, no-issue behavior, actionable errors with leaked
+  commits, missing remote-ref failures, docs, and
+  clean/dirty/remote-ref/configured-target tests.
+- Placeholder scan: No `TBD`, `TODO`, or undefined future steps remain; each
+  task has concrete files, commands, and expected outcomes.
+- Type consistency: The planned helper signature uses existing `CommandRunner`,
+  `repoRoot`, `baseRef`, `remote`, and `baseBranch` fields from
+  `AgentIssueConfig`; no new config fields or override switches are introduced.

--- a/docs/specs/2026-06-27-issue-40-hard-block-run-once-when-branch-base-has-unpushed-commits-design.md
+++ b/docs/specs/2026-06-27-issue-40-hard-block-run-once-when-branch-base-has-unpushed-commits-design.md
@@ -1,0 +1,182 @@
+# Hard-Block Run-Once When Issue Base Has Unpushed Commits Design
+
+## Goal
+
+Prevent `patchmill run-once` from starting any issue workflow when the
+configured issue branch base would cause local-only commits to leak into the
+issue PR.
+
+## Current behavior
+
+- `git.baseRef` defaults to `HEAD` and is passed to issue worktree creation in
+  `src/cli/commands/run-once/git.ts`.
+- `git.baseBranch` and `git.remote` identify the intended landing branch and
+  default to `main` and `origin`.
+- `runOneIssue()` currently selects an issue, then checks the repository
+  worktree is clean, claims the issue, comments, advances planning, and only
+  later creates or reuses the issue worktree.
+- A locally committed Patchmill setup commit on `HEAD` that has not been pushed
+  to `origin/main` can therefore become part of every generated issue branch and
+  PR.
+
+## Desired behavior
+
+Before `run-once` performs any mutating workflow step, it must validate that the
+configured issue branch base is already contained in the configured upstream PR
+base.
+
+The upstream PR base is derived from existing git config fields:
+
+```text
+refs/remotes/<git.remote>/<git.baseBranch>
+```
+
+For the defaults, the target base is `refs/remotes/origin/main`.
+
+If `git.baseRef` resolves to commits that are not contained in that target base,
+`run-once` must exit non-zero with an actionable safety error. The error must
+list the commits that would leak into the issue PR and must not offer a CLI or
+configuration override in the initial implementation. `--dry-run` must report
+the same safety failure because it previews whether the command is safe to
+start.
+
+## Proposed design
+
+### Git safety helper
+
+Add a focused helper in `src/cli/commands/run-once/git.ts`, for example
+`assertIssueBaseContainedInPrBase()`, that accepts the injected `CommandRunner`,
+`repoRoot`, `baseRef`, `remote`, and `baseBranch`.
+
+The helper should:
+
+1. Build the target ref as `refs/remotes/${remote}/${baseBranch}`.
+2. Resolve `baseRef` with `git rev-parse --verify <baseRef>^{commit}` so bad
+   local base refs fail with an explicit message.
+3. Resolve the target ref with
+   `git rev-parse --verify refs/remotes/<remote>/<baseBranch>^{commit}` so
+   missing or stale remote-tracking refs fail before mutation with remediation
+   to fetch or configure `git.remote`/`git.baseBranch` correctly.
+4. Detect leaked commits with a command equivalent to:
+
+   ```sh
+   git log --oneline refs/remotes/<remote>/<baseBranch>..<baseRef>
+   ```
+
+5. Return successfully when the log output is empty.
+6. Throw an error when output is non-empty. The message should include the
+   configured base ref, target base ref, the leaked commit list, and
+   remediation: push or merge the setup commits first, fetch the remote if it is
+   stale, or set `git.baseRef` to an upstream ref already contained in the PR
+   base.
+
+Use the existing `formatCommandFailure()` style for git command failures so
+stdout/stderr are preserved. The helper should not run `git fetch`; this feature
+is a guardrail, not an implicit network mutation.
+
+### Pipeline placement
+
+Call the helper in `runOneIssue()` after issue selection has identified the
+candidate issue and before any mutating operation:
+
+- before `assertCleanWorktree()`;
+- before label creation or application;
+- before comments;
+- before run-state writes;
+- before worktree creation;
+- before any Pi invocation.
+
+The call should happen before the current dry-run return so `--dry-run` also
+fails when the configured base is unsafe. It is acceptable that `run-once` still
+queries the issue host to know whether there is an issue to preview; the hard
+block requirement is about preventing mutating workflow steps.
+
+When no eligible issue exists, `run-once` can continue returning `no-issue`
+without running the safety check, because there is no issue branch to create.
+
+### Error shape and user output
+
+The existing `main()` error path already converts thrown errors into non-zero
+JSON output:
+
+```json
+{ "status": "error", "error": "...", "logPath": "..." }
+```
+
+Keep that shape for this safety failure. The important contract is that the
+error text is actionable and includes the leaking commits. Do not model this as
+an issue-level `blocked` result, because the operator must fix repository git
+state before any issue claim or issue comment is made.
+
+Example error text:
+
+```text
+Configured git.baseRef HEAD is not contained in refs/remotes/origin/main.
+These commits would be included in the issue PR:
+abc1234 chore: initialize Patchmill
+
+Push or merge these commits into origin/main, run git fetch if the remote ref is stale, or configure git.baseRef to a ref already contained in refs/remotes/origin/main.
+```
+
+### Documentation
+
+Update `docs/issue-agent-workflows.md` to document the preflight ordering and
+why the command blocks before claiming an issue. Update `docs/configuration.md`
+near the `git` config section to explain:
+
+- default target base derivation from `git.remote` and `git.baseBranch`;
+- why the default `git.baseRef: "HEAD"` can be unsafe after local-only setup
+  commits;
+- how to fix the failure by pushing/merging setup commits, fetching stale remote
+  refs, or setting `git.baseRef` to an upstream ref already contained in the
+  target base.
+
+## Affected components
+
+- `src/cli/commands/run-once/git.ts`
+  - Add the containment helper and tests for git command sequencing, clean
+    containment, leaked commits, and missing target refs.
+- `src/cli/commands/run-once/pipeline.ts`
+  - Call the helper after selecting an issue and before dry-run success or any
+    mutation.
+- `src/cli/commands/run-once/pipeline.test.ts`
+  - Add orchestration coverage proving clean bases proceed, unsafe bases stop
+    before claim/comment/worktree/Pi calls, and dry-run reports the same safety
+    failure.
+- `src/cli/commands/run-once/types.ts`
+  - No new config fields are expected; existing `remote`, `baseBranch`, and
+    `baseRef` are sufficient.
+- `docs/issue-agent-workflows.md` and `docs/configuration.md`
+  - Document the guardrail and operator remediation.
+
+## Verification strategy
+
+Add focused automated tests for:
+
+- clean case: `git.baseRef` is contained in `refs/remotes/<remote>/<baseBranch>`
+  and `run-once` proceeds to the existing clean-worktree and workflow logic;
+- dirty/ahead case: `git log <target>..<baseRef>` returns commits and `run-once`
+  exits before claiming, commenting, creating a worktree, writing run state, or
+  running Pi;
+- dry-run unsafe case: `--dry-run` reports the same safety error rather than a
+  successful preview;
+- remote-ref failure case: resolving `refs/remotes/<remote>/<baseBranch>` fails
+  and the error tells the operator to fetch or fix
+  `git.remote`/`git.baseBranch`;
+- configured target case: non-default `git.remote` and `git.baseBranch` produce
+  `refs/remotes/<remote>/<baseBranch>` in git commands and error text.
+
+Run targeted tests:
+
+```sh
+node --test src/cli/commands/run-once/git.test.ts src/cli/commands/run-once/pipeline.test.ts
+```
+
+Run the full suite before merge:
+
+```sh
+npm test
+```
+
+No npm dependency changes are required, so no Nix build is required for this
+feature unless implementation later changes package metadata.

--- a/src/cli/commands/run-once/git.test.ts
+++ b/src/cli/commands/run-once/git.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { createStaticCommandRunner } from "../../../../test-support/command-runner.ts";
 import {
   assertCleanWorktree,
+  assertIssueBaseContainedInPrBase,
   buildIssueBranchName,
   buildIssueWorktreePath,
   createIssueWorktree,
@@ -45,6 +46,166 @@ test("issue branch and worktree slugs truncate deterministically", () => {
   assert.equal(
     buildIssueWorktreePath(42, title),
     ".worktrees/patchmill-issue-42-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstu",
+  );
+});
+
+test("assertIssueBaseContainedInPrBase accepts a base contained in the target remote ref", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    { code: 0, stdout: "target-sha\n", stderr: "" },
+    { code: 0, stdout: "\n", stderr: "" },
+  ]);
+
+  await assertIssueBaseContainedInPrBase(
+    runner,
+    "/repo",
+    "HEAD",
+    "origin",
+    "main",
+  );
+
+  assert.deepEqual(runner.calls, [
+    {
+      command: "git",
+      args: ["rev-parse", "--verify", "HEAD^{commit}"],
+      cwd: "/repo",
+    },
+    {
+      command: "git",
+      args: ["rev-parse", "--verify", "refs/remotes/origin/main^{commit}"],
+      cwd: "/repo",
+    },
+    {
+      command: "git",
+      args: ["log", "--oneline", "refs/remotes/origin/main..HEAD"],
+      cwd: "/repo",
+    },
+  ]);
+});
+
+test("assertIssueBaseContainedInPrBase rejects commits that are not in the target remote ref", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    { code: 0, stdout: "target-sha\n", stderr: "" },
+    {
+      code: 0,
+      stdout:
+        "abc1234 chore: initialize Patchmill\ndef5678 docs: local setup\n",
+      stderr: "",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      assertIssueBaseContainedInPrBase(
+        runner,
+        "/repo",
+        "HEAD",
+        "origin",
+        "main",
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /Configured git\.baseRef HEAD is not contained in refs\/remotes\/origin\/main\./,
+      );
+      assert.match(error.message, /abc1234 chore: initialize Patchmill/);
+      assert.match(error.message, /def5678 docs: local setup/);
+      assert.match(
+        error.message,
+        /Push or merge these commits into origin\/main/,
+      );
+      assert.match(
+        error.message,
+        /configure git\.baseRef to a ref already contained/,
+      );
+      return true;
+    },
+  );
+});
+
+test("assertIssueBaseContainedInPrBase reports an unresolvable configured base ref", async () => {
+  const runner = createStaticCommandRunner([
+    {
+      code: 128,
+      stdout: "",
+      stderr: "fatal: Needed a single revision",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      assertIssueBaseContainedInPrBase(
+        runner,
+        "/repo",
+        "not-a-ref",
+        "origin",
+        "main",
+      ),
+    /Configured git\.baseRef not-a-ref could not be resolved to a commit with exit code 128: fatal: Needed a single revision/,
+  );
+});
+
+test("assertIssueBaseContainedInPrBase reports a missing target remote ref with remediation", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    {
+      code: 128,
+      stdout: "",
+      stderr: "fatal: Needed a single revision",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      assertIssueBaseContainedInPrBase(
+        runner,
+        "/repo",
+        "HEAD",
+        "origin",
+        "main",
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /Configured PR target base refs\/remotes\/origin\/main could not be resolved to a commit/,
+      );
+      assert.match(error.message, /Run git fetch origin/);
+      assert.match(error.message, /git\.remote/);
+      assert.match(error.message, /git\.baseBranch/);
+      return true;
+    },
+  );
+});
+
+test("assertIssueBaseContainedInPrBase uses configured remote and base branch", async () => {
+  const runner = createStaticCommandRunner([
+    { code: 0, stdout: "base-sha\n", stderr: "" },
+    { code: 0, stdout: "target-sha\n", stderr: "" },
+    { code: 0, stdout: "\n", stderr: "" },
+  ]);
+
+  await assertIssueBaseContainedInPrBase(
+    runner,
+    "/repo",
+    "refs/remotes/upstream/release/1.2",
+    "upstream",
+    "release/1.2",
+  );
+
+  assert.deepEqual(
+    runner.calls.map((call) => call.args),
+    [
+      ["rev-parse", "--verify", "refs/remotes/upstream/release/1.2^{commit}"],
+      ["rev-parse", "--verify", "refs/remotes/upstream/release/1.2^{commit}"],
+      [
+        "log",
+        "--oneline",
+        "refs/remotes/upstream/release/1.2..refs/remotes/upstream/release/1.2",
+      ],
+    ],
   );
 });
 

--- a/src/cli/commands/run-once/git.ts
+++ b/src/cli/commands/run-once/git.ts
@@ -82,6 +82,26 @@ function formatCommandFailure(message: string, result: CommandResult): string {
   return `${message} with exit code ${result.code}: ${output}`;
 }
 
+function issueBaseTargetRef(remote: string, baseBranch: string): string {
+  return `refs/remotes/${remote}/${baseBranch}`;
+}
+
+async function verifyCommitRef(
+  runner: CommandRunner,
+  repoRoot: string,
+  ref: string,
+  failure: string,
+): Promise<void> {
+  const result = await runner.run(
+    "git",
+    ["rev-parse", "--verify", `${ref}^{commit}`],
+    { cwd: repoRoot },
+  );
+  if (result.code !== 0) {
+    throw new Error(formatCommandFailure(failure, result));
+  }
+}
+
 function normalizeGitPath(path: string): string {
   return path.replaceAll("\\", "/").replace(/\/+$/u, "");
 }
@@ -154,6 +174,59 @@ export async function assertCleanWorktree(
   if (dirtyOutput !== "") {
     throw new Error(`Repository worktree is not clean: ${dirtyOutput}`);
   }
+}
+
+export async function assertIssueBaseContainedInPrBase(
+  runner: CommandRunner,
+  repoRoot: string,
+  baseRef: string,
+  remote: string,
+  baseBranch: string,
+): Promise<void> {
+  const targetRef = issueBaseTargetRef(remote, baseBranch);
+
+  await verifyCommitRef(
+    runner,
+    repoRoot,
+    baseRef,
+    `Configured git.baseRef ${baseRef} could not be resolved to a commit`,
+  );
+  await verifyCommitRef(
+    runner,
+    repoRoot,
+    targetRef,
+    `Configured PR target base ${targetRef} could not be resolved to a commit. Run git fetch ${remote}, or fix git.remote/git.baseBranch`,
+  );
+
+  const result = await runner.run(
+    "git",
+    ["log", "--oneline", `${targetRef}..${baseRef}`],
+    { cwd: repoRoot },
+  );
+  if (result.code !== 0) {
+    throw new Error(
+      formatCommandFailure(
+        `git log failed while checking whether git.baseRef ${baseRef} is contained in ${targetRef}`,
+        result,
+      ),
+    );
+  }
+
+  const leakedCommits = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (leakedCommits.length === 0) return;
+
+  throw new Error(
+    [
+      `Configured git.baseRef ${baseRef} is not contained in ${targetRef}.`,
+      `These commits would be included in the issue PR:`,
+      ...leakedCommits,
+      ``,
+      `Push or merge these commits into ${remote}/${baseBranch}, run git fetch if the remote ref is stale, or configure git.baseRef to a ref already contained in ${targetRef}.`,
+    ].join("\n"),
+  );
 }
 
 export async function createIssueWorktree(

--- a/src/cli/commands/run-once/pipeline.test.ts
+++ b/src/cli/commands/run-once/pipeline.test.ts
@@ -164,6 +164,40 @@ function normalizeRecordedPiCall(call: Call): Call {
   return call;
 }
 
+function gitBaseContainmentResult(call: Call): CommandResult | undefined {
+  if (call.command !== "git") return undefined;
+  if (call.args[0] === "rev-parse" && call.args[1] === "--verify") {
+    return { code: 0, stdout: "commit-sha\n", stderr: "" };
+  }
+  if (
+    call.args[0] === "log" &&
+    call.args[1] === "--oneline" &&
+    call.args[2]?.startsWith("refs/remotes/")
+  ) {
+    return { code: 0, stdout: "", stderr: "" };
+  }
+  return undefined;
+}
+
+function gitBaseContainmentFailure(call: Call): CommandResult | undefined {
+  if (call.command !== "git") return undefined;
+  if (call.args[0] === "rev-parse" && call.args[1] === "--verify") {
+    return { code: 0, stdout: "commit-sha\n", stderr: "" };
+  }
+  if (
+    call.args[0] === "log" &&
+    call.args[1] === "--oneline" &&
+    call.args[2]?.startsWith("refs/remotes/")
+  ) {
+    return {
+      code: 0,
+      stdout: "abc1234 chore: initialize Patchmill\n",
+      stderr: "",
+    };
+  }
+  return undefined;
+}
+
 function createMockRunner(
   handler: (call: Call) => Promise<CommandResult> | CommandResult,
 ): MockRunner {
@@ -188,6 +222,20 @@ function createMockRunner(
           if (fallback) return fallback;
           throw error;
         }
+      }
+      const baseContainment = gitBaseContainmentResult(call);
+      if (baseContainment) {
+        try {
+          const result = await handler(call);
+          if (result.stdout.includes("abc1234 chore: initialize Patchmill")) {
+            return result;
+          }
+        } catch {
+          // Most existing tests predate this preflight and throw on the new git
+          // commands. Treat those as a clean base unless a test explicitly
+          // returns the unsafe marker above.
+        }
+        return baseContainment;
       }
       return await handler(call);
     },
@@ -626,13 +674,139 @@ test("runOneIssue dry-run lists open issues and returns the selected agent-ready
   assert.equal(result.logPath, logPath);
   assert.deepEqual(
     events.map((event) => event.message),
-    ["listing open issues", "selected #3 Issue 3"],
+    [
+      "listing open issues",
+      "selected #3 Issue 3",
+      "checking issue branch base containment",
+    ],
   );
   assert.deepEqual(
     runner.calls.map(
       (call) => `${call.command} ${call.args[0]} ${call.args[1]}`,
     ),
-    ["tea issues list", "tea issues list"],
+    [
+      "tea issues list",
+      "tea issues list",
+      "git rev-parse --verify",
+      "git rev-parse --verify",
+      "git log --oneline",
+    ],
+  );
+});
+
+test("runOneIssue dry-run blocks when the configured issue base is ahead of the target PR base", async () => {
+  const config = await makeConfig();
+  const selected = issue(45, ["agent-ready"], "Unsafe base");
+  const runner = createMockRunner((call) => {
+    if (call.command === "tea" && call.args.includes("issues")) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    const preflight = gitBaseContainmentFailure(call);
+    if (preflight) return preflight;
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    /Configured git\.baseRef HEAD is not contained in refs\/remotes\/origin\/main/,
+  );
+
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "status",
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args.includes("labels"),
+    ),
+    false,
+  );
+});
+
+test("runOneIssue execute blocks unsafe issue base before claim, comments, run state, worktree, or Pi", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const selected = issue(45, ["agent-ready"], "Unsafe base");
+  const runner = createMockRunner((call) => {
+    if (call.command === "tea" && call.args.includes("issues")) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    const preflight = gitBaseContainmentFailure(call);
+    if (preflight) return preflight;
+    return { code: 0, stdout: "", stderr: "" };
+  });
+
+  await assert.rejects(
+    () => runOneIssue(runner, config, { now: NOW }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /abc1234 chore: initialize Patchmill/);
+      return true;
+    },
+  );
+
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "status",
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "git" && call.args[0] === "worktree",
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some((call) => call.command === "pi"),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args.includes("comment"),
+    ),
+    false,
+  );
+  assert.equal(
+    runner.calls.some(
+      (call) => call.command === "tea" && call.args.includes("labels"),
+    ),
+    false,
+  );
+  await assert.rejects(
+    () => readFile(runStatePath(config.runStateDir, selected.number), "utf8"),
+    /ENOENT/,
+  );
+});
+
+test("runOneIssue skips base containment preflight when no eligible issue exists", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const runner = createMockRunner((call) => {
+    if (call.command === "tea" && call.args.includes("issues")) {
+      return { code: 0, stdout: issueListPayload([]), stderr: "" };
+    }
+    throw new Error(
+      `unexpected command ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.deepEqual(result, { status: "no-issue" });
+  assert.equal(
+    runner.calls.some((call) => call.command === "git"),
+    false,
   );
 });
 
@@ -667,7 +841,11 @@ test("runOneIssue dry-run for blocked saved workspace skips recovery inspection"
   assert.equal(result.issue.number, 45);
   assert.equal(result.transition, "agent-ready -> agent-done");
   assert.equal(
-    runner.calls.some((call) => call.command === "git"),
+    runner.calls.some(
+      (call) =>
+        call.command === "git" &&
+        (call.args[0] === "status" || call.args[0] === "worktree"),
+    ),
     false,
   );
 });
@@ -831,7 +1009,12 @@ test("runOneIssue targeted GitHub issue reads issue by number", async () => {
     runner.calls.map((call) =>
       [call.command, ...call.args.slice(0, 3)].join(" "),
     ),
-    ["gh issue view 1001"],
+    [
+      "gh issue view 1001",
+      "git rev-parse --verify HEAD^{commit}",
+      "git rev-parse --verify refs/remotes/origin/main^{commit}",
+      "git log --oneline refs/remotes/origin/main..HEAD",
+    ],
   );
 });
 
@@ -5618,6 +5801,7 @@ test("runOneIssue creates a missing plan, then creates a worktree and runs Pi fr
     [
       "listing open issues",
       "selected #15 Ship automation pipeline",
+      "checking issue branch base containment",
       "checking repository status",
       "ensuring in-progress label exists",
       "claimed #15: agent-ready -> in-progress",
@@ -6067,6 +6251,8 @@ test("runOneIssue uses the configured worktree strategy for workspace names and 
       return { code: 0, stdout: labelListPayload(), stderr: "" };
     }
     if (call.command === "tea") return { code: 0, stdout: "", stderr: "" };
+    const preflight = gitBaseContainmentResult(call);
+    if (preflight) return preflight;
     if (call.command === "git" && call.args[0] === "status")
       return { code: 0, stdout: "", stderr: "" };
     if (call.command === "git" && call.args[0] === "show-ref")
@@ -6154,6 +6340,22 @@ test("runOneIssue uses the configured worktree strategy for workspace names and 
   assert.equal(
     runState.worktreePath,
     ".patchmill/worktrees/pm-issue-16-use-custom-worktrees",
+  );
+  assert.ok(
+    runner.calls.some(
+      (call) =>
+        call.command === "git" &&
+        call.args.join(" ") ===
+          "rev-parse --verify refs/remotes/upstream/release/1.2^{commit}",
+    ),
+  );
+  assert.ok(
+    runner.calls.some(
+      (call) =>
+        call.command === "git" &&
+        call.args.join(" ") ===
+          "log --oneline refs/remotes/upstream/release/1.2..refs/remotes/upstream/release/1.2",
+    ),
   );
 });
 

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -13,6 +13,7 @@ import { DEFAULT_TRIAGE_POLICY, planLabelChange } from "../triage/labels.ts";
 import { ensureAutomationLabel } from "./automation-labels.ts";
 import {
   assertCleanWorktree,
+  assertIssueBaseContainedInPrBase,
   cleanStatusIgnoredPaths as buildCleanStatusIgnoredPaths,
   ensureIssueWorktree,
 } from "./git.ts";
@@ -775,6 +776,20 @@ export async function runOneIssue(
     "select",
     `${resumed ? "resuming" : "selected"} #${issue.number} ${issue.title}`,
     { issueNumber: issue.number },
+  );
+  await progress(
+    options,
+    "info",
+    "git",
+    "checking issue branch base containment",
+    { issueNumber: issue.number },
+  );
+  await assertIssueBaseContainedInPrBase(
+    runner,
+    config.repoRoot,
+    config.baseRef,
+    config.remote,
+    config.baseBranch,
   );
   if (config.dryRun) {
     const { ready } = lifecycleLabels(config);


### PR DESCRIPTION
## Summary
- add a run-once git preflight that verifies git.baseRef is contained in the configured PR target base before dry-run success or mutations
- block unsafe bases with actionable leaked commit listings and remote-ref remediation
- document branch-base safety behavior and operator fixes

## Validation
- node --test src/cli/commands/run-once/git.test.ts src/cli/commands/run-once/pipeline.test.ts
- npm test
- rg "branch-base|refs/remotes/<git.remote>/<git.baseBranch>|git.baseRef" docs/issue-agent-workflows.md docs/configuration.md
- git diff --check HEAD~3..HEAD
- git diff --name-only HEAD~3..HEAD | rg '(^|/)(package.json|package-lock.json|npm-shrinkwrap.json)$' || true

Closes #40