### PR TITLE
fix: avoid github search for triage issue listing

### DIFF
--- a/docs/plans/2026-06-29-issue-57-github-triage-can-silently-ignore-open-issues-when-remote-slug-redirects.md
+++ b/docs/plans/2026-06-29-issue-57-github-triage-can-silently-ignore-open-issues-when-remote-slug-redirects.md
@@ -1,0 +1,308 @@
+# GitHub Triage Redirect-Safe Issue Listing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make default `patchmill triage` list GitHub open issues through the
+non-search `gh issue list` path so renamed/transferred repository slugs do not
+silently produce an empty triage run.
+
+**Architecture:** Keep the fix in the GitHub `gh` host provider by removing the
+search-backed ordering flag and relying on the existing `runTriage()` in-process
+ordering. Add focused provider regression coverage for the redirect/search
+false-empty case, and keep pipeline coverage proving selected issues are still
+ordered by `createdAt` before triage agents run.
+
+**Tech Stack:** TypeScript, Node.js built-in `node:test`, mocked
+`CommandRunner`, GitHub CLI (`gh`) command construction.
+
+---
+
+## File Structure
+
+- Modify `src/host/github-gh.ts`: change `GitHubGhHostProvider.listOpenIssues()`
+  command arguments and make non-zero list failures actionable for
+  authentication, remote slug, and permission problems.
+- Modify `src/host/github-gh.test.ts`: update the normal list expectation, add
+  an explicit no-`--search` assertion, add the redirect false-empty regression,
+  and assert the improved list failure message.
+- Modify `src/cli/commands/triage/pipeline.test.ts`: update the GitHub triage
+  command expectation from the old search-backed command to the non-search
+  command. Existing tests at the top of this file already prove oldest-first
+  ordering and number fallback through `runTriage()` selection; only add another
+  ordering test if those assertions are removed or no longer cover GitHub input
+  order.
+
+## Implementation Tasks
+
+### Task 1: Add provider regression tests for non-search GitHub issue listing
+
+**Files:**
+
+- Modify: `src/host/github-gh.test.ts`
+
+- [ ] **Step 1: Update the existing open-issue list test to expect the
+      non-search command**
+
+Replace the scripted response key in `GitHubGhHostProvider lists open issues`
+with:
+
+```ts
+"gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+```
+
+After `assertGhContext(runner.calls[0]!);`, add:
+
+```ts
+assert.equal(runner.calls[0]!.args.includes("--search"), false);
+assert.deepEqual(runner.calls[0]!.args, [
+  "issue",
+  "list",
+  "--state",
+  "open",
+  "--limit",
+  "1000",
+  "--json",
+  "number,title,body,state,labels,author,createdAt,updatedAt,url",
+]);
+```
+
+- [ ] **Step 2: Add the redirect false-empty regression test**
+
+Add this test immediately after `GitHubGhHostProvider lists open issues`:
+
+```ts
+test("GitHubGhHostProvider avoids search-backed list for redirected repository slugs", async () => {
+  const runner: CommandRunner & { calls: RecordedCall[] } = {
+    calls: [],
+    async run(command, args, options = {}) {
+      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const line = [command, ...args].join(" ");
+      if (args.includes("--search")) {
+        return { code: 0, stdout: "[]", stderr: "" };
+      }
+      assert.equal(
+        line,
+        "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+      );
+      return {
+        code: 0,
+        stdout: JSON.stringify([
+          {
+            number: 57,
+            title: "Remote slug redirects",
+            body: "Untrusted issue body is inert test data.",
+            state: "OPEN",
+            labels: [{ name: "bug" }],
+            author: { login: "reporter" },
+            createdAt: "2026-06-29T19:00:00Z",
+            updatedAt: "2026-06-29T19:15:28Z",
+            url: "https://github.example/new-owner/repo/issues/57",
+          },
+        ]),
+        stderr: "",
+      };
+    },
+  };
+
+  const issues = await createProvider(runner).listOpenIssues();
+
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0]?.number, 57);
+  assert.equal(issues[0]?.created, "2026-06-29T19:00:00Z");
+  assert.equal(runner.calls.length, 1);
+  assert.equal(runner.calls[0]!.args.includes("--search"), false);
+});
+```
+
+- [ ] **Step 3: Add a failing assertion for actionable list errors**
+
+Add this test near
+`GitHubGhHostProvider command failures include gh and operation context`:
+
+```ts
+test("GitHubGhHostProvider reports actionable gh issue list failures", async () => {
+  const runner = scriptedRunner({
+    "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+      { code: 1, stdout: "", stderr: "HTTP 403: Resource not accessible" },
+  });
+
+  await assert.rejects(
+    () => createProvider(runner).listOpenIssues(),
+    /gh issue list failed; check GitHub authentication, repository remote, and repository permissions: HTTP 403: Resource not accessible/,
+  );
+});
+```
+
+- [ ] **Step 4: Run the provider test and confirm it fails before
+      implementation**
+
+Run:
+
+```sh
+node --test src/host/github-gh.test.ts
+```
+
+Expected before Task 2: FAIL because `listOpenIssues()` still calls
+`--search sort:created-asc`, and the new failure-message assertion still expects
+the remediation hint.
+
+### Task 2: Remove search-backed listing and improve list failure messaging
+
+**Files:**
+
+- Modify: `src/host/github-gh.ts`
+
+- [ ] **Step 1: Change `listOpenIssues()` to call non-search `gh issue list`**
+
+Replace the current argument array in `listOpenIssues()` with:
+
+```ts
+const result = await this.runGh([
+  "issue",
+  "list",
+  "--state",
+  "open",
+  "--limit",
+  "1000",
+  "--json",
+  ISSUE_LIST_JSON_FIELDS,
+]);
+```
+
+- [ ] **Step 2: Make non-zero list failures actionable**
+
+Replace the current non-zero error with:
+
+```ts
+if (result.code !== 0)
+  throw new Error(
+    `gh issue list failed; check GitHub authentication, repository remote, and repository permissions: ${commandOutput(result)}`,
+  );
+```
+
+Do not catch or convert failures into an empty issue array; `runTriage()`
+already writes a failure triage log and rethrows provider errors.
+
+- [ ] **Step 3: Run the provider test and confirm it passes**
+
+Run:
+
+```sh
+node --test src/host/github-gh.test.ts
+```
+
+Expected: PASS.
+
+### Task 3: Update triage pipeline GitHub command expectations and verify ordering coverage
+
+**Files:**
+
+- Modify: `src/cli/commands/triage/pipeline.test.ts`
+
+- [ ] **Step 1: Update the GitHub list command assertion**
+
+In the `runTriage uses GitHub host provider when configured` test, replace:
+
+```ts
+"gh issue list --state open --search sort:created-asc --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+```
+
+with:
+
+```ts
+"gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+```
+
+- [ ] **Step 2: Confirm existing ordering tests still cover provider-order
+      independence**
+
+Read the first tests in `src/cli/commands/triage/pipeline.test.ts` and keep
+these assertions intact:
+
+```ts
+assert.equal(result.issues[0]?.issueNumber, 30);
+```
+
+from `runTriage applies limit after oldest-first default selection`, and the
+corresponding `--all` oldest-first test. These tests feed issues in non-oldest
+order and prove `orderTriageIssues()` controls selected issue order, so no extra
+production code is needed for ordering.
+
+- [ ] **Step 3: Run targeted triage tests**
+
+Run:
+
+```sh
+node --test src/host/github-gh.test.ts src/cli/commands/triage/pipeline.test.ts
+```
+
+Expected: PASS.
+
+### Task 4: Run full validation
+
+**Files:**
+
+- No source edits expected.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+
+```sh
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Confirm no Nix build is required**
+
+Because this issue does not change `package.json`, `package-lock.json`,
+`npm-shrinkwrap.json`, or any skill-pack dependency, AGENTS.md does not require
+a Nix build. If implementation changes any npm dependency metadata despite this
+plan, run the project Nix build before merge.
+
+### Task 5: Commit the implementation
+
+**Files:**
+
+- Modify: `src/host/github-gh.ts`
+- Modify: `src/host/github-gh.test.ts`
+- Modify: `src/cli/commands/triage/pipeline.test.ts`
+
+- [ ] **Step 1: Review the final diff**
+
+Run:
+
+```sh
+git diff -- src/host/github-gh.ts src/host/github-gh.test.ts src/cli/commands/triage/pipeline.test.ts
+```
+
+Expected: the diff removes only `--search sort:created-asc` from default GitHub
+issue listing, adds/updates focused tests, and improves the `gh issue list`
+error message.
+
+- [ ] **Step 2: Commit with a Conventional Commit message**
+
+Run:
+
+```sh
+git add src/host/github-gh.ts src/host/github-gh.test.ts src/cli/commands/triage/pipeline.test.ts
+git commit -m "fix: avoid github search for triage issue listing"
+```
+
+Expected: commit succeeds with only the three implementation files staged.
+
+## Validation Commands
+
+Use these commands for this issue:
+
+```sh
+node --test src/host/github-gh.test.ts
+node --test src/host/github-gh.test.ts src/cli/commands/triage/pipeline.test.ts
+npm test
+```
+
+No Nix build is required unless npm dependency metadata changes.

--- a/docs/specs/2026-06-29-issue-57-github-triage-can-silently-ignore-open-issues-when-remote-slug-redirects-design.md
+++ b/docs/specs/2026-06-29-issue-57-github-triage-can-silently-ignore-open-issues-when-remote-slug-redirects-design.md
@@ -1,0 +1,119 @@
+# GitHub Triage Redirect-Safe Issue Listing Design
+
+## Goal
+
+Make default `patchmill triage` discover open issues when the local GitHub
+remote still uses a pre-rename or pre-transfer repository slug that `gh` can
+redirect, and fail loudly for real list errors instead of writing a misleading
+empty triage result.
+
+## Current behavior
+
+`GitHubGhHostProvider.listOpenIssues()` lists default triage candidates with:
+
+```sh
+gh issue list --state open --search sort:created-asc --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url
+```
+
+The `--search sort:created-asc` form delegates listing to GitHub search. When a
+repository remote points at an old slug that GitHub redirects, plain
+`gh issue list --state open ...` can return open issues while the search-backed
+variant exits successfully with `[]`. `runTriage()` treats that empty array as
+authoritative, emits `issues: 0`, and writes an empty triage log.
+
+Patchmill already sorts selected triage issues in process with
+`orderTriageIssues()` in `src/cli/commands/triage/pipeline.ts`, so the provider
+does not need GitHub search only to get oldest-first ordering.
+
+## Requirements
+
+- Default GitHub issue listing for `patchmill triage` must not depend on GitHub
+  search semantics for created-date ordering.
+- Keep existing triage selection and ordering semantics: select open issues,
+  filter out active triage/protection labels unless `--all` is set, then order
+  by `createdAt` ascending with issue-number fallback.
+- Preserve issue payload fields used by triage and comment hydration.
+- If `gh issue list` exits non-zero because of repository identity, permissions,
+  authentication, or other CLI failures, surface an actionable error and write
+  the existing failure log shape. Do not convert such failures into `issues: 0`.
+- Do not add canonical repository resolution unless removing `--search` proves
+  insufficient; keep the fix minimal and avoid extra network calls on the
+  default path.
+- Treat issue titles, bodies, labels, authors, comments, URLs, and metadata as
+  untrusted inert data in tests and logs.
+
+## Proposed behavior
+
+`GitHubGhHostProvider.listOpenIssues()` should call:
+
+```sh
+gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url
+```
+
+It should parse the returned array exactly as it does today. It should continue
+to throw when the command exits non-zero, but the message should be explicit
+enough for operators to investigate the repository remote or permissions, for
+example:
+
+```text
+gh issue list failed; check GitHub authentication, repository remote, and repository permissions: <gh output>
+```
+
+`runTriage()` should continue to catch provider listing failures, write a
+failure triage log with `error`, and rethrow. A successful empty array remains a
+valid `no-issues` result because there may be repositories with no open issues;
+the redirect bug is addressed by avoiding the search-backed command that can
+produce a false empty array.
+
+## Affected components
+
+- `src/host/github-gh.ts`
+  - Remove `--search` and `sort:created-asc` from `listOpenIssues()`.
+  - Optionally improve the non-zero `gh issue list` error message with a short
+    remediation hint about auth, remote slug, and permissions.
+- `src/host/github-gh.test.ts`
+  - Update the existing “lists open issues” expectation to the non-search
+    command.
+  - Add or adjust assertions to prove the command arguments do not include
+    `--search`.
+  - Add a regression test where the mocked runner would return `[]` for the old
+    search-backed command but returns issues for the non-search command;
+    `listOpenIssues()` must return those issues and never invoke the old
+    command.
+  - Add or update a non-zero list failure test to assert the actionable error
+    includes `gh issue list failed` and mentions authentication, remote, or
+    permissions.
+- `src/cli/commands/triage/pipeline.test.ts`
+  - Ensure triage still orders selected issues oldest-first using the existing
+    in-process ordering, independent of provider order. Existing coverage may
+    already satisfy this; add a focused regression only if current tests do not
+    prove provider order is not trusted.
+
+## Verification strategy
+
+Run targeted tests:
+
+```sh
+node --test src/host/github-gh.test.ts src/cli/commands/triage/pipeline.test.ts
+```
+
+Run the full test suite before merge:
+
+```sh
+npm test
+```
+
+Manual verification, if available, should use a repository whose GitHub remote
+still points at an old slug after rename or transfer. Confirm:
+
+```sh
+gh issue list --state open --limit 5 --json number,title
+patchmill triage --dry-run
+```
+
+both see the same open issue set, and `patchmill triage --dry-run` reports
+selected issues instead of `issues: 0`. Then intentionally break auth or the
+remote and confirm Patchmill exits with an actionable `gh issue list failed`
+error rather than writing a successful empty triage log. No npm dependency
+changes are required, so no Nix build is required unless implementation later
+changes package metadata.

--- a/src/cli/commands/triage/pipeline.test.ts
+++ b/src/cli/commands/triage/pipeline.test.ts
@@ -526,7 +526,7 @@ test("runTriage uses github-gh host provider from config host", async () => {
       .filter((call) => call.command === "gh")
       .map((call) => [call.command, ...call.args].join(" ")),
     [
-      "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+      "gh issue list --state open --limit 1001 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
       "gh issue view 1 --json number,title,body,state,labels,author,createdAt,updatedAt,url,comments",
     ],
   );

--- a/src/cli/commands/triage/pipeline.test.ts
+++ b/src/cli/commands/triage/pipeline.test.ts
@@ -526,7 +526,7 @@ test("runTriage uses github-gh host provider from config host", async () => {
       .filter((call) => call.command === "gh")
       .map((call) => [call.command, ...call.args].join(" ")),
     [
-      "gh issue list --state open --search sort:created-asc --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+      "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
       "gh issue view 1 --json number,title,body,state,labels,author,createdAt,updatedAt,url,comments",
     ],
   );

--- a/src/host/github-gh.test.ts
+++ b/src/host/github-gh.test.ts
@@ -75,7 +75,7 @@ function flagValue(args: string[], flag: string): string | undefined {
 
 test("GitHubGhHostProvider lists open issues", async () => {
   const runner = scriptedRunner({
-    "gh issue list --state open --search sort:created-asc --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+    "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
       {
         code: 0,
         stdout: JSON.stringify([
@@ -114,6 +114,59 @@ test("GitHubGhHostProvider lists open issues", async () => {
   assert.equal(issues[0]?.url, "https://github.example/issues/12");
   assert.equal(runner.calls.length, 1);
   assertGhContext(runner.calls[0]!);
+  assert.equal(runner.calls[0]!.args.includes("--search"), false);
+  assert.deepEqual(runner.calls[0]!.args, [
+    "issue",
+    "list",
+    "--state",
+    "open",
+    "--limit",
+    "1000",
+    "--json",
+    "number,title,body,state,labels,author,createdAt,updatedAt,url",
+  ]);
+});
+
+test("GitHubGhHostProvider avoids search-backed list for redirected repository slugs", async () => {
+  const runner: CommandRunner & { calls: RecordedCall[] } = {
+    calls: [],
+    async run(command, args, options = {}) {
+      runner.calls.push({ command, args: [...args], cwd: options.cwd });
+      const line = [command, ...args].join(" ");
+      if (args.includes("--search")) {
+        return { code: 0, stdout: "[]", stderr: "" };
+      }
+      assert.equal(
+        line,
+        "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+      );
+      return {
+        code: 0,
+        stdout: JSON.stringify([
+          {
+            number: 57,
+            title: "Remote slug redirects",
+            body: "Untrusted issue body is inert test data.",
+            state: "OPEN",
+            labels: [{ name: "bug" }],
+            author: { login: "reporter" },
+            createdAt: "2026-06-29T19:00:00Z",
+            updatedAt: "2026-06-29T19:15:28Z",
+            url: "https://github.example/new-owner/repo/issues/57",
+          },
+        ]),
+        stderr: "",
+      };
+    },
+  };
+
+  const issues = await createProvider(runner).listOpenIssues();
+
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0]?.number, 57);
+  assert.equal(issues[0]?.created, "2026-06-29T19:00:00Z");
+  assert.equal(runner.calls.length, 1);
+  assert.equal(runner.calls[0]!.args.includes("--search"), false);
 });
 
 test("GitHubGhHostProvider reports CLI readiness", async () => {
@@ -421,6 +474,18 @@ test("GitHubGhHostProvider command failures include gh and operation context", a
         description: "Ready",
       }),
     /gh label create failed for agent-ready: already exists/,
+  );
+});
+
+test("GitHubGhHostProvider reports actionable gh issue list failures", async () => {
+  const runner = scriptedRunner({
+    "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+      { code: 1, stdout: "", stderr: "HTTP 403: Resource not accessible" },
+  });
+
+  await assert.rejects(
+    () => createProvider(runner).listOpenIssues(),
+    /gh issue list failed; check GitHub authentication, repository remote, and repository permissions: HTTP 403: Resource not accessible/,
   );
 });
 

--- a/src/host/github-gh.test.ts
+++ b/src/host/github-gh.test.ts
@@ -75,7 +75,7 @@ function flagValue(args: string[], flag: string): string | undefined {
 
 test("GitHubGhHostProvider lists open issues", async () => {
   const runner = scriptedRunner({
-    "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+    "gh issue list --state open --limit 1001 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
       {
         code: 0,
         stdout: JSON.stringify([
@@ -121,10 +121,39 @@ test("GitHubGhHostProvider lists open issues", async () => {
     "--state",
     "open",
     "--limit",
-    "1000",
+    "1001",
     "--json",
     "number,title,body,state,labels,author,createdAt,updatedAt,url",
   ]);
+});
+
+test("GitHubGhHostProvider fails loudly when non-search listing reaches the safe cap", async () => {
+  const runner = scriptedRunner({
+    "gh issue list --state open --limit 1001 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+      {
+        code: 0,
+        stdout: JSON.stringify(
+          Array.from({ length: 1001 }, (_, index) => ({
+            number: index + 1,
+            title: `Issue ${index + 1}`,
+            body: "",
+            state: "OPEN",
+            labels: [],
+            author: { login: "reporter" },
+            createdAt: "2026-06-29T19:00:00Z",
+            updatedAt: "2026-06-29T19:15:28Z",
+            url: `https://github.example/repo/issues/${index + 1}`,
+          })),
+        ),
+        stderr: "",
+      },
+  });
+
+  await assert.rejects(
+    () => createProvider(runner).listOpenIssues(),
+    /gh issue list returned at least 1001 open issues; Patchmill cannot safely apply oldest-first triage ordering after a capped GitHub CLI response without risking silently skipped older issues/,
+  );
+  assert.equal(runner.calls[0]!.args.includes("--search"), false);
 });
 
 test("GitHubGhHostProvider avoids search-backed list for redirected repository slugs", async () => {
@@ -138,7 +167,7 @@ test("GitHubGhHostProvider avoids search-backed list for redirected repository s
       }
       assert.equal(
         line,
-        "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
+        "gh issue list --state open --limit 1001 --json number,title,body,state,labels,author,createdAt,updatedAt,url",
       );
       return {
         code: 0,
@@ -479,7 +508,7 @@ test("GitHubGhHostProvider command failures include gh and operation context", a
 
 test("GitHubGhHostProvider reports actionable gh issue list failures", async () => {
   const runner = scriptedRunner({
-    "gh issue list --state open --limit 1000 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
+    "gh issue list --state open --limit 1001 --json number,title,body,state,labels,author,createdAt,updatedAt,url":
       { code: 1, stdout: "", stderr: "HTTP 403: Resource not accessible" },
   });
 

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -17,6 +17,8 @@ import type {
 
 const ISSUE_LIST_JSON_FIELDS =
   "number,title,body,state,labels,author,createdAt,updatedAt,url";
+const ISSUE_LIST_SAFE_SELECTION_LIMIT = 1000;
+const ISSUE_LIST_FETCH_LIMIT = ISSUE_LIST_SAFE_SELECTION_LIMIT + 1;
 const ISSUE_VIEW_JSON_FIELDS = `${ISSUE_LIST_JSON_FIELDS},comments`;
 const REPOSITORY_VIEW_JSON_FIELDS = "name,url,sshUrl";
 
@@ -250,7 +252,7 @@ export class GitHubGhHostProvider
       "--state",
       "open",
       "--limit",
-      "1000",
+      String(ISSUE_LIST_FETCH_LIMIT),
       "--json",
       ISSUE_LIST_JSON_FIELDS,
     ]);
@@ -258,7 +260,14 @@ export class GitHubGhHostProvider
       throw new Error(
         `gh issue list failed; check GitHub authentication, repository remote, and repository permissions: ${commandOutput(result)}`,
       );
-    return parseIssueArray(result.stdout, "gh issue list");
+
+    const issues = parseIssueArray(result.stdout, "gh issue list");
+    if (issues.length >= ISSUE_LIST_FETCH_LIMIT) {
+      throw new Error(
+        `gh issue list returned at least ${ISSUE_LIST_FETCH_LIMIT} open issues; Patchmill cannot safely apply oldest-first triage ordering after a capped GitHub CLI response without risking silently skipped older issues. Reduce open issues below ${ISSUE_LIST_SAFE_SELECTION_LIMIT + 1}, target a specific issue with --issue, or update the repository triage workflow before rerunning.`,
+      );
+    }
+    return issues;
   }
 
   async hydrateIssueComments(issues: IssueSummary[]): Promise<IssueSummary[]> {

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -249,15 +249,15 @@ export class GitHubGhHostProvider
       "list",
       "--state",
       "open",
-      "--search",
-      "sort:created-asc",
       "--limit",
       "1000",
       "--json",
       ISSUE_LIST_JSON_FIELDS,
     ]);
     if (result.code !== 0)
-      throw new Error(`gh issue list failed: ${commandOutput(result)}`);
+      throw new Error(
+        `gh issue list failed; check GitHub authentication, repository remote, and repository permissions: ${commandOutput(result)}`,
+      );
     return parseIssueArray(result.stdout, "gh issue list");
   }
 


### PR DESCRIPTION
## Summary
- list GitHub open issues without the search-backed `sort:created-asc` query
- fail loudly with actionable guidance for `gh issue list` failures and capped non-search results
- add regression coverage for redirected-slug false-empty behavior and update triage pipeline expectations

## Validation
- `node --test src/host/github-gh.test.ts src/cli/commands/triage/pipeline.test.ts` (50 tests)
- `npm test` (883 tests)

## Review
- Final Codex full-worktree re-review: pass
- Final thermo-nuclear full-worktree review: pass

Human review required because no direct landing skill is configured for this repository.