### PR TITLE
Add skill pack update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ change the default host login, installs Patchmill's recommended skills into
 machines and CI, consider committing `patchmill.config.json` and
 `.patchmill/skills/` explicitly.
 
+To update a repository after Patchmill publishes a newer bundled skill pack,
+run:
+
+```sh
+npx patchmill@latest skills update
+```
+
+The update command only changes Patchmill-managed project-local skills. It stops
+if managed skill files were edited locally. After a successful update, run
+`git diff` and commit the skill changes with the repository.
+
 Alternative initialization modes:
 
 ```sh

--- a/docs/plans/2026-06-30-issue-58-dry-run-triage-can-fail-on-malformed-pi-json-when-session-observation-is-enabled.md
+++ b/docs/plans/2026-06-30-issue-58-dry-run-triage-can-fail-on-malformed-pi-json-when-session-observation-is-enabled.md
@@ -1,0 +1,431 @@
+# Dry-Run Triage Malformed Pi JSON Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `patchmill triage --dry-run --issue <number>` recover from a
+complete preview JSON document followed by trailing Pi runner garbage while
+preserving useful errors for genuinely invalid stdout.
+
+**Architecture:** Keep the fix localized in
+`src/cli/commands/triage/dry-run-agent.ts`: strict parse direct/fenced JSON
+first, then run a narrow brace-depth extraction for a complete top-level object
+whose parsed value has a `previews` array. Reuse the existing
+`validateTriagePreviewDocument()` path for schema validation, and add bounded
+printable stdout snippets only to invalid-JSON parse failures.
+
+**Tech Stack:** Node.js 22 ESM, TypeScript, `node:test`, `node:assert/strict`,
+existing Patchmill triage command runner tests.
+
+---
+
+## File Structure
+
+- Modify `src/cli/commands/triage/dry-run-agent.ts`
+  - Keep `runTriageDryRunAgent()` read-only and session-observation behavior
+    unchanged.
+  - Add private helpers near `parseTriagePreviewJson()` for fenced-body
+    extraction, complete JSON object candidate scanning, parse-failure position
+    extraction, and bounded printable snippets.
+  - Update `parseTriagePreviewJson(stdout)` to strict-parse first, recover only
+    a complete document with top-level `previews`, then throw the existing
+    invalid-JSON prefix with snippet context when recovery fails.
+- Modify `src/cli/commands/triage/dry-run-agent.test.ts`
+  - Add parser regression tests for trailing `}` recovery and invalid-output
+    snippets.
+  - Add a runner test proving `runTriageDryRunAgent()` still enables
+    `--session-dir` and successfully parses stdout with the extra trailing
+    brace.
+- No changes to `package.json`, `package-lock.json`, `npm-shrinkwrap.json`, Pi
+  dependencies, skill packs, or generated `.pi/todos` files.
+
+## Validation Commands
+
+Run these after the implementation tasks:
+
+```sh
+node --test src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/pipeline.test.ts
+npm test
+```
+
+No npm dependency metadata changes are planned, so AGENTS.md does not require a
+Nix build. If an implementation unexpectedly changes `package.json`,
+`package-lock.json`, or `npm-shrinkwrap.json`, also run the repository Nix build
+before merge.
+
+## Tasks
+
+### Task 1: Add parser regression tests for recovery and snippets
+
+**Files:**
+
+- Modify: `src/cli/commands/triage/dry-run-agent.test.ts`
+- Test: `src/cli/commands/triage/dry-run-agent.test.ts`
+
+- [ ] **Step 1: Add a trailing-garbage parser test next to the existing
+      direct/fenced JSON test**
+
+Add this test after `parseTriagePreviewJson extracts direct and fenced JSON`:
+
+```ts
+test("parseTriagePreviewJson recovers preview document with trailing extra brace", () => {
+  const stdout =
+    '{"previews":[{"issueNumber":123,"currentLabels":["enhancement"],"proposedLabels":["enhancement","agent-ready"],"canonicalBucket":"agent-ready","blockedBy":[],"rationale":"Ready for implementation.","wouldComment":null,"wouldClose":false,"questions":[]}]}}';
+
+  assert.deepEqual(parseTriagePreviewJson(stdout), {
+    previews: [
+      {
+        issueNumber: 123,
+        currentLabels: ["enhancement"],
+        proposedLabels: ["enhancement", "agent-ready"],
+        canonicalBucket: "agent-ready",
+        blockedBy: [],
+        rationale: "Ready for implementation.",
+        wouldComment: null,
+        wouldClose: false,
+        questions: [],
+      },
+    ],
+  });
+});
+```
+
+- [ ] **Step 2: Add an invalid-output snippet test**
+
+Add this test after the trailing-garbage parser test:
+
+```ts
+test("parseTriagePreviewJson reports a bounded stdout snippet when recovery fails", () => {
+  const stdout = `${"x".repeat(90)}{"previews":[{"issueNumber":123,]${"y".repeat(90)}`;
+
+  assert.throws(
+    () => parseTriagePreviewJson(stdout),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^Pi triage dry-run returned invalid JSON:/);
+      assert.match(error.message, /stdout near parse failure:/);
+      assert.match(error.message, /"previews"/);
+      assert.equal(error.message.includes("x".repeat(90)), false);
+      assert.equal(error.message.includes("y".repeat(90)), false);
+      return true;
+    },
+  );
+});
+```
+
+- [ ] **Step 3: Run the targeted parser tests and verify they fail for the
+      expected reason**
+
+Run:
+
+```sh
+node --test src/cli/commands/triage/dry-run-agent.test.ts
+```
+
+Expected: the new trailing-garbage test fails with the existing
+`Unexpected non-whitespace character after JSON` invalid-JSON error, and the new
+snippet test fails because the current error has no `stdout near parse failure:`
+context.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```sh
+git add src/cli/commands/triage/dry-run-agent.test.ts
+git commit -m "test: cover dry-run triage malformed pi json"
+```
+
+### Task 2: Implement narrow preview JSON extraction and parse-failure snippets
+
+**Files:**
+
+- Modify: `src/cli/commands/triage/dry-run-agent.ts`
+- Test: `src/cli/commands/triage/dry-run-agent.test.ts`
+
+- [ ] **Step 1: Add helpers above `parseTriagePreviewJson()`**
+
+Insert this code immediately before `export function parseTriagePreviewJson`:
+
+````ts
+const STDOUT_SNIPPET_RADIUS = 80;
+
+function triagePreviewJsonBody(stdout: string): string {
+  const trimmed = stdout.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return fenced ? fenced[1] : trimmed;
+}
+
+function hasTopLevelPreviews(
+  value: unknown,
+): value is RawTriagePreviewDocument {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Array.isArray((value as Record<string, unknown>).previews)
+  );
+}
+
+function parseErrorPosition(error: unknown): number | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const match = error.message.match(/position (\d+)/);
+  if (!match) return undefined;
+  return Number.parseInt(match[1]!, 10);
+}
+
+function printableSnippet(value: string): string {
+  return value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "�");
+}
+
+function stdoutSnippet(stdout: string, position?: number): string {
+  const center =
+    position === undefined || !Number.isFinite(position)
+      ? Math.min(stdout.length, STDOUT_SNIPPET_RADIUS)
+      : Math.max(0, Math.min(stdout.length, position));
+  const start = Math.max(0, center - STDOUT_SNIPPET_RADIUS);
+  const end = Math.min(stdout.length, center + STDOUT_SNIPPET_RADIUS);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < stdout.length ? "…" : "";
+  return `${prefix}${printableSnippet(stdout.slice(start, end))}${suffix}`;
+}
+
+function recoverPreviewJsonDocument(
+  body: string,
+): RawTriagePreviewDocument | undefined {
+  let inString = false;
+  let escaped = false;
+  let depth = 0;
+  let start = -1;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index]!;
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{") {
+      if (depth === 0) start = index;
+      depth += 1;
+      continue;
+    }
+
+    if (char !== "}") continue;
+    if (depth === 0) continue;
+
+    depth -= 1;
+    if (depth !== 0 || start < 0) continue;
+
+    try {
+      const parsed = JSON.parse(body.slice(start, index + 1)) as unknown;
+      if (hasTopLevelPreviews(parsed)) return parsed;
+    } catch {
+      // Keep scanning for the next complete top-level object candidate.
+    }
+    start = -1;
+  }
+
+  return undefined;
+}
+````
+
+- [ ] **Step 2: Replace `parseTriagePreviewJson()` with strict-first recovery**
+
+Replace the existing function with:
+
+```ts
+export function parseTriagePreviewJson(
+  stdout: string,
+): RawTriagePreviewDocument {
+  const json = triagePreviewJsonBody(stdout);
+
+  try {
+    return JSON.parse(json) as RawTriagePreviewDocument;
+  } catch (error) {
+    const recovered = recoverPreviewJsonDocument(json);
+    if (recovered) return recovered;
+
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Pi triage dry-run returned invalid JSON: ${message}; stdout near parse failure: ${stdoutSnippet(
+        json,
+        parseErrorPosition(error),
+      )}`,
+      { cause: error },
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Run the parser test file and verify Task 1 tests pass**
+
+Run:
+
+```sh
+node --test src/cli/commands/triage/dry-run-agent.test.ts
+```
+
+Expected: all tests in `dry-run-agent.test.ts` pass, including direct JSON,
+fenced JSON, trailing extra `}`, invalid snippet, and existing validation tests.
+
+- [ ] **Step 4: Commit the implementation**
+
+```sh
+git add src/cli/commands/triage/dry-run-agent.ts src/cli/commands/triage/dry-run-agent.test.ts
+git commit -m "fix: recover dry-run triage preview json"
+```
+
+### Task 3: Prove session-observed dry-run triage parses the recovered preview
+
+**Files:**
+
+- Modify: `src/cli/commands/triage/dry-run-agent.test.ts`
+- Test: `src/cli/commands/triage/dry-run-agent.test.ts`
+
+- [ ] **Step 1: Add a focused runner class that returns the observed malformed
+      stdout**
+
+Add this class after `RecordingRunner`:
+
+```ts
+class TrailingBraceRunner extends RecordingRunner {
+  override async run(
+    command: string,
+    args: string[],
+    options: CommandRunOptions = {},
+  ) {
+    await super.run(command, args, options);
+    return {
+      code: 0,
+      stdout:
+        '{"previews":[{"issueNumber":42,"currentLabels":["needs-triage","enhancement"],"proposedLabels":["ready-for-agent","enhancement"],"canonicalBucket":"agent-ready","blockedBy":[],"rationale":"Clear enough for an agent.","wouldComment":"## Agent Brief\\nImplement CSV export.","wouldClose":false,"questions":[]}]}}',
+      stderr: "",
+    };
+  }
+}
+```
+
+If TypeScript formatting wraps the method signature, keep the same behavior:
+record the Pi call by delegating to `super.run()`, then return one preview JSON
+document plus one extra trailing `}`.
+
+- [ ] **Step 2: Add the session-observation regression test**
+
+Add this test after
+`runTriageDryRunAgent enables session observation for tool-call logging`:
+
+```ts
+test("runTriageDryRunAgent parses trailing garbage when session observation is enabled", async () => {
+  const runner = new TrailingBraceRunner();
+
+  const previews = await runTriageDryRunAgent(runner, "/repo", {
+    issues,
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    stateMap,
+    onToolCall() {},
+  });
+
+  assert.equal(previews[0]?.issueNumber, 42);
+  assert.equal(previews[0]?.canonicalBucket, "agent-ready");
+  const call = runner.calls[0]!;
+  const sessionDirIndex = call.args.indexOf("--session-dir");
+  assert.notEqual(sessionDirIndex, -1);
+  assert.equal(call.args.includes("--no-session"), false);
+});
+```
+
+- [ ] **Step 3: Run dry-run agent tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/triage/dry-run-agent.test.ts
+```
+
+Expected: the new session-observation test passes and confirms `--session-dir`
+is still used.
+
+- [ ] **Step 4: Commit the session regression test**
+
+```sh
+git add src/cli/commands/triage/dry-run-agent.test.ts
+git commit -m "test: cover observed dry-run triage preview recovery"
+```
+
+### Task 4: Run issue-level validation and prepare for merge
+
+**Files:**
+
+- Verify: `src/cli/commands/triage/dry-run-agent.ts`
+- Verify: `src/cli/commands/triage/dry-run-agent.test.ts`
+- Verify: repository test suite
+
+- [ ] **Step 1: Run targeted triage parser and pipeline coverage**
+
+Run:
+
+```sh
+node --test src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/pipeline.test.ts
+```
+
+Expected: both test files pass. This covers the parser,
+`runTriageDryRunAgent()`, and the existing pipeline assertion that dry-run
+progress observation enables `--session-dir`.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+
+```sh
+npm test
+```
+
+Expected: the full Node test suite passes.
+
+- [ ] **Step 3: Check dependency metadata was not changed**
+
+Run:
+
+```sh
+git diff -- package.json package-lock.json npm-shrinkwrap.json
+```
+
+Expected: no diff. If any of these files changed, revert unintended dependency
+changes or run the required Nix build before merge.
+
+- [ ] **Step 4: Commit validation notes if any tracked docs or tests were
+      adjusted during validation**
+
+If validation required no further file edits, do not create an empty commit. If
+validation exposed a small test-name or formatting fix, commit only that fix:
+
+```sh
+git add src/cli/commands/triage/dry-run-agent.ts src/cli/commands/triage/dry-run-agent.test.ts
+git commit -m "test: validate dry-run triage json recovery"
+```
+
+## Self-Review
+
+- Spec coverage: Task 1 covers the trailing `}` unit test and snippet assertion;
+  Task 2 implements strict-first parsing, fenced JSON preservation, narrow
+  complete-object recovery, and bounded printable snippets; Task 3 covers
+  session observation remaining enabled while parsing recovered previews; Task 4
+  covers required validation commands and AGENTS.md dependency/Nix guidance.
+- Placeholder scan: the plan includes concrete code snippets, paths, commands,
+  expected outcomes, and no TBD-style placeholders.
+- Type consistency: helpers return `RawTriagePreviewDocument`, tests import
+  existing `CommandRunOptions`, and all new tests call existing exported
+  functions without introducing public APIs.

--- a/docs/plans/2026-06-30-issue-59-add-skill-pack-update-command.md
+++ b/docs/plans/2026-06-30-issue-59-add-skill-pack-update-command.md
@@ -1,0 +1,868 @@
+# Skill Pack Update Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `patchmill skills update` so repositories can refresh
+Patchmill-managed project-local skills to the skill pack bundled in the running
+Patchmill CLI.
+
+**Architecture:** Put the update behavior in a reusable updater beside CLI
+command code, then wrap it with a small `skills` namespace. The updater treats
+existing metadata hashes as ownership proof for old files, treats the bundled
+recommended pack as ownership proof for new files, refuses unsafe writes before
+copying, and emits structured results that CLI code formats for users.
+
+**Tech Stack:** TypeScript ESM, Node `fs/promises`, Node test runner, existing
+Patchmill skill-pack metadata helpers and init skill-installer dependency
+abstractions.
+
+---
+
+## Global Constraints
+
+- Latest means `PATCHMILL_RECOMMENDED_SKILL_PACK` bundled in the currently
+  running CLI.
+- Do not query npm, GitHub, package registries, or release APIs.
+- Only update Patchmill-managed project-local skill packs under
+  `.patchmill/skills/`.
+- Require `.patchmill/skills/patchmill-skill-pack.json` metadata for the
+  `patchmill-recommended` pack.
+- Abort before writing when any old managed file is edited, missing, unreadable,
+  or when a new bundled file would overwrite an untracked local file.
+- Only edit paths recorded in the old metadata or present in the new bundled
+  recommended pack.
+- Do not implement global updates, custom skill directory updates,
+  merge/conflict resolution, or `--dry-run`.
+- Because this changes skill-pack behavior, verification must include AGENTS.md
+  integration checks: bundled upstream Superpowers skill files exist at resolved
+  paths, and Patchmill skill-pack config, metadata, tests, and live dependency
+  references agree on the upstream version.
+- No npm dependency files should change. If they unexpectedly do, rerun the Nix
+  build as required by AGENTS.md.
+
+## File Structure
+
+- Modify `src/workflow/skill-pack.ts`
+  - Widen metadata-facing types so older installed metadata versions and source
+    tags type-check.
+  - Keep `PATCHMILL_RECOMMENDED_SKILL_PACK` pinned to the current exact bundled
+    version.
+- Create `src/cli/commands/skills/update.ts`
+  - Export `SkillPackUpdateResult`, `SkillPackUpdateOptions`, and
+    `updateProjectSkills()`.
+  - Own metadata validation, hash preflight, bundled pack enumeration, unmanaged
+    collision detection, copy, obsolete-file removal, and metadata write.
+- Create `src/cli/commands/skills/update.test.ts`
+  - Cover clean update, already-current pack, dirty managed file, missing
+    managed file, missing metadata, and unmanaged new-file collision.
+- Create `src/cli/commands/skills/main.ts`
+  - Export `HELP_TEXT`, command option/output types, `runSkills()`, and
+    executable `main()`.
+  - Own `patchmill skills` help, `update` routing, unsupported argument errors,
+    and user-facing output.
+- Create `src/cli/commands/skills/main.test.ts`
+  - Cover help, update output, already-current output, unknown subcommands, and
+    unexpected args.
+- Modify `src/cli/main.ts`
+  - Add top-level help text and routing for `skills`.
+- Modify `src/cli/main.test.ts`
+  - Cover `skills` command resolution, top-level help entry, and dispatch.
+- Modify `README.md`
+  - Add short update guidance near the project-local skill installation
+    paragraph.
+- Modify `docs/skills.md`
+  - Add detailed update guidance under Project-local default skills.
+
+### Task 1: Add the reusable skill-pack updater
+
+**Files:**
+
+- Modify: `src/workflow/skill-pack.ts`
+- Create: `src/cli/commands/skills/update.ts`
+- Create: `src/cli/commands/skills/update.test.ts`
+
+- [ ] **Step 1: Widen skill-pack metadata types**
+
+In `src/workflow/skill-pack.ts`, replace the current `SkillPackSource`,
+`SkillPackSkill`, `SkillPack`, and `SkillPackMetadataFile` type block with:
+
+```ts
+export type SkillPackSource = {
+  type: "github-release";
+  repository: string;
+  tag: string;
+  tarballUrl: string;
+};
+
+export type SkillPackSkill = {
+  name: string;
+  source: "patchmill" | "superpowers";
+};
+
+export type SkillPack = {
+  name: "patchmill-recommended";
+  version: string;
+  source: SkillPackSource;
+  skills: SkillPackSkill[];
+};
+
+export type SkillPackMetadataFile = {
+  pack: {
+    name: string;
+    version: string;
+    source: SkillPackSource;
+  };
+  installedAt: "<generated-by-init>" | string;
+  skillDir: string;
+  metadataFile: typeof SKILL_PACK_METADATA_FILE;
+  files: Array<{ path: string; sha256: string }>;
+};
+```
+
+Do not change `PATCHMILL_RECOMMENDED_SKILL_PACK` values in this step.
+
+- [ ] **Step 2: Write failing updater tests**
+
+Create `src/cli/commands/skills/update.test.ts` with fixtures and tests that
+exercise the updater through a dependency-injected temp filesystem. Include
+these imports and dependency object:
+
+```ts
+import assert from "node:assert/strict";
+import {
+  access,
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "../../../workflow/skill-pack.ts";
+import type { SkillInstallerDependencies } from "../init/skill-installer.ts";
+import { updateProjectSkills } from "./update.ts";
+
+const dependencies: SkillInstallerDependencies = {
+  access,
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+};
+```
+
+Add helpers `tempRoot()`, `writeFileEnsuringParent()`, `writeSkill()`,
+`writeMetadata()`, and `oldMetadata()` so tests can install a fake old pack and
+fake bundled source roots. Then add these six tests:
+
+```ts
+test("updateProjectSkills updates clean managed project-local skills", async () => {
+  // old metadata contains writing-plans/SKILL.md and obsolete-skill/SKILL.md.
+  // bundled source contains writing-plans/SKILL.md plus writing-plans/notes.md.
+  // assert status "updated", old version -> current pack version, 2 updated files,
+  // 1 removed file, copied file contents, removed obsolete file, and sorted new metadata.
+});
+
+test("updateProjectSkills reports already current packs", async () => {
+  // metadata version/source/files match the bundled pack.
+  // assert { status: "up-to-date", version: PATCHMILL_RECOMMENDED_SKILL_PACK.version }.
+});
+
+test("updateProjectSkills aborts when managed files changed locally", async () => {
+  // metadata hash records old content, actual file contains "local edit\n".
+  // assert rejection starts with "Refusing to update customized project-local skills:" and lists the path.
+  // assert local file content is unchanged.
+});
+
+test("updateProjectSkills aborts when managed files are missing", async () => {
+  // metadata records writing-plans/SKILL.md but the file is absent.
+  // assert rejection lists ".patchmill/skills/writing-plans/SKILL.md (missing)".
+});
+
+test("updateProjectSkills requires Patchmill-managed project-local metadata", async () => {
+  // no metadata file exists.
+  // assert rejection equals the two-line missing metadata message from the spec.
+});
+
+test("updateProjectSkills aborts when new bundled files would overwrite local files", async () => {
+  // old metadata records only SKILL.md; bundled pack adds new-file.md;
+  // local untracked new-file.md already exists.
+  // assert rejection starts with "Refusing to overwrite unmanaged project-local skill files:".
+});
+```
+
+Use exact expected messages from the spec:
+
+```text
+No Patchmill-managed project-local skill pack found. Run `patchmill init` first,
+or reinstall project-local skills.
+```
+
+```text
+Refusing to update customized project-local skills:
+- .patchmill/skills/writing-plans/SKILL.md
+```
+
+```text
+Refusing to overwrite unmanaged project-local skill files:
+- .patchmill/skills/writing-plans/new-file.md
+```
+
+- [ ] **Step 3: Run updater tests and confirm the expected failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/skills/update.test.ts
+```
+
+Expected: fails because `src/cli/commands/skills/update.ts` does not exist yet.
+
+- [ ] **Step 4: Implement `updateProjectSkills()`**
+
+Create `src/cli/commands/skills/update.ts` with these exported interfaces:
+
+```ts
+export type SkillPackUpdateResult =
+  | { status: "up-to-date"; version: string }
+  | {
+      status: "updated";
+      fromVersion: string;
+      toVersion: string;
+      updatedFiles: number;
+      removedFiles: number;
+    };
+
+export type SkillPackUpdateOptions = {
+  repoRoot: string;
+  sourceRoots?: SourceRoots;
+  packSkills?: SkillPackSkill[];
+  installedAt?: string;
+  dependencies?: SkillInstallerDependencies;
+};
+
+export async function updateProjectSkills(
+  options: SkillPackUpdateOptions,
+): Promise<SkillPackUpdateResult>;
+```
+
+Implementation requirements:
+
+1. Import `DEFAULT_PROJECT_SKILL_DIR`, `PATCHMILL_RECOMMENDED_SKILL_PACK`,
+   `SKILL_PACK_METADATA_FILE`, `buildSkillPackMetadata`, `hashContent`,
+   `projectSkillPath`, and metadata/skill types from
+   `../../../workflow/skill-pack.ts`.
+2. Import `defaultSkillSourceRoots`, `SourceRoots`, and
+   `SkillInstallerDependencies` from `../init/skill-installer.ts`.
+3. Read metadata from
+   `resolve(repoRoot, DEFAULT_PROJECT_SKILL_DIR, SKILL_PACK_METADATA_FILE)` and
+   convert parse/read failures to the two-line missing metadata message.
+4. Validate `metadata.pack.name`, `metadata.skillDir`, `metadata.metadataFile`,
+   and `metadata.files` before trusting it.
+5. Hash every old metadata file with `hashContent(await readFile(path))`;
+   missing files should be reported as `path (missing)`, unreadable or changed
+   files as `path`.
+6. Enumerate bundled files recursively from each `packSkills` source root,
+   require `SKILL.md` to exist, normalize metadata paths with POSIX `/`, and
+   sort by path.
+7. Detect unmanaged new-file collisions by checking bundled paths absent from
+   old metadata that already exist under `repoRoot`.
+8. Build new metadata with
+   `buildSkillPackMetadata(newFiles, { installedAt, skillDir: DEFAULT_PROJECT_SKILL_DIR })`.
+9. Return `up-to-date` when old version, old source, and old file hash list
+   match new metadata.
+10. Otherwise remove obsolete old managed files, copy each bundled skill
+    directory into its target with
+    `cp(..., { recursive: true, force: true, errorOnExist: false })`, write new
+    metadata, and return updated counts.
+
+Use helper names that make the safety boundaries clear: `readInstalledMetadata`,
+`assertPatchmillManagedProjectLocal`, `customizedManagedFiles`,
+`collectBundledPackFiles`, `unmanagedNewFileCollisions`,
+`removeObsoleteManagedFiles`, and `copyBundledSkills`.
+
+- [ ] **Step 5: Run and fix updater tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/skills/update.test.ts src/workflow/skill-pack.test.ts
+```
+
+Expected: all tests pass. If `src/workflow/skill-pack.test.ts` fails, preserve
+its assertions that the current bundled source is `obra/superpowers` tag
+`v6.0.3` and pack version `2026.05`; only adjust type-facing code.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```sh
+git add src/workflow/skill-pack.ts src/cli/commands/skills/update.ts src/cli/commands/skills/update.test.ts
+git commit -m "feat(skills): update managed project skills"
+```
+
+### Task 2: Add the `patchmill skills` CLI namespace
+
+**Files:**
+
+- Create: `src/cli/commands/skills/main.ts`
+- Create: `src/cli/commands/skills/main.test.ts`
+- Modify: `src/cli/main.ts`
+- Modify: `src/cli/main.test.ts`
+
+- [ ] **Step 1: Write failing skills command tests**
+
+Create `src/cli/commands/skills/main.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HELP_TEXT, runSkills } from "./main.ts";
+
+const updatedResult = {
+  status: "updated" as const,
+  fromVersion: "2026.04",
+  toVersion: "2026.05",
+  updatedFiles: 14,
+  removedFiles: 2,
+};
+
+test("runSkills prints help", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runSkills(["--help"], {
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async () => updatedResult,
+    }),
+    0,
+  );
+
+  assert.deepEqual(stdout, [HELP_TEXT]);
+  assert.deepEqual(stderr, []);
+});
+
+test("runSkills updates project-local skills", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls: string[] = [];
+
+  assert.equal(
+    await runSkills(["update"], {
+      repoRoot: "/repo",
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async (options) => {
+        calls.push(options.repoRoot);
+        return updatedResult;
+      },
+    }),
+    0,
+  );
+
+  assert.deepEqual(calls, ["/repo"]);
+  assert.deepEqual(stdout, [
+    "Updated Patchmill skill pack 2026.04 -> 2026.05.",
+    "Updated 14 files, removed 2 obsolete files.",
+    "Run git diff to review changes.",
+  ]);
+  assert.deepEqual(stderr, []);
+});
+
+test("runSkills reports already current packs", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runSkills(["update"], {
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async () => ({
+        status: "up-to-date",
+        version: "2026.05",
+      }),
+    }),
+    0,
+  );
+
+  assert.deepEqual(stdout, ["Patchmill skill pack is already up to date."]);
+  assert.deepEqual(stderr, []);
+});
+
+test("runSkills rejects unknown subcommands", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runSkills(["reset"], {
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async () => updatedResult,
+    }),
+    1,
+  );
+
+  assert.deepEqual(stdout, []);
+  assert.deepEqual(stderr, ["Unknown skills command: reset", HELP_TEXT]);
+});
+
+test("runSkills rejects update arguments", async () => {
+  await assert.rejects(
+    runSkills(["update", "--dry-run"], {
+      updateProjectSkills: async () => updatedResult,
+    }),
+    /patchmill skills update does not accept arguments/u,
+  );
+});
+```
+
+- [ ] **Step 2: Run skills command tests and confirm the expected failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/skills/main.test.ts
+```
+
+Expected: fails because `src/cli/commands/skills/main.ts` does not exist yet.
+
+- [ ] **Step 3: Implement `src/cli/commands/skills/main.ts`**
+
+Create `src/cli/commands/skills/main.ts`:
+
+```ts
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import {
+  updateProjectSkills as defaultUpdateProjectSkills,
+  type SkillPackUpdateOptions,
+  type SkillPackUpdateResult,
+} from "./update.ts";
+
+export const HELP_TEXT = `Usage:
+  patchmill skills update
+
+Manage Patchmill project-local skills.
+
+Commands:
+  update  Update Patchmill-managed project-local skills.
+`;
+
+export type SkillsCommandOutput = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+};
+
+export type SkillsCommandOptions = {
+  repoRoot?: string;
+  output?: SkillsCommandOutput;
+  updateProjectSkills?: (
+    options: SkillPackUpdateOptions,
+  ) => Promise<SkillPackUpdateResult>;
+};
+
+const DEFAULT_OUTPUT: SkillsCommandOutput = {
+  stdout: (line) => console.log(line),
+  stderr: (line) => console.error(line),
+};
+
+function isHelp(arg: string | undefined): boolean {
+  return !arg || arg === "--help" || arg === "-h" || arg === "help";
+}
+
+function formatCount(count: number, singular: string): string {
+  return `${count} ${count === 1 ? singular : `${singular}s`}`;
+}
+
+function printUpdateResult(
+  output: SkillsCommandOutput,
+  result: SkillPackUpdateResult,
+): void {
+  if (result.status === "up-to-date") {
+    output.stdout("Patchmill skill pack is already up to date.");
+    return;
+  }
+
+  output.stdout(
+    `Updated Patchmill skill pack ${result.fromVersion} -> ${result.toVersion}.`,
+  );
+  output.stdout(
+    `Updated ${formatCount(result.updatedFiles, "file")}, removed ${formatCount(
+      result.removedFiles,
+      "obsolete file",
+    )}.`,
+  );
+  output.stdout("Run git diff to review changes.");
+}
+
+export async function runSkills(
+  args: string[],
+  options: SkillsCommandOptions = {},
+): Promise<number> {
+  const output = options.output ?? DEFAULT_OUTPUT;
+  const subcommand = args[0];
+  if (isHelp(subcommand)) {
+    output.stdout(HELP_TEXT);
+    return 0;
+  }
+
+  if (subcommand !== "update") {
+    output.stderr(`Unknown skills command: ${subcommand}`);
+    output.stderr(HELP_TEXT);
+    return 1;
+  }
+
+  if (args.length > 1) {
+    throw new Error("patchmill skills update does not accept arguments");
+  }
+
+  const updateProjectSkills =
+    options.updateProjectSkills ?? defaultUpdateProjectSkills;
+  const result = await updateProjectSkills({
+    repoRoot: options.repoRoot ?? process.cwd(),
+  });
+  printUpdateResult(output, result);
+  return 0;
+}
+
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  try {
+    return await runSkills(args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isMain) {
+  process.exitCode = await main();
+}
+```
+
+- [ ] **Step 4: Run skills command tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/skills/main.test.ts src/cli/commands/skills/update.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Write failing top-level CLI routing tests**
+
+Modify `src/cli/main.test.ts`.
+
+Add this test near other `resolveCommand maps ...` tests:
+
+```ts
+test("resolveCommand maps skills to the public command name", () => {
+  assert.deepEqual(resolveCommand(["skills", "update"], ["skills"]), {
+    command: "skills",
+    args: ["update"],
+  });
+});
+```
+
+In `createCliMain prints top-level help`, add:
+
+```ts
+assert.match(HELP_TEXT, /skills\s+Manage Patchmill project-local skills\./);
+```
+
+Add this dispatch test near other `createCliMain dispatches ...` tests:
+
+```ts
+test("createCliMain dispatches skills command", async () => {
+  const calls: string[][] = [];
+  const main = createCliMain(
+    new Map([
+      [
+        "skills",
+        async (args) => {
+          calls.push(args);
+          return 0;
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(await main(["skills", "update"]), 0);
+  assert.deepEqual(calls, [["update"]]);
+});
+```
+
+Run:
+
+```sh
+node --test src/cli/main.test.ts
+```
+
+Expected: fails because top-level help and routing do not include `skills` yet.
+
+- [ ] **Step 6: Wire `skills` into the top-level CLI**
+
+Modify `src/cli/main.ts`:
+
+1. Add the import:
+
+   ```ts
+   import { main as skillsMain } from "./commands/skills/main.ts";
+   ```
+
+2. Add this help line before `version`:
+
+   ```text
+     skills      Manage Patchmill project-local skills.
+   ```
+
+3. Add this `COMMANDS` entry:
+
+   ```ts
+   ["skills", skillsMain],
+   ```
+
+- [ ] **Step 7: Run top-level and skills command tests**
+
+Run:
+
+```sh
+node --test src/cli/main.test.ts src/cli/commands/skills/main.test.ts src/cli/commands/skills/update.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```sh
+git add src/cli/main.ts src/cli/main.test.ts src/cli/commands/skills/main.ts src/cli/commands/skills/main.test.ts
+git commit -m "feat(cli): add skills update command"
+```
+
+### Task 3: Document how maintainers update project-local skills
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/skills.md`
+
+- [ ] **Step 1: Update README**
+
+In `README.md`, after the paragraph ending with “consider committing
+`patchmill.config.json` and `.patchmill/skills/` explicitly.”, add:
+
+````md
+To update a repository after Patchmill publishes a newer bundled skill pack,
+run:
+
+```sh
+npx patchmill@latest skills update
+```
+
+The update command only changes Patchmill-managed project-local skills. It stops
+if managed skill files were edited locally. After a successful update, run
+`git diff` and commit the skill changes with the repository.
+````
+
+- [ ] **Step 2: Update `docs/skills.md`**
+
+In `docs/skills.md`, after the paragraph ending with “`.patchmill/skills/`
+explicitly.”, add:
+
+````md
+### Updating project-local skills
+
+When Patchmill publishes a newer bundled skill pack, update a repository with
+the latest CLI:
+
+```sh
+npx patchmill@latest skills update
+```
+
+The command only updates Patchmill-managed project-local skills under
+`.patchmill/skills/`. It refuses to run if managed skill files were edited or
+removed locally. Review the resulting `git diff`, then commit the skill changes
+with the repository.
+````
+
+- [ ] **Step 3: Run markdown lint**
+
+Run:
+
+```sh
+npm run lint:md -- README.md docs/skills.md docs/specs/2026-06-30-issue-59-add-skill-pack-update-command-design.md docs/plans/2026-06-30-issue-59-add-skill-pack-update-command.md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Commit Task 3**
+
+Run:
+
+```sh
+git add README.md docs/skills.md
+git commit -m "docs(skills): explain skill pack updates"
+```
+
+### Task 4: Run focused verification and final review
+
+**Files:**
+
+- Modify only if verification exposes a bug in files changed by Tasks 1-3.
+
+- [ ] **Step 1: Run focused automated tests**
+
+Run:
+
+```sh
+node --test src/workflow/skill-pack.test.ts src/cli/commands/init/skill-installer.test.ts src/cli/commands/skills/*.test.ts src/cli/main.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run TypeScript lint**
+
+Run:
+
+```sh
+npm run lint:ts
+```
+
+Expected: exits 0 with no ESLint errors.
+
+- [ ] **Step 3: Run markdown lint**
+
+Run:
+
+```sh
+npm run lint:md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```sh
+npm test
+```
+
+Expected: pass. If it fails only in `test-support/npm-shrinkwrap.test.ts` with
+missing nested `@earendil-works/*@0.77.0` integrity entries, record that as
+pre-existing and keep the focused test results from Step 1 as feature
+verification.
+
+- [ ] **Step 5: Verify skill-pack integration required by AGENTS.md**
+
+Run:
+
+```sh
+node --input-type=module <<'EOF'
+import { dirname, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { access, readFile } from "node:fs/promises";
+import { PATCHMILL_RECOMMENDED_SKILL_PACK } from "./src/workflow/skill-pack.ts";
+import { bundledTriageSkillPath } from "./src/workflow/skills.ts";
+
+const require = createRequire(import.meta.url);
+const superpowersRoot = dirname(require.resolve("superpowers/package.json"));
+const patchmillSkillsDir = resolve(dirname(bundledTriageSkillPath()), "..");
+const roots = {
+  patchmill: patchmillSkillsDir,
+  superpowers: join(superpowersRoot, "skills"),
+};
+for (const skill of PATCHMILL_RECOMMENDED_SKILL_PACK.skills) {
+  await access(join(roots[skill.source], skill.name, "SKILL.md"));
+}
+const superpowersPackage = JSON.parse(
+  await readFile(join(superpowersRoot, "package.json"), "utf8"),
+);
+console.log(JSON.stringify({
+  packVersion: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+  sourceTag: PATCHMILL_RECOMMENDED_SKILL_PACK.source.tag,
+  superpowersVersion: superpowersPackage.version,
+  checkedSkills: PATCHMILL_RECOMMENDED_SKILL_PACK.skills.length,
+}, null, 2));
+EOF
+```
+
+Expected: command prints the current pack version, source tag, installed
+`superpowers` package version, and checked skill count without throwing. Confirm
+the tag/version also match assertions in `src/workflow/skill-pack.test.ts` and
+any package lock metadata. If package files changed unexpectedly, run the
+project Nix build before handoff.
+
+- [ ] **Step 6: Inspect the final diff**
+
+Run:
+
+```sh
+git status --short
+git diff --stat HEAD~3..HEAD
+git diff -- src/cli/commands/skills/update.ts src/cli/commands/skills/main.ts README.md docs/skills.md
+```
+
+Expected: only skill update command, tests, and docs changed.
+
+- [ ] **Step 7: Commit final fixes only if needed**
+
+If Steps 1-6 required fixes, run:
+
+```sh
+git add src/workflow/skill-pack.ts src/cli/main.ts src/cli/main.test.ts src/cli/commands/skills README.md docs/skills.md
+git commit -m "fix(skills): polish update command"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+## Self-Review Notes
+
+- Spec coverage: The plan includes command routing, metadata validation, hash
+  preflight, missing/dirty/unreadable behavior, unmanaged collision checks,
+  already-current behavior, copy/remove/metadata update behavior, docs, and
+  verification.
+- Placeholder scan: Each task has explicit files, commands, expected outcomes,
+  and code or test structure. No `TBD` or open-ended implementation placeholders
+  remain.
+- Type consistency: `SkillPackUpdateOptions`, `SkillPackUpdateResult`,
+  `SourceRoots`, `SkillInstallerDependencies`, and metadata helper names match
+  the planned imports and usage across tasks.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -119,6 +119,20 @@ Project-local skills are local-only by default. For consistent Patchmill runs
 across local machines and CI, consider committing `patchmill.config.json` and
 `.patchmill/skills/` explicitly.
 
+### Updating project-local skills
+
+When Patchmill publishes a newer bundled skill pack, update a repository with
+the latest CLI:
+
+```sh
+npx patchmill@latest skills update
+```
+
+The command only updates Patchmill-managed project-local skills under
+`.patchmill/skills/`. It refuses to run if managed skill files were edited or
+removed locally. Review the resulting `git diff`, then commit the skill changes
+with the repository.
+
 Patchmill treats installed files as project-owned. It will not silently
 overwrite edited skill files and will preserve local edits.
 

--- a/docs/specs/2026-06-30-issue-58-dry-run-triage-can-fail-on-malformed-pi-json-when-session-observation-is-enabled-design.md
+++ b/docs/specs/2026-06-30-issue-58-dry-run-triage-can-fail-on-malformed-pi-json-when-session-observation-is-enabled-design.md
@@ -1,0 +1,120 @@
+# Dry-Run Triage Malformed Pi JSON Recovery Design
+
+## Goal
+
+Make `patchmill triage --dry-run --issue <number>` robust to the observed Pi
+session-output bug where an otherwise valid preview JSON document is followed by
+trailing garbage, while still reporting genuinely unparseable output with useful
+debug context.
+
+## Current behavior
+
+`runTriageDryRunAgent()` in `src/cli/commands/triage/dry-run-agent.ts` enables
+Pi session observation with `--session-dir` whenever triage progress has an
+`onToolCall` observer. Its stdout is parsed by `parseTriagePreviewJson()`, which
+currently trims stdout, optionally unwraps a full fenced JSON block, and calls
+`JSON.parse()` on the entire remaining string.
+
+When bundled Pi is invoked with `--session-dir`, it can return a valid preview
+document followed by an extra closing brace, for example:
+
+```json
+{"previews":[{"issueNumber":123,"currentLabels":["enhancement"],"proposedLabels":["enhancement","agent-ready"],"canonicalBucket":"agent-ready","blockedBy":[],"rationale":"...","wouldComment":null,"wouldClose":false,"questions":[]}]}}
+```
+
+The strict parse rejects this before validation, dry-run preview output is not
+shown, and Patchmill records the run as failed. The related `run-once` Pi parser
+already attempts final-JSON extraction instead of requiring the whole stdout to
+be exactly one JSON object.
+
+## Requirements
+
+- Keep dry-run triage read-only and keep session observation enabled when an
+  `onToolCall` observer is present.
+- `parseTriagePreviewJson()` must accept a valid triage preview document
+  followed only by trailing non-JSON garbage such as the observed extra `}`.
+- Preserve support for direct JSON and full fenced JSON responses.
+- Do not silently accept a malformed or partial preview document if no complete
+  object with a `previews` array can be extracted.
+- When parsing fails, throw an error that still starts with the existing context
+  (`Pi triage dry-run returned invalid JSON`) and includes a short stdout
+  snippet near the parse failure or failed extraction point.
+- Keep schema validation in `validateTriagePreviewDocument()` responsible for
+  preview shape, issue count, issue numbers, buckets, blocker metadata,
+  comments, closure flags, and questions.
+- Treat model stdout as untrusted data. Snippets in errors should be bounded and
+  printable; they must not trigger command execution or be interpreted as
+  instructions.
+
+## Proposed behavior
+
+Update `parseTriagePreviewJson(stdout)` to use a narrow recovery strategy:
+
+1. Trim stdout and unwrap a response that is entirely a fenced JSON block, as it
+   does today.
+2. Try `JSON.parse()` on the resulting body first. This keeps the normal path
+   strict and preserves existing behavior for valid output.
+3. If strict parsing fails, scan the body for a complete JSON object candidate
+   that parses successfully and has a top-level `previews` property. Prefer the
+   earliest complete candidate that consumes the main preview document rather
+   than a nested preview entry. A brace-depth scan that respects JSON strings is
+   sufficient and avoids accepting arbitrary text after arbitrary nested braces.
+4. Return the recovered object to the existing validation path. If validation
+   later rejects the object, surface the validation error as today.
+5. If no preview document can be recovered, throw an invalid-JSON error that
+   includes the original parse error plus a bounded snippet around the failure
+   position when available. For errors without a position, include a bounded
+   prefix/suffix snippet of stdout.
+
+This intentionally recovers only after a complete valid preview JSON document is
+found. It does not attempt to repair missing braces, invalid strings, invalid
+arrays, or schema errors.
+
+## Affected components
+
+- `src/cli/commands/triage/dry-run-agent.ts`
+  - Add a small helper for preview JSON extraction or inline it in
+    `parseTriagePreviewJson()`.
+  - Add a bounded stdout snippet helper for parse failures.
+  - Keep `runTriageDryRunAgent()` unchanged except for benefiting from the more
+    tolerant parser.
+- `src/cli/commands/triage/dry-run-agent.test.ts`
+  - Add a regression test that `parseTriagePreviewJson()` accepts preview JSON
+    followed by an extra `}`.
+  - Add a failure test asserting the invalid-JSON error includes a short stdout
+    snippet when no valid preview document can be extracted.
+  - Keep existing direct and fenced JSON tests passing.
+- Optional shared utility follow-up
+  - If implementation would duplicate substantial logic from
+    `src/cli/commands/run-once/pi.ts`, consider extracting a focused JSON object
+    extraction helper. This is optional; a localized fix is acceptable because
+    the dry-run parser needs a top-level `previews` document rather than a final
+    status object.
+
+## Verification strategy
+
+Run targeted triage parser and pipeline coverage:
+
+```sh
+node --test src/cli/commands/triage/dry-run-agent.test.ts src/cli/commands/triage/pipeline.test.ts
+```
+
+Run the full test suite before merge:
+
+```sh
+npm test
+```
+
+Manual verification, if a repository issue is available, should run:
+
+```sh
+patchmill triage --dry-run --issue <number>
+```
+
+with normal progress output enabled, confirm the Pi invocation includes
+`--session-dir`, and confirm Patchmill prints/writes the dry-run preview instead
+of failing on an extra trailing brace. Then test a deliberately unparseable Pi
+stdout fixture or mock and confirm the error includes
+`Pi triage dry-run returned invalid JSON` plus a bounded stdout snippet. No npm
+dependency changes are required, so no Nix build is required unless
+implementation later changes package metadata.

--- a/docs/specs/2026-06-30-issue-59-add-skill-pack-update-command-design.md
+++ b/docs/specs/2026-06-30-issue-59-add-skill-pack-update-command-design.md
@@ -1,0 +1,178 @@
+# Skill Pack Update Command Design
+
+## Goal
+
+Add `patchmill skills update` so repositories that use Patchmill-managed
+project-local skills can refresh `.patchmill/skills/` to the recommended skill
+pack bundled in the currently running Patchmill CLI.
+
+## Current behavior
+
+`patchmill init` installs the recommended skill pack into `.patchmill/skills/`
+when project-local skills are selected. The installation records pack
+provenance, installed file paths, and file hashes in
+`.patchmill/skills/patchmill-skill-pack.json` using helpers in
+`src/workflow/skill-pack.ts` and the copy/install logic in
+`src/cli/commands/init/skill-installer.ts`.
+
+After initialization, there is no supported command for refreshing those managed
+files when Patchmill updates its bundled Superpowers version or bundled
+Patchmill skills. Maintainers must currently reinstall or copy files manually,
+which makes it easy to overwrite local skill customizations or leave metadata
+out of sync.
+
+## Requirements
+
+- Add a public command:
+
+  ```sh
+  patchmill skills update
+  ```
+
+- Treat “latest” as the recommended skill pack bundled in the running Patchmill
+  CLI. The command must not query npm, GitHub, or any package registry for newer
+  Patchmill releases.
+- Scope the command to Patchmill-managed project-local skill packs under
+  `.patchmill/skills/`.
+- Require a valid Patchmill-managed
+  `.patchmill/skills/patchmill-skill-pack.json` metadata file before updating.
+- Refuse to overwrite local customizations by default:
+  - abort if any file recorded in existing metadata is missing, unreadable, or
+    has a hash different from the recorded hash;
+  - abort if a new bundled file would overwrite an existing file that was not
+    recorded in the previous metadata.
+- Only edit files that were recorded in the previous metadata or are part of the
+  new bundled recommended pack.
+- Remove old managed files that no longer exist in the bundled pack after the
+  preflight checks pass.
+- Write fresh metadata with the bundled pack version, source, install timestamp,
+  skill directory, metadata filename, and new file hashes.
+- Provide clear user-facing output for missing metadata, customized/missing
+  managed files, already-current packs, and successful updates.
+- Do not add global skill updates, custom skill directory updates, conflict
+  resolution, merge behavior, or `--dry-run` in this change.
+- Update user-facing documentation to show:
+
+  ```sh
+  npx patchmill@latest skills update
+  ```
+
+  and tell maintainers to review `git diff` and commit the resulting skill
+  changes.
+
+## Proposed behavior
+
+`patchmill skills update` should run from the repository root and read
+`.patchmill/skills/patchmill-skill-pack.json`. If metadata is missing,
+malformed, not for `patchmill-recommended`, not for `.patchmill/skills`, or not
+for the expected metadata filename, the command fails with:
+
+```text
+No Patchmill-managed project-local skill pack found. Run `patchmill init` first,
+or reinstall project-local skills.
+```
+
+The updater then validates the currently installed managed files against the old
+metadata hashes. If any managed file was edited, removed, or cannot be read, it
+aborts before writing and lists the affected paths:
+
+```text
+Refusing to update customized project-local skills:
+- .patchmill/skills/writing-plans/SKILL.md
+- .patchmill/skills/brainstorming/SKILL.md (missing)
+```
+
+Next, the updater enumerates the bundled recommended pack using the same source
+roots and skill-pack constants as `patchmill init`. Before copying, it checks
+for new-file collisions: a file in the bundled pack whose target path already
+exists locally but was not listed in the previous metadata is unmanaged local
+content and must not be overwritten.
+
+If the installed metadata version, source, and file hash list already match the
+bundled pack, the command exits successfully with:
+
+```text
+Patchmill skill pack is already up to date.
+```
+
+Otherwise, after all safety checks pass, the updater copies bundled skill files
+into `.patchmill/skills/`, removes obsolete old managed files, writes new
+metadata, and prints:
+
+```text
+Updated Patchmill skill pack 2026.05 -> 2026.06.
+Updated 14 files, removed 2 obsolete files.
+Run git diff to review changes.
+```
+
+Filesystem failures after preflight may surface as plain command errors. No
+rollback or recovery workflow is required for the first version.
+
+## Affected components
+
+- `src/workflow/skill-pack.ts`
+  - Keep the current bundled pack constant exact, but widen metadata-facing
+    types enough to parse older installed metadata versions and source tags.
+- `src/cli/commands/init/skill-installer.ts`
+  - Reuse its source-root and dependency abstractions from the updater rather
+    than duplicating package-resolution policy in CLI code.
+- `src/cli/commands/skills/update.ts` (new)
+  - Own reusable update behavior and return a structured result for CLI output.
+  - Validate metadata ownership, hash old managed files, collect bundled pack
+    file hashes, detect unmanaged collisions, copy current bundled skills,
+    remove obsolete managed files, and write new metadata.
+- `src/cli/commands/skills/main.ts` (new)
+  - Own `patchmill skills` subcommand parsing, help text, update-result
+    formatting, and errors for unknown subcommands or unsupported update args.
+- `src/cli/main.ts`
+  - Add top-level `skills` help and route `patchmill skills ...` to the skills
+    namespace.
+- Tests under `src/cli/commands/skills/` and existing CLI/skill-pack tests
+  - Cover clean updates, already-current packs, dirty/missing managed files,
+    missing metadata, unmanaged new-file collisions, namespace help, CLI
+    routing, unknown subcommands, and unsupported update arguments.
+- `README.md` and `docs/skills.md`
+  - Document the update command and its safety limits near the project-local
+    skills guidance.
+
+## Security and safety notes
+
+Skill files are executable process instructions for future agent runs, so the
+update command must be explicit and reviewable. It must never infer ownership
+from directory names alone. The metadata hash check is the authority for old
+managed files, and the bundled pack manifest is the authority for new managed
+files.
+
+Issue content, repository metadata, and skill file contents remain untrusted
+input. The command should print paths and status text only; it must not execute
+commands from metadata or skill contents.
+
+## Verification strategy
+
+Run focused automated tests for the updater, skill installer integration, CLI
+routing, and skill-pack metadata helpers:
+
+```sh
+node --test src/workflow/skill-pack.test.ts src/cli/commands/init/skill-installer.test.ts src/cli/commands/skills/*.test.ts src/cli/main.test.ts
+```
+
+Run TypeScript and Markdown lint:
+
+```sh
+npm run lint:ts
+npm run lint:md
+```
+
+Run the full suite before merge:
+
+```sh
+npm test
+```
+
+Because this change updates skill-pack behavior, release verification should
+also confirm both sides of the bundled-pack integration: installed upstream
+Superpowers skill files exist at the paths Patchmill resolves, and Patchmill
+skill-pack config, metadata, tests, and live dependency references all point at
+the same upstream version. No npm dependency changes are required by this
+design, so a Nix build is only required if implementation later changes
+`package.json`, `package-lock.json`, or `npm-shrinkwrap.json`.

--- a/src/cli/commands/init/skill-installer.ts
+++ b/src/cli/commands/init/skill-installer.ts
@@ -176,7 +176,7 @@ export async function collectSourceFiles(
   return files;
 }
 
-async function makeOwnerWritableRecursive(
+export async function makeOwnerWritableRecursive(
   path: string,
   dependencies: SkillInstallerDependencies = defaultDependencies,
 ): Promise<void> {

--- a/src/cli/commands/init/skill-installer.ts
+++ b/src/cli/commands/init/skill-installer.ts
@@ -80,7 +80,7 @@ export function defaultSkillSourceRoots(): SourceRoots {
   };
 }
 
-async function pathExists(
+export async function pathExists(
   path: string,
   dependencies: SkillInstallerDependencies = defaultDependencies,
 ): Promise<boolean> {
@@ -92,13 +92,16 @@ async function pathExists(
   }
 }
 
-function sourceRootFor(skill: SkillPackSkill, roots: SourceRoots): string {
+export function sourceRootFor(
+  skill: SkillPackSkill,
+  roots: SourceRoots,
+): string {
   return skill.source === "patchmill"
     ? roots.patchmillSkillsDir
     : roots.superpowersSkillsDir;
 }
 
-async function assertSkillFile(
+export async function assertSkillFile(
   path: string,
   displayPath: string,
   dependencies: SkillInstallerDependencies = defaultDependencies,
@@ -114,13 +117,13 @@ async function assertSkillFile(
   }
 }
 
-function comparePaths(a: string, b: string): number {
+export function comparePaths(a: string, b: string): number {
   if (a < b) return -1;
   if (a > b) return 1;
   return 0;
 }
 
-async function hashFile(
+export async function hashFile(
   path: string,
   dependencies: SkillInstallerDependencies = defaultDependencies,
 ): Promise<string> {
@@ -129,7 +132,7 @@ async function hashFile(
     .digest("hex");
 }
 
-async function collectSourceFiles(
+export async function collectSourceFiles(
   skillRoot: string,
   currentDir: string,
   targetRelativeDir: string,

--- a/src/cli/commands/skills/main.test.ts
+++ b/src/cli/commands/skills/main.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HELP_TEXT, runSkills } from "./main.ts";
+
+const updatedResult = {
+  status: "updated" as const,
+  fromVersion: "2026.04",
+  toVersion: "2026.05",
+  updatedFiles: 14,
+  removedFiles: 2,
+};
+
+test("runSkills prints help", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runSkills(["--help"], {
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async () => updatedResult,
+    }),
+    0,
+  );
+
+  assert.deepEqual(stdout, [HELP_TEXT]);
+  assert.deepEqual(stderr, []);
+});
+
+test("runSkills updates project-local skills", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls: string[] = [];
+
+  assert.equal(
+    await runSkills(["update"], {
+      repoRoot: "/repo",
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async (options) => {
+        calls.push(options.repoRoot);
+        return updatedResult;
+      },
+    }),
+    0,
+  );
+
+  assert.deepEqual(calls, ["/repo"]);
+  assert.deepEqual(stdout, [
+    "Updated Patchmill skill pack 2026.04 -> 2026.05.",
+    "Updated 14 files, removed 2 obsolete files.",
+    "Run git diff to review changes.",
+  ]);
+  assert.deepEqual(stderr, []);
+});
+
+test("runSkills reports already current packs", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runSkills(["update"], {
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async () => ({
+        status: "up-to-date",
+        version: "2026.05",
+      }),
+    }),
+    0,
+  );
+
+  assert.deepEqual(stdout, ["Patchmill skill pack is already up to date."]);
+  assert.deepEqual(stderr, []);
+});
+
+test("runSkills rejects unknown subcommands", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  assert.equal(
+    await runSkills(["reset"], {
+      output: {
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+      },
+      updateProjectSkills: async () => updatedResult,
+    }),
+    1,
+  );
+
+  assert.deepEqual(stdout, []);
+  assert.deepEqual(stderr, ["Unknown skills command: reset", HELP_TEXT]);
+});
+
+test("runSkills rejects update arguments", async () => {
+  await assert.rejects(
+    runSkills(["update", "--dry-run"], {
+      updateProjectSkills: async () => updatedResult,
+    }),
+    /patchmill skills update does not accept arguments/u,
+  );
+});

--- a/src/cli/commands/skills/main.ts
+++ b/src/cli/commands/skills/main.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import {
+  updateProjectSkills as defaultUpdateProjectSkills,
+  type SkillPackUpdateOptions,
+  type SkillPackUpdateResult,
+} from "./update.ts";
+
+export const HELP_TEXT = `Usage:
+  patchmill skills update
+
+Manage Patchmill project-local skills.
+
+Commands:
+  update  Update Patchmill-managed project-local skills.
+`;
+
+export type SkillsCommandOutput = {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+};
+
+export type SkillsCommandOptions = {
+  repoRoot?: string;
+  output?: SkillsCommandOutput;
+  updateProjectSkills?: (
+    options: SkillPackUpdateOptions,
+  ) => Promise<SkillPackUpdateResult>;
+};
+
+const DEFAULT_OUTPUT: SkillsCommandOutput = {
+  stdout: (line) => console.log(line),
+  stderr: (line) => console.error(line),
+};
+
+function isHelp(arg: string | undefined): boolean {
+  return !arg || arg === "--help" || arg === "-h" || arg === "help";
+}
+
+function formatCount(count: number, singular: string): string {
+  return `${count} ${count === 1 ? singular : `${singular}s`}`;
+}
+
+function printUpdateResult(
+  output: SkillsCommandOutput,
+  result: SkillPackUpdateResult,
+): void {
+  if (result.status === "up-to-date") {
+    output.stdout("Patchmill skill pack is already up to date.");
+    return;
+  }
+
+  output.stdout(
+    `Updated Patchmill skill pack ${result.fromVersion} -> ${result.toVersion}.`,
+  );
+  output.stdout(
+    `Updated ${formatCount(result.updatedFiles, "file")}, removed ${formatCount(
+      result.removedFiles,
+      "obsolete file",
+    )}.`,
+  );
+  output.stdout("Run git diff to review changes.");
+}
+
+export async function runSkills(
+  args: string[],
+  options: SkillsCommandOptions = {},
+): Promise<number> {
+  const output = options.output ?? DEFAULT_OUTPUT;
+  const subcommand = args[0];
+  if (isHelp(subcommand)) {
+    output.stdout(HELP_TEXT);
+    return 0;
+  }
+
+  if (subcommand !== "update") {
+    output.stderr(`Unknown skills command: ${subcommand}`);
+    output.stderr(HELP_TEXT);
+    return 1;
+  }
+
+  if (args.length > 1) {
+    throw new Error("patchmill skills update does not accept arguments");
+  }
+
+  const updateProjectSkills =
+    options.updateProjectSkills ?? defaultUpdateProjectSkills;
+  const result = await updateProjectSkills({
+    repoRoot: options.repoRoot ?? process.cwd(),
+  });
+  printUpdateResult(output, result);
+  return 0;
+}
+
+export async function main(args = process.argv.slice(2)): Promise<number> {
+  try {
+    return await runSkills(args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+const isMain = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isMain) {
+  process.exitCode = await main();
+}

--- a/src/cli/commands/skills/update.test.ts
+++ b/src/cli/commands/skills/update.test.ts
@@ -119,6 +119,7 @@ test("updateProjectSkills updates clean managed project-local skills", async () 
     "SKILL.md": newWritingPlans,
     "notes.md": "new notes\n",
   });
+  await chmod(join(superpowersSource, "writing-plans", "notes.md"), 0o400);
 
   await writeFileEnsuringParent(
     join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
@@ -167,13 +168,15 @@ test("updateProjectSkills updates clean managed project-local skills", async () 
     ),
     newWritingPlans,
   );
-  assert.equal(
-    await readFile(
-      join(repoRoot, ".patchmill", "skills", "writing-plans", "notes.md"),
-      "utf8",
-    ),
-    "new notes\n",
+  const updatedNotesPath = join(
+    repoRoot,
+    ".patchmill",
+    "skills",
+    "writing-plans",
+    "notes.md",
   );
+  assert.equal(await readFile(updatedNotesPath, "utf8"), "new notes\n");
+  assert.notEqual((await stat(updatedNotesPath)).mode & 0o200, 0);
   await assert.rejects(
     access(
       join(repoRoot, ".patchmill", "skills", "obsolete-skill", "SKILL.md"),
@@ -341,7 +344,7 @@ test("updateProjectSkills rejects malformed metadata shapes", async () => {
       pack: { name: "patchmill-recommended" },
       skillDir: ".patchmill/skills",
       metadataFile: SKILL_PACK_METADATA_FILE,
-      files: [null],
+      files: [null, { path: ".patchmill/skills/writing-plans/SKILL.md" }],
     }),
   );
 

--- a/src/cli/commands/skills/update.test.ts
+++ b/src/cli/commands/skills/update.test.ts
@@ -333,6 +333,24 @@ test("updateProjectSkills requires Patchmill-managed project-local metadata", as
   );
 });
 
+test("updateProjectSkills rejects malformed metadata shapes", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-malformed-metadata-repo-");
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+    JSON.stringify({
+      pack: { name: "patchmill-recommended" },
+      skillDir: ".patchmill/skills",
+      metadataFile: SKILL_PACK_METADATA_FILE,
+      files: [null],
+    }),
+  );
+
+  await assert.rejects(
+    updateProjectSkills({ repoRoot, dependencies }),
+    /No Patchmill-managed project-local skill pack found\. Run `patchmill init` first,\nor reinstall project-local skills\./u,
+  );
+});
+
 test("updateProjectSkills rejects metadata paths outside project-local skills", async () => {
   const repoRoot = await tempRoot("patchmill-skills-unsafe-metadata-repo-");
   await writeMetadata(

--- a/src/cli/commands/skills/update.test.ts
+++ b/src/cli/commands/skills/update.test.ts
@@ -341,7 +341,7 @@ test("updateProjectSkills rejects malformed metadata shapes", async () => {
   await writeFileEnsuringParent(
     join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
     JSON.stringify({
-      pack: { name: "patchmill-recommended" },
+      pack: { name: "patchmill-recommended", version: "2026.04" },
       skillDir: ".patchmill/skills",
       metadataFile: SKILL_PACK_METADATA_FILE,
       files: [null, { path: ".patchmill/skills/writing-plans/SKILL.md" }],
@@ -355,21 +355,26 @@ test("updateProjectSkills rejects malformed metadata shapes", async () => {
 });
 
 test("updateProjectSkills rejects metadata paths outside project-local skills", async () => {
-  const repoRoot = await tempRoot("patchmill-skills-unsafe-metadata-repo-");
-  await writeMetadata(
-    repoRoot,
-    oldMetadata([
-      {
-        path: ".patchmill/skills/../outside.md",
-        sha256: hashText(oldWritingPlans),
-      },
-    ]),
-  );
+  for (const unsafePath of [
+    ".patchmill/skills/../outside.md",
+    ".patchmill/skills/writing-plans\\..\\..\\outside.md",
+  ]) {
+    const repoRoot = await tempRoot("patchmill-skills-unsafe-metadata-repo-");
+    await writeMetadata(
+      repoRoot,
+      oldMetadata([
+        {
+          path: unsafePath,
+          sha256: hashText(oldWritingPlans),
+        },
+      ]),
+    );
 
-  await assert.rejects(
-    updateProjectSkills({ repoRoot, dependencies }),
-    /No Patchmill-managed project-local skill pack found\. Run `patchmill init` first,\nor reinstall project-local skills\./u,
-  );
+    await assert.rejects(
+      updateProjectSkills({ repoRoot, dependencies }),
+      /No Patchmill-managed project-local skill pack found\. Run `patchmill init` first,\nor reinstall project-local skills\./u,
+    );
+  }
 });
 
 test("updateProjectSkills aborts when new bundled files would overwrite local files", async () => {

--- a/src/cli/commands/skills/update.test.ts
+++ b/src/cli/commands/skills/update.test.ts
@@ -333,6 +333,24 @@ test("updateProjectSkills requires Patchmill-managed project-local metadata", as
   );
 });
 
+test("updateProjectSkills rejects metadata paths outside project-local skills", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-unsafe-metadata-repo-");
+  await writeMetadata(
+    repoRoot,
+    oldMetadata([
+      {
+        path: ".patchmill/skills/../outside.md",
+        sha256: hashText(oldWritingPlans),
+      },
+    ]),
+  );
+
+  await assert.rejects(
+    updateProjectSkills({ repoRoot, dependencies }),
+    /No Patchmill-managed project-local skill pack found\. Run `patchmill init` first,\nor reinstall project-local skills\./u,
+  );
+});
+
 test("updateProjectSkills aborts when new bundled files would overwrite local files", async () => {
   const repoRoot = await tempRoot("patchmill-skills-collision-repo-");
   const superpowersSource = await tempRoot(

--- a/src/cli/commands/skills/update.test.ts
+++ b/src/cli/commands/skills/update.test.ts
@@ -341,10 +341,23 @@ test("updateProjectSkills rejects malformed metadata shapes", async () => {
   await writeFileEnsuringParent(
     join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
     JSON.stringify({
-      pack: { name: "patchmill-recommended", version: "2026.04" },
+      pack: {
+        name: "patchmill-recommended",
+        version: "",
+        source: {
+          type: "github-release",
+          repository: "",
+          tag: "v5.0.7",
+          tarballUrl:
+            "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+        },
+      },
       skillDir: ".patchmill/skills",
       metadataFile: SKILL_PACK_METADATA_FILE,
-      files: [null, { path: ".patchmill/skills/writing-plans/SKILL.md" }],
+      files: [
+        null,
+        { path: ".patchmill/skills/writing-plans/SKILL.md", sha256: "notsha" },
+      ],
     }),
   );
 

--- a/src/cli/commands/skills/update.test.ts
+++ b/src/cli/commands/skills/update.test.ts
@@ -1,0 +1,377 @@
+import assert from "node:assert/strict";
+import {
+  access,
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  hashText,
+  type SkillPackMetadataFile,
+} from "../../../workflow/skill-pack.ts";
+import type { SkillInstallerDependencies } from "../init/skill-installer.ts";
+import { updateProjectSkills } from "./update.ts";
+
+const dependencies: SkillInstallerDependencies = {
+  access,
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+};
+
+const oldWritingPlans = `---
+name: writing-plans
+description: Old planning skill.
+---
+# Old planning
+`;
+
+const newWritingPlans = `---
+name: writing-plans
+description: New planning skill.
+---
+# New planning
+`;
+
+const oldObsoleteSkill = `---
+name: obsolete-skill
+description: Removed from the pack.
+---
+# Obsolete
+`;
+
+async function tempRoot(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function writeFileEnsuringParent(path: string, content: string) {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, content);
+}
+
+async function writeSkill(
+  root: string,
+  name: string,
+  files: Record<string, string>,
+) {
+  for (const [relativePath, content] of Object.entries(files)) {
+    await writeFileEnsuringParent(join(root, name, relativePath), content);
+  }
+}
+
+async function writeMetadata(
+  repoRoot: string,
+  metadata: SkillPackMetadataFile,
+) {
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+}
+
+function oldMetadata(
+  files: Array<{ path: string; sha256: string }>,
+): SkillPackMetadataFile {
+  return {
+    pack: {
+      name: "patchmill-recommended",
+      version: "2026.04",
+      source: {
+        type: "github-release",
+        repository: "obra/superpowers",
+        tag: "v5.0.7",
+        tarballUrl:
+          "https://github.com/obra/superpowers/archive/refs/tags/v5.0.7.tar.gz",
+      },
+    },
+    installedAt: "2026-05-01T00:00:00.000Z",
+    skillDir: ".patchmill/skills",
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files,
+  };
+}
+
+test("updateProjectSkills updates clean managed project-local skills", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-update-repo-");
+  const superpowersSource = await tempRoot(
+    "patchmill-skills-update-superpowers-",
+  );
+  await writeSkill(superpowersSource, "writing-plans", {
+    "SKILL.md": newWritingPlans,
+    "notes.md": "new notes\n",
+  });
+
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+    oldWritingPlans,
+  );
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", "obsolete-skill", "SKILL.md"),
+    oldObsoleteSkill,
+  );
+  await writeMetadata(
+    repoRoot,
+    oldMetadata([
+      {
+        path: ".patchmill/skills/obsolete-skill/SKILL.md",
+        sha256: hashText(oldObsoleteSkill),
+      },
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(oldWritingPlans),
+      },
+    ]),
+  );
+
+  const result = await updateProjectSkills({
+    repoRoot,
+    sourceRoots: {
+      patchmillSkillsDir: await tempRoot("patchmill-skills-update-patchmill-"),
+      superpowersSkillsDir: superpowersSource,
+    },
+    packSkills: [{ name: "writing-plans", source: "superpowers" }],
+    installedAt: "2026-06-27T00:00:00.000Z",
+    dependencies,
+  });
+
+  assert.deepEqual(result, {
+    status: "updated",
+    fromVersion: "2026.04",
+    toVersion: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+    updatedFiles: 2,
+    removedFiles: 1,
+  });
+  assert.equal(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+      "utf8",
+    ),
+    newWritingPlans,
+  );
+  assert.equal(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", "writing-plans", "notes.md"),
+      "utf8",
+    ),
+    "new notes\n",
+  );
+  await assert.rejects(
+    access(
+      join(repoRoot, ".patchmill", "skills", "obsolete-skill", "SKILL.md"),
+    ),
+    (error: unknown) =>
+      error instanceof Error && "code" in error && error.code === "ENOENT",
+  );
+
+  const metadata = JSON.parse(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", SKILL_PACK_METADATA_FILE),
+      "utf8",
+    ),
+  ) as SkillPackMetadataFile;
+  assert.equal(metadata.pack.version, PATCHMILL_RECOMMENDED_SKILL_PACK.version);
+  assert.equal(metadata.installedAt, "2026-06-27T00:00:00.000Z");
+  assert.deepEqual(metadata.files, [
+    {
+      path: ".patchmill/skills/writing-plans/SKILL.md",
+      sha256: hashText(newWritingPlans),
+    },
+    {
+      path: ".patchmill/skills/writing-plans/notes.md",
+      sha256: hashText("new notes\n"),
+    },
+  ]);
+});
+
+test("updateProjectSkills reports already current packs", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-current-repo-");
+  const superpowersSource = await tempRoot(
+    "patchmill-skills-current-superpowers-",
+  );
+  await writeSkill(superpowersSource, "writing-plans", {
+    "SKILL.md": newWritingPlans,
+  });
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+    newWritingPlans,
+  );
+  await writeMetadata(repoRoot, {
+    pack: {
+      name: PATCHMILL_RECOMMENDED_SKILL_PACK.name,
+      version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+      source: PATCHMILL_RECOMMENDED_SKILL_PACK.source,
+    },
+    installedAt: "2026-06-01T00:00:00.000Z",
+    skillDir: ".patchmill/skills",
+    metadataFile: SKILL_PACK_METADATA_FILE,
+    files: [
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(newWritingPlans),
+      },
+    ],
+  });
+
+  const result = await updateProjectSkills({
+    repoRoot,
+    sourceRoots: {
+      patchmillSkillsDir: await tempRoot("patchmill-skills-current-patchmill-"),
+      superpowersSkillsDir: superpowersSource,
+    },
+    packSkills: [{ name: "writing-plans", source: "superpowers" }],
+    dependencies,
+  });
+
+  assert.deepEqual(result, {
+    status: "up-to-date",
+    version: PATCHMILL_RECOMMENDED_SKILL_PACK.version,
+  });
+});
+
+test("updateProjectSkills aborts when managed files changed locally", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-dirty-repo-");
+  const superpowersSource = await tempRoot(
+    "patchmill-skills-dirty-superpowers-",
+  );
+  await writeSkill(superpowersSource, "writing-plans", {
+    "SKILL.md": newWritingPlans,
+  });
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+    "local edit\n",
+  );
+  await writeMetadata(
+    repoRoot,
+    oldMetadata([
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(oldWritingPlans),
+      },
+    ]),
+  );
+
+  await assert.rejects(
+    updateProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: await tempRoot("patchmill-skills-dirty-patchmill-"),
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [{ name: "writing-plans", source: "superpowers" }],
+      dependencies,
+    }),
+    /Refusing to update customized project-local skills:\n- \.patchmill\/skills\/writing-plans\/SKILL\.md/u,
+  );
+  assert.equal(
+    await readFile(
+      join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+      "utf8",
+    ),
+    "local edit\n",
+  );
+});
+
+test("updateProjectSkills aborts when managed files are missing", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-missing-repo-");
+  const superpowersSource = await tempRoot(
+    "patchmill-skills-missing-superpowers-",
+  );
+  await writeSkill(superpowersSource, "writing-plans", {
+    "SKILL.md": newWritingPlans,
+  });
+  await writeMetadata(
+    repoRoot,
+    oldMetadata([
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(oldWritingPlans),
+      },
+    ]),
+  );
+
+  await assert.rejects(
+    updateProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: await tempRoot(
+          "patchmill-skills-missing-patchmill-",
+        ),
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [{ name: "writing-plans", source: "superpowers" }],
+      dependencies,
+    }),
+    /Refusing to update customized project-local skills:\n- \.patchmill\/skills\/writing-plans\/SKILL\.md \(missing\)/u,
+  );
+});
+
+test("updateProjectSkills requires Patchmill-managed project-local metadata", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-no-metadata-repo-");
+
+  await assert.rejects(
+    updateProjectSkills({ repoRoot, dependencies }),
+    /No Patchmill-managed project-local skill pack found\. Run `patchmill init` first,\nor reinstall project-local skills\./u,
+  );
+});
+
+test("updateProjectSkills aborts when new bundled files would overwrite local files", async () => {
+  const repoRoot = await tempRoot("patchmill-skills-collision-repo-");
+  const superpowersSource = await tempRoot(
+    "patchmill-skills-collision-superpowers-",
+  );
+  await writeSkill(superpowersSource, "writing-plans", {
+    "SKILL.md": newWritingPlans,
+    "new-file.md": "bundled file\n",
+  });
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "SKILL.md"),
+    oldWritingPlans,
+  );
+  await writeFileEnsuringParent(
+    join(repoRoot, ".patchmill", "skills", "writing-plans", "new-file.md"),
+    "local file\n",
+  );
+  await writeMetadata(
+    repoRoot,
+    oldMetadata([
+      {
+        path: ".patchmill/skills/writing-plans/SKILL.md",
+        sha256: hashText(oldWritingPlans),
+      },
+    ]),
+  );
+
+  await assert.rejects(
+    updateProjectSkills({
+      repoRoot,
+      sourceRoots: {
+        patchmillSkillsDir: await tempRoot(
+          "patchmill-skills-collision-patchmill-",
+        ),
+        superpowersSkillsDir: superpowersSource,
+      },
+      packSkills: [{ name: "writing-plans", source: "superpowers" }],
+      dependencies,
+    }),
+    /Refusing to overwrite unmanaged project-local skill files:\n- \.patchmill\/skills\/writing-plans\/new-file\.md/u,
+  );
+});

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -99,13 +99,21 @@ function isProjectSkillFilePath(path: unknown): path is string {
   );
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
 function isSkillPackSource(source: unknown): boolean {
   return (
     isRecord(source) &&
     source.type === "github-release" &&
-    typeof source.repository === "string" &&
-    typeof source.tag === "string" &&
-    typeof source.tarballUrl === "string"
+    isNonEmptyString(source.repository) &&
+    isNonEmptyString(source.tag) &&
+    isNonEmptyString(source.tarballUrl)
   );
 }
 
@@ -117,7 +125,7 @@ function assertPatchmillManagedProjectLocal(
   }
   if (
     metadata.pack.name !== PATCHMILL_RECOMMENDED_SKILL_PACK.name ||
-    typeof metadata.pack.version !== "string" ||
+    !isNonEmptyString(metadata.pack.version) ||
     !isSkillPackSource(metadata.pack.source) ||
     metadata.skillDir !== DEFAULT_PROJECT_SKILL_DIR ||
     metadata.metadataFile !== SKILL_PACK_METADATA_FILE ||
@@ -126,7 +134,7 @@ function assertPatchmillManagedProjectLocal(
       (file) =>
         !isRecord(file) ||
         !isProjectSkillFilePath(file.path) ||
-        typeof file.sha256 !== "string",
+        !isSha256(file.sha256),
     )
   ) {
     throw new Error(MISSING_METADATA_MESSAGE);

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -1,4 +1,3 @@
-import { constants } from "node:fs";
 import {
   access,
   chmod,
@@ -12,19 +11,24 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   DEFAULT_PROJECT_SKILL_DIR,
   PATCHMILL_RECOMMENDED_SKILL_PACK,
   SKILL_PACK_METADATA_FILE,
   buildSkillPackMetadata,
-  hashContent,
   projectSkillPath,
   type SkillPackMetadataFile,
   type SkillPackSkill,
 } from "../../../workflow/skill-pack.ts";
 import {
+  assertSkillFile,
+  collectSourceFiles,
+  comparePaths,
   defaultSkillSourceRoots,
+  hashFile,
+  pathExists,
+  sourceRootFor,
   type SkillInstallerDependencies,
   type SourceRoots,
 } from "../init/skill-installer.ts";
@@ -65,97 +69,24 @@ const MISSING_METADATA_MESSAGE =
   "No Patchmill-managed project-local skill pack found. Run `patchmill init` first,\n" +
   "or reinstall project-local skills.";
 
-function comparePaths(a: string, b: string): number {
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
-}
-
-async function pathExists(
-  path: string,
-  dependencies: SkillInstallerDependencies,
-): Promise<boolean> {
-  try {
-    await dependencies.access(path, constants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function hashFile(
-  path: string,
-  dependencies: SkillInstallerDependencies,
-): Promise<string> {
-  return hashContent(await dependencies.readFile(path));
-}
-
-function sourceRootFor(skill: SkillPackSkill, roots: SourceRoots): string {
-  return skill.source === "patchmill"
-    ? roots.patchmillSkillsDir
-    : roots.superpowersSkillsDir;
-}
-
-async function collectSourceFiles(
-  skillRoot: string,
-  currentDir: string,
-  targetRelativeDir: string,
-  displayRoot: string,
-  dependencies: SkillInstallerDependencies,
-): Promise<Array<{ path: string; sha256: string }>> {
-  const files: Array<{ path: string; sha256: string }> = [];
-  const entries = await dependencies.readdir(currentDir, {
-    withFileTypes: true,
-  });
-  entries.sort((a, b) => comparePaths(a.name, b.name));
-
-  for (const entry of entries) {
-    const entryPath = join(currentDir, entry.name);
-    const relativePath = relative(skillRoot, entryPath).split(sep).join("/");
-    const metadataPath = `${targetRelativeDir}/${relativePath}`;
-    const displayPath = `${displayRoot}/${relativePath}`;
-
-    if (entry.isDirectory()) {
-      files.push(
-        ...(await collectSourceFiles(
-          skillRoot,
-          entryPath,
-          targetRelativeDir,
-          displayRoot,
-          dependencies,
-        )),
-      );
-      continue;
-    }
-    if (!entry.isFile()) {
-      throw new Error(`Unsupported skill source entry: ${displayPath}`);
-    }
-
-    files.push({
-      path: metadataPath,
-      sha256: await hashFile(entryPath, dependencies),
-    });
-  }
-
-  return files;
-}
-
 async function readInstalledMetadata(
   repoRoot: string,
   dependencies: SkillInstallerDependencies,
-): Promise<SkillPackMetadataFile> {
+): Promise<unknown> {
   const metadataPath = resolve(
     repoRoot,
     DEFAULT_PROJECT_SKILL_DIR,
     SKILL_PACK_METADATA_FILE,
   );
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(await dependencies.readFile(metadataPath, "utf8"));
+    return JSON.parse(await dependencies.readFile(metadataPath, "utf8"));
   } catch {
     throw new Error(MISSING_METADATA_MESSAGE);
   }
-  return parsed as SkillPackMetadataFile;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function isProjectSkillFilePath(path: unknown): path is string {
@@ -167,14 +98,19 @@ function isProjectSkillFilePath(path: unknown): path is string {
 }
 
 function assertPatchmillManagedProjectLocal(
-  metadata: SkillPackMetadataFile,
-): void {
+  metadata: unknown,
+): asserts metadata is SkillPackMetadataFile {
+  if (!isRecord(metadata) || !isRecord(metadata.pack)) {
+    throw new Error(MISSING_METADATA_MESSAGE);
+  }
   if (
-    metadata.pack?.name !== PATCHMILL_RECOMMENDED_SKILL_PACK.name ||
+    metadata.pack.name !== PATCHMILL_RECOMMENDED_SKILL_PACK.name ||
     metadata.skillDir !== DEFAULT_PROJECT_SKILL_DIR ||
     metadata.metadataFile !== SKILL_PACK_METADATA_FILE ||
     !Array.isArray(metadata.files) ||
-    metadata.files.some((file) => !isProjectSkillFilePath(file.path))
+    metadata.files.some(
+      (file) => !isRecord(file) || !isProjectSkillFilePath(file.path),
+    )
   ) {
     throw new Error(MISSING_METADATA_MESSAGE);
   }
@@ -191,13 +127,11 @@ async function collectBundledPackFiles(options: {
       sourceRootFor(skill, options.sourceRoots),
       skill.name,
     );
-    const skillFile = join(sourceDir, "SKILL.md");
-    try {
-      const entry = await options.dependencies.stat(skillFile);
-      if (!entry.isFile()) throw new Error("not a file");
-    } catch {
-      throw new Error(`Missing required skill file: ${skill.name}/SKILL.md`);
-    }
+    await assertSkillFile(
+      join(sourceDir, "SKILL.md"),
+      `${skill.name}/SKILL.md`,
+      options.dependencies,
+    );
     files.push(
       ...(await collectSourceFiles(
         sourceDir,

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -1,0 +1,385 @@
+import { constants } from "node:fs";
+import {
+  access,
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import {
+  DEFAULT_PROJECT_SKILL_DIR,
+  PATCHMILL_RECOMMENDED_SKILL_PACK,
+  SKILL_PACK_METADATA_FILE,
+  buildSkillPackMetadata,
+  hashContent,
+  projectSkillPath,
+  type SkillPackMetadataFile,
+  type SkillPackSkill,
+} from "../../../workflow/skill-pack.ts";
+import {
+  defaultSkillSourceRoots,
+  type SkillInstallerDependencies,
+  type SourceRoots,
+} from "../init/skill-installer.ts";
+
+export type SkillPackUpdateResult =
+  | { status: "up-to-date"; version: string }
+  | {
+      status: "updated";
+      fromVersion: string;
+      toVersion: string;
+      updatedFiles: number;
+      removedFiles: number;
+    };
+
+export type SkillPackUpdateOptions = {
+  repoRoot: string;
+  sourceRoots?: SourceRoots;
+  packSkills?: SkillPackSkill[];
+  installedAt?: string;
+  dependencies?: SkillInstallerDependencies;
+};
+
+const defaultDependencies: SkillInstallerDependencies = {
+  access,
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+};
+
+const MISSING_METADATA_MESSAGE =
+  "No Patchmill-managed project-local skill pack found. Run `patchmill init` first,\n" +
+  "or reinstall project-local skills.";
+
+function comparePaths(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+async function pathExists(
+  path: string,
+  dependencies: SkillInstallerDependencies,
+): Promise<boolean> {
+  try {
+    await dependencies.access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hashFile(
+  path: string,
+  dependencies: SkillInstallerDependencies,
+): Promise<string> {
+  return hashContent(await dependencies.readFile(path));
+}
+
+function sourceRootFor(skill: SkillPackSkill, roots: SourceRoots): string {
+  return skill.source === "patchmill"
+    ? roots.patchmillSkillsDir
+    : roots.superpowersSkillsDir;
+}
+
+async function collectSourceFiles(
+  skillRoot: string,
+  currentDir: string,
+  targetRelativeDir: string,
+  displayRoot: string,
+  dependencies: SkillInstallerDependencies,
+): Promise<Array<{ path: string; sha256: string }>> {
+  const files: Array<{ path: string; sha256: string }> = [];
+  const entries = await dependencies.readdir(currentDir, {
+    withFileTypes: true,
+  });
+  entries.sort((a, b) => comparePaths(a.name, b.name));
+
+  for (const entry of entries) {
+    const entryPath = join(currentDir, entry.name);
+    const relativePath = relative(skillRoot, entryPath).split(sep).join("/");
+    const metadataPath = `${targetRelativeDir}/${relativePath}`;
+    const displayPath = `${displayRoot}/${relativePath}`;
+
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await collectSourceFiles(
+          skillRoot,
+          entryPath,
+          targetRelativeDir,
+          displayRoot,
+          dependencies,
+        )),
+      );
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(`Unsupported skill source entry: ${displayPath}`);
+    }
+
+    files.push({
+      path: metadataPath,
+      sha256: await hashFile(entryPath, dependencies),
+    });
+  }
+
+  return files;
+}
+
+async function readInstalledMetadata(
+  repoRoot: string,
+  dependencies: SkillInstallerDependencies,
+): Promise<SkillPackMetadataFile> {
+  const metadataPath = resolve(
+    repoRoot,
+    DEFAULT_PROJECT_SKILL_DIR,
+    SKILL_PACK_METADATA_FILE,
+  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await dependencies.readFile(metadataPath, "utf8"));
+  } catch {
+    throw new Error(MISSING_METADATA_MESSAGE);
+  }
+  return parsed as SkillPackMetadataFile;
+}
+
+function assertPatchmillManagedProjectLocal(
+  metadata: SkillPackMetadataFile,
+): void {
+  if (
+    metadata.pack?.name !== PATCHMILL_RECOMMENDED_SKILL_PACK.name ||
+    metadata.skillDir !== DEFAULT_PROJECT_SKILL_DIR ||
+    metadata.metadataFile !== SKILL_PACK_METADATA_FILE ||
+    !Array.isArray(metadata.files)
+  ) {
+    throw new Error(MISSING_METADATA_MESSAGE);
+  }
+}
+
+async function collectBundledPackFiles(options: {
+  sourceRoots: SourceRoots;
+  packSkills: SkillPackSkill[];
+  dependencies: SkillInstallerDependencies;
+}): Promise<Array<{ path: string; sha256: string }>> {
+  const files: Array<{ path: string; sha256: string }> = [];
+  for (const skill of options.packSkills) {
+    const sourceDir = join(
+      sourceRootFor(skill, options.sourceRoots),
+      skill.name,
+    );
+    const skillFile = join(sourceDir, "SKILL.md");
+    try {
+      const entry = await options.dependencies.stat(skillFile);
+      if (!entry.isFile()) throw new Error("not a file");
+    } catch {
+      throw new Error(`Missing required skill file: ${skill.name}/SKILL.md`);
+    }
+    files.push(
+      ...(await collectSourceFiles(
+        sourceDir,
+        sourceDir,
+        projectSkillPath(skill.name),
+        skill.name,
+        options.dependencies,
+      )),
+    );
+  }
+  files.sort((a, b) => comparePaths(a.path, b.path));
+  return files;
+}
+
+async function customizedManagedFiles(
+  repoRoot: string,
+  metadata: SkillPackMetadataFile,
+  dependencies: SkillInstallerDependencies,
+): Promise<string[]> {
+  const changed: string[] = [];
+  for (const file of metadata.files) {
+    const absolutePath = resolve(repoRoot, file.path);
+    if (!(await pathExists(absolutePath, dependencies))) {
+      changed.push(`${file.path} (missing)`);
+      continue;
+    }
+    try {
+      if ((await hashFile(absolutePath, dependencies)) !== file.sha256) {
+        changed.push(file.path);
+      }
+    } catch {
+      changed.push(file.path);
+    }
+  }
+  return changed;
+}
+
+async function unmanagedNewFileCollisions(
+  repoRoot: string,
+  oldFiles: Array<{ path: string; sha256: string }>,
+  newFiles: Array<{ path: string; sha256: string }>,
+  dependencies: SkillInstallerDependencies,
+): Promise<string[]> {
+  const oldPaths = new Set(oldFiles.map((file) => file.path));
+  const collisions: string[] = [];
+  for (const file of newFiles) {
+    if (oldPaths.has(file.path)) continue;
+    if (await pathExists(resolve(repoRoot, file.path), dependencies)) {
+      collisions.push(file.path);
+    }
+  }
+  return collisions;
+}
+
+function sameFiles(
+  left: Array<{ path: string; sha256: string }>,
+  right: Array<{ path: string; sha256: string }>,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function countUpdatedFiles(
+  oldFiles: Array<{ path: string; sha256: string }>,
+  newFiles: Array<{ path: string; sha256: string }>,
+): number {
+  const oldByPath = new Map(oldFiles.map((file) => [file.path, file.sha256]));
+  return newFiles.filter((file) => oldByPath.get(file.path) !== file.sha256)
+    .length;
+}
+
+async function copyBundledSkills(options: {
+  repoRoot: string;
+  sourceRoots: SourceRoots;
+  packSkills: SkillPackSkill[];
+  dependencies: SkillInstallerDependencies;
+}): Promise<void> {
+  for (const skill of options.packSkills) {
+    const sourceDir = join(
+      sourceRootFor(skill, options.sourceRoots),
+      skill.name,
+    );
+    const targetDir = resolve(options.repoRoot, projectSkillPath(skill.name));
+    await options.dependencies.mkdir(dirname(targetDir), { recursive: true });
+    await options.dependencies.cp(sourceDir, targetDir, {
+      recursive: true,
+      force: true,
+      errorOnExist: false,
+    });
+  }
+}
+
+async function removeObsoleteManagedFiles(options: {
+  repoRoot: string;
+  oldFiles: Array<{ path: string; sha256: string }>;
+  newFiles: Array<{ path: string; sha256: string }>;
+  dependencies: SkillInstallerDependencies;
+}): Promise<number> {
+  const newPaths = new Set(options.newFiles.map((file) => file.path));
+  const obsolete = options.oldFiles.filter((file) => !newPaths.has(file.path));
+  for (const file of obsolete) {
+    await options.dependencies.rm(resolve(options.repoRoot, file.path), {
+      force: true,
+    });
+  }
+  return obsolete.length;
+}
+
+export async function updateProjectSkills(
+  options: SkillPackUpdateOptions,
+): Promise<SkillPackUpdateResult> {
+  const dependencies = options.dependencies ?? defaultDependencies;
+  const sourceRoots = options.sourceRoots ?? defaultSkillSourceRoots();
+  const packSkills =
+    options.packSkills ?? PATCHMILL_RECOMMENDED_SKILL_PACK.skills;
+  const metadata = await readInstalledMetadata(options.repoRoot, dependencies);
+  assertPatchmillManagedProjectLocal(metadata);
+
+  const changed = await customizedManagedFiles(
+    options.repoRoot,
+    metadata,
+    dependencies,
+  );
+  if (changed.length > 0) {
+    throw new Error(
+      [
+        "Refusing to update customized project-local skills:",
+        ...changed.map((path) => `- ${path}`),
+      ].join("\n"),
+    );
+  }
+
+  const newFiles = await collectBundledPackFiles({
+    sourceRoots,
+    packSkills,
+    dependencies,
+  });
+  const collisions = await unmanagedNewFileCollisions(
+    options.repoRoot,
+    metadata.files,
+    newFiles,
+    dependencies,
+  );
+  if (collisions.length > 0) {
+    throw new Error(
+      [
+        "Refusing to overwrite unmanaged project-local skill files:",
+        ...collisions.map((path) => `- ${path}`),
+      ].join("\n"),
+    );
+  }
+
+  const newMetadata = buildSkillPackMetadata(newFiles, {
+    installedAt: options.installedAt ?? new Date().toISOString(),
+    skillDir: DEFAULT_PROJECT_SKILL_DIR,
+  });
+  if (
+    metadata.pack.version === newMetadata.pack.version &&
+    JSON.stringify(metadata.pack.source) ===
+      JSON.stringify(newMetadata.pack.source) &&
+    sameFiles(metadata.files, newMetadata.files)
+  ) {
+    return { status: "up-to-date", version: newMetadata.pack.version };
+  }
+
+  const updatedFiles = countUpdatedFiles(metadata.files, newMetadata.files);
+  const removedFiles = await removeObsoleteManagedFiles({
+    repoRoot: options.repoRoot,
+    oldFiles: metadata.files,
+    newFiles: newMetadata.files,
+    dependencies,
+  });
+  await copyBundledSkills({
+    repoRoot: options.repoRoot,
+    sourceRoots,
+    packSkills,
+    dependencies,
+  });
+  await dependencies.writeFile(
+    resolve(
+      options.repoRoot,
+      DEFAULT_PROJECT_SKILL_DIR,
+      SKILL_PACK_METADATA_FILE,
+    ),
+    `${JSON.stringify(newMetadata, null, 2)}\n`,
+  );
+
+  return {
+    status: "updated",
+    fromVersion: metadata.pack.version,
+    toVersion: newMetadata.pack.version,
+    updatedFiles,
+    removedFiles,
+  };
+}

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -158,6 +158,14 @@ async function readInstalledMetadata(
   return parsed as SkillPackMetadataFile;
 }
 
+function isProjectSkillFilePath(path: unknown): path is string {
+  return (
+    typeof path === "string" &&
+    path.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`) &&
+    !path.split("/").includes("..")
+  );
+}
+
 function assertPatchmillManagedProjectLocal(
   metadata: SkillPackMetadataFile,
 ): void {
@@ -165,7 +173,8 @@ function assertPatchmillManagedProjectLocal(
     metadata.pack?.name !== PATCHMILL_RECOMMENDED_SKILL_PACK.name ||
     metadata.skillDir !== DEFAULT_PROJECT_SKILL_DIR ||
     metadata.metadataFile !== SKILL_PACK_METADATA_FILE ||
-    !Array.isArray(metadata.files)
+    !Array.isArray(metadata.files) ||
+    metadata.files.some((file) => !isProjectSkillFilePath(file.path))
   ) {
     throw new Error(MISSING_METADATA_MESSAGE);
   }

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -94,7 +94,18 @@ function isProjectSkillFilePath(path: unknown): path is string {
   return (
     typeof path === "string" &&
     path.startsWith(`${DEFAULT_PROJECT_SKILL_DIR}/`) &&
+    !path.includes("\\") &&
     !path.split("/").includes("..")
+  );
+}
+
+function isSkillPackSource(source: unknown): boolean {
+  return (
+    isRecord(source) &&
+    source.type === "github-release" &&
+    typeof source.repository === "string" &&
+    typeof source.tag === "string" &&
+    typeof source.tarballUrl === "string"
   );
 }
 
@@ -106,6 +117,8 @@ function assertPatchmillManagedProjectLocal(
   }
   if (
     metadata.pack.name !== PATCHMILL_RECOMMENDED_SKILL_PACK.name ||
+    typeof metadata.pack.version !== "string" ||
+    !isSkillPackSource(metadata.pack.source) ||
     metadata.skillDir !== DEFAULT_PROJECT_SKILL_DIR ||
     metadata.metadataFile !== SKILL_PACK_METADATA_FILE ||
     !Array.isArray(metadata.files) ||

--- a/src/cli/commands/skills/update.ts
+++ b/src/cli/commands/skills/update.ts
@@ -27,6 +27,7 @@ import {
   comparePaths,
   defaultSkillSourceRoots,
   hashFile,
+  makeOwnerWritableRecursive,
   pathExists,
   sourceRootFor,
   type SkillInstallerDependencies,
@@ -109,7 +110,10 @@ function assertPatchmillManagedProjectLocal(
     metadata.metadataFile !== SKILL_PACK_METADATA_FILE ||
     !Array.isArray(metadata.files) ||
     metadata.files.some(
-      (file) => !isRecord(file) || !isProjectSkillFilePath(file.path),
+      (file) =>
+        !isRecord(file) ||
+        !isProjectSkillFilePath(file.path) ||
+        typeof file.sha256 !== "string",
     )
   ) {
     throw new Error(MISSING_METADATA_MESSAGE);
@@ -220,6 +224,7 @@ async function copyBundledSkills(options: {
       force: true,
       errorOnExist: false,
     });
+    await makeOwnerWritableRecursive(targetDir, options.dependencies);
   }
 }
 

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -39,6 +39,13 @@ test("resolveCommand maps setup-test-repo to the public command name", () => {
   );
 });
 
+test("resolveCommand maps skills to the public command name", () => {
+  assert.deepEqual(resolveCommand(["skills", "update"], ["skills"]), {
+    command: "skills",
+    args: ["update"],
+  });
+});
+
 test("resolveCommand maps init to the public command name", () => {
   assert.deepEqual(resolveCommand(["init"], ["init"]), {
     command: "init",
@@ -114,6 +121,7 @@ test("createCliMain prints top-level help", async () => {
     /auth\s+Configure or repair repo-local Pi provider authentication\./,
   );
   assert.match(HELP_TEXT, /doctor\s+Run read-only readiness checks\./);
+  assert.match(HELP_TEXT, /skills\s+Manage Patchmill project-local skills\./);
   assert.match(HELP_TEXT, /version\s+Print the Patchmill CLI version\./);
   assert.match(
     HELP_TEXT,
@@ -186,6 +194,24 @@ test("createCliMain dispatches auth command", async () => {
 
   assert.equal(await main(["auth", "--help"]), 0);
   assert.deepEqual(calls, [["--help"]]);
+});
+
+test("createCliMain dispatches skills command", async () => {
+  const calls: string[][] = [];
+  const main = createCliMain(
+    new Map([
+      [
+        "skills",
+        async (args) => {
+          calls.push(args);
+          return 0;
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(await main(["skills", "update"]), 0);
+  assert.deepEqual(calls, [["update"]]);
 });
 
 test("createCliMain dispatches init and doctor commands", async () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,6 +3,7 @@ import { main as doctorMain } from "./commands/doctor/main.ts";
 import { main as initMain } from "./commands/init/main.ts";
 import { main as runOnceMain } from "./commands/run-once/main.ts";
 import { main as setupTestRepoMain } from "./commands/setup-test-repo/main.ts";
+import { main as skillsMain } from "./commands/skills/main.ts";
 import { main as triageMain } from "./commands/triage/main.ts";
 import { main as versionMain } from "./commands/version/main.ts";
 
@@ -15,6 +16,7 @@ Commands:
   doctor      Run read-only readiness checks.
   triage      Classify repository issues for agent readiness.
   run-once    Claim and process one agent-ready issue.
+  skills      Manage Patchmill project-local skills.
   version     Print the Patchmill CLI version.
   setup-test-repo  Create or reset a disposable Patchmill demo repository.
 `;
@@ -98,6 +100,7 @@ const COMMANDS = new Map<string, CommandHandler>([
   ["doctor", doctorMain],
   ["triage", triageMain],
   ["run-once", runOnceMain],
+  ["skills", skillsMain],
   ["version", versionMain],
   ["setup-test-repo", setupTestRepoMain],
 ]);

--- a/src/workflow/skill-pack.ts
+++ b/src/workflow/skill-pack.ts
@@ -10,9 +10,9 @@ export const SINGLE_SUBAGENT_DEV_WITH_CODEX_AND_THERMO_REVIEWS_SKILL =
 
 export type SkillPackSource = {
   type: "github-release";
-  repository: "obra/superpowers";
-  tag: "v6.0.3";
-  tarballUrl: "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz";
+  repository: string;
+  tag: string;
+  tarballUrl: string;
 };
 
 export type SkillPackSkill = {
@@ -22,15 +22,15 @@ export type SkillPackSkill = {
 
 export type SkillPack = {
   name: "patchmill-recommended";
-  version: "2026.05";
+  version: string;
   source: SkillPackSource;
   skills: SkillPackSkill[];
 };
 
 export type SkillPackMetadataFile = {
   pack: {
-    name: SkillPack["name"];
-    version: SkillPack["version"];
+    name: string;
+    version: string;
     source: SkillPackSource;
   };
   installedAt: "<generated-by-init>" | string;


### PR DESCRIPTION
## Summary
- add `patchmill skills update` CLI namespace and updater for managed project-local skill packs
- preflight metadata, hashes, unsafe paths, permissions, and unmanaged new-file collisions before writes
- document update workflow with `npx patchmill@latest skills update`

## Validation
- `node --test src/workflow/skill-pack.test.ts src/cli/commands/init/skill-installer.test.ts src/cli/commands/skills/*.test.ts src/cli/main.test.ts` (50 passing)
- `npm run lint:ts`
- `npm run lint:md`
- `npm test` (898 passing)
- AGENTS skill-pack integration check: pack 2026.05, source tag v6.0.3, superpowers 6.0.3, checked 18 skills

## Review
- Final Codex full-worktree review: pass
- Final thermo-nuclear full-worktree review: pass

Human review is required because this repository has no configured direct-landing skill, so the issue policy requires PR fallback.
