### PR TITLE
fix(run-once): report untrusted artifact authors

### DIFF
--- a/src/cli/commands/run-once/artifact-source-stage.test.ts
+++ b/src/cli/commands/run-once/artifact-source-stage.test.ts
@@ -158,3 +158,38 @@ test("runArtifactSourceStage trusts only host-resolved artifact publishers", asy
   assert.equal(result.resolvedArtifacts.spec?.path, "docs/specs/trusted.md");
   assert.equal(result.resolvedArtifacts.spec?.content, "# Trusted Spec");
 });
+
+test("runArtifactSourceStage emits console-only diagnostics for untrusted artifact authors", async () => {
+  const config = await makeConfig();
+  const consoleMessages: string[] = [];
+  const artifactHost: IssueHostProvider = {
+    ...host,
+    async trustedTriageCommentAuthors() {
+      return ["patchmill-bot"];
+    },
+  };
+  const untrustedSpec = formatPublishedArtifactComment({
+    kind: "spec",
+    path: "docs/specs/untrusted.md",
+    content: "# Untrusted Spec",
+  });
+
+  const result = await runArtifactSourceStage({
+    host: artifactHost,
+    config,
+    issue: {
+      ...issue,
+      comments: [{ authorLogin: "roche", body: untrustedSpec }],
+    },
+    now: new Date("2026-07-09T00:00:00Z"),
+    progress: async (_level, _stage, _message, extras) => {
+      if (extras?.consoleMessage) consoleMessages.push(extras.consoleMessage);
+    },
+    runStep: async (_label, fn) => await fn(),
+  });
+
+  assert.deepEqual(result.resolvedArtifacts, {});
+  assert.deepEqual(consoleMessages, [
+    "⚠ found spec artifact from roche, but roche is not a trusted artifact author",
+  ]);
+});

--- a/src/cli/commands/run-once/artifact-source-stage.ts
+++ b/src/cli/commands/run-once/artifact-source-stage.ts
@@ -1,6 +1,7 @@
 import type { IssueHostProvider } from "../../../host/types.ts";
 import {
   extractPublishedArtifactsFromIssue,
+  findUntrustedPublishedArtifactDiagnostics,
   issueHasPublishedArtifactMarker,
 } from "../../../workflow/artifacts/published-artifacts.ts";
 import {
@@ -28,7 +29,10 @@ type ArtifactSourceStageOptions = {
     stage: string,
     message: string,
     extras?: Partial<
-      Pick<AgentIssueProgressEvent, "issueNumber" | "elapsedSeconds" | "data">
+      Pick<
+        AgentIssueProgressEvent,
+        "issueNumber" | "elapsedSeconds" | "data" | "consoleMessage"
+      >
     >,
   ) => Promise<void>;
   runStep: <T>(label: string, fn: () => Promise<T>) => Promise<T>;
@@ -64,6 +68,20 @@ export async function runArtifactSourceStage(
       const trustedAuthors = issueHasPublishedArtifactMarker(issue)
         ? await options.host.trustedTriageCommentAuthors()
         : [];
+      for (const diagnostic of findUntrustedPublishedArtifactDiagnostics(
+        issue,
+        { trustedAuthors },
+      )) {
+        await options.progress(
+          "info",
+          "artifact-extraction",
+          "untrusted deterministic issue artifact source",
+          {
+            issueNumber: issue.number,
+            consoleMessage: `⚠ found ${diagnostic.kind} artifact from ${diagnostic.authorLogin}, but ${diagnostic.authorLogin} is not a trusted artifact author`,
+          },
+        );
+      }
       return extractPublishedArtifactsFromIssue(issue, { trustedAuthors });
     },
   );

--- a/src/cli/commands/run-once/console-progress.test.ts
+++ b/src/cli/commands/run-once/console-progress.test.ts
@@ -310,6 +310,43 @@ test("console reporter suppresses heartbeat and raw text observations", () => {
   ]);
 });
 
+test("console reporter renders console-only messages inside the current step", () => {
+  const lines: string[] = [];
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => lines.push(line),
+    startedAt: BASE,
+  });
+
+  reporter.event(
+    event({
+      message: "extract issue artifact sources",
+      step: { type: "step-start", label: "extract issue artifact sources" },
+    }),
+  );
+  reporter.event(
+    event({
+      level: "info",
+      stage: "artifact-extraction",
+      message: "untrusted artifact author",
+      consoleMessage:
+        "⚠ found spec artifact from roche, but roche is not a trusted artifact author",
+    }),
+  );
+  reporter.event(
+    event({
+      time: "2026-05-22T10:00:04.000Z",
+      message: "extract issue artifact sources",
+      step: { type: "step-complete", label: "extract issue artifact sources" },
+    }),
+  );
+
+  assert.deepEqual(lines, [
+    "01 extract issue artifact sources",
+    "   ⚠ found spec artifact from roche, but roche is not a trusted artifact author",
+    "   tokens: task 0.0k total 0.0k   time elapsed: 4s",
+  ]);
+});
+
 test("console reporter renders mandatory implementation task labels", () => {
   const lines: string[] = [];
   const reporter = new AgentIssueConsoleProgressReporter({

--- a/src/cli/commands/run-once/console-progress.ts
+++ b/src/cli/commands/run-once/console-progress.ts
@@ -97,6 +97,13 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
   event(event: AgentIssueProgressEvent): void {
     if (event.level === "heartbeat") return;
 
+    if (event.consoleMessage) {
+      this.writeLine(
+        this.currentStep ? `   ${event.consoleMessage}` : event.consoleMessage,
+      );
+      return;
+    }
+
     if (event.step?.type === "run-start") {
       this.writeLine(`issue #${event.step.issueNumber} · ${event.step.title}`);
       return;

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -81,7 +81,10 @@ async function progress(
   stage: string,
   message: string,
   extras: Partial<
-    Pick<AgentIssueProgressEvent, "issueNumber" | "elapsedSeconds" | "data">
+    Pick<
+      AgentIssueProgressEvent,
+      "issueNumber" | "elapsedSeconds" | "data" | "consoleMessage"
+    >
   > = {},
 ): Promise<void> {
   await options.progress?.event({

--- a/src/cli/commands/run-once/progress.test.ts
+++ b/src/cli/commands/run-once/progress.test.ts
@@ -83,6 +83,26 @@ test("jsonl reporter preserves step completion accounting fields", async () => {
   assert.equal(parsed.elapsedSeconds, 72);
 });
 
+test("jsonl reporter omits console-only messages", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "agent-issue-progress-"));
+  const path = join(dir, "run.jsonl");
+  const reporter = new JsonlProgressReporter(path);
+
+  await reporter.event({
+    time: "2026-05-10T03:12:40.000Z",
+    level: "info",
+    stage: "artifact-extraction",
+    message: "untrusted artifact author",
+    consoleMessage:
+      "⚠ found spec artifact from roche, but roche is not a trusted artifact author",
+  });
+
+  const [line] = (await readFile(path, "utf8")).trim().split("\n");
+  const parsed = JSON.parse(line);
+  assert.equal(parsed.consoleMessage, undefined);
+  assert.equal(JSON.stringify(parsed).includes("roche"), false);
+});
+
 test("composite reporter sends events to all reporters", async () => {
   const seen: string[] = [];
   const reporter = compositeProgressReporter([

--- a/src/cli/commands/run-once/progress.ts
+++ b/src/cli/commands/run-once/progress.ts
@@ -19,6 +19,7 @@ export type AgentIssueProgressEvent = {
   level: "info" | "heartbeat" | "error" | "debug";
   stage: string;
   message: string;
+  consoleMessage?: string;
   issueNumber?: number;
   elapsedSeconds?: number;
   step?: AgentIssueStepEvent;
@@ -59,7 +60,7 @@ export class ConsoleProgressReporter implements ProgressReporter {
 
   event(event: AgentIssueProgressEvent): void {
     if (event.level === "debug") return;
-    this.writeLine(event.message);
+    this.writeLine(event.consoleMessage ?? event.message);
   }
 }
 
@@ -71,8 +72,9 @@ export class JsonlProgressReporter implements ProgressReporter {
   }
 
   async event(event: AgentIssueProgressEvent): Promise<void> {
+    const { consoleMessage: _consoleMessage, ...logEvent } = event;
     await mkdir(dirname(this.path), { recursive: true });
-    await appendFile(this.path, `${JSON.stringify(event)}\n`, "utf8");
+    await appendFile(this.path, `${JSON.stringify(logEvent)}\n`, "utf8");
   }
 }
 

--- a/src/host/forgejo-tea.test.ts
+++ b/src/host/forgejo-tea.test.ts
@@ -116,7 +116,7 @@ test("ForgejoTeaHostProvider reports CLI readiness", async () => {
   assert.deepEqual(calls, ["tea --help"]);
 });
 
-test("ForgejoTeaHostProvider resolves tea login profile to trusted triage comment author", async () => {
+test("ForgejoTeaHostProvider trusts configured and default tea login authors", async () => {
   const runner = createFakeRunner((_command, args) => {
     if (args.join(" ") === "logins list --output json") {
       return {
@@ -133,7 +133,7 @@ test("ForgejoTeaHostProvider resolves tea login profile to trusted triage commen
 
   const authors = await createProvider(runner).trustedTriageCommentAuthors();
 
-  assert.deepEqual(authors, ["triage-agent"]);
+  assert.deepEqual(authors, ["triage-agent", "roche"]);
   assert.deepEqual(runner.calls[0]?.args, [
     "logins",
     "list",

--- a/src/host/forgejo-tea.ts
+++ b/src/host/forgejo-tea.ts
@@ -357,8 +357,11 @@ export class ForgejoTeaHostProvider
     const selected = this.options.login
       ? entries.find((entry) => entry.name === this.options.login)
       : entries.find(isDefaultTeaLogin);
-    const user = selected?.user?.trim();
-    return user ? [user] : [];
+    const defaultLogin = entries.find(isDefaultTeaLogin);
+    return [selected?.user, defaultLogin?.user]
+      .map((user) => user?.trim() ?? "")
+      .filter((user) => user.length > 0)
+      .filter((user, index, users) => users.indexOf(user) === index);
   }
 
   listLabels(): Promise<string[]>;

--- a/src/workflow/artifacts/published-artifacts.ts
+++ b/src/workflow/artifacts/published-artifacts.ts
@@ -21,6 +21,11 @@ export type PublishedWorkflowArtifacts = Partial<
   Record<WorkflowArtifactKind, PublishedWorkflowArtifact>
 >;
 
+export type UntrustedPublishedArtifactDiagnostic = {
+  kind: WorkflowArtifactKind;
+  authorLogin: string;
+};
+
 export type PublishedArtifactTrustOptions = {
   trustedAuthors: readonly string[];
 };
@@ -304,6 +309,32 @@ export function extractPublishedArtifactsFromIssue(
   }
 
   return artifacts;
+}
+
+export function findUntrustedPublishedArtifactDiagnostics(
+  issue: PublishedArtifactIssue,
+  options: PublishedArtifactTrustOptions,
+): UntrustedPublishedArtifactDiagnostic[] {
+  const trustedAuthors = trustedAuthorSet(options.trustedAuthors);
+  const diagnostics: UntrustedPublishedArtifactDiagnostic[] = [];
+  const seen = new Set<string>();
+
+  for (const source of sourceBlocks(issue).reverse()) {
+    const authorLogin = source.authorLogin?.trim();
+    if (!authorLogin || trustedAuthors.has(authorLogin)) continue;
+
+    for (const match of publishedArtifactMatches(source).reverse()) {
+      const parsed = parseMetadata(match[1] ?? "", source.label);
+      if (parsed.status !== "valid") continue;
+
+      const key = `${parsed.metadata.kind}\0${authorLogin}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      diagnostics.push({ kind: parsed.metadata.kind, authorLogin });
+    }
+  }
+
+  return diagnostics;
 }
 
 export function formatPublishedArtifactComment(


### PR DESCRIPTION
## Summary
- trust both configured and default Forgejo tea users for deterministic artifact comments
- emit a terminal-only warning when deterministic spec/plan artifacts are skipped for an untrusted author
- strip username-bearing console messages from JSONL run logs

## Verification
- node --test src/cli/commands/run-once/console-progress.test.ts src/cli/commands/run-once/progress.test.ts src/cli/commands/run-once/artifact-source-stage.test.ts
- node --test src/workflow/artifacts/published-artifacts.test.ts src/cli/commands/run-once/artifact-source-stage.test.ts src/cli/commands/run-once/artifact-sources.test.ts src/cli/commands/run-once/console-progress.test.ts src/cli/commands/run-once/progress.test.ts src/host/forgejo-tea.test.ts
- npm test
- npm run lint:ts
- npx prettier --check src/cli/commands/run-once/artifact-source-stage.ts src/cli/commands/run-once/artifact-source-stage.test.ts src/cli/commands/run-once/console-progress.ts src/cli/commands/run-once/console-progress.test.ts src/cli/commands/run-once/pipeline.ts src/cli/commands/run-once/progress.ts src/cli/commands/run-once/progress.test.ts src/workflow/artifacts/published-artifacts.ts src/host/forgejo-tea.ts src/host/forgejo-tea.test.ts