### PR TITLE
Refactor bundled skill handling into registry

### DIFF
--- a/docs/plans/2026-07-14-issue-76-refactor-bundled-skill-handling-into-a-central-registry.md
+++ b/docs/plans/2026-07-14-issue-76-refactor-bundled-skill-handling-into-a-central-registry.md
@@ -1,0 +1,397 @@
+# Bundled Skill Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor Patchmill bundled skill metadata into one registry that
+drives defaults, resolution, skill-pack wiring, init validation, and doctor
+verification.
+
+**Architecture:** Add a low-level `src/workflow/bundled-skills.ts` registry with
+data-only entries and small lookup/path helpers. Update existing modules to
+consume registry helpers while keeping current public constants and path
+wrappers as compatibility exports.
+
+**Tech Stack:** TypeScript on Node.js 24, Node built-in test runner via
+`npm test`, existing workflow/init/doctor test helpers, no npm dependency
+changes.
+
+---
+
+## File structure
+
+- Create `src/workflow/bundled-skills.ts`
+  - Own canonical bundled Patchmill skill entries for `triage` and
+    `visualEvidence`.
+  - Export lookups by key, config reference, and global name/dir name.
+  - Export source-tree/built-package path helpers and required-file helpers.
+- Create `src/workflow/bundled-skills.test.ts`
+  - Assert registry metadata preserves public strings and required sidecar
+    files.
+  - Assert compatibility helpers resolve bundled `SKILL.md` paths and required
+    files.
+- Modify `src/workflow/skill-resolution.ts`
+  - Replace hardcoded bundled-reference branches with registry lookup.
+  - Preserve `BUNDLED_TRIAGE_SKILL_REFERENCE`,
+    `BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE`, `bundledTriageSkillPath()`, and
+    `bundledVisualEvidenceSkillPath()` as derived wrappers.
+- Modify `src/workflow/skills.ts`
+  - Derive default and global bundled skill values from registry helpers.
+  - Keep planning and implementation defaults as Superpowers references.
+- Modify `src/workflow/skill-pack.ts`
+  - Use registry required files and recommended project-local entries for
+    Patchmill bundled skills.
+  - Keep recommended pack contents and public config values unchanged.
+- Modify `src/cli/commands/init/skill-installer.ts`
+  - Derive Patchmill source root from a bundled registry path helper.
+  - Validate project-local recommended bundled skills using registry-derived
+    names and required files.
+- Modify `src/cli/commands/doctor/checks.ts`
+  - Verify registered bundled config references generically, including all
+    sidecar files.
+  - Keep warning behavior for unregistered named/global skills and path-like
+    skill validation.
+- Modify focused tests:
+  - `src/workflow/skills.test.ts`
+  - `src/workflow/skill-resolution.test.ts`
+  - `src/workflow/skill-pack.test.ts`
+  - `src/cli/commands/init/skill-installer.test.ts`
+  - `src/cli/commands/doctor/checks.test.ts`
+  - `src/workflow/visual-evidence-skill.test.ts` only if path helper imports
+    change.
+
+## Global constraints
+
+- Preserve these public values exactly:
+  - `patchmill:bundled-issue-triage`
+  - `patchmill:bundled-visual-evidence`
+  - `patchmill-issue-triage`
+  - `patchmill-visual-evidence`
+- Do not move or rewrite bundled skill prose or sidecar scripts.
+- Do not add npm dependencies. If `package.json`, `package-lock.json`, or
+  `npm-shrinkwrap.json` changes, revert or run the Nix build required by
+  `AGENTS.md`.
+- Unknown skill names must continue to require only `SKILL.md`.
+- Non-bundled Superpowers skills stay outside the bundled Patchmill registry.
+
+---
+
+### Task 1: Add the bundled skill registry and unit tests
+
+**Files:**
+
+- Create: `src/workflow/bundled-skills.ts`
+- Create: `src/workflow/bundled-skills.test.ts`
+
+- [ ] **Step 1: Write failing registry tests**
+
+Add tests that assert the registry contains exactly the initial bundled entries
+and preserves current metadata:
+
+```ts
+assert.deepEqual(
+  BUNDLED_PATCHMILL_SKILLS.map((skill) => skill.key),
+  ["triage", "visualEvidence"],
+);
+assert.equal(
+  bundledSkillByKey("triage")?.configReference,
+  "patchmill:bundled-issue-triage",
+);
+assert.equal(
+  bundledSkillByKey("visualEvidence")?.globalName,
+  "patchmill-visual-evidence",
+);
+assert.deepEqual(
+  requiredFilesForBundledSkillName("patchmill-visual-evidence"),
+  ["SKILL.md", "scripts/capture-visual-evidence.cjs"],
+);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/workflow/bundled-skills.test.ts`
+
+Expected: FAIL because `src/workflow/bundled-skills.ts` does not exist yet.
+
+- [ ] **Step 3: Implement the registry module**
+
+Create `BundledPatchmillSkill`, `BundledPatchmillSkillKey`,
+`BUNDLED_PATCHMILL_SKILLS`, lookup helpers, `bundledSkillPath(entry)`,
+`bundledSkillPathForReference(reference)`, `bundledSkillDir(entry)`, and
+`requiredFilesForBundledSkillName(name)`.
+
+- [ ] **Step 4: Run registry tests**
+
+Run: `npm test -- src/workflow/bundled-skills.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit registry foundation**
+
+```bash
+git add src/workflow/bundled-skills.ts src/workflow/bundled-skills.test.ts
+git commit -m "feat: add bundled skill registry"
+```
+
+---
+
+### Task 2: Derive skill resolution and default skill config from the registry
+
+**Files:**
+
+- Modify: `src/workflow/skill-resolution.ts`
+- Modify: `src/workflow/skills.ts`
+- Modify: `src/workflow/skill-resolution.test.ts`
+- Modify: `src/workflow/skills.test.ts`
+
+- [ ] **Step 1: Add/adjust resolver tests**
+
+Cover both bundled references through the generic lookup and keep named/global
+skills non-invokable. Include assertions that compatibility wrappers still
+return paths ending in the current skill directories.
+
+- [ ] **Step 2: Run focused tests to see current behavior**
+
+Run:
+`npm test -- src/workflow/skills.test.ts src/workflow/skill-resolution.test.ts`
+
+Expected before implementation: existing tests pass; new generic-registry
+assertions fail until imports and resolver logic are updated.
+
+- [ ] **Step 3: Replace hardcoded resolver branches**
+
+Import registry helpers in `src/workflow/skill-resolution.ts`. Derive bundled
+constants from `bundledSkillByKey()`, implement wrapper path functions through
+`bundledSkillPath()`, and replace the two `if (skill === BUNDLED_...)` branches
+with `bundledSkillPathForReference(skill)`.
+
+- [ ] **Step 4: Derive defaults/globals in `skills.ts`**
+
+Use registry lookup values for `DEFAULT_PATCHMILL_SKILLS.triage`,
+`DEFAULT_PATCHMILL_SKILLS.visualEvidence`, `GLOBAL_PATCHMILL_SKILLS.triage`, and
+`GLOBAL_PATCHMILL_SKILLS.visualEvidence`. Leave planning and implementation
+unchanged.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+`npm test -- src/workflow/skills.test.ts src/workflow/skill-resolution.test.ts src/workflow/bundled-skills.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit resolver/default changes**
+
+```bash
+git add src/workflow/skill-resolution.ts src/workflow/skills.ts src/workflow/skill-resolution.test.ts src/workflow/skills.test.ts src/workflow/bundled-skills.test.ts
+git commit -m "refactor: derive bundled skill resolution from registry"
+```
+
+---
+
+### Task 3: Derive skill-pack metadata and project-local config from the registry
+
+**Files:**
+
+- Modify: `src/workflow/skill-pack.ts`
+- Modify: `src/workflow/skill-pack.test.ts`
+
+- [ ] **Step 1: Add skill-pack regression tests**
+
+Assert `requiredSkillFiles("patchmill-visual-evidence")` returns `SKILL.md` plus
+`scripts/capture-visual-evidence.cjs`, `requiredSkillFiles("unknown")` returns
+`SKILL.md`, recommended pack entries are unchanged, and
+`buildRecommendedProjectSkillConfig()` still returns the same four paths.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+`npm test -- src/workflow/skill-pack.test.ts src/workflow/bundled-skills.test.ts`
+
+Expected: existing behavior passes; any newly imported registry assertions fail
+until wiring is updated.
+
+- [ ] **Step 3: Update `skill-pack.ts` to consume registry helpers**
+
+Replace the local `REQUIRED_SKILL_FILES` map with registry-derived required
+files for bundled Patchmill skill names. Build triage and visual evidence
+project-local config values from registry entries marked
+`recommendedProjectLocal` while preserving planning and implementation
+Superpowers paths.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+`npm test -- src/workflow/skill-pack.test.ts src/workflow/bundled-skills.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit skill-pack changes**
+
+```bash
+git add src/workflow/skill-pack.ts src/workflow/skill-pack.test.ts
+git commit -m "refactor: derive skill pack bundled metadata from registry"
+```
+
+---
+
+### Task 4: Use registry-derived required files during init install and validation
+
+**Files:**
+
+- Modify: `src/cli/commands/init/skill-installer.ts`
+- Modify: `src/cli/commands/init/skill-installer.test.ts`
+
+- [ ] **Step 1: Add init validation regression tests**
+
+Add or update tests that validate an existing project-local visual evidence
+skill fails when `scripts/capture-visual-evidence.cjs` is missing and passes
+when present. Assert `defaultSkillSourceRoots().patchmillSkillsDir` is still the
+bundled `skills` root.
+
+- [ ] **Step 2: Run focused init tests**
+
+Run: `npm test -- src/cli/commands/init/skill-installer.test.ts`
+
+Expected: current tests pass; new registry-specific tests fail if the
+implementation still hardcodes only selected names.
+
+- [ ] **Step 3: Update installer source-root and validation logic**
+
+Import registry helpers. Derive the Patchmill skills source root from a
+registered bundled skill directory helper rather than from
+`bundledTriageSkillPath()`. Build the project-local validation list from
+`buildRecommendedProjectSkillConfig()` plus registered `recommendedProjectLocal`
+entries, keeping planning and implementation validation explicit for Superpowers
+skills.
+
+- [ ] **Step 4: Run focused init tests**
+
+Run:
+`npm test -- src/cli/commands/init/skill-installer.test.ts src/workflow/skill-pack.test.ts src/workflow/bundled-skills.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit init installer changes**
+
+```bash
+git add src/cli/commands/init/skill-installer.ts src/cli/commands/init/skill-installer.test.ts
+git commit -m "refactor: validate init bundled skills through registry"
+```
+
+---
+
+### Task 5: Verify bundled defaults through the registry in doctor
+
+**Files:**
+
+- Modify: `src/cli/commands/doctor/checks.ts`
+- Modify: `src/cli/commands/doctor/checks.test.ts`
+
+- [ ] **Step 1: Add doctor sidecar verification tests**
+
+Add tests proving doctor verifies every required file for registered bundled
+config references and fails if the bundled visual evidence sidecar path is
+unreadable or missing. Keep tests for named/global skills warning rather than
+being verified.
+
+- [ ] **Step 2: Run focused doctor tests**
+
+Run: `npm test -- src/cli/commands/doctor/checks.test.ts`
+
+Expected: new generic bundled verification tests fail until doctor no longer
+uses key-specific branches.
+
+- [ ] **Step 3: Replace key-specific bundled doctor branches**
+
+In `checkSkills()`, look up `bundledSkillByConfigReference(skill)`. If found,
+call
+`verifyBundledSkill(key, skill, bundledSkillPath(entry), entry.requiredFiles)`.
+Remove imports for key-specific bundled path helpers where no longer needed.
+
+- [ ] **Step 4: Keep path-like required-file behavior**
+
+Ensure `requiredFilesForConfiguredSkill()` still derives sidecar requirements
+for local `.patchmill/skills/patchmill-visual-evidence` and custom path-like
+skills whose frontmatter name is `patchmill-visual-evidence`.
+
+- [ ] **Step 5: Run focused doctor tests**
+
+Run:
+`npm test -- src/cli/commands/doctor/checks.test.ts src/workflow/bundled-skills.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit doctor changes**
+
+```bash
+git add src/cli/commands/doctor/checks.ts src/cli/commands/doctor/checks.test.ts
+git commit -m "refactor: verify bundled skills through registry"
+```
+
+---
+
+### Task 6: Final regression sweep and cleanup
+
+**Files:**
+
+- Review: `src/workflow/visual-evidence-skill.test.ts`
+- Review: all files changed in Tasks 1-5
+
+- [ ] **Step 1: Run all issue-specific focused tests**
+
+Run:
+
+```bash
+npm test -- src/workflow/bundled-skills.test.ts src/workflow/skills.test.ts src/workflow/skill-resolution.test.ts src/workflow/skill-pack.test.ts src/cli/commands/init/skill-installer.test.ts src/cli/commands/doctor/checks.test.ts src/workflow/visual-evidence-skill.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Check dependency files**
+
+Run: `git diff -- package.json package-lock.json npm-shrinkwrap.json`
+
+Expected: no output. If any dependency file changed intentionally, run the
+project Nix build before completion as required by `AGENTS.md`; otherwise revert
+accidental dependency-file changes.
+
+- [ ] **Step 4: Review public behavior diffs**
+
+Run: `git diff -- src/workflow src/cli/commands/init src/cli/commands/doctor`
+
+Expected: registry-driven refactor only; no changes to public skill references,
+global names, recommended pack version/source, or bundled skill content.
+
+- [ ] **Step 5: Commit final cleanup if needed**
+
+If Step 4 required cleanup changes, commit them:
+
+```bash
+git add <cleaned-files>
+git commit -m "chore: clean up bundled skill registry refactor"
+```
+
+If no cleanup was needed, do not create an empty commit.
+
+## Validation commands
+
+Run these during implementation and before landing:
+
+```bash
+npm test -- src/workflow/bundled-skills.test.ts src/workflow/skills.test.ts src/workflow/skill-resolution.test.ts src/workflow/skill-pack.test.ts
+npm test -- src/cli/commands/init/skill-installer.test.ts src/cli/commands/doctor/checks.test.ts
+npm test -- src/workflow/visual-evidence-skill.test.ts
+npm test
+git diff -- package.json package-lock.json npm-shrinkwrap.json
+```
+
+A Nix build is not required for this issue unless implementation changes
+`package.json`, `package-lock.json`, or `npm-shrinkwrap.json`.

--- a/docs/specs/2026-07-14-issue-76-refactor-bundled-skill-handling-into-a-central-registry-design.md
+++ b/docs/specs/2026-07-14-issue-76-refactor-bundled-skill-handling-into-a-central-registry-design.md
@@ -1,0 +1,209 @@
+# Issue 76: central bundled-skill registry design
+
+## Context
+
+Patchmill has several bundled skills that can be used without project-local
+installation. Today their metadata is split across multiple modules:
+
+- `src/workflow/skill-resolution.ts` defines bundled config-reference constants,
+  path helpers, and resolver branches for triage and visual evidence.
+- `src/workflow/skills.ts` repeats bundled references in default and global
+  skill config.
+- `src/workflow/skill-pack.ts` separately defines Patchmill skill names,
+  recommended pack entries, project-local config, and required sidecar files.
+- `src/cli/commands/doctor/checks.ts` has special-case verification for bundled
+  triage and visual evidence.
+- `src/cli/commands/init/skill-installer.ts` derives Patchmill source roots from
+  the triage path and validates selected project-local recommended skills by
+  hand.
+
+This was workable when bundled skills were modeled as single `SKILL.md` files,
+but `patchmill-visual-evidence` now includes the required sidecar script
+`scripts/capture-visual-evidence.cjs`. Adding another bundled skill should not
+require adding matching one-off constants, resolver branches, doctor branches,
+and required-file maps in different places.
+
+## Goals
+
+- Define bundled Patchmill skill metadata once in a canonical registry.
+- Use that registry to derive bundled config references, global names, resolved
+  `SKILL.md` paths, required files, and project-local recommended config where
+  applicable.
+- Verify all required files for bundled skills, including sidecar scripts, not
+  just `SKILL.md`.
+- Preserve current behavior for bundled issue triage, recommended project-local
+  skill installation, visual evidence, and existing global/named skills.
+- Make adding a new bundled skill a data change in the registry plus targeted
+  tests, not a set of unrelated resolver and doctor branches.
+
+## Non-goals
+
+- Do not redesign Pi's skill loading or project-local skill directory discovery.
+- Do not change configured skill names, existing default values, or public
+  config syntax.
+- Do not add, remove, or rewrite bundled skill prose as part of this refactor.
+- Do not change the recommended Superpowers version or npm dependencies.
+
+## Proposed design
+
+Introduce a small workflow module, for example `src/workflow/bundled-skills.ts`,
+that owns the registry and derived helpers. Each registry entry should include
+at least:
+
+```ts
+export type BundledPatchmillSkill = {
+  key: PatchmillSkillKey;
+  configReference: string;
+  globalName: string;
+  dirName: string;
+  requiredFiles: readonly string[];
+  recommendedProjectLocal?: boolean;
+};
+```
+
+Initial entries should preserve current public values:
+
+| key              | configReference                     | globalName / dirName        | requiredFiles                                     | recommendedProjectLocal |
+| ---------------- | ----------------------------------- | --------------------------- | ------------------------------------------------- | ----------------------- |
+| `triage`         | `patchmill:bundled-issue-triage`    | `patchmill-issue-triage`    | `SKILL.md`                                        | yes                     |
+| `visualEvidence` | `patchmill:bundled-visual-evidence` | `patchmill-visual-evidence` | `SKILL.md`, `scripts/capture-visual-evidence.cjs` | yes                     |
+
+The implementation may include additional Patchmill-managed skills in the same
+registry if they are bundled and have required-file metadata, but the refactor
+must not force every recommended pack skill to become a default workflow skill.
+Non-bundled Superpowers skills should stay outside this registry.
+
+The registry module should provide derived helpers rather than inviting call
+sites to duplicate predicates:
+
+- lookup by workflow key;
+- lookup by config reference;
+- lookup by global skill name / directory name;
+- `bundledSkillPath(entry)` or `bundledSkillPathForReference(reference)` that
+  preserves the current source-tree vs built-package path behavior;
+- `requiredFilesForBundledSkillName(name)` or equivalent;
+- an iterable list for doctor and tests.
+
+Existing public exports such as `BUNDLED_TRIAGE_SKILL_REFERENCE`,
+`BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE`, `bundledTriageSkillPath()`, and
+`bundledVisualEvidenceSkillPath()` may remain as compatibility wrappers, but
+they should be derived from the registry.
+
+## Affected components
+
+### Skill resolution
+
+`src/workflow/skill-resolution.ts` should replace hardcoded bundled-reference
+branches with a registry lookup. `resolveConfiguredSkillInvocation()` should map
+any registered `configReference` to that skill's bundled `SKILL.md` path. Named
+or namespace-style skills that are not registered bundled references should keep
+existing behavior.
+
+The generic path helper should continue looking in both the source tree and the
+built package layout so tests and packaged CLI runs keep working.
+
+### Default and global skill config
+
+`src/workflow/skills.ts` should derive bundled defaults from the registry:
+
+- `DEFAULT_PATCHMILL_SKILLS.triage` remains `patchmill:bundled-issue-triage`.
+- `DEFAULT_PATCHMILL_SKILLS.visualEvidence` remains
+  `patchmill:bundled-visual-evidence`.
+- `GLOBAL_PATCHMILL_SKILLS.triage` remains `patchmill-issue-triage`.
+- `GLOBAL_PATCHMILL_SKILLS.visualEvidence` remains `patchmill-visual-evidence`.
+
+Planning and implementation defaults remain Superpowers references and do not
+belong in the bundled Patchmill registry.
+
+### Skill pack metadata and project-local config
+
+`src/workflow/skill-pack.ts` should use the registry for Patchmill bundled skill
+names and required files. `requiredSkillFiles("patchmill-visual-evidence")`
+should still return both `SKILL.md` and `scripts/capture-visual-evidence.cjs`;
+unknown skills should still default to `["SKILL.md"]`.
+
+`buildRecommendedProjectSkillConfig()` should derive project-local paths for
+registered default workflow skills instead of hardcoding Patchmill bundled
+names. The recommended pack should continue including the same Patchmill and
+Superpowers skills it includes today.
+
+### Init skill installer
+
+`src/cli/commands/init/skill-installer.ts` should use registry-derived source
+roots and required-file lists when installing or validating Patchmill skills.
+`validateExistingSkillDirectory()` should preserve its current contract: return
+local paths for triage, planning, implementation, and visual evidence, and fail
+when visual evidence is missing its helper script.
+
+### Doctor
+
+`src/cli/commands/doctor/checks.ts` should verify bundled defaults through a
+registry lookup instead of key-specific branches. When a configured skill equals
+a registered bundled `configReference`, doctor should verify every required file
+relative to the bundled skill directory. The visual evidence bundled default
+must therefore fail if `scripts/capture-visual-evidence.cjs` is missing or
+unreadable.
+
+Doctor should keep existing warnings for unregistered named/global skills and
+existing validation for path-like local skills. For path-like skills, required
+files may still be inferred from the resolved skill frontmatter name and the
+registry/required-file helper.
+
+### Tests and documentation
+
+Update existing tests rather than adding broad integration rewrites. Important
+coverage includes:
+
+- registry contains triage and visual evidence metadata with current public
+  strings;
+- bundled config references resolve through the generic resolver;
+- public compatibility exports still return the same paths and constants;
+- visual evidence required files are derived from the registry for skill-pack,
+  init validation, and doctor;
+- doctor verifies all registered required files for bundled defaults;
+- recommended project-local config and pack entries are unchanged.
+
+Documentation changes are optional for this internal refactor unless public docs
+currently describe a hardcoded implementation detail that becomes inaccurate.
+
+## Compatibility and migration
+
+No user migration is required. Existing `patchmill.config.json` values should
+continue to work:
+
+- bundled references such as `patchmill:bundled-issue-triage` and
+  `patchmill:bundled-visual-evidence`;
+- global names such as `patchmill-issue-triage` and `patchmill-visual-evidence`;
+- project-local paths such as `.patchmill/skills/patchmill-visual-evidence`;
+- custom path-like visual evidence skills with the same frontmatter name and
+  required helper script.
+
+The refactor should preserve public exports used by tests and internal modules,
+or update all call sites in the same change if an export is intentionally
+renamed.
+
+## Verification strategy
+
+- Run focused tests for workflow skill modules:
+  `npm test -- src/workflow/skills.test.ts src/workflow/skill-resolution.test.ts src/workflow/skill-pack.test.ts`.
+- Run focused init and doctor tests:
+  `npm test -- src/cli/commands/init/skill-installer.test.ts src/cli/commands/doctor/checks.test.ts`.
+- Run visual-evidence-specific tests:
+  `npm test -- src/workflow/visual-evidence-skill.test.ts`.
+- Run the full test suite if focused tests pass.
+- Because this design does not require npm dependency changes, a Nix build is
+  not required unless implementation changes `package.json`,
+  `package-lock.json`, or `npm-shrinkwrap.json`.
+
+## Risks and mitigations
+
+- **Circular imports:** put registry helpers in a low-level workflow module and
+  import only type-only `PatchmillSkillKey` references if needed, or define the
+  registry key type locally to avoid cycles.
+- **Over-generalization:** keep the registry limited to bundled Patchmill skill
+  metadata and simple lookup helpers; avoid a new plugin framework.
+- **Behavior drift:** assert unchanged default/global config objects and
+  recommended project-local paths in tests.
+- **Sidecar regressions:** include tests that intentionally remove or omit
+  `scripts/capture-visual-evidence.cjs` and expect init/doctor validation to
+  fail.

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { runDoctorChecks } from "./checks.ts";
 import { installProjectSkills } from "../init/skill-installer.ts";
 import type { CommandRunner } from "../triage/types.ts";
-import { bundledVisualEvidenceSkillPath } from "../../../workflow/skills.ts";
+import {
+  DEFAULT_PATCHMILL_SKILLS,
+  bundledVisualEvidenceSkillPath,
+} from "../../../workflow/skills.ts";
 import {
   DEFAULT_PROJECT_SKILL_DIR,
   PATCHMILL_RECOMMENDED_SKILL_PACK,
@@ -303,6 +306,81 @@ test("runDoctorChecks aggregates successful read-only checks", async () => {
     results.some((result) => result.status === "fail"),
     false,
   );
+});
+
+test("runDoctorChecks verifies registered bundled config references", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      triage: DEFAULT_PATCHMILL_SKILLS.triage,
+      planning: "superpowers:writing-plans",
+      implementation: "superpowers:subagent-driven-development",
+      visualEvidence: DEFAULT_PATCHMILL_SKILLS.visualEvidence,
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await mkdir(join(repoRoot, ".patchmill"), { recursive: true });
+
+  const results = await runDoctorChecks(runnerFrom(successMocks()), {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+  });
+  const skills = results.find((result) => result.name === "skills");
+
+  assert.equal(skills?.status, "warn");
+  assert.match(
+    skills?.message ?? "",
+    /triage: `patchmill:bundled-issue-triage` \(bundled skill verified\)/,
+  );
+  assert.match(
+    skills?.message ?? "",
+    /visualEvidence: `patchmill:bundled-visual-evidence` \(bundled skill verified\)/,
+  );
+  assert.match(
+    skills?.message ?? "",
+    /planning: `superpowers:writing-plans` \(named skill configured; doctor did not verify it\)/,
+  );
+});
+
+test("runDoctorChecks fails when bundled visual evidence sidecar is missing", async () => {
+  const repoRoot = await tempRepo();
+  await writeConfig(repoRoot, {
+    host: { provider: "forgejo-tea", login: "triage-agent" },
+    skills: {
+      visualEvidence: DEFAULT_PATCHMILL_SKILLS.visualEvidence,
+    },
+  });
+  await mkdir(join(repoRoot, "docs"), { recursive: true });
+  await mkdir(join(repoRoot, ".patchmill"), { recursive: true });
+
+  const sidecarPath = join(
+    dirname(bundledVisualEvidenceSkillPath()),
+    "scripts",
+    "capture-visual-evidence.cjs",
+  );
+  const temporarySidecarPath = `${sidecarPath}.doctor-test-backup`;
+
+  await rename(sidecarPath, temporarySidecarPath);
+  try {
+    const results = await runDoctorChecks(runnerFrom(successMocks()), {
+      repoRoot,
+      teaRepoRootForTests: "/repo",
+    });
+    const skills = results.find((result) => result.name === "skills");
+
+    assert.equal(skills?.status, "fail");
+    assert.match(
+      skills?.message ?? "",
+      /visualEvidence: `patchmill:bundled-visual-evidence`/,
+    );
+    assert.match(
+      skills?.message ?? "",
+      /required skill file unreadable at .*patchmill-visual-evidence.*scripts.*capture-visual-evidence\.cjs/,
+    );
+  } finally {
+    await rename(temporarySidecarPath, sidecarPath);
+  }
 });
 
 test("runDoctorChecks points Pi provider failures to guided setup", async () => {

--- a/src/cli/commands/doctor/checks.test.ts
+++ b/src/cli/commands/doctor/checks.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { test } from "node:test";
 import { runDoctorChecks } from "./checks.ts";
 import { installProjectSkills } from "../init/skill-installer.ts";
@@ -354,33 +354,34 @@ test("runDoctorChecks fails when bundled visual evidence sidecar is missing", as
   await mkdir(join(repoRoot, "docs"), { recursive: true });
   await mkdir(join(repoRoot, ".patchmill"), { recursive: true });
 
-  const sidecarPath = join(
-    dirname(bundledVisualEvidenceSkillPath()),
-    "scripts",
-    "capture-visual-evidence.cjs",
+  const bundledFixtureRoot = await mkdtemp(
+    join(tmpdir(), "patchmill-doctor-bundled-skill-"),
   );
-  const temporarySidecarPath = `${sidecarPath}.doctor-test-backup`;
+  const bundledFixtureSkillPath = await writeSkillFile(
+    bundledFixtureRoot,
+    "patchmill-visual-evidence",
+    skillDocument(
+      "patchmill-visual-evidence",
+      "Capture browser screenshots as visual evidence",
+    ),
+  );
 
-  await rename(sidecarPath, temporarySidecarPath);
-  try {
-    const results = await runDoctorChecks(runnerFrom(successMocks()), {
-      repoRoot,
-      teaRepoRootForTests: "/repo",
-    });
-    const skills = results.find((result) => result.name === "skills");
+  const results = await runDoctorChecks(runnerFrom(successMocks()), {
+    repoRoot,
+    teaRepoRootForTests: "/repo",
+    bundledSkillPathForTests: () => bundledFixtureSkillPath,
+  });
+  const skills = results.find((result) => result.name === "skills");
 
-    assert.equal(skills?.status, "fail");
-    assert.match(
-      skills?.message ?? "",
-      /visualEvidence: `patchmill:bundled-visual-evidence`/,
-    );
-    assert.match(
-      skills?.message ?? "",
-      /required skill file unreadable at .*patchmill-visual-evidence.*scripts.*capture-visual-evidence\.cjs/,
-    );
-  } finally {
-    await rename(temporarySidecarPath, sidecarPath);
-  }
+  assert.equal(skills?.status, "fail");
+  assert.match(
+    skills?.message ?? "",
+    /visualEvidence: `patchmill:bundled-visual-evidence`/,
+  );
+  assert.match(
+    skills?.message ?? "",
+    /required skill file unreadable at .*patchmill-visual-evidence.*scripts.*capture-visual-evidence\.cjs/,
+  );
 });
 
 test("runDoctorChecks points Pi provider failures to guided setup", async () => {

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -19,10 +19,11 @@ import { missingLabelDefinitions } from "../triage/labels.ts";
 import type { CommandRunner } from "../triage/types.ts";
 import type { PatchmillConfig } from "../../../config/types.ts";
 import {
-  DEFAULT_PATCHMILL_SKILLS,
+  bundledSkillByConfigReference,
+  bundledSkillPath,
+} from "../../../workflow/bundled-skills.ts";
+import {
   PATCHMILL_SKILL_KEYS,
-  bundledTriageSkillPath,
-  bundledVisualEvidenceSkillPath,
   isPathLikeSkill,
   resolveConfiguredSkillInvocation,
   resolvePathLikeSkillPath,
@@ -437,19 +438,13 @@ async function checkSkills(
 
   const entries: SkillCheckEntry[] = await Promise.all(
     configuredSkills.map(async ({ key, skill }) => {
-      if (key === "triage" && skill === DEFAULT_PATCHMILL_SKILLS.triage) {
-        return await verifyBundledSkill(key, skill, bundledTriageSkillPath());
-      }
-
-      if (
-        key === "visualEvidence" &&
-        skill === DEFAULT_PATCHMILL_SKILLS.visualEvidence
-      ) {
+      const bundledSkill = bundledSkillByConfigReference(skill);
+      if (bundledSkill) {
         return await verifyBundledSkill(
           key,
           skill,
-          bundledVisualEvidenceSkillPath(),
-          requiredSkillFiles("patchmill-visual-evidence"),
+          bundledSkillPath(bundledSkill),
+          bundledSkill.requiredFiles,
         );
       }
 

--- a/src/cli/commands/doctor/checks.ts
+++ b/src/cli/commands/doctor/checks.ts
@@ -43,6 +43,7 @@ type DoctorOptions = {
   repoRoot: string;
   env?: Record<string, string | undefined>;
   teaRepoRootForTests?: string;
+  bundledSkillPathForTests?: typeof bundledSkillPath;
 };
 
 type SkillCheckEntry = {
@@ -422,6 +423,7 @@ async function checkSkills(
   config: PatchmillConfig,
   repoRoot: string,
   piAgentDir: string,
+  bundledSkillPathResolver: typeof bundledSkillPath = bundledSkillPath,
 ): Promise<DoctorCheckResult> {
   const configuredSkills = PATCHMILL_SKILL_KEYS.flatMap((key) => {
     const skill = config.skills[key];
@@ -443,7 +445,7 @@ async function checkSkills(
         return await verifyBundledSkill(
           key,
           skill,
-          bundledSkillPath(bundledSkill),
+          bundledSkillPathResolver(bundledSkill),
           bundledSkill.requiredFiles,
         );
       }
@@ -592,7 +594,13 @@ export async function runDoctorChecks(
     }
 
     results.push(
-      await checkSkills(runner, config, options.repoRoot, piAgentDir),
+      await checkSkills(
+        runner,
+        config,
+        options.repoRoot,
+        piAgentDir,
+        options.bundledSkillPathForTests,
+      ),
     );
 
     const paths = [

--- a/src/cli/commands/init/skill-installer.ts
+++ b/src/cli/commands/init/skill-installer.ts
@@ -16,6 +16,11 @@ import {
 import { createRequire } from "node:module";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import {
+  BUNDLED_PATCHMILL_SKILLS,
+  bundledSkillByKey,
+  bundledSkillDir,
+} from "../../../workflow/bundled-skills.ts";
+import {
   DEFAULT_PROJECT_SKILL_DIR,
   PATCHMILL_RECOMMENDED_SKILL_PACK,
   SKILL_PACK_METADATA_FILE,
@@ -25,7 +30,6 @@ import {
   requiredSkillFiles,
   type SkillPackSkill,
 } from "../../../workflow/skill-pack.ts";
-import { bundledTriageSkillPath } from "../../../workflow/skills.ts";
 import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
 
 const require = createRequire(import.meta.url);
@@ -75,8 +79,12 @@ const defaultDependencies: SkillInstallerDependencies = {
 
 export function defaultSkillSourceRoots(): SourceRoots {
   const superpowersRoot = dirname(require.resolve("superpowers/package.json"));
+  const bundledTriageSkill = bundledSkillByKey("triage");
+  if (!bundledTriageSkill) {
+    throw new Error("Bundled Patchmill skill registry is missing triage skill");
+  }
   return {
-    patchmillSkillsDir: resolve(dirname(bundledTriageSkillPath()), ".."),
+    patchmillSkillsDir: resolve(bundledSkillDir(bundledTriageSkill), ".."),
     superpowersSkillsDir: join(superpowersRoot, "skills"),
   };
 }
@@ -352,16 +360,23 @@ export async function validateExistingSkillDirectory(
   >
 > {
   const skillConfig = buildRecommendedProjectSkillConfig(skillDir);
+  const bundledRecommendedSkills = BUNDLED_PATCHMILL_SKILLS.flatMap((skill) =>
+    skill.recommendedProjectLocal && skill.projectSkillConfigKey
+      ? [
+          {
+            name: skill.globalName,
+            skillPath: skillConfig[skill.projectSkillConfigKey],
+          },
+        ]
+      : [],
+  );
+
   for (const { name, skillPath } of [
-    { name: "patchmill-issue-triage", skillPath: skillConfig.triage },
+    ...bundledRecommendedSkills,
     { name: "writing-plans", skillPath: skillConfig.planning },
     {
       name: "subagent-driven-development",
       skillPath: skillConfig.implementation,
-    },
-    {
-      name: "patchmill-visual-evidence",
-      skillPath: skillConfig.visualEvidence,
     },
   ]) {
     await assertRequiredSkillFiles(

--- a/src/workflow/bundled-skills.test.ts
+++ b/src/workflow/bundled-skills.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  BUNDLED_PATCHMILL_SKILLS,
+  bundledSkillByConfigReference,
+  bundledSkillByKey,
+  bundledSkillByName,
+  bundledSkillDir,
+  bundledSkillPath,
+  bundledSkillPathForReference,
+  requiredFilesForBundledSkillName,
+} from "./bundled-skills.ts";
+
+test("bundled skill registry preserves public metadata", () => {
+  assert.deepEqual(
+    BUNDLED_PATCHMILL_SKILLS.map((skill) => skill.key),
+    ["triage", "visualEvidence"],
+  );
+  assert.equal(
+    bundledSkillByKey("triage")?.configReference,
+    "patchmill:bundled-issue-triage",
+  );
+  assert.equal(
+    bundledSkillByKey("visualEvidence")?.globalName,
+    "patchmill-visual-evidence",
+  );
+  assert.deepEqual(
+    requiredFilesForBundledSkillName("patchmill-visual-evidence"),
+    ["SKILL.md", "scripts/capture-visual-evidence.cjs"],
+  );
+});
+
+test("bundled skill registry resolves lookups by reference and name", () => {
+  assert.equal(
+    bundledSkillByConfigReference("patchmill:bundled-issue-triage")?.key,
+    "triage",
+  );
+  assert.equal(
+    bundledSkillByName("patchmill-issue-triage")?.configReference,
+    "patchmill:bundled-issue-triage",
+  );
+  assert.equal(
+    bundledSkillByConfigReference("superpowers:writing-plans"),
+    undefined,
+  );
+  assert.deepEqual(requiredFilesForBundledSkillName("unknown"), ["SKILL.md"]);
+});
+
+test("bundled skill registry resolves skill directories and SKILL.md paths", () => {
+  const triage = bundledSkillByKey("triage");
+  const visualEvidence = bundledSkillByKey("visualEvidence");
+  assert.ok(triage);
+  assert.ok(visualEvidence);
+
+  assert.ok(
+    bundledSkillDir(triage).endsWith(join("skills", "patchmill-issue-triage")),
+  );
+  assert.ok(
+    bundledSkillPath(visualEvidence).endsWith(
+      join("skills", "patchmill-visual-evidence", "SKILL.md"),
+    ),
+  );
+  assert.equal(
+    bundledSkillPathForReference("patchmill:bundled-visual-evidence"),
+    bundledSkillPath(visualEvidence),
+  );
+  assert.equal(bundledSkillPathForReference("patchmill-unknown"), undefined);
+});

--- a/src/workflow/bundled-skills.ts
+++ b/src/workflow/bundled-skills.ts
@@ -1,0 +1,88 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type BundledPatchmillSkillKey = "triage" | "visualEvidence";
+
+export type BundledPatchmillSkill = {
+  key: BundledPatchmillSkillKey;
+  configReference: string;
+  globalName: string;
+  dirName: string;
+  requiredFiles: string[];
+  recommendedProjectLocal?: true;
+  projectSkillConfigKey?: "triage" | "visualEvidence";
+};
+
+export const BUNDLED_PATCHMILL_SKILLS = [
+  {
+    key: "triage",
+    configReference: "patchmill:bundled-issue-triage",
+    globalName: "patchmill-issue-triage",
+    dirName: "patchmill-issue-triage",
+    requiredFiles: ["SKILL.md"],
+    recommendedProjectLocal: true,
+    projectSkillConfigKey: "triage",
+  },
+  {
+    key: "visualEvidence",
+    configReference: "patchmill:bundled-visual-evidence",
+    globalName: "patchmill-visual-evidence",
+    dirName: "patchmill-visual-evidence",
+    requiredFiles: ["SKILL.md", "scripts/capture-visual-evidence.cjs"],
+    recommendedProjectLocal: true,
+    projectSkillConfigKey: "visualEvidence",
+  },
+] as const satisfies readonly BundledPatchmillSkill[];
+
+export function bundledSkillByKey(
+  key: BundledPatchmillSkillKey,
+): BundledPatchmillSkill | undefined {
+  return BUNDLED_PATCHMILL_SKILLS.find((skill) => skill.key === key);
+}
+
+export function bundledSkillByConfigReference(
+  reference: string,
+): BundledPatchmillSkill | undefined {
+  return BUNDLED_PATCHMILL_SKILLS.find(
+    (skill) => skill.configReference === reference,
+  );
+}
+
+export function bundledSkillByName(
+  name: string,
+): BundledPatchmillSkill | undefined {
+  return BUNDLED_PATCHMILL_SKILLS.find(
+    (skill) => skill.globalName === name || skill.dirName === name,
+  );
+}
+
+export function bundledSkillDir(entry: BundledPatchmillSkill): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const sourceTreePath = join(here, "..", "..", "skills", entry.dirName);
+  const builtPackagePath = join(
+    here,
+    "..",
+    "..",
+    "..",
+    "skills",
+    entry.dirName,
+  );
+
+  return existsSync(sourceTreePath) ? sourceTreePath : builtPackagePath;
+}
+
+export function bundledSkillPath(entry: BundledPatchmillSkill): string {
+  return join(bundledSkillDir(entry), "SKILL.md");
+}
+
+export function bundledSkillPathForReference(
+  reference: string,
+): string | undefined {
+  const entry = bundledSkillByConfigReference(reference);
+  return entry ? bundledSkillPath(entry) : undefined;
+}
+
+export function requiredFilesForBundledSkillName(name: string): string[] {
+  return bundledSkillByName(name)?.requiredFiles ?? ["SKILL.md"];
+}

--- a/src/workflow/skill-pack.test.ts
+++ b/src/workflow/skill-pack.test.ts
@@ -10,6 +10,7 @@ import {
   hashContent,
   hashText,
   projectSkillPath,
+  requiredSkillFiles,
 } from "./skill-pack.ts";
 
 const unixNewline = "name: sample\n";
@@ -24,6 +25,15 @@ test("recommended project skill paths are repo-relative POSIX paths", () => {
     projectSkillPath("subagent-driven-development", "project/skills/"),
     "project/skills/subagent-driven-development",
   );
+});
+
+test("requiredSkillFiles returns bundled sidecars and SKILL.md fallback", () => {
+  assert.deepEqual(requiredSkillFiles("patchmill-visual-evidence"), [
+    "SKILL.md",
+    "scripts/capture-visual-evidence.cjs",
+  ]);
+  assert.deepEqual(requiredSkillFiles("patchmill-issue-triage"), ["SKILL.md"]);
+  assert.deepEqual(requiredSkillFiles("unknown"), ["SKILL.md"]);
 });
 
 test("buildRecommendedProjectSkillConfig maps required workflow stages locally", () => {

--- a/src/workflow/skill-pack.ts
+++ b/src/workflow/skill-pack.ts
@@ -1,4 +1,9 @@
 import { createHash, type BinaryLike } from "node:crypto";
+import {
+  BUNDLED_PATCHMILL_SKILLS,
+  bundledSkillByKey,
+  requiredFilesForBundledSkillName,
+} from "./bundled-skills.ts";
 import type { PatchmillSkillsConfig } from "./skills.ts";
 
 export const DEFAULT_PROJECT_SKILL_DIR = ".patchmill/skills";
@@ -7,7 +12,17 @@ export const SUBAGENT_DEV_WITH_CODEX_AND_THERMO_REVIEWS_SKILL =
   "subagent-dev-with-codex-and-thermo-reviews";
 export const SINGLE_SUBAGENT_DEV_WITH_CODEX_AND_THERMO_REVIEWS_SKILL =
   "single-subagent-dev-with-codex-and-thermo-reviews";
-export const PATCHMILL_VISUAL_EVIDENCE_SKILL = "patchmill-visual-evidence";
+const bundledTriageSkill = bundledSkillByKey("triage");
+const bundledVisualEvidenceSkill = bundledSkillByKey("visualEvidence");
+
+if (!bundledTriageSkill || !bundledVisualEvidenceSkill) {
+  throw new Error(
+    "Bundled Patchmill skill registry is missing required skills",
+  );
+}
+
+export const PATCHMILL_VISUAL_EVIDENCE_SKILL =
+  bundledVisualEvidenceSkill.globalName;
 
 export type SkillPackSource = {
   type: "github-release";
@@ -40,15 +55,8 @@ export type SkillPackMetadataFile = {
   files: Array<{ path: string; sha256: string }>;
 };
 
-const REQUIRED_SKILL_FILES: Record<string, string[]> = {
-  [PATCHMILL_VISUAL_EVIDENCE_SKILL]: [
-    "SKILL.md",
-    "scripts/capture-visual-evidence.cjs",
-  ],
-};
-
 export function requiredSkillFiles(skillName: string): string[] {
-  return REQUIRED_SKILL_FILES[skillName] ?? ["SKILL.md"];
+  return requiredFilesForBundledSkillName(skillName);
 }
 
 export const PATCHMILL_RECOMMENDED_SKILL_PACK: SkillPack = {
@@ -62,7 +70,7 @@ export const PATCHMILL_RECOMMENDED_SKILL_PACK: SkillPack = {
       "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz",
   },
   skills: [
-    { name: "patchmill-issue-triage", source: "patchmill" },
+    { name: bundledTriageSkill.globalName, source: "patchmill" },
     {
       name: SUBAGENT_DEV_WITH_CODEX_AND_THERMO_REVIEWS_SKILL,
       source: "patchmill",
@@ -107,11 +115,24 @@ export function buildRecommendedProjectSkillConfig(
   PatchmillSkillsConfig,
   "triage" | "planning" | "implementation" | "visualEvidence"
 > {
+  const bundledProjectLocalConfig = Object.fromEntries(
+    BUNDLED_PATCHMILL_SKILLS.flatMap((skill) =>
+      skill.recommendedProjectLocal && skill.projectSkillConfigKey
+        ? [
+            [
+              skill.projectSkillConfigKey,
+              projectSkillPath(skill.globalName, skillDir),
+            ],
+          ]
+        : [],
+    ),
+  ) as Pick<PatchmillSkillsConfig, "triage" | "visualEvidence">;
+
   return {
-    triage: projectSkillPath("patchmill-issue-triage", skillDir),
+    triage: bundledProjectLocalConfig.triage,
     planning: projectSkillPath("writing-plans", skillDir),
     implementation: projectSkillPath("subagent-driven-development", skillDir),
-    visualEvidence: projectSkillPath(PATCHMILL_VISUAL_EVIDENCE_SKILL, skillDir),
+    visualEvidence: bundledProjectLocalConfig.visualEvidence,
   };
 }
 

--- a/src/workflow/skill-resolution.test.ts
+++ b/src/workflow/skill-resolution.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import {
   BUNDLED_TRIAGE_SKILL_REFERENCE,
+  BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE,
   GLOBAL_PATCHMILL_SKILLS,
 } from "./skills.ts";
 import {
@@ -16,6 +17,7 @@ import {
 } from "./skill-pack.ts";
 import {
   bundledTriageSkillPath,
+  bundledVisualEvidenceSkillPath,
   isNamespaceStyleSkill,
   isPathLikeSkill,
   resolveConfiguredSkillInvocation,
@@ -65,10 +67,15 @@ async function writeMetadata(
   );
 }
 
-test("bundledTriageSkillPath points at the bundled SKILL.md file", () => {
+test("bundled skill compatibility path helpers point at bundled SKILL.md files", () => {
   assert.ok(
     bundledTriageSkillPath().endsWith(
       join("skills", "patchmill-issue-triage", "SKILL.md"),
+    ),
+  );
+  assert.ok(
+    bundledVisualEvidenceSkillPath().endsWith(
+      join("skills", "patchmill-visual-evidence", "SKILL.md"),
     ),
   );
 });
@@ -96,8 +103,16 @@ test("skillInvocationArgs resolves bundled, local, and named skills", () => {
     [],
   );
   assert.deepEqual(
+    skillInvocationArgs(GLOBAL_PATCHMILL_SKILLS.visualEvidence, "/repo"),
+    [],
+  );
+  assert.deepEqual(
     skillInvocationArgs(BUNDLED_TRIAGE_SKILL_REFERENCE, "/repo"),
     ["--skill", bundledTriageSkillPath()],
+  );
+  assert.deepEqual(
+    skillInvocationArgs(BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE, "/repo"),
+    ["--skill", bundledVisualEvidenceSkillPath()],
   );
   assert.deepEqual(
     skillInvocationArgs(".patchmill/skills/writing-plans", "/repo"),
@@ -157,6 +172,7 @@ test("skillInvocationPaths keeps only invokable skill paths in order", () => {
         "superpowers:writing-plans",
         undefined,
         BUNDLED_TRIAGE_SKILL_REFERENCE,
+        BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE,
         "skills\\implementation",
       ],
       "/repo",
@@ -164,6 +180,7 @@ test("skillInvocationPaths keeps only invokable skill paths in order", () => {
     [
       "/repo/.patchmill/skills/writing-plans/SKILL.md",
       bundledTriageSkillPath(),
+      bundledVisualEvidenceSkillPath(),
       "/repo/skills/implementation/SKILL.md",
     ],
   );

--- a/src/workflow/skill-resolution.ts
+++ b/src/workflow/skill-resolution.ts
@@ -1,6 +1,10 @@
-import { existsSync, statSync } from "node:fs";
-import { dirname, join, resolve, win32 } from "node:path";
-import { fileURLToPath } from "node:url";
+import { statSync } from "node:fs";
+import { resolve, win32 } from "node:path";
+import {
+  bundledSkillByKey,
+  bundledSkillPath,
+  bundledSkillPathForReference,
+} from "./bundled-skills.ts";
 import { DEFAULT_PROJECT_SKILL_DIR } from "./skill-pack.ts";
 
 export type SkillResolutionStatus = "pass" | "warn" | "fail";
@@ -17,43 +21,30 @@ export type SkillInvocationResolution = {
   usedProjectLocalPack: boolean;
 };
 
-export const BUNDLED_TRIAGE_SKILL_REFERENCE = "patchmill:bundled-issue-triage";
+const bundledTriageSkill = bundledSkillByKey("triage");
+const bundledVisualEvidenceSkill = bundledSkillByKey("visualEvidence");
+
+if (!bundledTriageSkill || !bundledVisualEvidenceSkill) {
+  throw new Error(
+    "Bundled Patchmill skill registry is missing required skills",
+  );
+}
+
+export const BUNDLED_TRIAGE_SKILL_REFERENCE =
+  bundledTriageSkill.configReference;
 export const BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE =
-  "patchmill:bundled-visual-evidence";
+  bundledVisualEvidenceSkill.configReference;
 
 const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
 const SKILL_NAMESPACE_PATTERN = /^[a-z0-9-]+:.+$/iu;
 const SKILL_FILE_NAME = "SKILL.md";
 
-function bundledSkillPath(skillDirName: string): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const sourceTreePath = join(
-    here,
-    "..",
-    "..",
-    "skills",
-    skillDirName,
-    "SKILL.md",
-  );
-  const builtPackagePath = join(
-    here,
-    "..",
-    "..",
-    "..",
-    "skills",
-    skillDirName,
-    "SKILL.md",
-  );
-
-  return existsSync(sourceTreePath) ? sourceTreePath : builtPackagePath;
-}
-
 export function bundledTriageSkillPath(): string {
-  return bundledSkillPath("patchmill-issue-triage");
+  return bundledSkillPath(bundledTriageSkill);
 }
 
 export function bundledVisualEvidenceSkillPath(): string {
-  return bundledSkillPath("patchmill-visual-evidence");
+  return bundledSkillPath(bundledVisualEvidenceSkill);
 }
 
 export function isNamespaceStyleSkill(skill: string): boolean {
@@ -145,12 +136,8 @@ export function resolveConfiguredSkillInvocation(
   const diagnostics: SkillResolutionDiagnostic[] = [];
   const configuredPaths = skills.flatMap((skill) => {
     if (!skill) return [];
-    if (skill === BUNDLED_TRIAGE_SKILL_REFERENCE) {
-      return [bundledTriageSkillPath()];
-    }
-    if (skill === BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE) {
-      return [bundledVisualEvidenceSkillPath()];
-    }
+    const bundledPath = bundledSkillPathForReference(skill);
+    if (bundledPath) return [bundledPath];
     if (!isPathLikeSkill(skill)) return [];
     return [resolvePathLikeSkillPath(skill, repoRoot)];
   });

--- a/src/workflow/skills.ts
+++ b/src/workflow/skills.ts
@@ -1,3 +1,4 @@
+import { bundledSkillByKey } from "./bundled-skills.ts";
 import {
   BUNDLED_TRIAGE_SKILL_REFERENCE,
   BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE,
@@ -39,18 +40,27 @@ export {
   BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE,
 };
 
+const bundledTriageSkill = bundledSkillByKey("triage");
+const bundledVisualEvidenceSkill = bundledSkillByKey("visualEvidence");
+
+if (!bundledTriageSkill || !bundledVisualEvidenceSkill) {
+  throw new Error(
+    "Bundled Patchmill skill registry is missing required skills",
+  );
+}
+
 export const DEFAULT_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
-  triage: BUNDLED_TRIAGE_SKILL_REFERENCE,
+  triage: bundledTriageSkill.configReference,
   planning: "superpowers:writing-plans",
   implementation: "superpowers:subagent-driven-development",
-  visualEvidence: BUNDLED_VISUAL_EVIDENCE_SKILL_REFERENCE,
+  visualEvidence: bundledVisualEvidenceSkill.configReference,
 };
 
 export const GLOBAL_PATCHMILL_SKILLS: PatchmillSkillsConfig = {
-  triage: "patchmill-issue-triage",
+  triage: bundledTriageSkill.globalName,
   planning: "superpowers:writing-plans",
   implementation: "superpowers:subagent-driven-development",
-  visualEvidence: "patchmill-visual-evidence",
+  visualEvidence: bundledVisualEvidenceSkill.globalName,
 };
 
 export function cloneSkillsConfig(


### PR DESCRIPTION
Summary

- Added a canonical bundled Patchmill skill registry for triage and visual evidence metadata, paths, and required files.
- Derived bundled skill defaults, resolution, skill-pack metadata, init validation, and doctor verification from the registry.
- Added regression coverage for sidecar verification and preserved public bundled skill references/names.

## Validation

- npm test -- src/workflow/bundled-skills.test.ts src/workflow/skills.test.ts src/workflow/skill-resolution.test.ts src/workflow/skill-pack.test.ts
- npm test -- src/cli/commands/init/skill-installer.test.ts src/cli/commands/doctor/checks.test.ts
- npm test -- src/workflow/visual-evidence-skill.test.ts
- npm test
- git diff -- package.json package-lock.json npm-shrinkwrap.json (no output)

## Reviews

- Final Codex full-worktree review: passed after fixing doctor test sidecar mutation.
- Final thermo-nuclear full-worktree review: pass with one deferred minor maintainability note about required registry lookup ergonomics.

Closes #76
