### PR TITLE
Fix patchmill init Pi AuthStorage compatibility

### DIFF
--- a/docs/plans/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent.md
+++ b/docs/plans/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent.md
@@ -1,0 +1,426 @@
+# Issue 94 Patchmill Init AuthStorage Export Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `patchmill init` from crashing at module import time when
+Patchmill depends on Pi init/auth runtime exports such as `AuthStorage`.
+
+**Architecture:** Keep the current exact compatible Pi package pins and add a
+runtime dependency-contract regression test for the Pi symbols imported by the
+init/auth path. Verify static package metadata directly instead of adding tests
+that merely restate dependency strings.
+
+**Tech Stack:** Node.js `node:test`, TypeScript ESM, npm package metadata,
+Patchmill CLI init modules, Nix flake build when npm dependency metadata
+changes.
+
+## Global Constraints
+
+- Issue #94 is scoped to the exact-pin compatibility fix; do not migrate init
+  auth to Pi `0.80.8+` credential APIs in this issue.
+- Preserve current init readiness detection, interactive API-key auth,
+  subscription/OAuth auth, repo-local `.patchmill/pi-agent/auth.json`, and model
+  selection behavior.
+- `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` must agree on
+  `@earendil-works/pi-coding-agent` version `0.80.3` and
+  `@earendil-works/pi-tui` version `0.80.3` if dependency metadata is touched.
+- If `package.json`, `package-lock.json`, or `npm-shrinkwrap.json` changes,
+  rerun the Nix build as required by `AGENTS.md`.
+- Testing Value Gate: add automated coverage only for runtime behavior or
+  contract regressions. Do not add a test that only asserts static dependency
+  strings; verify those with direct commands.
+- Commit implementation work in small conventional commits. Do not commit
+  `.pi/todos` local operator state.
+
+---
+
+## File Structure
+
+- Modify: `src/cli/commands/init/pi-preflight.ts` only if the runtime import
+  list has drifted from the current `AuthStorage`, `getAgentDir`, and
+  `ModelRegistry` contract.
+- Modify: `src/cli/commands/init/pi-auth-flow.ts` only if the runtime import
+  list has drifted from the current `AuthStorage` and `ModelRegistry` contract.
+- Create: `src/cli/commands/init/pi-dependency-contract.test.ts` for the
+  runtime export compatibility regression test.
+- Modify: `package.json` only if the Pi dependencies are not exact `0.80.3`.
+- Modify: `package-lock.json` only if its root dependencies or installed package
+  entries are not exact `0.80.3`.
+- Modify: `npm-shrinkwrap.json` only if its root dependencies or installed
+  package entries are not exact `0.80.3`.
+
+---
+
+### Task 1: Add Pi runtime export compatibility regression test
+
+**Files:**
+
+- Create: `src/cli/commands/init/pi-dependency-contract.test.ts`
+- Read: `src/cli/commands/init/pi-preflight.ts`
+- Read: `src/cli/commands/init/pi-auth-flow.ts`
+
+**Interfaces:**
+
+- Consumes: runtime exports from `@earendil-works/pi-coding-agent`.
+- Produces: a `node:test` regression that fails if the resolved Pi package does
+  not export the runtime symbols imported by the Patchmill init/auth modules.
+
+- [ ] **Step 1: Confirm runtime imports in init/auth modules**
+
+  Run:
+
+  ```bash
+  rg 'from "@earendil-works/pi-coding-agent"|AuthStorage|ModelRegistry|getAgentDir' \
+    src/cli/commands/init/pi-preflight.ts \
+    src/cli/commands/init/pi-auth-flow.ts
+  ```
+
+  Expected: `pi-preflight.ts` runtime-imports `AuthStorage`, `getAgentDir`, and
+  `ModelRegistry`; `pi-auth-flow.ts` runtime-imports `AuthStorage` and
+  `ModelRegistry`. `AuthCredential` remains a type-only import.
+
+- [ ] **Step 2: Write the failing contract test**
+
+  Create `src/cli/commands/init/pi-dependency-contract.test.ts` with:
+
+  ```ts
+  import assert from "node:assert/strict";
+  import { test } from "node:test";
+  import * as piCodingAgent from "@earendil-works/pi-coding-agent";
+
+  const REQUIRED_INIT_RUNTIME_EXPORTS = [
+    "AuthStorage",
+    "ModelRegistry",
+    "getAgentDir",
+  ] as const;
+
+  test("resolved pi-coding-agent exports the runtime symbols used by patchmill init", () => {
+    for (const exportName of REQUIRED_INIT_RUNTIME_EXPORTS) {
+      assert.equal(
+        exportName in piCodingAgent,
+        true,
+        `@earendil-works/pi-coding-agent must export ${exportName}`,
+      );
+      assert.notEqual(
+        piCodingAgent[exportName],
+        undefined,
+        `@earendil-works/pi-coding-agent export ${exportName} must be defined`,
+      );
+    }
+  });
+  ```
+
+- [ ] **Step 3: Run the new test**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/init/pi-dependency-contract.test.ts
+  ```
+
+  Expected: PASS with the pinned compatible Pi dependency. If it fails because a
+  required export is missing, stop and inspect dependency metadata before
+  changing source APIs.
+
+- [ ] **Step 4: Run neighboring init/auth tests**
+
+  Run:
+
+  ```bash
+  node --test \
+    src/cli/commands/init/pi-preflight.test.ts \
+    src/cli/commands/init/pi-auth-flow.test.ts \
+    src/cli/commands/init/pi-dependency-contract.test.ts
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 5: Commit the regression test**
+
+  Run:
+
+  ```bash
+  git add src/cli/commands/init/pi-dependency-contract.test.ts
+  git commit -m "test: cover patchmill init pi runtime exports"
+  ```
+
+---
+
+### Task 2: Verify and repair Pi dependency metadata pins
+
+**Files:**
+
+- Modify: `package.json` if needed
+- Modify: `package-lock.json` if needed
+- Modify: `npm-shrinkwrap.json` if needed
+
+**Interfaces:**
+
+- Consumes: npm dependency metadata for Patchmill's publish/install contract.
+- Produces: package metadata that cannot resolve
+  `@earendil-works/pi-coding-agent` above `0.80.3` for the current release line.
+
+- [ ] **Step 1: Check root dependency pins directly**
+
+  Run:
+
+  ```bash
+  node --input-type=module <<'NODE'
+  import { readFileSync } from "node:fs";
+
+  const expected = {
+    "@earendil-works/pi-coding-agent": "0.80.3",
+    "@earendil-works/pi-tui": "0.80.3",
+  };
+
+  for (const file of ["package.json", "package-lock.json", "npm-shrinkwrap.json"]) {
+    const json = JSON.parse(readFileSync(file, "utf8"));
+    const deps = file === "package.json"
+      ? json.dependencies
+      : json.packages?.[""]?.dependencies;
+    for (const [name, version] of Object.entries(expected)) {
+      if (deps?.[name] !== version) {
+        throw new Error(`${file} root dependency ${name} is ${deps?.[name]}, expected ${version}`);
+      }
+    }
+  }
+  NODE
+  ```
+
+  Expected: command exits 0. This is direct verification, not an automated test,
+  because it checks static metadata strings.
+
+- [ ] **Step 2: Check installed lock/shrinkwrap package entries directly**
+
+  Run:
+
+  ```bash
+  node --input-type=module <<'NODE'
+  import { readFileSync } from "node:fs";
+
+  const expected = {
+    "node_modules/@earendil-works/pi-coding-agent": "0.80.3",
+    "node_modules/@earendil-works/pi-tui": "0.80.3",
+  };
+
+  for (const file of ["package-lock.json", "npm-shrinkwrap.json"]) {
+    const json = JSON.parse(readFileSync(file, "utf8"));
+    for (const [entry, version] of Object.entries(expected)) {
+      const actual = json.packages?.[entry]?.version;
+      if (actual !== version) {
+        throw new Error(`${file} ${entry} version is ${actual}, expected ${version}`);
+      }
+    }
+  }
+  NODE
+  ```
+
+  Expected: command exits 0.
+
+- [ ] **Step 3: Repair metadata only if either direct check fails**
+
+  If Step 1 or Step 2 fails, update all three metadata files so the root
+  dependencies and installed package entries use exact `0.80.3` for both Pi
+  packages. Prefer regenerating lock metadata with npm over hand-editing:
+
+  ```bash
+  npm install \
+    @earendil-works/pi-coding-agent@0.80.3 \
+    @earendil-works/pi-tui@0.80.3 \
+    --package-lock-only
+  cp package-lock.json npm-shrinkwrap.json
+  ```
+
+  Expected: `git diff -- package.json package-lock.json npm-shrinkwrap.json`
+  shows only the dependency-contract repair needed for this issue.
+
+- [ ] **Step 4: Re-run direct metadata checks**
+
+  Re-run the exact Node commands from Steps 1 and 2.
+
+  Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit metadata repairs if files changed**
+
+  If `git diff --quiet -- package.json package-lock.json npm-shrinkwrap.json`
+  exits non-zero, run:
+
+  ```bash
+  git add package.json package-lock.json npm-shrinkwrap.json
+  git commit -m "fix: pin patchmill pi dependencies"
+  ```
+
+  If no metadata files changed, do not create an empty commit for this task.
+
+---
+
+### Task 3: Verify packaged install metadata and built init imports
+
+**Files:**
+
+- Read: `package.json`
+- Read: `package-lock.json`
+- Read: `npm-shrinkwrap.json`
+- Generated by command: `dist/`
+
+**Interfaces:**
+
+- Consumes: source imports, package metadata, and npm pack output.
+- Produces: evidence that the next package tarball keeps exact Pi pins and the
+  built init modules import symbols provided by the resolved dependency.
+
+- [ ] **Step 1: Build the project**
+
+  Run:
+
+  ```bash
+  npm run build
+  ```
+
+  Expected: `tsc -p tsconfig.build.json` completes successfully.
+
+- [ ] **Step 2: Inspect built init imports for expected runtime symbols**
+
+  Run:
+
+  ```bash
+  rg 'AuthStorage|ModelRegistry|getAgentDir|@earendil-works/pi-coding-agent' \
+    dist/src/cli/commands/init/pi-preflight.js \
+    dist/src/cli/commands/init/pi-auth-flow.js
+  ```
+
+  Expected: built JS imports the same runtime Pi symbols covered by
+  `pi-dependency-contract.test.ts`.
+
+- [ ] **Step 3: Verify the package tarball metadata dry-run**
+
+  Run:
+
+  ```bash
+  npm pack --dry-run
+  ```
+
+  Expected: dry-run succeeds after running the `prepack` build. Review the
+  output to confirm the package includes `package.json`, `package-lock.json`,
+  and `npm-shrinkwrap.json` and does not report packaging errors.
+
+- [ ] **Step 4: Inspect publish metadata with `npm pack --json --dry-run`**
+
+  Run:
+
+  ```bash
+  npm pack --json --dry-run > /tmp/patchmill-issue-94-pack.json
+  node --input-type=module <<'NODE'
+  import { readFileSync } from "node:fs";
+
+  const [pack] = JSON.parse(readFileSync("/tmp/patchmill-issue-94-pack.json", "utf8"));
+  const names = new Set(pack.files.map((file) => file.path));
+  for (const file of ["package.json", "package-lock.json", "npm-shrinkwrap.json"]) {
+    if (!names.has(file)) throw new Error(`packed tarball is missing ${file}`);
+  }
+  NODE
+  ```
+
+  Expected: command exits 0. This verifies packaging structure without adding a
+  brittle test for static file lists.
+
+- [ ] **Step 5: Commit no generated build output unless the repository already
+  tracks it for this change**
+
+  Run:
+
+  ```bash
+  git status --short dist package.json package-lock.json npm-shrinkwrap.json
+  ```
+
+  Expected: if `dist/` is untracked or ignored, do not force-add it. If tracked
+  build output changed and project history expects it to be committed, include it
+  in the relevant implementation commit with a conventional message.
+
+---
+
+### Task 4: Run final validation for issue 94
+
+**Files:**
+
+- Read: all files changed by Tasks 1 through 3
+
+**Interfaces:**
+
+- Consumes: completed dependency contract test, dependency metadata, and build
+  state.
+- Produces: final validation evidence for landing the issue.
+
+- [ ] **Step 1: Run targeted init/auth regression tests**
+
+  Run:
+
+  ```bash
+  node --test \
+    src/cli/commands/init/pi-preflight.test.ts \
+    src/cli/commands/init/pi-auth-flow.test.ts \
+    src/cli/commands/init/pi-dependency-contract.test.ts
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 2: Run the full test suite**
+
+  Run:
+
+  ```bash
+  npm test
+  ```
+
+  Expected: all repository tests pass.
+
+- [ ] **Step 3: Run lint**
+
+  Run:
+
+  ```bash
+  npm run lint
+  ```
+
+  Expected: formatting, TypeScript lint, and Markdown lint pass.
+
+- [ ] **Step 4: Run build**
+
+  Run:
+
+  ```bash
+  npm run build
+  ```
+
+  Expected: build passes.
+
+- [ ] **Step 5: Run Nix build if npm dependency metadata changed**
+
+  If `git diff --name-only origin/main...HEAD` or the task commits include
+  `package.json`, `package-lock.json`, or `npm-shrinkwrap.json`, run:
+
+  ```bash
+  nix build .#patchmill
+  ```
+
+  Expected: Nix build succeeds. If no npm dependency metadata changed, record
+  `Nix build skipped: npm dependency metadata unchanged` in the final handoff.
+
+- [ ] **Step 6: Record final evidence**
+
+  Capture the command names and pass/fail results for:
+
+  ```text
+  node --test src/cli/commands/init/pi-preflight.test.ts src/cli/commands/init/pi-auth-flow.test.ts src/cli/commands/init/pi-dependency-contract.test.ts
+  npm test
+  npm run lint
+  npm run build
+  npm pack --dry-run
+  nix build .#patchmill (only if npm dependency metadata changed)
+  ```
+
+  Expected: final handoff states exact results and whether Nix was required by
+  `AGENTS.md`.

--- a/docs/plans/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent.md
+++ b/docs/plans/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent.md
@@ -44,8 +44,8 @@ changes.
   `ModelRegistry` contract.
 - Modify: `src/cli/commands/init/pi-auth-flow.ts` only if the runtime import
   list has drifted from the current `AuthStorage` and `ModelRegistry` contract.
-- Create: `src/cli/commands/init/pi-dependency-contract.test.ts` for the
-  runtime export compatibility regression test.
+- Create: `src/cli/commands/init/pi-dependency-contract.test.ts` for the runtime
+  export compatibility regression test.
 - Modify: `package.json` only if the Pi dependencies are not exact `0.80.3`.
 - Modify: `package-lock.json` only if its root dependencies or installed package
   entries are not exact `0.80.3`.
@@ -328,7 +328,7 @@ changes.
   brittle test for static file lists.
 
 - [ ] **Step 5: Commit no generated build output unless the repository already
-  tracks it for this change**
+      tracks it for this change**
 
   Run:
 
@@ -337,8 +337,8 @@ changes.
   ```
 
   Expected: if `dist/` is untracked or ignored, do not force-add it. If tracked
-  build output changed and project history expects it to be committed, include it
-  in the relevant implementation commit with a conventional message.
+  build output changed and project history expects it to be committed, include
+  it in the relevant implementation commit with a conventional message.
 
 ---
 

--- a/docs/plans/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent.md
+++ b/docs/plans/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent.md
@@ -304,8 +304,11 @@ changes.
   ```
 
   Expected: dry-run succeeds after running the `prepack` build. Review the
-  output to confirm the package includes `package.json`, `package-lock.json`,
-  and `npm-shrinkwrap.json` and does not report packaging errors.
+  output to confirm the package includes `package.json` and
+  `npm-shrinkwrap.json` and does not report packaging errors.
+  `package-lock.json` is intentionally verified directly in Task 2 because npm
+  excludes package locks from package tarballs in favor of
+  `npm-shrinkwrap.json`.
 
 - [ ] **Step 4: Inspect publish metadata with `npm pack --json --dry-run`**
 
@@ -318,14 +321,15 @@ changes.
 
   const [pack] = JSON.parse(readFileSync("/tmp/patchmill-issue-94-pack.json", "utf8"));
   const names = new Set(pack.files.map((file) => file.path));
-  for (const file of ["package.json", "package-lock.json", "npm-shrinkwrap.json"]) {
+  for (const file of ["package.json", "npm-shrinkwrap.json"]) {
     if (!names.has(file)) throw new Error(`packed tarball is missing ${file}`);
   }
   NODE
   ```
 
   Expected: command exits 0. This verifies packaging structure without adding a
-  brittle test for static file lists.
+  brittle test for static file lists. `package-lock.json` remains covered by the
+  direct metadata checks in Task 2 rather than package-tarball inspection.
 
 - [ ] **Step 5: Commit no generated build output unless the repository already
       tracks it for this change**

--- a/docs/specs/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent-design.md
+++ b/docs/specs/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent-design.md
@@ -1,0 +1,155 @@
+# Issue 94 Patchmill init AuthStorage export compatibility design
+
+## Context
+
+Issue #94 reports that a fresh global install of `patchmill@0.16.0` can fail
+before `patchmill init` starts because the resolved
+`@earendil-works/pi-coding-agent` package does not export `AuthStorage`:
+
+```text
+SyntaxError: The requested module '@earendil-works/pi-coding-agent' does not provide an export named 'AuthStorage'
+```
+
+Patchmill's init path imports `AuthStorage` in two modules:
+
+- `src/cli/commands/init/pi-preflight.ts`, which builds a Pi `ModelRegistry` for
+  readiness detection.
+- `src/cli/commands/init/pi-auth-flow.ts`, which creates repo-local auth storage
+  and registry objects for interactive auth setup.
+
+The current checkout already pins `@earendil-works/pi-coding-agent` and
+`@earendil-works/pi-tui` exactly to `0.80.3` in both `package.json` and
+`package-lock.json`. That version exports `AuthStorage`, so the immediate crash
+is a dependency-resolution regression in the published `0.16.0` metadata that
+allowed newer `0.80.x` Pi packages to satisfy Patchmill's dependency range.
+
+## Decision
+
+Fix this release line by making Patchmill's Pi package dependency contract
+explicit and verified instead of migrating the init/auth code to the newer Pi
+credential API in this issue.
+
+Patchmill should continue using the `AuthStorage` + `ModelRegistry` API for the
+current init implementation, and it must publish package metadata that prevents
+npm from resolving a Pi version that removed `AuthStorage`. The implementation
+should confirm the exact pins are present in the root package and lockfile, then
+add regression coverage that fails if Patchmill's runtime dependency no longer
+exports every Pi symbol imported by the init/auth path.
+
+A later feature can migrate init/auth to `readStoredCredential` or other newer Pi
+APIs, but that migration should be planned separately because `AuthStorage` is
+also used for writes, OAuth login, provider selection state, and registry
+construction. A dependency-contract fix is the lowest-risk high-priority bug fix
+for the reported install-time crash.
+
+## Goals
+
+- A fresh install of the next Patchmill package cannot resolve a
+  `pi-coding-agent` version that omits `AuthStorage` while Patchmill still
+  imports it.
+- `package.json` and `package-lock.json` enforce the same compatible
+  `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` versions.
+- Init/auth source continues to import only symbols that exist in the resolved Pi
+  dependency.
+- Add a regression test or verification script that would fail if
+  `patchmill init` could import a missing Pi export.
+- Preserve current init readiness detection, interactive API-key auth,
+  subscription/OAuth auth, repo-local `.patchmill/pi-agent/auth.json`, and model
+  selection behavior.
+
+## Non-goals
+
+- Do not migrate Patchmill init/auth to Pi `0.80.8+` credential APIs in this
+  issue.
+- Do not redesign Pi's auth storage, registry, OAuth, or model configuration
+  behavior.
+- Do not change user-facing init prompts except for any incidental wording from
+  existing code paths.
+- Do not add automated tests that merely assert static dependency strings. Use
+  direct package metadata checks for static pins and behavioral/import tests for
+  runtime compatibility.
+
+## Proposed approaches considered
+
+### Recommended: keep exact compatible Pi pins and test imported exports
+
+Keep the exact Pi dependency pins and add a runtime export-compatibility
+regression test. This directly addresses the reported crash, is small enough for
+a high-priority patch, and avoids coupling this bug fix to a larger auth API
+migration.
+
+### Alternative: migrate to newer Pi credential APIs now
+
+Updating init/auth to newer Pi APIs may be desirable later, but it is riskier for
+this bug. The current code needs auth reads, writes, OAuth login, auth-status
+labels, OAuth provider discovery, and model registry refreshes. The issue only
+requires preventing incompatible install resolution, not changing those
+semantics.
+
+### Alternative: loosen the pin but add an upper bound
+
+A semver range such as `<0.80.8` would also block the missing export, but exact
+pins better match Patchmill's current package-lock state and reduce future
+install-time drift for tightly coupled Pi internals.
+
+## Affected components
+
+### Package metadata
+
+- `package.json` must use exact versions for:
+  - `@earendil-works/pi-coding-agent`
+  - `@earendil-works/pi-tui`
+- `package-lock.json` must resolve those same exact versions at the root package
+  and installed package entries.
+- If either file changes, the Nix build must be rerun as required by project
+  instructions.
+
+### Init/auth modules
+
+- `src/cli/commands/init/pi-preflight.ts` may continue constructing
+  `AuthStorage.create(join(agentDir, "auth.json"))` and
+  `ModelRegistry.create(auth, join(agentDir, "models.json"))`.
+- `src/cli/commands/init/pi-auth-flow.ts` may continue constructing repo-local
+  auth storage and registry objects with `AuthStorage` and `ModelRegistry`.
+- Type-only imports such as `AuthCredential` and `AuthStatus` should remain
+  type-only so runtime import validation focuses on actual runtime symbols.
+
+### Regression coverage
+
+Add coverage that imports the resolved `@earendil-works/pi-coding-agent` module
+and verifies the runtime symbols Patchmill imports from it exist, including at
+least:
+
+- `AuthStorage`
+- `ModelRegistry`
+- `getAgentDir`
+
+This test should live near the init/auth tests or another CLI dependency
+contract test location. It should fail with the same class of problem as the
+reported crash: Patchmill's source imports a runtime symbol that the resolved Pi
+package does not export.
+
+Optionally, a second lightweight packaging verification can run `npm pack --dry-run`
+or inspect the generated package metadata to confirm the published package would
+carry the exact pins. That should be verification, not a unit test that only
+repeats static JSON values.
+
+## Verification strategy
+
+- Run the new Pi export-compatibility regression test.
+- Run relevant init/auth tests, including:
+  - `src/cli/commands/init/pi-preflight.test.ts`
+  - `src/cli/commands/init/pi-auth-flow.test.ts`
+  - any new dependency-contract test file.
+- Run the standard test suite or at least the CLI/init subset selected by the
+  implementation plan.
+- Run `npm run build` so generated `dist` code reflects the source imports and
+  package metadata.
+- If dependency metadata changes, run the Nix build per `AGENTS.md`.
+- Verify packaging metadata with `npm pack --dry-run` or equivalent so the next
+  published tarball cannot reintroduce the broad Pi range that caused the crash.
+
+## Open questions
+
+None. The issue is clear enough for automated implementation using the exact-pin
+compatibility fix described above.

--- a/docs/specs/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent-design.md
+++ b/docs/specs/2026-07-17-issue-94-patchmill-init-crashes-authstorage-not-exported-by-resolved-earendil-works-pi-coding-agent-design.md
@@ -36,9 +36,9 @@ should confirm the exact pins are present in the root package and lockfile, then
 add regression coverage that fails if Patchmill's runtime dependency no longer
 exports every Pi symbol imported by the init/auth path.
 
-A later feature can migrate init/auth to `readStoredCredential` or other newer Pi
-APIs, but that migration should be planned separately because `AuthStorage` is
-also used for writes, OAuth login, provider selection state, and registry
+A later feature can migrate init/auth to `readStoredCredential` or other newer
+Pi APIs, but that migration should be planned separately because `AuthStorage`
+is also used for writes, OAuth login, provider selection state, and registry
 construction. A dependency-contract fix is the lowest-risk high-priority bug fix
 for the reported install-time crash.
 
@@ -49,8 +49,8 @@ for the reported install-time crash.
   imports it.
 - `package.json` and `package-lock.json` enforce the same compatible
   `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` versions.
-- Init/auth source continues to import only symbols that exist in the resolved Pi
-  dependency.
+- Init/auth source continues to import only symbols that exist in the resolved
+  Pi dependency.
 - Add a regression test or verification script that would fail if
   `patchmill init` could import a missing Pi export.
 - Preserve current init readiness detection, interactive API-key auth,
@@ -80,11 +80,11 @@ migration.
 
 ### Alternative: migrate to newer Pi credential APIs now
 
-Updating init/auth to newer Pi APIs may be desirable later, but it is riskier for
-this bug. The current code needs auth reads, writes, OAuth login, auth-status
-labels, OAuth provider discovery, and model registry refreshes. The issue only
-requires preventing incompatible install resolution, not changing those
-semantics.
+Updating init/auth to newer Pi APIs may be desirable later, but it is riskier
+for this bug. The current code needs auth reads, writes, OAuth login,
+auth-status labels, OAuth provider discovery, and model registry refreshes. The
+issue only requires preventing incompatible install resolution, not changing
+those semantics.
 
 ### Alternative: loosen the pin but add an upper bound
 
@@ -129,10 +129,10 @@ contract test location. It should fail with the same class of problem as the
 reported crash: Patchmill's source imports a runtime symbol that the resolved Pi
 package does not export.
 
-Optionally, a second lightweight packaging verification can run `npm pack --dry-run`
-or inspect the generated package metadata to confirm the published package would
-carry the exact pins. That should be verification, not a unit test that only
-repeats static JSON values.
+Optionally, a second lightweight packaging verification can run
+`npm pack --dry-run` or inspect the generated package metadata to confirm the
+published package would carry the exact pins. That should be verification, not a
+unit test that only repeats static JSON values.
 
 ## Verification strategy
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "CHANGELOG.md",
     "LICENSE",
     "THIRD_PARTY_NOTICES.md",
+    "npm-shrinkwrap.json",
     "tsconfig.build.json"
   ],
   "repository": {

--- a/src/cli/commands/init/pi-dependency-contract.test.ts
+++ b/src/cli/commands/init/pi-dependency-contract.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import * as piCodingAgent from "@earendil-works/pi-coding-agent";
+
+const REQUIRED_INIT_RUNTIME_EXPORTS = [
+  "AuthStorage",
+  "ModelRegistry",
+  "getAgentDir",
+] as const;
+
+test("resolved pi-coding-agent exports the runtime symbols used by patchmill init", () => {
+  for (const exportName of REQUIRED_INIT_RUNTIME_EXPORTS) {
+    assert.equal(
+      exportName in piCodingAgent,
+      true,
+      `@earendil-works/pi-coding-agent must export ${exportName}`,
+    );
+    assert.notEqual(
+      piCodingAgent[exportName],
+      undefined,
+      `@earendil-works/pi-coding-agent export ${exportName} must be defined`,
+    );
+  }
+});


### PR DESCRIPTION
Summary

- Added a runtime dependency-contract regression test for the Pi exports used by `patchmill init`.
- Published `npm-shrinkwrap.json` with the package so fresh installs preserve the compatible Pi dependency resolution.
- Added/updated issue #94 planning artifacts documenting the exact-pin compatibility fix.

## Validation

- Runtime import inspection: confirmed init/auth imports match `AuthStorage`, `ModelRegistry`, and `getAgentDir` contract.
- Direct metadata root pin check for `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`: PASS.
- Direct lock/shrinkwrap package entry check: PASS.
- `node --test src/cli/commands/init/pi-dependency-contract.test.ts`: PASS.
- `node --test src/cli/commands/init/pi-preflight.test.ts src/cli/commands/init/pi-auth-flow.test.ts src/cli/commands/init/pi-dependency-contract.test.ts`: PASS.
- `npm test`: PASS, 1030/1030.
- `npm run lint`: PASS.
- `npm run build`: PASS.
- `npm pack --dry-run`: PASS.
- `npm pack --json --dry-run` + package metadata file check: PASS.
- `nix build .#patchmill`: PASS.

## Reviews

- Final Codex full-worktree review: pass, no findings.
- Final thermo-nuclear full-worktree review: pass, no findings.

Closes #94
