### PR TITLE
Upgrade Patchmill to Pi 0.80.10

### DIFF
--- a/docs/plans/2026-07-18-pi-0-80-10-upgrade.md
+++ b/docs/plans/2026-07-18-pi-0-80-10-upgrade.md
@@ -1,0 +1,1745 @@
+# Pi 0.80.10 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade Patchmill's validated Pi runtime dependencies from `0.80.3` to
+`0.80.10` without depending on Pi's removed root `AuthStorage` export.
+
+**Architecture:** Keep Patchmill's init/auth feature behavior behind a small
+repo-local Pi runtime adapter. The adapter owns `ModelRuntime` construction,
+credential reads, provider login, and model snapshots; existing readiness,
+provider selection, auth setup, and model selection modules consume
+Patchmill-owned interfaces.
+
+**Tech Stack:** Node.js 22.19+, TypeScript ESM, Node `node:test`, npm
+lockfile/shrinkwrap, Nix `buildNpmPackage`,
+`@earendil-works/pi-coding-agent@0.80.10`, `@earendil-works/pi-tui@0.80.10`.
+
+## Global Constraints
+
+- `@earendil-works/pi-coding-agent` must be pinned exactly to `0.80.10` in
+  `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`.
+- `@earendil-works/pi-tui` must be pinned exactly to `0.80.10` in
+  `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`.
+- Patchmill production code must not import `AuthStorage` from the root
+  `@earendil-works/pi-coding-agent` package.
+- Patchmill init/auth must keep using repo-local `.patchmill/pi-agent/auth.json`
+  and `.patchmill/pi-agent/models.json`.
+- Do not use `ModelRuntime.setRuntimeApiKey` for Patchmill init/auth
+  persistence; Pi documents it as a non-persisted runtime override.
+- Exact Pi pins remain Patchmill's compatibility boundary until issue #96
+  automates validated upgrade PRs.
+- Because npm dependencies change, rerun the Nix build and update
+  `nix/package.nix` `npmDepsHash` before completion.
+
+---
+
+## File Structure
+
+- Modify `package.json`: exact Pi dependency pins.
+- Modify `package-lock.json`: resolved dependency graph for Pi `0.80.10`.
+- Modify `npm-shrinkwrap.json`: published install dependency graph for Pi
+  `0.80.10`.
+- Modify `nix/package.nix`: updated `npmDepsHash` after dependency graph
+  changes.
+- Modify `src/cli/commands/init/pi-dependency-contract.test.ts`: current Pi SDK
+  compatibility contract.
+- Create `src/cli/commands/init/pi-runtime.ts`: narrow Patchmill-owned adapter
+  around Pi `ModelRuntime`.
+- Create `src/cli/commands/init/pi-runtime.test.ts`: adapter unit tests with
+  fake runtime/readers.
+- Modify `src/cli/commands/init/pi-preflight.ts`: async readiness detection
+  through the adapter.
+- Modify `src/cli/commands/init/pi-preflight.test.ts`: readiness tests for pure
+  and async paths.
+- Modify `src/cli/commands/init/pi-auth-provider-state.ts`: provider choice
+  state consumes the adapter, not `AuthStorage`.
+- Modify `src/cli/commands/init/pi-auth-provider-state.test.ts`: provider choice
+  tests use fake adapter state.
+- Modify `src/cli/commands/init/pi-auth-flow.ts`: interactive API-key/OAuth
+  setup uses adapter login and awaits refresh.
+- Modify `src/cli/commands/init/pi-auth-flow.test.ts`: auth flow tests assert
+  login calls, refreshes, cancellation, and empty-key handling.
+- Modify `src/cli/commands/init/main.ts`: await readiness detectors.
+- Modify `src/cli/commands/auth/main.ts`: await readiness detectors.
+- Modify affected command tests under `src/cli/commands/init/*.test.ts` and
+  `src/cli/commands/auth/*.test.ts` only where TypeScript requires the async
+  readiness type.
+
+The new adapter file keeps vendor-specific SDK interactions out of
+`pi-auth-flow.ts` and `pi-preflight.ts`. `pi-auth-flow.ts` is already large
+enough that adding raw `ModelRuntime` event handling there would make it harder
+to review.
+
+---
+
+### Task 1: Pin Pi 0.80.10 and update dependency contract
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `npm-shrinkwrap.json`
+- Modify: `src/cli/commands/init/pi-dependency-contract.test.ts`
+
+**Interfaces:**
+
+- Consumes: current exact Pi dependency names from `package.json`.
+- Produces: package metadata that resolves Pi `0.80.10`, plus a contract test
+  requiring `ModelRuntime`, `ModelRegistry`, `readStoredCredential`, and
+  `getAgentDir` instead of `AuthStorage`.
+
+- [ ] **Step 1: Replace the dependency contract test with the new expected SDK
+      boundary**
+
+Replace `src/cli/commands/init/pi-dependency-contract.test.ts` with:
+
+```ts
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+import * as piCodingAgent from "@earendil-works/pi-coding-agent";
+
+const require = createRequire(import.meta.url);
+const EXPECTED_PI_VERSION = "0.80.10";
+
+const REQUIRED_INIT_RUNTIME_EXPORTS = [
+  "ModelRuntime",
+  "ModelRegistry",
+  "readStoredCredential",
+  "getAgentDir",
+] as const;
+
+type PackageJson = {
+  version: string;
+  dependencies?: Record<string, string>;
+};
+
+function packageJson(name: string): PackageJson {
+  return require(`${name}/package.json`) as PackageJson;
+}
+
+test("resolved Pi packages use the validated exact version", () => {
+  assert.equal(
+    packageJson("@earendil-works/pi-coding-agent").version,
+    EXPECTED_PI_VERSION,
+  );
+  assert.equal(
+    packageJson("@earendil-works/pi-tui").version,
+    EXPECTED_PI_VERSION,
+  );
+});
+
+test("resolved pi-coding-agent exports the runtime symbols used by patchmill init", () => {
+  for (const exportName of REQUIRED_INIT_RUNTIME_EXPORTS) {
+    assert.equal(
+      exportName in piCodingAgent,
+      true,
+      `@earendil-works/pi-coding-agent must export ${exportName}`,
+    );
+    assert.notEqual(
+      piCodingAgent[exportName],
+      undefined,
+      `@earendil-works/pi-coding-agent export ${exportName} must be defined`,
+    );
+  }
+
+  assert.equal(typeof piCodingAgent.ModelRuntime.create, "function");
+  assert.equal(typeof piCodingAgent.ModelRegistry, "function");
+});
+
+test("patchmill no longer requires the removed AuthStorage root export", () => {
+  assert.equal(
+    "AuthStorage" in piCodingAgent,
+    false,
+    "Patchmill must not rely on the removed root AuthStorage export",
+  );
+});
+```
+
+- [ ] **Step 2: Run the contract test to verify it fails against Pi 0.80.3**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-dependency-contract.test.ts
+```
+
+Expected: FAIL. The output should show the resolved
+`@earendil-works/pi-coding-agent` version is `0.80.3` or that
+`ModelRuntime`/`readStoredCredential` is missing.
+
+- [ ] **Step 3: Update package metadata and both lockfiles to exact Pi 0.80.10
+      pins**
+
+Run:
+
+```bash
+npm install --save-exact \
+  @earendil-works/pi-coding-agent@0.80.10 \
+  @earendil-works/pi-tui@0.80.10
+
+shrinkwrap_copy="$(mktemp)"
+cp npm-shrinkwrap.json "$shrinkwrap_copy"
+rm npm-shrinkwrap.json
+npm install --package-lock-only --ignore-scripts
+mv "$shrinkwrap_copy" npm-shrinkwrap.json
+npm install --ignore-scripts
+npx prettier --write package.json package-lock.json npm-shrinkwrap.json
+```
+
+Expected: `package.json` dependencies are exact `"0.80.10"`; `package-lock.json`
+and `npm-shrinkwrap.json` root package records both resolve Pi `0.80.10`.
+
+- [ ] **Step 4: Assert metadata consistency with a focused script**
+
+Run:
+
+```bash
+node <<'NODE'
+const fs = require("node:fs");
+const expected = "0.80.10";
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const packageLock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
+const shrinkwrap = JSON.parse(fs.readFileSync("npm-shrinkwrap.json", "utf8"));
+
+function assertEqual(actual, expectedValue, label) {
+  if (actual !== expectedValue) {
+    throw new Error(`${label}: expected ${expectedValue}, got ${actual}`);
+  }
+  console.log(`${label}: ${actual}`);
+}
+
+for (const name of ["@earendil-works/pi-coding-agent", "@earendil-works/pi-tui"]) {
+  assertEqual(packageJson.dependencies[name], expected, `package.json ${name}`);
+  assertEqual(
+    packageLock.packages[`node_modules/${name}`].version,
+    expected,
+    `package-lock ${name}`,
+  );
+  assertEqual(
+    shrinkwrap.packages[`node_modules/${name}`].version,
+    expected,
+    `npm-shrinkwrap ${name}`,
+  );
+}
+NODE
+```
+
+Expected: six lines ending in `0.80.10`; exit 0.
+
+- [ ] **Step 5: Run the updated dependency contract test**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-dependency-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add package.json package-lock.json npm-shrinkwrap.json \
+  src/cli/commands/init/pi-dependency-contract.test.ts
+git commit -m "chore(pi): pin runtime packages to 0.80.10"
+```
+
+---
+
+### Task 2: Add a narrow ModelRuntime adapter
+
+**Files:**
+
+- Create: `src/cli/commands/init/pi-runtime.ts`
+- Create: `src/cli/commands/init/pi-runtime.test.ts`
+
+**Interfaces:**
+
+- Consumes: Pi `ModelRuntime`, `readStoredCredential`, and repo-local
+  `agentDir`.
+- Produces:
+  - `createRepoLocalPiRuntime(options: { agentDir: string }): Promise<PatchmillPiRuntime>`
+  - `createModelRuntimeAdapter(options: { runtime: ModelRuntimeLike; authPath: string; readCredential?: StoredCredentialReader }): PatchmillPiRuntime`
+  - `repoLocalPiRuntimePaths(agentDir: string): { authPath: string; modelsPath: string }`
+  - Patchmill-owned structural types for models, providers, credentials, auth
+    status, and login interactions.
+
+- [ ] **Step 1: Write adapter tests first**
+
+Create `src/cli/commands/init/pi-runtime.test.ts` with:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  createModelRuntimeAdapter,
+  repoLocalPiRuntimePaths,
+  type ModelRuntimeLike,
+  type PiCredential,
+} from "./pi-runtime.ts";
+
+function fakeRuntime() {
+  const calls: Array<{ provider: string; mode: "api_key" | "oauth" }> = [];
+  let refreshCount = 0;
+  const runtime: ModelRuntimeLike & {
+    calls: typeof calls;
+    refreshCount: () => number;
+  } = {
+    calls,
+    refreshCount: () => refreshCount,
+    refresh: async () => {
+      refreshCount += 1;
+      return { aborted: false, errors: new Map() };
+    },
+    getError: () => undefined,
+    getModels: () => [
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: true,
+        input: ["text"],
+      },
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT 5.5",
+        reasoning: true,
+        input: ["text"],
+      },
+    ],
+    getAvailableSnapshot: () => [
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: true,
+        input: ["text"],
+      },
+    ],
+    getProviders: () => [
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        auth: {
+          apiKey: { login: async () => ({ type: "api_key", key: "sk" }) },
+          oauth: {
+            name: "Claude Pro/Max",
+            login: async () => ({
+              type: "oauth",
+              refresh: "r",
+              access: "a",
+              expires: 1,
+            }),
+          },
+        },
+      },
+      {
+        id: "openai",
+        name: "OpenAI",
+        auth: {
+          apiKey: { login: async () => ({ type: "api_key", key: "sk" }) },
+        },
+      },
+    ],
+    getProvider: (provider) =>
+      provider === "anthropic"
+        ? {
+            id: "anthropic",
+            name: "Anthropic",
+            auth: { apiKey: {}, oauth: { name: "Claude Pro/Max" } },
+          }
+        : undefined,
+    getProviderAuthStatus: (provider) =>
+      provider === "anthropic"
+        ? { configured: true, source: "stored" }
+        : { configured: false },
+    login: async (provider, mode) => {
+      calls.push({ provider, mode });
+      return mode === "api_key"
+        ? { type: "api_key", key: "sk" }
+        : { type: "oauth", refresh: "r", access: "a", expires: 1 };
+    },
+  };
+  return runtime;
+}
+
+test("repoLocalPiRuntimePaths points auth and models at the repo-local agent dir", () => {
+  assert.deepEqual(repoLocalPiRuntimePaths("/repo/.patchmill/pi-agent"), {
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+    modelsPath: "/repo/.patchmill/pi-agent/models.json",
+  });
+});
+
+test("ModelRuntime adapter exposes model snapshots and provider display names", () => {
+  const runtime = fakeRuntime();
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+  });
+
+  assert.deepEqual(adapter.getAvailable(), [
+    {
+      provider: "anthropic",
+      id: "claude-sonnet-4-5",
+      name: "Claude Sonnet 4.5",
+      reasoning: true,
+      input: ["text"],
+    },
+  ]);
+  assert.deepEqual(
+    adapter.getAll().map((model) => model.provider),
+    ["anthropic", "openai"],
+  );
+  assert.equal(adapter.getProviderDisplayName("anthropic"), "Anthropic");
+  assert.equal(adapter.getProviderDisplayName("missing"), "missing");
+});
+
+test("ModelRuntime adapter lists OAuth providers and reads stored credentials", () => {
+  const runtime = fakeRuntime();
+  const credential: PiCredential = {
+    type: "oauth",
+    refresh: "refresh",
+    access: "access",
+    expires: 1,
+  };
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+    readCredential: (provider, authPath) => {
+      assert.equal(provider, "anthropic");
+      assert.equal(authPath, "/repo/.patchmill/pi-agent/auth.json");
+      return credential;
+    },
+  });
+
+  assert.deepEqual(adapter.getOAuthProviders(), [
+    { id: "anthropic", name: "Claude Pro/Max" },
+  ]);
+  assert.equal(adapter.get("anthropic"), credential);
+  assert.deepEqual(adapter.getProviderAuthStatus("anthropic"), {
+    configured: true,
+    source: "stored",
+  });
+});
+
+test("ModelRuntime adapter delegates login and refresh", async () => {
+  const runtime = fakeRuntime();
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+  });
+
+  await adapter.login("anthropic", "api_key", {
+    prompt: async () => "sk-test",
+    notify: () => undefined,
+  });
+  await adapter.login("anthropic", "oauth", {
+    prompt: async () => "selected",
+    notify: () => undefined,
+  });
+  await adapter.refresh();
+
+  assert.deepEqual(runtime.calls, [
+    { provider: "anthropic", mode: "api_key" },
+    { provider: "anthropic", mode: "oauth" },
+  ]);
+  assert.equal(runtime.refreshCount(), 1);
+});
+```
+
+- [ ] **Step 2: Run the new adapter tests to verify they fail**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-runtime.test.ts
+```
+
+Expected: FAIL because `src/cli/commands/init/pi-runtime.ts` does not exist.
+
+- [ ] **Step 3: Implement the adapter**
+
+Create `src/cli/commands/init/pi-runtime.ts` with:
+
+```ts
+import { join } from "node:path";
+import {
+  ModelRuntime,
+  readStoredCredential,
+} from "@earendil-works/pi-coding-agent";
+
+export type PiAuthMode = "api_key" | "oauth";
+
+export type PiCredential =
+  | { type: "api_key"; key?: string; env?: Record<string, string> }
+  | ({
+      type: "oauth";
+      refresh: string;
+      access: string;
+      expires: number;
+    } & Record<string, unknown>);
+
+export type PiAuthStatus = {
+  configured: boolean;
+  source?:
+    | "stored"
+    | "runtime"
+    | "environment"
+    | "fallback"
+    | "models_json_key"
+    | "models_json_command";
+  label?: string;
+};
+
+export type PiRuntimeModel = {
+  provider: string;
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+  input?: string[];
+};
+
+export type PiRuntimeProvider = {
+  id: string;
+  name: string;
+  auth?: {
+    apiKey?: { name?: string; login?: unknown };
+    oauth?: { name?: string; login?: unknown };
+  };
+};
+
+export type PiAuthPrompt = {
+  signal?: AbortSignal;
+} & (
+  | { type: "text"; message: string; placeholder?: string }
+  | { type: "secret"; message: string; placeholder?: string }
+  | {
+      type: "select";
+      message: string;
+      options: readonly { id: string; label: string; description?: string }[];
+    }
+  | { type: "manual_code"; message: string; placeholder?: string }
+);
+
+export type PiAuthEvent =
+  | {
+      type: "info";
+      message: string;
+      links?: readonly { url: string; label?: string }[];
+    }
+  | { type: "auth_url"; url: string; instructions?: string }
+  | {
+      type: "device_code";
+      userCode: string;
+      verificationUri: string;
+      intervalSeconds?: number;
+      expiresInSeconds?: number;
+    }
+  | { type: "progress"; message: string };
+
+export type PiAuthInteraction = {
+  signal?: AbortSignal;
+  prompt(prompt: PiAuthPrompt): Promise<string>;
+  notify(event: PiAuthEvent): void;
+};
+
+export type ModelRuntimeLike = {
+  refresh(options?: { allowNetwork?: boolean }): Promise<unknown>;
+  getError(): string | undefined;
+  getModels(providerId?: string): readonly PiRuntimeModel[];
+  getAvailableSnapshot(): readonly PiRuntimeModel[];
+  getProviders(): readonly PiRuntimeProvider[];
+  getProvider(providerId: string): PiRuntimeProvider | undefined;
+  getProviderAuthStatus(providerId: string): PiAuthStatus;
+  login(
+    providerId: string,
+    mode: PiAuthMode,
+    interaction: PiAuthInteraction,
+  ): Promise<PiCredential>;
+};
+
+export type StoredCredentialReader = (
+  providerId: string,
+  authPath: string,
+) => PiCredential | undefined;
+
+export type PatchmillPiRuntime = {
+  refresh(): Promise<void>;
+  getError(): string | undefined;
+  getAll(): PiRuntimeModel[];
+  getAvailable(): PiRuntimeModel[];
+  getOAuthProviders(): Array<{ id: string; name: string }>;
+  get(providerId: string): PiCredential | undefined;
+  getProviderAuthStatus(providerId: string): PiAuthStatus;
+  getProviderDisplayName(providerId: string): string;
+  login(
+    providerId: string,
+    mode: PiAuthMode,
+    interaction: PiAuthInteraction,
+  ): Promise<PiCredential>;
+};
+
+export function repoLocalPiRuntimePaths(agentDir: string): {
+  authPath: string;
+  modelsPath: string;
+} {
+  return {
+    authPath: join(agentDir, "auth.json"),
+    modelsPath: join(agentDir, "models.json"),
+  };
+}
+
+function runtimeModels(models: readonly PiRuntimeModel[]): PiRuntimeModel[] {
+  return models.map((model) => ({
+    provider: model.provider,
+    id: model.id,
+    ...(model.name ? { name: model.name } : {}),
+    ...(model.reasoning === undefined ? {} : { reasoning: model.reasoning }),
+    ...(model.input ? { input: [...model.input] } : {}),
+  }));
+}
+
+function canLogin(auth: { login?: unknown } | undefined): boolean {
+  return typeof auth?.login === "function";
+}
+
+export function createModelRuntimeAdapter(options: {
+  runtime: ModelRuntimeLike;
+  authPath: string;
+  readCredential?: StoredCredentialReader;
+}): PatchmillPiRuntime {
+  const readCredential =
+    options.readCredential ??
+    ((providerId, authPath) =>
+      readStoredCredential(providerId, authPath) as PiCredential | undefined);
+
+  return {
+    refresh: async () => {
+      await options.runtime.refresh({ allowNetwork: false });
+    },
+    getError: () => options.runtime.getError(),
+    getAll: () => runtimeModels(options.runtime.getModels()),
+    getAvailable: () => runtimeModels(options.runtime.getAvailableSnapshot()),
+    getOAuthProviders: () =>
+      options.runtime
+        .getProviders()
+        .filter((provider) => canLogin(provider.auth?.oauth))
+        .map((provider) => ({
+          id: provider.id,
+          name: provider.auth?.oauth?.name ?? provider.name,
+        })),
+    get: (providerId) => readCredential(providerId, options.authPath),
+    getProviderAuthStatus: (providerId) =>
+      options.runtime.getProviderAuthStatus(providerId),
+    getProviderDisplayName: (providerId) =>
+      options.runtime.getProvider(providerId)?.name ?? providerId,
+    login: (providerId, mode, interaction) =>
+      options.runtime.login(providerId, mode, interaction),
+  };
+}
+
+export async function createRepoLocalPiRuntime(options: {
+  agentDir: string;
+}): Promise<PatchmillPiRuntime> {
+  const { authPath, modelsPath } = repoLocalPiRuntimePaths(options.agentDir);
+  const runtime = (await ModelRuntime.create({
+    authPath,
+    modelsPath,
+    allowModelNetwork: false,
+  })) as ModelRuntimeLike;
+  await runtime.refresh({ allowNetwork: false });
+  return createModelRuntimeAdapter({ runtime, authPath });
+}
+```
+
+- [ ] **Step 4: Run adapter tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-runtime.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src/cli/commands/init/pi-runtime.ts \
+  src/cli/commands/init/pi-runtime.test.ts
+git commit -m "feat(pi): add repo-local runtime adapter"
+```
+
+---
+
+### Task 3: Make Pi readiness detection async through the adapter
+
+**Files:**
+
+- Modify: `src/cli/commands/init/pi-preflight.ts`
+- Modify: `src/cli/commands/init/pi-preflight.test.ts`
+- Modify: `src/cli/commands/init/main.ts`
+- Modify: `src/cli/commands/auth/main.ts`
+- Modify: affected tests under `src/cli/commands/init/*.test.ts` and
+  `src/cli/commands/auth/*.test.ts` where TypeScript expects a readiness
+  detector type.
+
+**Interfaces:**
+
+- Consumes: `createRepoLocalPiRuntime`, `PatchmillPiRuntime`, and existing
+  `PiReadiness`/`PiModelChoice` types.
+- Produces:
+  - `detectPiReadiness(options?: { registry?: PiRegistryLike; agentDir?: string }): Promise<PiReadiness>`
+  - `detectPiReadinessFromRegistry(registry: PiRegistryLike): PiReadiness`
+  - command code that awaits readiness detectors.
+
+- [ ] **Step 1: Update readiness tests first**
+
+In `src/cli/commands/init/pi-preflight.test.ts`:
+
+1. Replace imports of `createPiRegistry` with `createRepoLocalPiRuntime`
+   coverage in `pi-runtime.test.ts`; this file should import
+   `detectPiReadinessFromRegistry` instead.
+1. Change tests that call `detectPiReadiness({ registry })` to
+   `detectPiReadinessFromRegistry(registry)`.
+1. Add an async detector test:
+
+```ts
+test("detectPiReadiness creates a repo-local runtime when no registry is injected", async () => {
+  const readiness = await detectPiReadiness({
+    createRuntime: async () =>
+      registry([
+        {
+          provider: "anthropic",
+          id: "claude-sonnet-4-5",
+          name: "Claude Sonnet 4.5",
+          reasoning: true,
+          input: ["text"],
+        },
+      ]),
+    agentDir: "/repo/.patchmill/pi-agent",
+  });
+
+  assert.equal(readiness.status, "ready");
+  assert.equal(readiness.models[0]?.value, "anthropic/claude-sonnet-4-5");
+});
+```
+
+Update the local fake `registry` helper so it satisfies the new `PiRegistryLike`
+imported from `pi-preflight.ts`.
+
+- [ ] **Step 2: Run the readiness tests to verify they fail**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-preflight.test.ts
+```
+
+Expected: FAIL because `detectPiReadinessFromRegistry` and the async factory
+option do not exist yet.
+
+- [ ] **Step 3: Update `pi-preflight.ts`**
+
+Change the top imports to use the adapter:
+
+```ts
+import {
+  createRepoLocalPiRuntime,
+  type PatchmillPiRuntime,
+  type PiAuthStatus,
+  type PiRuntimeModel,
+} from "./pi-runtime.ts";
+```
+
+Replace `PiAuthStatus`, `PiRegistryModel`, and `PiRegistryLike` with
+adapter-shaped types:
+
+```ts
+export type PiRegistryModel = PiRuntimeModel;
+
+export type PiRegistryLike = Pick<
+  PatchmillPiRuntime,
+  | "getAvailable"
+  | "getError"
+  | "getProviderAuthStatus"
+  | "getProviderDisplayName"
+>;
+```
+
+Replace the old `createPiRegistry` function with an async runtime factory:
+
+```ts
+export async function createPiRegistry(
+  options: { agentDir?: string } = {},
+): Promise<PiRegistryLike> {
+  return createRepoLocalPiRuntime({
+    agentDir: options.agentDir ?? getAgentDir(),
+  });
+}
+```
+
+Move the existing body of `detectPiReadiness` into a pure function:
+
+```ts
+export function detectPiReadinessFromRegistry(
+  registry: PiRegistryLike,
+): PiReadiness {
+  const models = registry
+    .getAvailable()
+    .map((model) => toChoice(registry, model));
+  const loadError = registry.getError();
+
+  if (models.length === 0 && loadError) {
+    return {
+      status: "error",
+      models: [],
+      message: `Pi model registry could not load provider configuration: ${loadError}`,
+    };
+  }
+
+  if (models.length === 0) {
+    return {
+      status: "missing",
+      models: [],
+      message: "Pi did not report any provider/model with configured auth.",
+    };
+  }
+
+  return {
+    status: "ready",
+    models: models as NonEmptyArray<PiModelChoice>,
+    message: `Pi reported ${models.length} provider/model option${models.length === 1 ? "" : "s"} with configured auth.`,
+    ...(loadError
+      ? {
+          warning: `Pi model registry reported provider configuration issues: ${loadError}`,
+        }
+      : {}),
+  };
+}
+```
+
+Then make `detectPiReadiness` async:
+
+```ts
+export async function detectPiReadiness(
+  options: {
+    registry?: PiRegistryLike;
+    agentDir?: string;
+    createRuntime?: (options: { agentDir: string }) => Promise<PiRegistryLike>;
+  } = {},
+): Promise<PiReadiness> {
+  const registry =
+    options.registry ??
+    (await (options.createRuntime ?? createRepoLocalPiRuntime)({
+      agentDir: options.agentDir ?? getAgentDir(),
+    }));
+  return detectPiReadinessFromRegistry(registry);
+}
+```
+
+Keep `toChoice` and `formatPiModelLabel` behavior unchanged.
+
+- [ ] **Step 4: Await readiness in `patchmill init` and `patchmill auth`**
+
+In both command modules, change the detector type to allow async injected fakes:
+
+```ts
+type MaybePromise<T> = T | Promise<T>;
+
+export type PiReadinessDetector = (options: {
+  agentDir: string;
+}) => MaybePromise<PiReadiness>;
+```
+
+In `src/cli/commands/init/main.ts`, replace:
+
+```ts
+const readiness = (options.detectPiReadiness ?? detectPiReadiness)({
+  agentDir: piAgentDir,
+});
+```
+
+with:
+
+```ts
+const readiness = await (options.detectPiReadiness ?? detectPiReadiness)({
+  agentDir: piAgentDir,
+});
+```
+
+In `src/cli/commands/auth/main.ts`, make the same replacement before checking
+`readiness.status`.
+
+- [ ] **Step 5: Run focused readiness and command tests**
+
+Run:
+
+```bash
+node --test \
+  src/cli/commands/init/pi-preflight.test.ts \
+  src/cli/commands/init/main.test.ts \
+  src/cli/commands/auth/main.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run TypeScript build to find missed async detector types**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: it may fail with TypeScript errors for tests or command types that
+still expect sync `PiReadiness`. Fix each error by either adding `await` in
+production code or allowing `MaybePromise<PiReadiness>` for injected tests.
+Re-run until PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add src/cli/commands/init/pi-preflight.ts \
+  src/cli/commands/init/pi-preflight.test.ts \
+  src/cli/commands/init/main.ts \
+  src/cli/commands/auth/main.ts \
+  src/cli/commands/init/*.test.ts \
+  src/cli/commands/auth/*.test.ts
+git commit -m "refactor(pi): use async runtime readiness"
+```
+
+---
+
+### Task 4: Migrate interactive auth setup to ModelRuntime login
+
+**Files:**
+
+- Modify: `src/cli/commands/init/pi-auth-provider-state.ts`
+- Modify: `src/cli/commands/init/pi-auth-provider-state.test.ts`
+- Modify: `src/cli/commands/init/pi-auth-flow.ts`
+- Modify: `src/cli/commands/init/pi-auth-flow.test.ts`
+- Modify: `src/cli/commands/init/pi-auth-dialog.ts` only if a generic
+  select/text prompt helper must be exported for Pi `AuthInteraction` mapping.
+
+**Interfaces:**
+
+- Consumes: `PatchmillPiRuntime`, `PiAuthInteraction`, `PiAuthPrompt`, and
+  `PiAuthEvent` from `pi-runtime.ts`.
+- Produces:
+  - `createAuthProviderChoices(options: { mode: AuthMode; runtime: AuthProviderRuntimeLike }): AuthProviderChoice[]`
+  - `runInteractivePiAuthSetup` options using `runtime: PiAuthFlowRuntime`
+    instead of `authStorage` and `registry`.
+  - API-key and OAuth setup through
+    `runtime.login(provider.id, mode, interaction)` followed by
+    `await runtime.refresh()`.
+
+- [ ] **Step 1: Update provider-state tests first**
+
+In `src/cli/commands/init/pi-auth-provider-state.test.ts`:
+
+1. Remove imports of `AuthCredential` and `AuthStatus` from
+   `@earendil-works/pi-coding-agent`.
+1. Import `type PiCredential, type PiAuthStatus` from `./pi-runtime.ts`.
+1. Replace the separate `storage()` and `registry()` helpers with one
+   `runtime()` helper:
+
+```ts
+function runtime(
+  options: {
+    oauth?: Array<{ id: string; name: string }>;
+    credentials?: Record<string, PiCredential>;
+    statuses?: Record<string, PiAuthStatus>;
+    models?: FakeModel[];
+    names?: Record<string, string>;
+  } = {},
+) {
+  const credentials = options.credentials ?? {};
+  const statuses = options.statuses ?? {};
+  return {
+    getOAuthProviders: () => options.oauth ?? [],
+    get: (provider: string) => credentials[provider],
+    getAll: () => options.models ?? [],
+    getProviderDisplayName: (provider: string) =>
+      options.names?.[provider] ?? provider,
+    getProviderAuthStatus: (provider: string) =>
+      statuses[provider] ?? {
+        configured: Boolean(credentials[provider]),
+        source: credentials[provider] ? "stored" : undefined,
+      },
+  };
+}
+```
+
+1. Change every `createAuthProviderChoices` call from:
+
+```ts
+createAuthProviderChoices({ mode, authStorage: storage(...), registry: registry(...) })
+```
+
+to:
+
+```ts
+createAuthProviderChoices({ mode, runtime: runtime(...) })
+```
+
+Keep all existing expected labels unchanged.
+
+- [ ] **Step 2: Run provider-state tests to verify failure**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-auth-provider-state.test.ts
+```
+
+Expected: FAIL because production `createAuthProviderChoices` still expects
+`authStorage` and `registry`.
+
+- [ ] **Step 3: Update provider-state production code**
+
+In `src/cli/commands/init/pi-auth-provider-state.ts`:
+
+1. Remove type imports from `@earendil-works/pi-coding-agent`.
+1. Import adapter types:
+
+```ts
+import type {
+  PiAuthStatus,
+  PiCredential,
+  PiRuntimeModel,
+} from "./pi-runtime.ts";
+```
+
+1. Replace `AuthStorageLike`, `RegistryModelLike`, and `AuthRegistryLike` with:
+
+```ts
+export type AuthProviderRuntimeLike = {
+  getOAuthProviders(): OAuthProviderLike[];
+  get(provider: string): PiCredential | undefined;
+  getAll(): PiRuntimeModel[];
+  getProviderDisplayName(provider: string): string;
+  getProviderAuthStatus(provider: string): PiAuthStatus;
+};
+```
+
+1. Change `statusLabel` and `choice` parameter types from
+   `AuthCredential`/`AuthStatus` to `PiCredential`/`PiAuthStatus`.
+1. Change `apiProviderIds` to accept `AuthProviderRuntimeLike`.
+1. Change `createAuthProviderChoices` signature to:
+
+```ts
+export function createAuthProviderChoices(options: {
+  mode: AuthMode;
+  runtime: AuthProviderRuntimeLike;
+}): AuthProviderChoice[] {
+  if (options.mode === "oauth") {
+    return options.runtime.getOAuthProviders().map((provider) =>
+      choice({
+        id: provider.id,
+        name: provider.name,
+        mode: options.mode,
+        credential: options.runtime.get(provider.id),
+        status: options.runtime.getProviderAuthStatus(provider.id),
+      }),
+    );
+  }
+
+  return apiProviderIds(options.runtime).map((provider) =>
+    choice({
+      id: provider,
+      name: options.runtime.getProviderDisplayName(provider),
+      mode: options.mode,
+      credential: options.runtime.get(provider),
+      status: options.runtime.getProviderAuthStatus(provider),
+    }),
+  );
+}
+```
+
+- [ ] **Step 4: Run provider-state tests**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-auth-provider-state.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Update auth-flow tests first**
+
+In `src/cli/commands/init/pi-auth-flow.test.ts`:
+
+1. Remove `AuthCredential` and `AuthStatus` imports from
+   `@earendil-works/pi-coding-agent`.
+1. Import adapter types:
+
+```ts
+import type {
+  PatchmillPiRuntime,
+  PiAuthInteraction,
+  PiAuthMode,
+  PiAuthStatus,
+  PiCredential,
+} from "./pi-runtime.ts";
+```
+
+1. Replace `fakeStorage` and `fakeRegistry` with one `fakeRuntime` helper:
+
+```ts
+function fakeRuntime(
+  options: {
+    oauthProviders?: Array<{ id: string; name: string }>;
+    credentials?: Record<string, PiCredential>;
+    statuses?: Record<string, PiAuthStatus>;
+    allModels?: ReturnType<typeof model>[];
+    availableModels?: ReturnType<typeof model>[];
+    names?: Record<string, string>;
+  } = {},
+) {
+  const credentials = { ...(options.credentials ?? {}) };
+  const loginCalls: Array<{ provider: string; mode: PiAuthMode }> = [];
+  let refreshed = 0;
+  const runtime: PatchmillPiRuntime & {
+    loginCalls: typeof loginCalls;
+    refreshCount: () => number;
+  } = {
+    loginCalls,
+    refreshCount: () => refreshed,
+    refresh: async () => {
+      refreshed += 1;
+    },
+    getError: () => undefined,
+    getAll: () => options.allModels ?? [],
+    getAvailable: () => options.availableModels ?? [],
+    getOAuthProviders: () => options.oauthProviders ?? [],
+    get: (provider) => credentials[provider],
+    getProviderAuthStatus: (provider) =>
+      options.statuses?.[provider] ?? {
+        configured: Boolean(credentials[provider]),
+        source: credentials[provider] ? "stored" : undefined,
+      },
+    getProviderDisplayName: (provider) => options.names?.[provider] ?? provider,
+    login: async (provider, mode, interaction: PiAuthInteraction) => {
+      loginCalls.push({ provider, mode });
+      if (mode === "api_key") {
+        const key = await interaction.prompt({
+          type: "secret",
+          message: "Enter API key:",
+        });
+        credentials[provider] = { type: "api_key", key };
+        return credentials[provider];
+      }
+      credentials[provider] = {
+        type: "oauth",
+        refresh: "refresh",
+        access: "access",
+        expires: 1,
+      };
+      return credentials[provider];
+    },
+  };
+  return runtime;
+}
+```
+
+1. Update each `runInteractivePiAuthSetup` call to pass `runtime` instead of
+   `authStorage` and `registry`.
+1. In the API-key test, assert:
+
+```ts
+assert.deepEqual(runtime.loginCalls, [
+  { provider: "anthropic", mode: "api_key" },
+]);
+assert.equal(runtime.get("anthropic")?.type, "api_key");
+assert.equal(runtime.refreshCount(), 1);
+```
+
+1. In the OAuth test, assert:
+
+```ts
+assert.deepEqual(runtime.loginCalls, [
+  { provider: "openai-codex", mode: "oauth" },
+]);
+assert.equal(runtime.refreshCount(), 1);
+```
+
+1. In the empty-key test, assert:
+
+```ts
+assert.deepEqual(runtime.loginCalls, []);
+```
+
+- [ ] **Step 6: Run auth-flow tests to verify failure**
+
+Run:
+
+```bash
+node --test src/cli/commands/init/pi-auth-flow.test.ts
+```
+
+Expected: FAIL because production code still expects `authStorage` and
+`registry`.
+
+- [ ] **Step 7: Update `pi-auth-flow.ts` types and factory**
+
+In `src/cli/commands/init/pi-auth-flow.ts`:
+
+1. Remove imports of `join`, `AuthStorage`, `ModelRegistry`, and
+   `AuthCredential`.
+1. Import adapter APIs:
+
+```ts
+import {
+  createRepoLocalPiRuntime,
+  type PatchmillPiRuntime,
+  type PiAuthEvent,
+  type PiAuthInteraction,
+  type PiAuthPrompt,
+} from "./pi-runtime.ts";
+```
+
+1. Replace `PiAuthFlowStorage` and `PiAuthFlowRegistry` with:
+
+```ts
+export type PiAuthFlowRuntime = PatchmillPiRuntime;
+```
+
+1. Replace the `InteractivePiAuthSetupOptions` fields:
+
+```ts
+runtime: PiAuthFlowRuntime;
+```
+
+and remove `authStorage` and `registry`.
+
+1. Replace `createRepoLocalPiAuth` with:
+
+```ts
+export async function createRepoLocalPiAuth(options: {
+  agentDir: string;
+}): Promise<{ runtime: PiAuthFlowRuntime }> {
+  return {
+    runtime: await createRepoLocalPiRuntime({ agentDir: options.agentDir }),
+  };
+}
+```
+
+- [ ] **Step 8: Add interaction helpers in `pi-auth-flow.ts`**
+
+Add these helpers near the existing type definitions:
+
+```ts
+type SelectAuthPromptOption = (prompt: {
+  message: string;
+  options: Array<{ id: string; label: string }>;
+}) => Promise<string | undefined>;
+
+function loginCancelled(): Error {
+  return new Error("Login cancelled");
+}
+
+function assertApiKey(value: string | undefined): string {
+  if (value === undefined) throw loginCancelled();
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("API key cannot be empty.");
+  return trimmed;
+}
+
+async function promptForAuthValue(options: {
+  prompt: PiAuthPrompt;
+  provider: AuthProviderChoice;
+  promptApiKey: PromptApiKey;
+  selectOption: SelectAuthPromptOption;
+}): Promise<string> {
+  if (options.prompt.type === "select") {
+    const selected = await options.selectOption({
+      message: options.prompt.message,
+      options: options.prompt.options.map((option) => ({
+        id: option.id,
+        label: option.description
+          ? `${option.label} — ${option.description}`
+          : option.label,
+      })),
+    });
+    if (selected === undefined) throw loginCancelled();
+    return selected;
+  }
+
+  if (options.prompt.type === "manual_code") {
+    const selected = await options.selectOption({
+      message: options.prompt.message,
+      options: [
+        { id: "manual", label: options.prompt.placeholder ?? "Enter code" },
+      ],
+    });
+    if (selected === undefined) throw loginCancelled();
+    return selected;
+  }
+
+  return assertApiKey(await options.promptApiKey(options.provider));
+}
+
+function createApiKeyInteraction(options: {
+  provider: AuthProviderChoice;
+  promptApiKey: PromptApiKey;
+  selectOption: SelectAuthPromptOption;
+}): PiAuthInteraction {
+  return {
+    prompt: (prompt) =>
+      promptForAuthValue({
+        prompt,
+        provider: options.provider,
+        promptApiKey: options.promptApiKey,
+        selectOption: options.selectOption,
+      }),
+    notify: () => undefined,
+  };
+}
+
+function createPiAuthInteraction(
+  callbacks: OAuthLoginCallbacksLike,
+): PiAuthInteraction {
+  return {
+    signal: callbacks.signal,
+    notify: (event: PiAuthEvent) => {
+      if (event.type === "auth_url") {
+        callbacks.onAuth({ url: event.url, instructions: event.instructions });
+      } else if (event.type === "device_code") {
+        callbacks.onDeviceCode({
+          userCode: event.userCode,
+          verificationUri: event.verificationUri,
+          intervalSeconds: event.intervalSeconds,
+          expiresInSeconds: event.expiresInSeconds,
+        });
+      } else if (event.type === "progress" || event.type === "info") {
+        callbacks.onProgress?.(event.message);
+      }
+    },
+    prompt: async (prompt: PiAuthPrompt) => {
+      if (prompt.type === "select") {
+        const selected = await callbacks.onSelect({
+          message: prompt.message,
+          options: prompt.options.map((option) => ({
+            id: option.id,
+            label: option.description
+              ? `${option.label} — ${option.description}`
+              : option.label,
+          })),
+        });
+        if (selected === undefined) throw loginCancelled();
+        return selected;
+      }
+      if (prompt.type === "manual_code") {
+        if (!callbacks.onManualCodeInput) throw loginCancelled();
+        return callbacks.onManualCodeInput();
+      }
+      return callbacks.onPrompt({
+        message: prompt.message,
+        placeholder: prompt.placeholder,
+        allowEmpty: prompt.type === "text",
+      });
+    },
+  };
+}
+```
+
+If TypeScript reports that `manual_code` cannot use `selectOption`, change
+`OAuthLoginCallbacksLike.onManualCodeInput` to be required for generic
+manual-code prompts and add a focused test for cancellation. Do not silently
+return an empty string for active prompts.
+
+- [ ] **Step 9: Update `runInteractivePiAuthSetup` behavior**
+
+In `runInteractivePiAuthSetup`:
+
+1. Build choices with the runtime:
+
+```ts
+const choices = createAuthProviderChoices({
+  mode,
+  runtime: options.runtime,
+});
+```
+
+1. In the API-key branch, keep Bedrock guidance unchanged. For other providers,
+   replace direct storage writes with:
+
+```ts
+try {
+  await options.runtime.login(
+    provider.id,
+    "api_key",
+    createApiKeyInteraction({
+      provider,
+      promptApiKey: options.promptApiKey,
+      selectOption: (prompt) =>
+        options.oauthCallbacks?.(provider).onSelect(prompt) ??
+        Promise.resolve(undefined),
+    }),
+  );
+} catch (error) {
+  if (error instanceof Error && error.message === "API key cannot be empty.") {
+    return unavailable(
+      options.initialReadiness,
+      "invalid-selection",
+      "API key cannot be empty.",
+    );
+  }
+  if (error instanceof Error && error.message === "Login cancelled") {
+    return unavailable(
+      options.initialReadiness,
+      "cancelled",
+      "Pi provider authentication was cancelled.",
+    );
+  }
+  throw error;
+}
+```
+
+1. In the OAuth branch, replace `options.authStorage.login` with:
+
+```ts
+const callbacks = options.oauthCallbacks?.(provider) ?? createOAuthCallbacks();
+try {
+  await options.runtime.login(
+    provider.id,
+    "oauth",
+    createPiAuthInteraction(callbacks),
+  );
+} finally {
+  callbacks.dispose?.();
+}
+```
+
+1. Replace refresh/readiness lines with:
+
+```ts
+await options.runtime.refresh();
+const readiness = detectPiReadinessFromRegistry(options.runtime);
+```
+
+- [ ] **Step 10: Update `setupPiInteractively`**
+
+Change:
+
+```ts
+const { authStorage, registry } = createRepoLocalPiAuth({
+  agentDir: options.agentDir,
+});
+```
+
+into:
+
+```ts
+const { runtime } = await createRepoLocalPiAuth({
+  agentDir: options.agentDir,
+});
+```
+
+and pass `runtime` into `runInteractivePiAuthSetup`.
+
+- [ ] **Step 11: Run focused auth tests**
+
+Run:
+
+```bash
+node --test \
+  src/cli/commands/init/pi-auth-provider-state.test.ts \
+  src/cli/commands/init/pi-auth-flow.test.ts \
+  src/cli/commands/init/pi-runtime.test.ts \
+  src/cli/commands/init/pi-preflight.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Run TypeScript build and fix import/type drift**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS after removing all root `AuthStorage` and `AuthCredential`
+imports. If it fails, fix only the reported import/type drift and rerun.
+
+- [ ] **Step 13: Confirm production code no longer imports removed Pi exports**
+
+Run:
+
+```bash
+rg -n 'AuthStorage|AuthCredential|AuthStatus|ModelRegistry\.create|registry\.refresh\(\)' \
+  bin src extensions package.json \
+  --glob '!node_modules/**'
+```
+
+Expected: no production imports of `AuthStorage` or `ModelRegistry.create`. Test
+files may mention `AuthStorage` only in the dependency-contract test message
+that asserts Patchmill does not rely on it.
+
+- [ ] **Step 14: Commit Task 4**
+
+```bash
+git add src/cli/commands/init/pi-auth-provider-state.ts \
+  src/cli/commands/init/pi-auth-provider-state.test.ts \
+  src/cli/commands/init/pi-auth-flow.ts \
+  src/cli/commands/init/pi-auth-flow.test.ts \
+  src/cli/commands/init/pi-auth-dialog.ts
+git commit -m "refactor(pi): migrate auth setup to ModelRuntime"
+```
+
+---
+
+### Task 5: Update Nix hash and run artifact-level smoke checks
+
+**Files:**
+
+- Modify: `nix/package.nix`
+- No new test file unless smoke verification exposes a repeatable regression
+  worth preserving.
+
+**Interfaces:**
+
+- Consumes: updated npm dependency graph from Tasks 1-4.
+- Produces: matching Nix `npmDepsHash` and evidence that the packed package
+  installs with Pi `0.80.10` and runs `patchmill --help`/`patchmill init`.
+
+- [ ] **Step 1: Run full Node tests before Nix hash work**
+
+Run:
+
+```bash
+npm test
+npm run build
+npm run lint
+```
+
+Expected: all PASS. If `npm run lint` reformats or reports generated lockfile
+formatting, run
+`npx prettier --write package-lock.json npm-shrinkwrap.json package.json` and
+rerun lint.
+
+- [ ] **Step 2: Update `npmDepsHash` with the existing helper**
+
+Run:
+
+```bash
+scripts/update-npm-deps-hash.sh .#patchmill
+```
+
+Expected: either `npmDepsHash already matches the build output.` or
+`Updated npmDepsHash to sha256-...`. If the script reports a non-hash Nix
+failure, fix the reported package/build error before proceeding.
+
+- [ ] **Step 3: Run the Nix package build explicitly**
+
+Run:
+
+```bash
+nix build .#patchmill --print-build-logs
+```
+
+Expected: PASS. The Nix package install check runs `$out/bin/patchmill --help`
+and `$out/bin/patchmill init`, so this validates the Nix-packaged runtime path.
+
+- [ ] **Step 4: Run packed npm artifact smoke test**
+
+Run:
+
+```bash
+smoke_root="$(mktemp -d)"
+tarball="$(npm pack --silent)"
+tarball_path="$(pwd)/$tarball"
+install_dir="$smoke_root/install"
+project_dir="$smoke_root/project"
+mkdir -p "$install_dir" "$project_dir" "$smoke_root/home" "$smoke_root/config"
+(
+  cd "$install_dir"
+  npm init -y >/dev/null
+  npm install "$tarball_path" --ignore-scripts >/dev/null
+  PATCHMILL="$install_dir/node_modules/.bin/patchmill"
+  "$PATCHMILL" --help >/dev/null
+  node --input-type=module <<'NODE'
+import { createRequire } from "node:module";
+const require = createRequire(`${process.cwd()}/package.json`);
+const patchmillPackage = require.resolve("patchmill/package.json");
+const patchmillRequire = createRequire(patchmillPackage);
+const expected = "0.80.10";
+for (const name of ["@earendil-works/pi-coding-agent", "@earendil-works/pi-tui"]) {
+  const version = patchmillRequire(`${name}/package.json`).version;
+  if (version !== expected) {
+    throw new Error(`${name}: expected ${expected}, got ${version}`);
+  }
+  console.log(`${name}: ${version}`);
+}
+NODE
+  cd "$project_dir"
+  HOME="$smoke_root/home" \
+    XDG_CONFIG_HOME="$smoke_root/config" \
+    "$PATCHMILL" init --skills none --yes >/tmp/patchmill-packed-init.log
+  test -f patchmill.config.json
+)
+rm -f "$tarball_path"
+rm -rf "$smoke_root"
+```
+
+Expected: exit 0, version assertions print `0.80.10`, and
+`patchmill.config.json` is created in the temporary project.
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add nix/package.nix package.json package-lock.json npm-shrinkwrap.json
+git commit -m "chore(nix): refresh patchmill npm deps hash"
+```
+
+If `nix/package.nix` did not change because the existing hash already matched,
+commit only remaining metadata changes not already committed. If no files
+remain, skip the commit and record the smoke output in the final handoff.
+
+---
+
+### Task 6: Final verification and handoff
+
+**Files:**
+
+- Modify only files changed by formatting during verification.
+
+**Interfaces:**
+
+- Consumes: all previous task commits.
+- Produces: clean branch with verification evidence and no dependency or
+  compatibility drift.
+
+- [ ] **Step 1: Run the required targeted suite**
+
+Run:
+
+```bash
+node --test \
+  src/cli/commands/init/pi-runtime.test.ts \
+  src/cli/commands/init/pi-auth-flow.test.ts \
+  src/cli/commands/init/pi-auth-provider-state.test.ts \
+  src/cli/commands/init/pi-preflight.test.ts \
+  src/cli/commands/init/pi-dependency-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full verification suite**
+
+Run:
+
+```bash
+npm test
+npm run build
+npm run lint
+nix build .#patchmill --print-build-logs
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run dependency drift checks**
+
+Run:
+
+```bash
+node <<'NODE'
+const fs = require("node:fs");
+const expected = "0.80.10";
+const files = ["package.json", "package-lock.json", "npm-shrinkwrap.json"];
+for (const file of files) {
+  const json = JSON.parse(fs.readFileSync(file, "utf8"));
+  const rootDeps = json.packages?.[""]?.dependencies ?? json.dependencies ?? {};
+  for (const name of ["@earendil-works/pi-coding-agent", "@earendil-works/pi-tui"]) {
+    const version = file === "package.json"
+      ? json.dependencies[name]
+      : json.packages[`node_modules/${name}`]?.version;
+    if (version !== expected) throw new Error(`${file} ${name}: ${version}`);
+    if (file !== "package.json" && rootDeps[name] !== expected) {
+      throw new Error(`${file} root dependency ${name}: ${rootDeps[name]}`);
+    }
+  }
+}
+console.log("Pi dependency metadata is pinned to 0.80.10 in all package files.");
+NODE
+
+if rg -n 'from "@earendil-works/pi-coding-agent"|from "@earendil-works/pi-ai"' src/cli/commands/init src/cli/commands/auth; then
+  rg -n 'AuthStorage|AuthCredential|AuthStatus' src/cli/commands/init src/cli/commands/auth \
+    --glob '!pi-dependency-contract.test.ts' && exit 1 || true
+fi
+```
+
+Expected: metadata script exits 0. The grep block must not find production
+`AuthStorage`, `AuthCredential`, or `AuthStatus` references in init/auth
+modules.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat main...HEAD
+git diff --check
+```
+
+Expected: working tree clean except intentional final edits before commit;
+`git diff --check` exits 0.
+
+- [ ] **Step 5: Commit final verification fixes if any**
+
+If verification caused formatting or small fixes, commit them:
+
+```bash
+git add package.json package-lock.json npm-shrinkwrap.json nix/package.nix \
+  src/cli/commands/init/pi-dependency-contract.test.ts \
+  src/cli/commands/init/pi-runtime.ts \
+  src/cli/commands/init/pi-runtime.test.ts \
+  src/cli/commands/init/pi-preflight.ts \
+  src/cli/commands/init/pi-preflight.test.ts \
+  src/cli/commands/init/pi-auth-provider-state.ts \
+  src/cli/commands/init/pi-auth-provider-state.test.ts \
+  src/cli/commands/init/pi-auth-flow.ts \
+  src/cli/commands/init/pi-auth-flow.test.ts \
+  src/cli/commands/init/pi-auth-dialog.ts \
+  src/cli/commands/init/main.ts \
+  src/cli/commands/auth/main.ts \
+  src/cli/commands/init/*.test.ts \
+  src/cli/commands/auth/*.test.ts
+git commit -m "chore(pi): finalize 0.80.10 verification"
+```
+
+If there are no changes, skip this commit.
+
+- [ ] **Step 6: Prepare handoff summary**
+
+Include this exact information in the implementation handoff:
+
+```text
+Implemented Pi 0.80.10 manual compatibility upgrade.
+
+Changed:
+- Replaced Patchmill init/auth reliance on root-exported AuthStorage with a repo-local ModelRuntime adapter.
+- Updated exact Pi pins to @earendil-works/pi-coding-agent@0.80.10 and @earendil-works/pi-tui@0.80.10.
+- Updated package-lock.json, npm-shrinkwrap.json, and nix/package.nix npmDepsHash.
+- Updated compatibility tests to require current Pi runtime exports and reject AuthStorage as a required root export.
+
+Verified:
+- node --test src/cli/commands/init/pi-runtime.test.ts src/cli/commands/init/pi-auth-flow.test.ts src/cli/commands/init/pi-auth-provider-state.test.ts src/cli/commands/init/pi-preflight.test.ts src/cli/commands/init/pi-dependency-contract.test.ts
+- npm test
+- npm run build
+- npm run lint
+- nix build .#patchmill --print-build-logs
+- npm packed-artifact smoke with patchmill --help, patchmill init, and resolved Pi version assertions
+
+Issue #96 remains future work for automating validated Pi upgrade PRs.
+```

--- a/docs/specs/2026-07-18-pi-0-80-10-upgrade-design.md
+++ b/docs/specs/2026-07-18-pi-0-80-10-upgrade-design.md
@@ -1,0 +1,254 @@
+# Pi 0.80.10 compatibility upgrade design
+
+## Context
+
+Patchmill currently pins `@earendil-works/pi-coding-agent` and
+`@earendil-works/pi-tui` to `0.80.3` in `package.json`, `package-lock.json`, and
+`npm-shrinkwrap.json`. Pi `0.80.10` is available, but the release train between
+those versions includes a breaking SDK migration that affects Patchmill's `init`
+and `auth` code.
+
+This upgrade is a manual prerequisite before issue #96. Issue #96 should
+automate future Pi dependency upgrade PRs after Patchmill's compatibility
+boundary is updated to work with current Pi APIs.
+
+## Release-note findings
+
+- `v0.80.5`: no migration or breaking notice found.
+- `v0.80.6`: added the `max` thinking level and input-token pricing tiers. No
+  direct Patchmill migration required.
+- `v0.80.7`: breaking `models.json` compatibility rename for OpenAI Responses
+  custom models: `compat.sendSessionIdHeader` was removed and replaced by
+  `compat.sessionAffinityFormat`. Patchmill does not currently reference
+  `sendSessionIdHeader`, so no repository migration is needed.
+- `v0.80.8`: breaking SDK auth/model runtime migration:
+  - `CreateAgentSessionOptions.authStorage` and `modelRegistry` were replaced by
+    async `modelRuntime`.
+  - `AuthStorage` and storage backends are no longer exported from the root
+    `@earendil-works/pi-coding-agent` package.
+  - `ModelRegistry.refresh()` is now asynchronous.
+  - `ModelRuntime` is the canonical SDK facade for model configuration, provider
+    authentication, provider-owned login, and dynamic catalogs.
+- `v0.80.9`: added Kimi K3/deferred tool loading and removed several built-in
+  xAI model catalog entries. No direct Patchmill migration required.
+- `v0.80.10`: fixed Kimi thinking metadata and restored xAI catalog generation
+  issues from `0.80.9`. No direct Patchmill migration required beyond the
+  `0.80.8` SDK migration.
+
+Confirmed against the `0.80.10` packages: `@earendil-works/pi-coding-agent` root
+exports `ModelRuntime`, `ModelRegistry`, `readStoredCredential`, and
+`getAgentDir`; it does not export `AuthStorage`. Other direct Patchmill imports
+from `@earendil-works/pi-tui`, `@earendil-works/pi-ai`, and coding-agent UI
+helpers remain available.
+
+## Decision
+
+Upgrade Patchmill to Pi `0.80.10` by migrating Patchmill's repo-local Pi
+auth/readiness boundary from root-exported `AuthStorage` to `ModelRuntime`.
+
+Do not implement issue #96 automation in this change. This work should leave
+Patchmill in a known-good manual-upgrade state so issue #96 can later automate
+the same metadata updates and run the compatibility checks.
+
+## Goals
+
+- Patchmill builds, tests, and packages with
+  `@earendil-works/pi-coding-agent@0.80.10` and `@earendil-works/pi-tui@0.80.10`
+  exact pins.
+- `patchmill init` and `patchmill auth` continue to use repo-local
+  `.patchmill/pi-agent/auth.json` and `.patchmill/pi-agent/models.json`.
+- Patchmill no longer imports the removed root `AuthStorage` export from
+  `@earendil-works/pi-coding-agent`.
+- Compatibility coverage fails clearly if future Pi packages remove or change
+  the SDK symbols Patchmill uses.
+- Nix packaging uses the updated npm dependency graph and verifies the
+  packed/install-level behavior.
+
+## Non-goals
+
+- Do not build the issue #96 scheduled/automated upgrade PR workflow in this
+  change.
+- Do not change upstream Pi APIs or vendor Pi internals into Patchmill.
+- Do not migrate user auth file formats beyond Pi's normal `ModelRuntime`
+  handling of the existing `auth.json` shape.
+- Do not alter Patchmill's default model-selection UX except where necessary to
+  adapt to async Pi runtime APIs.
+
+## Design
+
+### Repo-local Pi runtime factory
+
+Introduce a small Patchmill-owned adapter around
+`ModelRuntime.create({ authPath, modelsPath })`. The adapter should be
+responsible for constructing the Pi runtime for repo-local auth and model
+configuration paths:
+
+- `authPath`: `join(agentDir, "auth.json")`
+- `modelsPath`: `join(agentDir, "models.json")`
+
+The adapter should expose only the methods Patchmill needs:
+
+- list provider/model choices for API-key setup;
+- list OAuth-capable providers for subscription setup;
+- read current provider credential/status labels;
+- persist API-key credentials;
+- run provider-owned OAuth login;
+- refresh model/catalog availability;
+- provide synchronous snapshots where the model selector needs stable arrays.
+
+Keeping this adapter local prevents Pi SDK shape changes from leaking through
+the rest of Patchmill's init/auth code.
+
+### Readiness detection
+
+Update `src/cli/commands/init/pi-preflight.ts` to construct readiness from
+`ModelRuntime` instead of `AuthStorage + ModelRegistry.create(...)`.
+
+`ModelRuntime.create` and `ModelRuntime.refresh` are async, so the default
+readiness detector path should become async. Callers that inject fake readiness
+in tests can keep passing a ready-made detector, but production `runInit` and
+`patchmill auth` paths must await readiness before selecting models or running
+smoke tests.
+
+The readiness data model can remain unchanged:
+
+- `ready` when one or more configured provider/model choices are available;
+- `missing` when Pi reports no configured provider/model choices;
+- `error` when the runtime reports model/provider configuration errors and no
+  usable choices are available.
+
+### Interactive auth setup
+
+Update `src/cli/commands/init/pi-auth-flow.ts` to use the same local runtime
+adapter.
+
+API-key setup should persist credentials through Pi's credential store path
+rather than runtime-only overrides. The Pi `CredentialStore` contract persists a
+credential with:
+
+```ts
+await credentials.modify(providerId, async () => ({ type: "api_key", key }));
+```
+
+If the adapter cannot access the credential store directly from public APIs, use
+`ModelRuntime.login(providerId, "api_key", interaction)` and route the
+interaction prompt through Patchmill's existing `promptApiKey` callback. Do not
+use `setRuntimeApiKey` for Patchmill init/auth because Pi documents that as a
+non-persisted runtime override.
+
+OAuth/subscription setup should use
+`ModelRuntime.login(providerId, "oauth", interaction)`. Map Pi's
+`AuthInteraction` events to Patchmill's existing OAuth callbacks:
+
+- `auth_url` -> display/open auth URL;
+- `device_code` -> display/open verification URI and code;
+- `progress`/`info` -> terminal progress messages;
+- `prompt` text/secret/manual-code/select -> existing TUI prompt/select helpers.
+
+After any successful login, await runtime refresh before detecting readiness and
+prompting for a default model.
+
+### Provider choices and status labels
+
+Replace `AuthStorageLike` with adapter-level provider credential/status reads.
+`createAuthProviderChoices` can keep returning the same `AuthProviderChoice`
+objects, but it should not assume `AuthStorage.getOAuthProviders()`, `get()`, or
+`getAuthStatus()` exist.
+
+For OAuth choices, use Pi provider metadata exposed by
+`ModelRuntime.getProviders()` and include providers that support OAuth login.
+For API-key choices, use the providers represented by all configured/built-in
+models. Status labels should preserve current user-facing behavior where
+possible:
+
+- stored API key -> `✓ configured` for API-key mode;
+- stored OAuth -> `✓ configured` for OAuth mode;
+- environment/runtime/models.json sources -> the existing descriptive labels;
+- unconfigured -> `• unconfigured`.
+
+### Compatibility contract tests
+
+Update `src/cli/commands/init/pi-dependency-contract.test.ts` so it reflects the
+new compatibility boundary:
+
+- require root exports `ModelRuntime`, `ModelRegistry`, and `getAgentDir`;
+- require `ModelRuntime.create` to be a function;
+- require `ModelRegistry.prototype.refresh` to be a function and treat it as
+  async in Patchmill code;
+- assert `AuthStorage` is not part of Patchmill's required root-export contract.
+
+Add focused tests around the adapter behavior so future Pi changes fail with
+actionable messages before package publication.
+
+### Dependency metadata updates
+
+Update exact Pi pins together:
+
+- `package.json`: `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`
+  to `0.80.10`.
+- `package-lock.json`: resolved root package records and nested Pi dependency
+  graph.
+- `npm-shrinkwrap.json`: same resolved dependency graph for published installs.
+- `nix/package.nix`: update `npmDepsHash` after lockfile changes.
+
+Do not widen the Pi dependency ranges. Exact pins remain part of Patchmill's
+compatibility boundary until issue #96 automates validated updates.
+
+## Testing and verification
+
+Use automated tests for the SDK migration because it changes production
+behavior, reusable auth logic, async control flow, and dependency compatibility.
+
+Required verification:
+
+1. Targeted init/auth tests:
+   - `node --test src/cli/commands/init/pi-auth-flow.test.ts src/cli/commands/init/pi-auth-provider-state.test.ts src/cli/commands/init/pi-preflight.test.ts src/cli/commands/init/pi-dependency-contract.test.ts`
+2. Full Node test suite:
+   - `npm test`
+3. Type/build verification:
+   - `npm run build`
+4. Lint/format verification:
+   - `npm run lint`
+5. Packed artifact smoke:
+   - `npm pack`
+   - install the tarball into a temporary project;
+   - run `patchmill --help`;
+   - run `patchmill init --skills none --yes` or the current non-interactive
+     equivalent;
+   - assert the installed package resolves
+     `@earendil-works/pi-coding-agent/package.json` version `0.80.10` and
+     `@earendil-works/pi-tui/package.json` version `0.80.10`.
+6. Nix verification after npm dependency changes:
+   - run the package build/install checks exposed by the flake, including the
+     Patchmill package output;
+   - if the flake exposes broader checks, run the relevant package check set.
+
+Because npm dependencies change, rerun the Nix build as part of verification per
+project instructions.
+
+## Risks and mitigations
+
+- **Risk: persisted API keys accidentally become runtime-only.** Mitigation: do
+  not use `ModelRuntime.setRuntimeApiKey` for init/auth persistence; test that
+  API-key setup writes `auth.json` through the persistent login/credential path.
+- **Risk: async refresh timing hides configured models.** Mitigation: await
+  `ModelRuntime.create` and refresh before readiness detection; add tests that
+  fail when selection reads stale snapshots.
+- **Risk: provider-owned login prompts differ from the older OAuth callback
+  shape.** Mitigation: centralize prompt/event mapping in one adapter and cover
+  text, secret/manual code, select, auth URL, device code, and progress paths.
+- **Risk: npm lockfile and shrinkwrap drift.** Mitigation: update both lockfiles
+  in the same task and assert the same `0.80.10` root dependency versions.
+- **Risk: Nix `npmDepsHash` mismatch.** Mitigation: rebuild once to obtain the
+  new hash, update `nix/package.nix`, and rerun the Nix package build.
+
+## Relationship to issue #96
+
+This design deliberately does not automate future upgrades. After this manual
+compatibility upgrade lands, issue #96 can automate the metadata bump and
+validation workflow with a cleaner target:
+
+- exact Pi pins remain the source of truth;
+- compatibility tests check Patchmill's current Pi SDK boundary;
+- packed artifact smoke tests assert installed Pi versions;
+- Nix hash updates become a mechanical part of an upgrade PR.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -25,7 +25,7 @@ buildNpmPackageNode24 rec {
         || baseName == "result");
   };
 
-  npmDepsHash = "sha256-aLgTlUGcsGYbnDwKJVGPnfAa/tNU/C6TXxmKP/nT4yM=";
+  npmDepsHash = "sha256-G5AGldQs8dHpFJOPR4U0bejOykipdtkcfLyUi6VwuIc=";
   npmDepsFetcherVersion = 2;
 
   dontNpmBuild = true;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -515,7 +515,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.80.10",
@@ -539,7 +540,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.80.10",
@@ -551,7 +553,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,8 +9,8 @@
       "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.3",
-        "@earendil-works/pi-tui": "0.80.3",
+        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
         "pi-subagents": "^0.25.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
@@ -33,15 +33,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
-      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -504,12 +504,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
-      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -519,9 +518,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -537,16 +535,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
-      "integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -1869,9 +1866,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
-      "integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,7 +515,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.80.10",
@@ -539,7 +540,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.80.10",
@@ -551,7 +553,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "0.80.3",
-        "@earendil-works/pi-tui": "0.80.3",
+        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
         "pi-subagents": "^0.25.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
@@ -33,15 +33,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
-      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -504,23 +504,22 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -536,16 +535,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -553,8 +551,7 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",
@@ -1869,9 +1866,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
-      "integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3136,6 +3133,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4560,6 +4558,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4883,7 +4882,9 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "typescript-eslint": "^8.59.4"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "0.80.3",
-    "@earendil-works/pi-tui": "0.80.3",
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
     "pi-subagents": "^0.25.0",
     "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
   }

--- a/src/cli/commands/auth/main.ts
+++ b/src/cli/commands/auth/main.ts
@@ -30,9 +30,11 @@ export type AuthOutput = {
   stderr: (line: string) => void;
 };
 
+type MaybePromise<T> = T | Promise<T>;
+
 export type PiReadinessDetector = (options: {
   agentDir: string;
-}) => PiReadiness;
+}) => MaybePromise<PiReadiness>;
 export type PiSmokeTestRunner = typeof runPiSmokeTest;
 
 const DEFAULT_OUTPUT: AuthOutput = {
@@ -92,7 +94,7 @@ export async function runAuth(
 
   const resolvedRepoRoot = repoRoot;
   const piAgentDir = localPiAgentDir(resolvedRepoRoot);
-  const readiness = (options.detectPiReadiness ?? detectPiReadiness)({
+  const readiness = await (options.detectPiReadiness ?? detectPiReadiness)({
     agentDir: piAgentDir,
   });
   const isInteractive = options.isInteractive ?? Boolean(process.stdin.isTTY);

--- a/src/cli/commands/init/main.ts
+++ b/src/cli/commands/init/main.ts
@@ -60,9 +60,11 @@ export type InitOutput = {
 };
 
 export type InitPrompt = (question: string) => Promise<string>;
+type MaybePromise<T> = T | Promise<T>;
+
 export type PiReadinessDetector = (options: {
   agentDir: string;
-}) => PiReadiness;
+}) => MaybePromise<PiReadiness>;
 export type PiSmokeTestRunner = typeof runPiSmokeTest;
 export type ProjectSkillInstaller = (options: {
   repoRoot: string;
@@ -270,7 +272,7 @@ export async function runInit(
     ].join("\n");
   }
 
-  const readiness = (options.detectPiReadiness ?? detectPiReadiness)({
+  const readiness = await (options.detectPiReadiness ?? detectPiReadiness)({
     agentDir: piAgentDir,
   });
   const persistDefaultModel = settingsWarning

--- a/src/cli/commands/init/pi-auth-dialog.test.ts
+++ b/src/cli/commands/init/pi-auth-dialog.test.ts
@@ -4,7 +4,6 @@ import type { Terminal } from "@earendil-works/pi-tui";
 import {
   createOAuthCallbacks,
   promptApiKeyInteractively,
-  showBedrockInfoInteractively,
 } from "./pi-auth-dialog.ts";
 
 class FakeTerminal implements Terminal {
@@ -76,19 +75,6 @@ test("promptApiKeyInteractively cancels on escape", async () => {
   terminal.sendInput("\u001b");
 
   assert.equal(await prompt, undefined);
-});
-
-test("showBedrockInfoInteractively resolves when escape closes the panel", async () => {
-  const terminal = new FakeTerminal();
-  const panel = showBedrockInfoInteractively({ terminal });
-
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.match(terminal.writes.join(""), /Amazon Bedrock setup/);
-
-  terminal.sendInput("\u001b");
-  await panel;
-
-  assert.equal(terminal.stopCalls, 1);
 });
 
 test("createOAuthCallbacks opens browser URLs for auth callbacks", () => {

--- a/src/cli/commands/init/pi-auth-dialog.ts
+++ b/src/cli/commands/init/pi-auth-dialog.ts
@@ -68,26 +68,6 @@ class PromptComponent extends Container implements Focusable {
   }
 }
 
-class InfoComponent extends Container {
-  private readonly onClose: () => void;
-
-  constructor(lines: string[], onClose: () => void) {
-    super();
-    this.onClose = onClose;
-    for (const line of lines) this.addChild(new Text(line, 0, 0));
-  }
-
-  handleInput(data: string): void {
-    if (
-      matchesKey(data, Key.escape) ||
-      matchesKey(data, Key.ctrl("c")) ||
-      matchesKey(data, Key.enter)
-    ) {
-      this.onClose();
-    }
-  }
-}
-
 class OptionComponent extends Container {
   private selectedIndex = 0;
   private readonly title: string;
@@ -182,41 +162,6 @@ export function promptApiKeyInteractively(options: {
     title: options.providerName,
     prompt: "Enter API key:",
     terminal: options.terminal,
-  });
-}
-
-export async function showBedrockInfoInteractively(
-  options: {
-    terminal?: Terminal;
-  } = {},
-): Promise<void> {
-  const terminal = options.terminal ?? new ProcessTerminal();
-  const tui = new TUI(terminal, false);
-
-  await new Promise<void>((resolve) => {
-    let finished = false;
-    const finish = (): void => {
-      if (finished) return;
-      finished = true;
-      void stopTui(tui, terminal).finally(() => resolve());
-    };
-
-    const component = new InfoComponent(
-      [
-        "Amazon Bedrock setup",
-        "",
-        "Amazon Bedrock uses AWS credentials instead of a single API key.",
-        "Configure an AWS profile, IAM keys, bearer token, or role-based credentials.",
-        "See Pi providers.md for details.",
-        "",
-        "(escape/ctrl+c/enter to close)",
-      ],
-      finish,
-    );
-    tui.addChild(component);
-    tui.setFocus(component);
-    tui.start();
-    tui.requestRender(true);
   });
 }
 

--- a/src/cli/commands/init/pi-auth-flow.test.ts
+++ b/src/cli/commands/init/pi-auth-flow.test.ts
@@ -1,15 +1,14 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import {
-  runInteractivePiAuthSetup,
-  type PiAuthFlowRegistry,
-  type PiAuthFlowStorage,
-} from "./pi-auth-flow.ts";
-import type {
-  AuthCredential,
-  AuthStatus,
-} from "@earendil-works/pi-coding-agent";
+import { runInteractivePiAuthSetup } from "./pi-auth-flow.ts";
 import type { PiModelChoice, PiReadiness } from "./pi-preflight.ts";
+import type {
+  PatchmillPiRuntime,
+  PiAuthInteraction,
+  PiAuthMode,
+  PiCredentialStatus,
+  PiCredential,
+} from "./pi-runtime.ts";
 
 function missingReadiness(): PiReadiness {
   return {
@@ -45,73 +44,64 @@ function choice(
   };
 }
 
-function fakeStorage(
+function fakeRuntime(
   options: {
     oauthProviders?: Array<{ id: string; name: string }>;
-    credentials?: Record<string, AuthCredential>;
-    statuses?: Record<string, AuthStatus>;
+    credentials?: Record<string, PiCredential>;
+    statuses?: Record<string, PiCredentialStatus>;
+    allModels?: ReturnType<typeof model>[];
+    availableModels?: ReturnType<typeof model>[];
+    names?: Record<string, string>;
   } = {},
 ) {
   const credentials = { ...(options.credentials ?? {}) };
-  const setCalls: Array<[string, AuthCredential]> = [];
-  const loginCalls: string[] = [];
-  const storage: PiAuthFlowStorage & {
-    setCalls: Array<[string, AuthCredential]>;
-    loginCalls: string[];
+  const loginCalls: Array<{ provider: string; mode: PiAuthMode }> = [];
+  let refreshed = 0;
+  const runtime: PatchmillPiRuntime & {
+    loginCalls: typeof loginCalls;
+    refreshCount: () => number;
   } = {
-    setCalls,
     loginCalls,
+    refreshCount: () => refreshed,
+    refresh: async () => {
+      refreshed += 1;
+    },
+    getError: () => undefined,
+    getAll: () => options.allModels ?? [],
+    getAvailable: () => options.availableModels ?? [],
     getOAuthProviders: () => options.oauthProviders ?? [],
     get: (provider) => credentials[provider],
-    getAuthStatus: (provider) =>
+    getProviderAuthStatus: (provider) =>
       options.statuses?.[provider] ?? {
         configured: Boolean(credentials[provider]),
         source: credentials[provider] ? "stored" : undefined,
       },
-    set: (provider, credential) => {
-      credentials[provider] = credential;
-      setCalls.push([provider, credential]);
-    },
-    login: async (provider) => {
+    getProviderDisplayName: (provider) => options.names?.[provider] ?? provider,
+    login: async (provider, mode, interaction: PiAuthInteraction) => {
+      if (mode === "api_key") {
+        const key = await interaction.prompt({
+          type: "secret",
+          message: "Enter API key:",
+        });
+        loginCalls.push({ provider, mode });
+        credentials[provider] = { type: "api_key", key };
+        return credentials[provider];
+      }
+      loginCalls.push({ provider, mode });
       credentials[provider] = {
         type: "oauth",
         refresh: "refresh",
         access: "access",
         expires: 1,
       };
-      loginCalls.push(provider);
+      return credentials[provider];
     },
   };
-  return storage;
-}
-
-function fakeRegistry(
-  options: {
-    allModels?: ReturnType<typeof model>[];
-    availableModels?: ReturnType<typeof model>[];
-    names?: Record<string, string>;
-    statuses?: Record<string, AuthStatus>;
-  } = {},
-) {
-  let refreshed = 0;
-  const registry: PiAuthFlowRegistry & { refreshCount: () => number } = {
-    refreshCount: () => refreshed,
-    refresh: () => {
-      refreshed += 1;
-    },
-    getAll: () => options.allModels ?? [],
-    getAvailable: () => options.availableModels ?? [],
-    getError: () => undefined,
-    getProviderAuthStatus: (provider) =>
-      options.statuses?.[provider] ?? { configured: false },
-    getProviderDisplayName: (provider) => options.names?.[provider] ?? provider,
-  };
-  return registry;
+  return runtime;
 }
 
 test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and selects a refreshed model", async () => {
-  const storage = fakeStorage();
-  const registry = fakeRegistry({
+  const runtime = fakeRuntime({
     allModels: [model("anthropic")],
     availableModels: [model("anthropic")],
     names: { anthropic: "Anthropic" },
@@ -123,8 +113,7 @@ test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and sel
     agentDir: "/repo/.patchmill/pi-agent",
     currentDefault: undefined,
     initialReadiness: missingReadiness(),
-    authStorage: storage,
-    registry,
+    runtime,
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "sk-ant-test",
@@ -135,10 +124,11 @@ test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and sel
     },
   });
 
-  assert.deepEqual(storage.setCalls, [
-    ["anthropic", { type: "api_key", key: "sk-ant-test" }],
+  assert.deepEqual(runtime.loginCalls, [
+    { provider: "anthropic", mode: "api_key" },
   ]);
-  assert.equal(registry.refreshCount(), 1);
+  assert.equal(runtime.get("anthropic")?.type, "api_key");
+  assert.equal(runtime.refreshCount(), 1);
   assert.deepEqual(
     selectorModels.map((selected) => selected.value),
     ["anthropic/claude-sonnet-4-5"],
@@ -151,10 +141,8 @@ test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and sel
 });
 
 test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async () => {
-  const storage = fakeStorage({
+  const runtime = fakeRuntime({
     oauthProviders: [{ id: "openai-codex", name: "ChatGPT Plus/Pro" }],
-  });
-  const registry = fakeRegistry({
     availableModels: [model("openai-codex", "gpt-5.5")],
   });
 
@@ -163,8 +151,7 @@ test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async
     agentDir: "/repo/.patchmill/pi-agent",
     currentDefault: undefined,
     initialReadiness: missingReadiness(),
-    authStorage: storage,
-    registry,
+    runtime,
     selectAuthMethod: async () => "oauth",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "unused",
@@ -173,14 +160,15 @@ test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async
       choice(models[0]?.provider, models[0]?.id),
   });
 
-  assert.deepEqual(storage.loginCalls, ["openai-codex"]);
-  assert.equal(registry.refreshCount(), 1);
+  assert.deepEqual(runtime.loginCalls, [
+    { provider: "openai-codex", mode: "oauth" },
+  ]);
+  assert.equal(runtime.refreshCount(), 1);
   assert.equal(result.selection.status, "selected");
 });
 
 test("runInteractivePiAuthSetup shows Bedrock guidance without storing a key", async () => {
-  const storage = fakeStorage();
-  const registry = fakeRegistry({
+  const runtime = fakeRuntime({
     allModels: [model("amazon-bedrock", "us.anthropic.claude")],
     availableModels: [],
     names: { "amazon-bedrock": "Amazon Bedrock" },
@@ -192,8 +180,7 @@ test("runInteractivePiAuthSetup shows Bedrock guidance without storing a key", a
     agentDir: "/repo/.patchmill/pi-agent",
     currentDefault: undefined,
     initialReadiness: missingReadiness(),
-    authStorage: storage,
-    registry,
+    runtime,
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "unused",
@@ -204,8 +191,8 @@ test("runInteractivePiAuthSetup shows Bedrock guidance without storing a key", a
   });
 
   assert.equal(bedrockShown, true);
-  assert.deepEqual(storage.setCalls, []);
-  assert.equal(registry.refreshCount(), 1);
+  assert.deepEqual(runtime.loginCalls, []);
+  assert.equal(runtime.refreshCount(), 1);
   assert.equal(result.selection.status, "unavailable");
   assert.equal(
     result.selection.status === "unavailable" && result.selection.reason,
@@ -219,8 +206,7 @@ test("runInteractivePiAuthSetup treats cancelled auth method as cancelled select
     agentDir: "/repo/.patchmill/pi-agent",
     currentDefault: undefined,
     initialReadiness: missingReadiness(),
-    authStorage: fakeStorage(),
-    registry: fakeRegistry(),
+    runtime: fakeRuntime(),
     selectAuthMethod: async () => undefined,
     selectProvider: async () => undefined,
     promptApiKey: async () => undefined,
@@ -236,14 +222,13 @@ test("runInteractivePiAuthSetup treats cancelled auth method as cancelled select
 });
 
 test("runInteractivePiAuthSetup rejects an empty API key", async () => {
-  const storage = fakeStorage();
+  const runtime = fakeRuntime({ allModels: [model("anthropic")] });
   const result = await runInteractivePiAuthSetup({
     repoRoot: "/repo",
     agentDir: "/repo/.patchmill/pi-agent",
     currentDefault: undefined,
     initialReadiness: missingReadiness(),
-    authStorage: storage,
-    registry: fakeRegistry({ allModels: [model("anthropic")] }),
+    runtime,
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "   ",
@@ -251,7 +236,7 @@ test("runInteractivePiAuthSetup rejects an empty API key", async () => {
     selectModelInteractively: async () => undefined,
   });
 
-  assert.deepEqual(storage.setCalls, []);
+  assert.deepEqual(runtime.loginCalls, []);
   assert.equal(result.selection.status, "unavailable");
   assert.equal(
     result.selection.status === "unavailable" && result.selection.reason,

--- a/src/cli/commands/init/pi-auth-flow.test.ts
+++ b/src/cli/commands/init/pi-auth-flow.test.ts
@@ -52,6 +52,7 @@ function fakeRuntime(
     allModels?: ReturnType<typeof model>[];
     availableModels?: ReturnType<typeof model>[];
     names?: Record<string, string>;
+    apiKeyPrompts?: Array<Parameters<PiAuthInteraction["prompt"]>[0]>;
   } = {},
 ) {
   const credentials = { ...(options.credentials ?? {}) };
@@ -79,12 +80,18 @@ function fakeRuntime(
     getProviderDisplayName: (provider) => options.names?.[provider] ?? provider,
     login: async (provider, mode, interaction: PiAuthInteraction) => {
       if (mode === "api_key") {
-        const key = await interaction.prompt({
-          type: "secret",
-          message: "Enter API key:",
-        });
+        const prompts = options.apiKeyPrompts ?? [
+          {
+            type: "secret" as const,
+            message: "Enter API key:",
+          },
+        ];
+        const values = [];
+        for (const prompt of prompts) {
+          values.push(await interaction.prompt(prompt));
+        }
         loginCalls.push({ provider, mode });
-        credentials[provider] = { type: "api_key", key };
+        credentials[provider] = { type: "api_key", key: values[0] };
         return credentials[provider];
       }
       loginCalls.push({ provider, mode });
@@ -138,6 +145,57 @@ test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and sel
     result.selection.status === "selected" && result.selection.model,
     "anthropic/claude-sonnet-4-5",
   );
+});
+
+test("runInteractivePiAuthSetup routes provider-owned API-key text prompts through generic prompt callbacks", async () => {
+  const runtime = fakeRuntime({
+    allModels: [model("cloudflare", "workers-ai")],
+    availableModels: [model("cloudflare", "workers-ai")],
+    names: { cloudflare: "Cloudflare" },
+    apiKeyPrompts: [
+      { type: "secret", message: "Enter API key:" },
+      { type: "text", message: "Enter Cloudflare account ID:" },
+    ],
+  });
+  const genericPrompts: Array<{
+    message: string;
+    placeholder?: string;
+    allowEmpty?: boolean;
+  }> = [];
+
+  await runInteractivePiAuthSetup({
+    repoRoot: "/repo",
+    agentDir: "/repo/.patchmill/pi-agent",
+    currentDefault: undefined,
+    initialReadiness: missingReadiness(),
+    runtime,
+    selectAuthMethod: async () => "api_key",
+    selectProvider: async ({ choices }) => choices[0],
+    promptApiKey: async () => "sk-cloudflare-test",
+    showBedrockInfo: async () => undefined,
+    selectModelInteractively: async ({ models }) =>
+      choice(models[0]?.provider, models[0]?.id),
+    oauthCallbacks: () => ({
+      onAuth: () => undefined,
+      onDeviceCode: () => undefined,
+      onPrompt: async (prompt) => {
+        genericPrompts.push(prompt);
+        return "account-id";
+      },
+      onSelect: async () => undefined,
+    }),
+  });
+
+  assert.deepEqual(runtime.loginCalls, [
+    { provider: "cloudflare", mode: "api_key" },
+  ]);
+  assert.deepEqual(genericPrompts, [
+    {
+      message: "Enter Cloudflare account ID:",
+      placeholder: undefined,
+      allowEmpty: true,
+    },
+  ]);
 });
 
 test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async () => {

--- a/src/cli/commands/init/pi-auth-flow.test.ts
+++ b/src/cli/commands/init/pi-auth-flow.test.ts
@@ -133,7 +133,6 @@ test("runInteractivePiAuthSetup stores API key auth, refreshes registry, and sel
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "sk-ant-test",
-    showBedrockInfo: async () => undefined,
     selectModelInteractively: async ({ models }) => {
       selectorModels = models;
       return choice("anthropic");
@@ -181,7 +180,6 @@ test("runInteractivePiAuthSetup routes provider-owned API-key text prompts throu
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "sk-cloudflare-test",
-    showBedrockInfo: async () => undefined,
     selectModelInteractively: async ({ models }) =>
       choice(models[0]?.provider, models[0]?.id),
     oauthCallbacks: () => ({
@@ -222,7 +220,6 @@ test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async
     selectAuthMethod: async () => "oauth",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "unused",
-    showBedrockInfo: async () => undefined,
     selectModelInteractively: async ({ models }) =>
       choice(models[0]?.provider, models[0]?.id),
   });
@@ -234,13 +231,33 @@ test("runInteractivePiAuthSetup calls OAuth login for subscription setup", async
   assert.equal(result.selection.status, "selected");
 });
 
-test("runInteractivePiAuthSetup shows Bedrock guidance without storing a key", async () => {
+test("runInteractivePiAuthSetup runs Bedrock through persisted API-key login prompts", async () => {
   const runtime = fakeRuntime({
     allModels: [model("amazon-bedrock", "us.anthropic.claude")],
-    availableModels: [],
+    availableModels: [model("amazon-bedrock", "us.anthropic.claude")],
     names: { "amazon-bedrock": "Amazon Bedrock" },
+    apiKeyPrompts: [
+      {
+        type: "select",
+        message: "Select Amazon Bedrock authentication method:",
+        options: [
+          { id: "bearer-token", label: "Bearer token" },
+          { id: "aws-profile", label: "AWS profile" },
+          { id: "credential-chain", label: "Existing AWS credential chain" },
+        ],
+      },
+      { type: "text", message: "Enter AWS profile name" },
+    ],
   });
-  let bedrockShown = false;
+  const selectPrompts: Array<{
+    message: string;
+    options: Array<{ id: string; label: string }>;
+  }> = [];
+  const textPrompts: Array<{
+    message: string;
+    placeholder?: string;
+    allowEmpty?: boolean;
+  }> = [];
 
   const result = await runInteractivePiAuthSetup({
     repoRoot: "/repo",
@@ -251,20 +268,44 @@ test("runInteractivePiAuthSetup shows Bedrock guidance without storing a key", a
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "unused",
-    showBedrockInfo: async () => {
-      bedrockShown = true;
-    },
-    selectModelInteractively: async () => undefined,
+    selectModelInteractively: async ({ models }) =>
+      choice(models[0]?.provider, models[0]?.id),
+    oauthCallbacks: () => ({
+      onAuth: () => undefined,
+      onDeviceCode: () => undefined,
+      onPrompt: async (prompt) => {
+        textPrompts.push(prompt);
+        return "dev-profile";
+      },
+      onSelect: async (prompt) => {
+        selectPrompts.push(prompt);
+        return "aws-profile";
+      },
+    }),
   });
 
-  assert.equal(bedrockShown, true);
-  assert.deepEqual(runtime.loginCalls, []);
+  assert.deepEqual(runtime.loginCalls, [
+    { provider: "amazon-bedrock", mode: "api_key" },
+  ]);
+  assert.deepEqual(selectPrompts, [
+    {
+      message: "Select Amazon Bedrock authentication method:",
+      options: [
+        { id: "bearer-token", label: "Bearer token" },
+        { id: "aws-profile", label: "AWS profile" },
+        { id: "credential-chain", label: "Existing AWS credential chain" },
+      ],
+    },
+  ]);
+  assert.deepEqual(textPrompts, [
+    {
+      message: "Enter AWS profile name",
+      placeholder: undefined,
+      allowEmpty: true,
+    },
+  ]);
   assert.equal(runtime.refreshCount(), 1);
-  assert.equal(result.selection.status, "unavailable");
-  assert.equal(
-    result.selection.status === "unavailable" && result.selection.reason,
-    "not-ready",
-  );
+  assert.equal(result.selection.status, "selected");
 });
 
 test("runInteractivePiAuthSetup treats cancelled auth method as cancelled selection", async () => {
@@ -277,7 +318,6 @@ test("runInteractivePiAuthSetup treats cancelled auth method as cancelled select
     selectAuthMethod: async () => undefined,
     selectProvider: async () => undefined,
     promptApiKey: async () => undefined,
-    showBedrockInfo: async () => undefined,
     selectModelInteractively: async () => undefined,
   });
 
@@ -299,7 +339,6 @@ test("runInteractivePiAuthSetup rejects an empty API key", async () => {
     selectAuthMethod: async () => "api_key",
     selectProvider: async ({ choices }) => choices[0],
     promptApiKey: async () => "   ",
-    showBedrockInfo: async () => undefined,
     selectModelInteractively: async () => undefined,
   });
 

--- a/src/cli/commands/init/pi-auth-flow.test.ts
+++ b/src/cli/commands/init/pi-auth-flow.test.ts
@@ -71,7 +71,7 @@ function fakeRuntime(
     getAvailable: () => options.availableModels ?? [],
     getOAuthProviders: () => options.oauthProviders ?? [],
     get: (provider) => credentials[provider],
-    getProviderAuthStatus: (provider) =>
+    getProviderCredentialState: (provider) =>
       options.statuses?.[provider] ?? {
         configured: Boolean(credentials[provider]),
         source: credentials[provider] ? "stored" : undefined,

--- a/src/cli/commands/init/pi-auth-flow.test.ts
+++ b/src/cli/commands/init/pi-auth-flow.test.ts
@@ -70,6 +70,15 @@ function fakeRuntime(
     getError: () => undefined,
     getAll: () => options.allModels ?? [],
     getAvailable: () => options.availableModels ?? [],
+    getApiKeyProviders: () =>
+      Array.from(
+        new Set((options.allModels ?? []).map((item) => item.provider)),
+      )
+        .filter((provider) => provider.length > 0)
+        .map((provider) => ({
+          id: provider,
+          name: options.names?.[provider] ?? provider,
+        })),
     getOAuthProviders: () => options.oauthProviders ?? [],
     get: (provider) => credentials[provider],
     getProviderCredentialState: (provider) =>

--- a/src/cli/commands/init/pi-auth-flow.ts
+++ b/src/cli/commands/init/pi-auth-flow.ts
@@ -1,6 +1,3 @@
-import { join } from "node:path";
-import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
-import type { AuthCredential } from "@earendil-works/pi-coding-agent";
 import type { LocalPiDefaultModel } from "./pi-agent-settings.ts";
 import {
   createOAuthCallbacks,
@@ -11,8 +8,6 @@ import {
   createAuthProviderChoices,
   type AuthMode,
   type AuthProviderChoice,
-  type AuthRegistryLike,
-  type AuthStorageLike,
 } from "./pi-auth-provider-state.ts";
 import {
   selectPiModel,
@@ -25,7 +20,17 @@ import {
   selectProviderInteractively,
 } from "./pi-auth-selector.ts";
 import { selectModelInteractively as defaultSelectModelInteractively } from "./pi-model-selector.ts";
-import { detectPiReadiness, type PiReadiness } from "./pi-preflight.ts";
+import {
+  detectPiReadinessFromRegistry,
+  type PiReadiness,
+} from "./pi-preflight.ts";
+import {
+  createRepoLocalPiRuntime,
+  type PatchmillPiRuntime,
+  type PiAuthEvent,
+  type PiAuthInteraction,
+  type PiAuthPrompt,
+} from "./pi-runtime.ts";
 
 export type OAuthLoginCallbacksLike = {
   onAuth: (info: { url: string; instructions?: string }) => void;
@@ -50,22 +55,7 @@ export type OAuthLoginCallbacksLike = {
   dispose?: () => void;
 };
 
-export type PiAuthFlowStorage = AuthStorageLike & {
-  set(provider: string, credential: AuthCredential): void;
-  login(provider: string, callbacks: OAuthLoginCallbacksLike): Promise<void>;
-};
-
-export type PiAuthFlowRegistry = AuthRegistryLike & {
-  refresh(): void;
-  getAvailable(): Array<{
-    provider: string;
-    id: string;
-    name?: string;
-    reasoning?: boolean;
-    input?: string[];
-  }>;
-  getError(): string | undefined;
-};
+export type PiAuthFlowRuntime = PatchmillPiRuntime;
 
 export type SelectAuthMethod = () => Promise<AuthMode | undefined>;
 export type SelectAuthProvider = (options: {
@@ -80,13 +70,17 @@ export type OAuthCallbacksFactory = (
   provider: AuthProviderChoice,
 ) => OAuthLoginCallbacksLike;
 
+type SelectAuthPromptOption = (prompt: {
+  message: string;
+  options: Array<{ id: string; label: string }>;
+}) => Promise<string | undefined>;
+
 export type InteractivePiAuthSetupOptions = {
   repoRoot: string;
   agentDir: string;
   currentDefault: LocalPiDefaultModel | undefined;
   initialReadiness: PiReadiness;
-  authStorage: PiAuthFlowStorage;
-  registry: PiAuthFlowRegistry;
+  runtime: PiAuthFlowRuntime;
   selectAuthMethod: SelectAuthMethod;
   selectProvider: SelectAuthProvider;
   promptApiKey: PromptApiKey;
@@ -116,17 +110,120 @@ function unavailable(
   };
 }
 
-export function createRepoLocalPiAuth(options: { agentDir: string }): {
-  authStorage: PiAuthFlowStorage;
-  registry: PiAuthFlowRegistry;
-} {
-  const authStorage = AuthStorage.create(join(options.agentDir, "auth.json"));
-  const registry = ModelRegistry.create(
-    authStorage,
-    join(options.agentDir, "models.json"),
-  );
-  registry.refresh();
-  return { authStorage, registry };
+function loginCancelled(): Error {
+  return new Error("Login cancelled");
+}
+
+function assertApiKey(value: string | undefined): string {
+  if (value === undefined) throw loginCancelled();
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("API key cannot be empty.");
+  return trimmed;
+}
+
+async function promptForAuthValue(options: {
+  prompt: PiAuthPrompt;
+  provider: AuthProviderChoice;
+  promptApiKey: PromptApiKey;
+  selectOption: SelectAuthPromptOption;
+}): Promise<string> {
+  if (options.prompt.type === "select") {
+    const selected = await options.selectOption({
+      message: options.prompt.message,
+      options: options.prompt.options.map((option) => ({
+        id: option.id,
+        label: option.description
+          ? `${option.label} — ${option.description}`
+          : option.label,
+      })),
+    });
+    if (selected === undefined) throw loginCancelled();
+    return selected;
+  }
+
+  if (options.prompt.type === "manual_code") {
+    const selected = await options.selectOption({
+      message: options.prompt.message,
+      options: [
+        { id: "manual", label: options.prompt.placeholder ?? "Enter code" },
+      ],
+    });
+    if (selected === undefined) throw loginCancelled();
+    return selected;
+  }
+
+  return assertApiKey(await options.promptApiKey(options.provider));
+}
+
+function createApiKeyInteraction(options: {
+  provider: AuthProviderChoice;
+  promptApiKey: PromptApiKey;
+  selectOption: SelectAuthPromptOption;
+}): PiAuthInteraction {
+  return {
+    prompt: (prompt) =>
+      promptForAuthValue({
+        prompt,
+        provider: options.provider,
+        promptApiKey: options.promptApiKey,
+        selectOption: options.selectOption,
+      }),
+    notify: () => undefined,
+  };
+}
+
+function createPiAuthInteraction(
+  callbacks: OAuthLoginCallbacksLike,
+): PiAuthInteraction {
+  return {
+    signal: callbacks.signal,
+    notify: (event: PiAuthEvent) => {
+      if (event.type === "auth_url") {
+        callbacks.onAuth({ url: event.url, instructions: event.instructions });
+      } else if (event.type === "device_code") {
+        callbacks.onDeviceCode({
+          userCode: event.userCode,
+          verificationUri: event.verificationUri,
+          intervalSeconds: event.intervalSeconds,
+          expiresInSeconds: event.expiresInSeconds,
+        });
+      } else if (event.type === "progress" || event.type === "info") {
+        callbacks.onProgress?.(event.message);
+      }
+    },
+    prompt: async (prompt: PiAuthPrompt) => {
+      if (prompt.type === "select") {
+        const selected = await callbacks.onSelect({
+          message: prompt.message,
+          options: prompt.options.map((option) => ({
+            id: option.id,
+            label: option.description
+              ? `${option.label} — ${option.description}`
+              : option.label,
+          })),
+        });
+        if (selected === undefined) throw loginCancelled();
+        return selected;
+      }
+      if (prompt.type === "manual_code") {
+        if (!callbacks.onManualCodeInput) throw loginCancelled();
+        return callbacks.onManualCodeInput();
+      }
+      return callbacks.onPrompt({
+        message: prompt.message,
+        placeholder: prompt.placeholder,
+        allowEmpty: prompt.type === "text",
+      });
+    },
+  };
+}
+
+export async function createRepoLocalPiAuth(options: {
+  agentDir: string;
+}): Promise<{ runtime: PiAuthFlowRuntime }> {
+  return {
+    runtime: await createRepoLocalPiRuntime({ agentDir: options.agentDir }),
+  };
 }
 
 export async function runInteractivePiAuthSetup(
@@ -143,8 +240,7 @@ export async function runInteractivePiAuthSetup(
 
   const choices = createAuthProviderChoices({
     mode,
-    authStorage: options.authStorage,
-    registry: options.registry,
+    runtime: options.runtime,
   });
   const provider = await options.selectProvider({ mode, choices });
   if (!provider) {
@@ -159,36 +255,55 @@ export async function runInteractivePiAuthSetup(
     if (provider.id === "amazon-bedrock") {
       await options.showBedrockInfo();
     } else {
-      const apiKey = await options.promptApiKey(provider);
-      if (apiKey === undefined) {
-        return unavailable(
-          options.initialReadiness,
-          "cancelled",
-          "Pi provider authentication was cancelled.",
+      try {
+        await options.runtime.login(
+          provider.id,
+          "api_key",
+          createApiKeyInteraction({
+            provider,
+            promptApiKey: options.promptApiKey,
+            selectOption: (prompt) =>
+              options.oauthCallbacks?.(provider).onSelect(prompt) ??
+              Promise.resolve(undefined),
+          }),
         );
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "API key cannot be empty."
+        ) {
+          return unavailable(
+            options.initialReadiness,
+            "invalid-selection",
+            "API key cannot be empty.",
+          );
+        }
+        if (error instanceof Error && error.message === "Login cancelled") {
+          return unavailable(
+            options.initialReadiness,
+            "cancelled",
+            "Pi provider authentication was cancelled.",
+          );
+        }
+        throw error;
       }
-      const trimmed = apiKey.trim();
-      if (!trimmed) {
-        return unavailable(
-          options.initialReadiness,
-          "invalid-selection",
-          "API key cannot be empty.",
-        );
-      }
-      options.authStorage.set(provider.id, { type: "api_key", key: trimmed });
     }
   } else {
     const callbacks =
       options.oauthCallbacks?.(provider) ?? createOAuthCallbacks();
     try {
-      await options.authStorage.login(provider.id, callbacks);
+      await options.runtime.login(
+        provider.id,
+        "oauth",
+        createPiAuthInteraction(callbacks),
+      );
     } finally {
       callbacks.dispose?.();
     }
   }
 
-  options.registry.refresh();
-  const readiness = detectPiReadiness({ registry: options.registry });
+  await options.runtime.refresh();
+  const readiness = detectPiReadinessFromRegistry(options.runtime);
   const selection = await selectPiModel({
     readiness,
     isInteractive: true,
@@ -207,7 +322,7 @@ export async function setupPiInteractively(options: {
   selectModelInteractively?: SelectInteractiveModel;
   persistDefaultModel?: PersistDefaultModel;
 }): Promise<InteractivePiAuthSetupResult> {
-  const { authStorage, registry } = createRepoLocalPiAuth({
+  const { runtime } = await createRepoLocalPiAuth({
     agentDir: options.agentDir,
   });
   return runInteractivePiAuthSetup({
@@ -215,8 +330,7 @@ export async function setupPiInteractively(options: {
     agentDir: options.agentDir,
     currentDefault: options.currentDefault,
     initialReadiness: options.initialReadiness,
-    authStorage,
-    registry,
+    runtime,
     selectAuthMethod: () => selectAuthMethodInteractively(),
     selectProvider: ({ mode, choices }) =>
       selectProviderInteractively({ mode, choices }),

--- a/src/cli/commands/init/pi-auth-flow.ts
+++ b/src/cli/commands/init/pi-auth-flow.ts
@@ -75,6 +75,12 @@ type SelectAuthPromptOption = (prompt: {
   options: Array<{ id: string; label: string }>;
 }) => Promise<string | undefined>;
 
+type PromptAuthText = (prompt: {
+  message: string;
+  placeholder?: string;
+  allowEmpty?: boolean;
+}) => Promise<string | undefined>;
+
 export type InteractivePiAuthSetupOptions = {
   repoRoot: string;
   agentDir: string;
@@ -125,6 +131,7 @@ async function promptForAuthValue(options: {
   prompt: PiAuthPrompt;
   provider: AuthProviderChoice;
   promptApiKey: PromptApiKey;
+  promptText?: PromptAuthText;
   selectOption: SelectAuthPromptOption;
 }): Promise<string> {
   if (options.prompt.type === "select") {
@@ -152,12 +159,25 @@ async function promptForAuthValue(options: {
     return selected;
   }
 
+  if (options.prompt.type === "text") {
+    const value = options.promptText
+      ? await options.promptText({
+          message: options.prompt.message,
+          placeholder: options.prompt.placeholder,
+          allowEmpty: true,
+        })
+      : await options.promptApiKey(options.provider);
+    if (value === undefined) throw loginCancelled();
+    return value;
+  }
+
   return assertApiKey(await options.promptApiKey(options.provider));
 }
 
 function createApiKeyInteraction(options: {
   provider: AuthProviderChoice;
   promptApiKey: PromptApiKey;
+  promptText?: PromptAuthText;
   selectOption: SelectAuthPromptOption;
 }): PiAuthInteraction {
   return {
@@ -166,6 +186,7 @@ function createApiKeyInteraction(options: {
         prompt,
         provider: options.provider,
         promptApiKey: options.promptApiKey,
+        promptText: options.promptText,
         selectOption: options.selectOption,
       }),
     notify: () => undefined,
@@ -255,6 +276,7 @@ export async function runInteractivePiAuthSetup(
     if (provider.id === "amazon-bedrock") {
       await options.showBedrockInfo();
     } else {
+      const callbacks = options.oauthCallbacks?.(provider);
       try {
         await options.runtime.login(
           provider.id,
@@ -262,9 +284,9 @@ export async function runInteractivePiAuthSetup(
           createApiKeyInteraction({
             provider,
             promptApiKey: options.promptApiKey,
+            promptText: callbacks?.onPrompt,
             selectOption: (prompt) =>
-              options.oauthCallbacks?.(provider).onSelect(prompt) ??
-              Promise.resolve(undefined),
+              callbacks?.onSelect(prompt) ?? Promise.resolve(undefined),
           }),
         );
       } catch (error) {
@@ -286,6 +308,8 @@ export async function runInteractivePiAuthSetup(
           );
         }
         throw error;
+      } finally {
+        callbacks?.dispose?.();
       }
     }
   } else {

--- a/src/cli/commands/init/pi-auth-flow.ts
+++ b/src/cli/commands/init/pi-auth-flow.ts
@@ -2,7 +2,6 @@ import type { LocalPiDefaultModel } from "./pi-agent-settings.ts";
 import {
   createOAuthCallbacks,
   promptApiKeyInteractively,
-  showBedrockInfoInteractively,
 } from "./pi-auth-dialog.ts";
 import {
   createAuthProviderChoices,
@@ -65,7 +64,6 @@ export type SelectAuthProvider = (options: {
 export type PromptApiKey = (
   provider: AuthProviderChoice,
 ) => Promise<string | undefined>;
-export type ShowBedrockInfo = () => Promise<void>;
 export type OAuthCallbacksFactory = (
   provider: AuthProviderChoice,
 ) => OAuthLoginCallbacksLike;
@@ -90,7 +88,6 @@ export type InteractivePiAuthSetupOptions = {
   selectAuthMethod: SelectAuthMethod;
   selectProvider: SelectAuthProvider;
   promptApiKey: PromptApiKey;
-  showBedrockInfo: ShowBedrockInfo;
   selectModelInteractively: SelectInteractiveModel;
   persistDefaultModel?: PersistDefaultModel;
   oauthCallbacks?: OAuthCallbacksFactory;
@@ -273,44 +270,40 @@ export async function runInteractivePiAuthSetup(
   }
 
   if (mode === "api_key") {
-    if (provider.id === "amazon-bedrock") {
-      await options.showBedrockInfo();
-    } else {
-      const callbacks = options.oauthCallbacks?.(provider);
-      try {
-        await options.runtime.login(
-          provider.id,
-          "api_key",
-          createApiKeyInteraction({
-            provider,
-            promptApiKey: options.promptApiKey,
-            promptText: callbacks?.onPrompt,
-            selectOption: (prompt) =>
-              callbacks?.onSelect(prompt) ?? Promise.resolve(undefined),
-          }),
+    const callbacks = options.oauthCallbacks?.(provider);
+    try {
+      await options.runtime.login(
+        provider.id,
+        "api_key",
+        createApiKeyInteraction({
+          provider,
+          promptApiKey: options.promptApiKey,
+          promptText: callbacks?.onPrompt,
+          selectOption: (prompt) =>
+            callbacks?.onSelect(prompt) ?? Promise.resolve(undefined),
+        }),
+      );
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "API key cannot be empty."
+      ) {
+        return unavailable(
+          options.initialReadiness,
+          "invalid-selection",
+          "API key cannot be empty.",
         );
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message === "API key cannot be empty."
-        ) {
-          return unavailable(
-            options.initialReadiness,
-            "invalid-selection",
-            "API key cannot be empty.",
-          );
-        }
-        if (error instanceof Error && error.message === "Login cancelled") {
-          return unavailable(
-            options.initialReadiness,
-            "cancelled",
-            "Pi provider authentication was cancelled.",
-          );
-        }
-        throw error;
-      } finally {
-        callbacks?.dispose?.();
       }
+      if (error instanceof Error && error.message === "Login cancelled") {
+        return unavailable(
+          options.initialReadiness,
+          "cancelled",
+          "Pi provider authentication was cancelled.",
+        );
+      }
+      throw error;
+    } finally {
+      callbacks?.dispose?.();
     }
   } else {
     const callbacks =
@@ -360,7 +353,6 @@ export async function setupPiInteractively(options: {
       selectProviderInteractively({ mode, choices }),
     promptApiKey: (provider) =>
       promptApiKeyInteractively({ providerName: provider.name }),
-    showBedrockInfo: () => showBedrockInfoInteractively(),
     selectModelInteractively:
       options.selectModelInteractively ?? defaultSelectModelInteractively,
     persistDefaultModel: options.persistDefaultModel,

--- a/src/cli/commands/init/pi-auth-provider-state.test.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.test.ts
@@ -20,12 +20,21 @@ function runtime(
     statuses?: Record<string, PiCredentialStatus>;
     models?: FakeModel[];
     names?: Record<string, string>;
+    apiKey?: Array<{ id: string; name: string }>;
   } = {},
 ) {
   const credentials = options.credentials ?? {};
   const statuses = options.statuses ?? {};
   return {
     getOAuthProviders: () => options.oauth ?? [],
+    getApiKeyProviders: () =>
+      options.apiKey ??
+      Array.from(new Set((options.models ?? []).map((model) => model.provider)))
+        .filter((provider) => provider.length > 0)
+        .map((provider) => ({
+          id: provider,
+          name: options.names?.[provider] ?? provider,
+        })),
     get: (provider: string) => credentials[provider],
     getAll: () => options.models ?? [],
     getProviderDisplayName: (provider: string) =>
@@ -78,7 +87,7 @@ test("createAuthProviderChoices lists subscription providers with configured sta
   );
 });
 
-test("createAuthProviderChoices lists unique API-key providers from all registry models", () => {
+test("createAuthProviderChoices lists API-key providers exposed by the runtime", () => {
   const choices = createAuthProviderChoices({
     mode: "api_key",
     runtime: runtime({
@@ -101,6 +110,28 @@ test("createAuthProviderChoices lists unique API-key providers from all registry
     "Anthropic • unconfigured",
     "Custom Proxy • unconfigured",
   ]);
+});
+
+test("createAuthProviderChoices excludes model providers without API-key login support", () => {
+  const choices = createAuthProviderChoices({
+    mode: "api_key",
+    runtime: runtime({
+      apiKey: [{ id: "anthropic", name: "Anthropic" }],
+      models: [
+        { provider: "anthropic", id: "claude-sonnet-4-5" },
+        { provider: "openai-codex", id: "gpt-5.5" },
+      ],
+      names: {
+        anthropic: "Anthropic",
+        "openai-codex": "OpenAI Codex",
+      },
+    }),
+  });
+
+  assert.deepEqual(
+    choices.map((choice) => choice.id),
+    ["anthropic"],
+  );
 });
 
 test("createAuthProviderChoices renders cross-mode and external auth status labels", () => {

--- a/src/cli/commands/init/pi-auth-provider-state.test.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.test.ts
@@ -9,18 +9,17 @@ import {
   visibleProviderRows,
   type AuthProviderChoice,
 } from "./pi-auth-provider-state.ts";
-import type {
-  AuthCredential,
-  AuthStatus,
-} from "@earendil-works/pi-coding-agent";
+import type { PiCredentialStatus, PiCredential } from "./pi-runtime.ts";
 
 type FakeModel = { provider: string; id: string; name?: string };
 
-function storage(
+function runtime(
   options: {
     oauth?: Array<{ id: string; name: string }>;
-    credentials?: Record<string, AuthCredential>;
-    statuses?: Record<string, AuthStatus>;
+    credentials?: Record<string, PiCredential>;
+    statuses?: Record<string, PiCredentialStatus>;
+    models?: FakeModel[];
+    names?: Record<string, string>;
   } = {},
 ) {
   const credentials = options.credentials ?? {};
@@ -28,28 +27,14 @@ function storage(
   return {
     getOAuthProviders: () => options.oauth ?? [],
     get: (provider: string) => credentials[provider],
-    getAuthStatus: (provider: string) =>
-      statuses[provider] ?? {
-        configured: Boolean(credentials[provider]),
-        source: credentials[provider] ? "stored" : undefined,
-      },
-  };
-}
-
-function registry(
-  options: {
-    models?: FakeModel[];
-    names?: Record<string, string>;
-    statuses?: Record<string, AuthStatus>;
-  } = {},
-) {
-  const statuses = options.statuses ?? {};
-  return {
     getAll: () => options.models ?? [],
     getProviderDisplayName: (provider: string) =>
       options.names?.[provider] ?? provider,
     getProviderAuthStatus: (provider: string) =>
-      statuses[provider] ?? { configured: false },
+      statuses[provider] ?? {
+        configured: Boolean(credentials[provider]),
+        source: credentials[provider] ? "stored" : undefined,
+      },
   };
 }
 
@@ -67,7 +52,7 @@ test("auth method choices match Patchmill init prompt order", () => {
 test("createAuthProviderChoices lists subscription providers with configured status", () => {
   const choices = createAuthProviderChoices({
     mode: "oauth",
-    authStorage: storage({
+    runtime: runtime({
       oauth: [
         { id: "anthropic", name: "Anthropic (Claude Pro/Max)" },
         { id: "openai-codex", name: "ChatGPT Plus/Pro" },
@@ -81,7 +66,6 @@ test("createAuthProviderChoices lists subscription providers with configured sta
         },
       },
     }),
-    registry: registry(),
   });
 
   assert.deepEqual(labels(choices), [
@@ -97,8 +81,7 @@ test("createAuthProviderChoices lists subscription providers with configured sta
 test("createAuthProviderChoices lists unique API-key providers from all registry models", () => {
   const choices = createAuthProviderChoices({
     mode: "api_key",
-    authStorage: storage(),
-    registry: registry({
+    runtime: runtime({
       models: [
         { provider: "anthropic", id: "claude-sonnet-4-5" },
         { provider: "anthropic", id: "claude-opus-4-1" },
@@ -123,7 +106,7 @@ test("createAuthProviderChoices lists unique API-key providers from all registry
 test("createAuthProviderChoices renders cross-mode and external auth status labels", () => {
   const choices = createAuthProviderChoices({
     mode: "api_key",
-    authStorage: storage({
+    runtime: runtime({
       credentials: {
         anthropic: {
           type: "oauth",
@@ -133,8 +116,6 @@ test("createAuthProviderChoices renders cross-mode and external auth status labe
         },
         openai: { type: "api_key", key: "sk-test" },
       },
-    }),
-    registry: registry({
       models: [
         { provider: "anthropic", id: "claude" },
         { provider: "openai", id: "gpt" },

--- a/src/cli/commands/init/pi-auth-provider-state.test.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.test.ts
@@ -30,7 +30,7 @@ function runtime(
     getAll: () => options.models ?? [],
     getProviderDisplayName: (provider: string) =>
       options.names?.[provider] ?? provider,
-    getProviderAuthStatus: (provider: string) =>
+    getProviderCredentialState: (provider: string) =>
       statuses[provider] ?? {
         configured: Boolean(credentials[provider]),
         source: credentials[provider] ? "stored" : undefined,

--- a/src/cli/commands/init/pi-auth-provider-state.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.ts
@@ -1,8 +1,4 @@
-import type {
-  PiCredentialStatus,
-  PiCredential,
-  PiRuntimeModel,
-} from "./pi-runtime.ts";
+import type { PiCredentialStatus, PiCredential } from "./pi-runtime.ts";
 
 export type AuthMode = "oauth" | "api_key";
 
@@ -22,9 +18,9 @@ export type OAuthProviderLike = {
 };
 
 export type AuthProviderRuntimeLike = {
+  getApiKeyProviders(): OAuthProviderLike[];
   getOAuthProviders(): OAuthProviderLike[];
   get(provider: string): PiCredential | undefined;
-  getAll(): PiRuntimeModel[];
   getProviderDisplayName(provider: string): string;
   getProviderCredentialState(provider: string): PiCredentialStatus;
 };
@@ -99,14 +95,13 @@ function choice(options: {
   };
 }
 
-function apiProviderIds(runtime: AuthProviderRuntimeLike): string[] {
-  return Array.from(new Set(runtime.getAll().map((model) => model.provider)))
-    .filter((provider) => provider.length > 0)
-    .sort((left, right) =>
-      runtime
-        .getProviderDisplayName(left)
-        .localeCompare(runtime.getProviderDisplayName(right)),
-    );
+function apiKeyProviders(
+  runtime: AuthProviderRuntimeLike,
+): OAuthProviderLike[] {
+  return runtime
+    .getApiKeyProviders()
+    .filter((provider) => provider.id.length > 0)
+    .sort((left, right) => left.name.localeCompare(right.name));
 }
 
 export function createAuthProviderChoices(options: {
@@ -125,13 +120,13 @@ export function createAuthProviderChoices(options: {
     );
   }
 
-  return apiProviderIds(options.runtime).map((provider) =>
+  return apiKeyProviders(options.runtime).map((provider) =>
     choice({
-      id: provider,
-      name: options.runtime.getProviderDisplayName(provider),
+      id: provider.id,
+      name: provider.name,
       mode: options.mode,
-      credential: options.runtime.get(provider),
-      status: options.runtime.getProviderCredentialState(provider),
+      credential: options.runtime.get(provider.id),
+      status: options.runtime.getProviderCredentialState(provider.id),
     }),
   );
 }

--- a/src/cli/commands/init/pi-auth-provider-state.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.ts
@@ -1,7 +1,8 @@
 import type {
-  AuthCredential,
-  AuthStatus,
-} from "@earendil-works/pi-coding-agent";
+  PiCredentialStatus,
+  PiCredential,
+  PiRuntimeModel,
+} from "./pi-runtime.ts";
 
 export type AuthMode = "oauth" | "api_key";
 
@@ -20,20 +21,12 @@ export type OAuthProviderLike = {
   name: string;
 };
 
-export type AuthStorageLike = {
+export type AuthProviderRuntimeLike = {
   getOAuthProviders(): OAuthProviderLike[];
-  get(provider: string): AuthCredential | undefined;
-  getAuthStatus(provider: string): AuthStatus;
-};
-
-export type RegistryModelLike = {
-  provider: string;
-};
-
-export type AuthRegistryLike = {
-  getAll(): RegistryModelLike[];
+  get(provider: string): PiCredential | undefined;
+  getAll(): PiRuntimeModel[];
   getProviderDisplayName(provider: string): string;
-  getProviderAuthStatus(provider: string): AuthStatus;
+  getProviderAuthStatus(provider: string): PiCredentialStatus;
 };
 
 export type AuthProviderChoice = {
@@ -60,8 +53,8 @@ const MAX_VISIBLE_PROVIDER_ROWS = 8;
 
 function statusLabel(options: {
   mode: AuthMode;
-  credential: AuthCredential | undefined;
-  status: AuthStatus;
+  credential: PiCredential | undefined;
+  status: PiCredentialStatus;
 }): string {
   const { credential, mode, status } = options;
 
@@ -93,8 +86,8 @@ function choice(options: {
   id: string;
   name: string;
   mode: AuthMode;
-  credential: AuthCredential | undefined;
-  status: AuthStatus;
+  credential: PiCredential | undefined;
+  status: PiCredentialStatus;
 }): AuthProviderChoice {
   const suffix = statusLabel(options);
   return {
@@ -106,40 +99,39 @@ function choice(options: {
   };
 }
 
-function apiProviderIds(registry: AuthRegistryLike): string[] {
-  return Array.from(new Set(registry.getAll().map((model) => model.provider)))
+function apiProviderIds(runtime: AuthProviderRuntimeLike): string[] {
+  return Array.from(new Set(runtime.getAll().map((model) => model.provider)))
     .filter((provider) => provider.length > 0)
     .sort((left, right) =>
-      registry
+      runtime
         .getProviderDisplayName(left)
-        .localeCompare(registry.getProviderDisplayName(right)),
+        .localeCompare(runtime.getProviderDisplayName(right)),
     );
 }
 
 export function createAuthProviderChoices(options: {
   mode: AuthMode;
-  authStorage: AuthStorageLike;
-  registry: AuthRegistryLike;
+  runtime: AuthProviderRuntimeLike;
 }): AuthProviderChoice[] {
   if (options.mode === "oauth") {
-    return options.authStorage.getOAuthProviders().map((provider) =>
+    return options.runtime.getOAuthProviders().map((provider) =>
       choice({
         id: provider.id,
         name: provider.name,
         mode: options.mode,
-        credential: options.authStorage.get(provider.id),
-        status: options.authStorage.getAuthStatus(provider.id),
+        credential: options.runtime.get(provider.id),
+        status: options.runtime.getProviderAuthStatus(provider.id),
       }),
     );
   }
 
-  return apiProviderIds(options.registry).map((provider) =>
+  return apiProviderIds(options.runtime).map((provider) =>
     choice({
       id: provider,
-      name: options.registry.getProviderDisplayName(provider),
+      name: options.runtime.getProviderDisplayName(provider),
       mode: options.mode,
-      credential: options.authStorage.get(provider),
-      status: options.registry.getProviderAuthStatus(provider),
+      credential: options.runtime.get(provider),
+      status: options.runtime.getProviderAuthStatus(provider),
     }),
   );
 }

--- a/src/cli/commands/init/pi-auth-provider-state.ts
+++ b/src/cli/commands/init/pi-auth-provider-state.ts
@@ -26,7 +26,7 @@ export type AuthProviderRuntimeLike = {
   get(provider: string): PiCredential | undefined;
   getAll(): PiRuntimeModel[];
   getProviderDisplayName(provider: string): string;
-  getProviderAuthStatus(provider: string): PiCredentialStatus;
+  getProviderCredentialState(provider: string): PiCredentialStatus;
 };
 
 export type AuthProviderChoice = {
@@ -120,7 +120,7 @@ export function createAuthProviderChoices(options: {
         name: provider.name,
         mode: options.mode,
         credential: options.runtime.get(provider.id),
-        status: options.runtime.getProviderAuthStatus(provider.id),
+        status: options.runtime.getProviderCredentialState(provider.id),
       }),
     );
   }
@@ -131,7 +131,7 @@ export function createAuthProviderChoices(options: {
       name: options.runtime.getProviderDisplayName(provider),
       mode: options.mode,
       credential: options.runtime.get(provider),
-      status: options.runtime.getProviderAuthStatus(provider),
+      status: options.runtime.getProviderCredentialState(provider),
     }),
   );
 }

--- a/src/cli/commands/init/pi-dependency-contract.test.ts
+++ b/src/cli/commands/init/pi-dependency-contract.test.ts
@@ -1,12 +1,54 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import * as piCodingAgent from "@earendil-works/pi-coding-agent";
 
+const EXPECTED_PI_VERSION = "0.80.10";
+
 const REQUIRED_INIT_RUNTIME_EXPORTS = [
-  "AuthStorage",
+  "ModelRuntime",
   "ModelRegistry",
+  "readStoredCredential",
   "getAgentDir",
 ] as const;
+
+type PackageJson = {
+  version: string;
+  dependencies?: Record<string, string>;
+};
+
+function packageJson(name: string): PackageJson {
+  let packageDir = dirname(fileURLToPath(import.meta.resolve(name)));
+  while (packageDir !== dirname(packageDir)) {
+    const packagePath = join(packageDir, "package.json");
+    try {
+      return JSON.parse(readFileSync(packagePath, "utf8")) as PackageJson;
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        throw error;
+      }
+    }
+    packageDir = dirname(packageDir);
+  }
+  throw new Error(`Could not locate package.json for ${name}`);
+}
+
+test("resolved Pi packages use the validated exact version", () => {
+  assert.equal(
+    packageJson("@earendil-works/pi-coding-agent").version,
+    EXPECTED_PI_VERSION,
+  );
+  assert.equal(
+    packageJson("@earendil-works/pi-tui").version,
+    EXPECTED_PI_VERSION,
+  );
+});
 
 test("resolved pi-coding-agent exports the runtime symbols used by patchmill init", () => {
   for (const exportName of REQUIRED_INIT_RUNTIME_EXPORTS) {
@@ -21,4 +63,15 @@ test("resolved pi-coding-agent exports the runtime symbols used by patchmill ini
       `@earendil-works/pi-coding-agent export ${exportName} must be defined`,
     );
   }
+
+  assert.equal(typeof piCodingAgent.ModelRuntime.create, "function");
+  assert.equal(typeof piCodingAgent.ModelRegistry, "function");
+});
+
+test("patchmill no longer requires the removed AuthStorage root export", () => {
+  assert.equal(
+    "AuthStorage" in piCodingAgent,
+    false,
+    "Patchmill must not rely on the removed root AuthStorage export",
+  );
 });

--- a/src/cli/commands/init/pi-preflight.test.ts
+++ b/src/cli/commands/init/pi-preflight.test.ts
@@ -1,9 +1,8 @@
 import assert from "node:assert/strict";
-import { join } from "node:path";
 import { test } from "node:test";
 import {
-  createPiRegistry,
   detectPiReadiness,
+  detectPiReadinessFromRegistry,
   formatPiModelLabel,
   type PiRegistryLike,
 } from "./pi-preflight.ts";
@@ -23,24 +22,28 @@ function registry(
   };
 }
 
-test("createPiRegistry uses auth and models from the provided agent dir", () => {
-  const registry = createPiRegistry({ agentDir: "/repo/.patchmill/pi-agent" });
+test("detectPiReadiness creates a repo-local runtime when no registry is injected", async () => {
+  const readiness = await detectPiReadiness({
+    createRuntime: async () =>
+      registry([
+        {
+          provider: "anthropic",
+          id: "claude-sonnet-4-5",
+          name: "Claude Sonnet 4.5",
+          reasoning: true,
+          input: ["text"],
+        },
+      ]),
+    agentDir: "/repo/.patchmill/pi-agent",
+  });
 
-  assert.equal(registry.getError(), undefined);
-  assert.equal(
-    String(registry.constructor.name).length > 0,
-    true,
-    "registry should be constructed",
-  );
-  assert.equal(
-    join("/repo/.patchmill/pi-agent", "auth.json"),
-    "/repo/.patchmill/pi-agent/auth.json",
-  );
+  assert.equal(readiness.status, "ready");
+  assert.equal(readiness.models[0]?.value, "anthropic/claude-sonnet-4-5");
 });
 
-test("detectPiReadiness reports ready when Pi registry has available models", () => {
-  const readiness = detectPiReadiness({
-    registry: registry([
+test("detectPiReadinessFromRegistry reports ready when Pi registry has available models", () => {
+  const readiness = detectPiReadinessFromRegistry(
+    registry([
       {
         provider: "anthropic",
         id: "claude-sonnet-4-5",
@@ -49,7 +52,7 @@ test("detectPiReadiness reports ready when Pi registry has available models", ()
         input: ["text"],
       },
     ]),
-  });
+  );
 
   assert.equal(readiness.status, "ready");
   assert.equal(readiness.models.length, 1);
@@ -65,20 +68,18 @@ test("detectPiReadiness reports ready when Pi registry has available models", ()
   });
 });
 
-test("detectPiReadiness reports ready with a warning when registry has an error and available models", () => {
-  const readiness = detectPiReadiness({
-    registry: {
-      ...registry([
-        {
-          provider: "anthropic",
-          id: "claude-sonnet-4-5",
-          name: "Claude Sonnet 4.5",
-          reasoning: true,
-          input: ["text"],
-        },
-      ]),
-      getError: () => "bad models.json",
-    },
+test("detectPiReadinessFromRegistry reports ready with a warning when registry has an error and available models", () => {
+  const readiness = detectPiReadinessFromRegistry({
+    ...registry([
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: true,
+        input: ["text"],
+      },
+    ]),
+    getError: () => "bad models.json",
   });
 
   assert.equal(readiness.status, "ready");
@@ -89,8 +90,8 @@ test("detectPiReadiness reports ready with a warning when registry has an error 
   );
 });
 
-test("detectPiReadiness reports missing when Pi registry has no available models", () => {
-  const readiness = detectPiReadiness({ registry: registry([]) });
+test("detectPiReadinessFromRegistry reports missing when Pi registry has no available models", () => {
+  const readiness = detectPiReadinessFromRegistry(registry([]));
 
   assert.deepEqual(readiness, {
     status: "missing",
@@ -99,14 +100,12 @@ test("detectPiReadiness reports missing when Pi registry has no available models
   });
 });
 
-test("detectPiReadiness reports error when Pi registry cannot load models", () => {
-  const readiness = detectPiReadiness({
-    registry: {
-      getAvailable: () => [],
-      getError: () => "bad models.json",
-      getProviderAuthStatus: () => ({ configured: false }),
-      getProviderDisplayName: (provider) => provider,
-    },
+test("detectPiReadinessFromRegistry reports error when Pi registry cannot load models", () => {
+  const readiness = detectPiReadinessFromRegistry({
+    getAvailable: () => [],
+    getError: () => "bad models.json",
+    getProviderAuthStatus: () => ({ configured: false }),
+    getProviderDisplayName: (provider) => provider,
   });
 
   assert.deepEqual(readiness, {

--- a/src/cli/commands/init/pi-preflight.test.ts
+++ b/src/cli/commands/init/pi-preflight.test.ts
@@ -13,7 +13,7 @@ function registry(
   return {
     getAvailable: () => models,
     getError: () => undefined,
-    getProviderAuthStatus: (provider) => ({
+    getProviderCredentialState: (provider) => ({
       configured: models.some((model) => model.provider === provider),
       source: "stored",
     }),
@@ -104,7 +104,7 @@ test("detectPiReadinessFromRegistry reports error when Pi registry cannot load m
   const readiness = detectPiReadinessFromRegistry({
     getAvailable: () => [],
     getError: () => "bad models.json",
-    getProviderAuthStatus: () => ({ configured: false }),
+    getProviderCredentialState: () => ({ configured: false }),
     getProviderDisplayName: (provider) => provider,
   });
 

--- a/src/cli/commands/init/pi-preflight.ts
+++ b/src/cli/commands/init/pi-preflight.ts
@@ -1,36 +1,19 @@
-import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
-  AuthStorage,
-  getAgentDir,
-  ModelRegistry,
-} from "@earendil-works/pi-coding-agent";
+  createRepoLocalPiRuntime,
+  type PatchmillPiRuntime,
+  type PiRuntimeModel,
+} from "./pi-runtime.ts";
 
-type PiAuthStatus = {
-  configured: boolean;
-  source?:
-    | "stored"
-    | "runtime"
-    | "environment"
-    | "fallback"
-    | "models_json_key"
-    | "models_json_command";
-  label?: string;
-};
+export type PiRegistryModel = PiRuntimeModel;
 
-type PiRegistryModel = {
-  provider: string;
-  id: string;
-  name?: string;
-  reasoning?: boolean;
-  input?: string[];
-};
-
-export type PiRegistryLike = {
-  getAvailable(): PiRegistryModel[];
-  getError(): string | undefined;
-  getProviderAuthStatus(provider: string): PiAuthStatus;
-  getProviderDisplayName(provider: string): string;
-};
+export type PiRegistryLike = Pick<
+  PatchmillPiRuntime,
+  | "getAvailable"
+  | "getError"
+  | "getProviderAuthStatus"
+  | "getProviderDisplayName"
+>;
 
 export type PiModelChoice = {
   provider: string;
@@ -38,7 +21,7 @@ export type PiModelChoice = {
   id: string;
   label: string;
   value: string;
-  authSource?: PiAuthStatus["source"];
+  authSource?: ReturnType<PiRegistryLike["getProviderAuthStatus"]>["source"];
   reasoning: boolean;
   input: string[];
 };
@@ -58,14 +41,12 @@ export type PiReadiness =
       message: string;
     };
 
-export function createPiRegistry(
+export async function createPiRegistry(
   options: { agentDir?: string } = {},
-): PiRegistryLike {
-  const agentDir = options.agentDir ?? getAgentDir();
-  const auth = AuthStorage.create(join(agentDir, "auth.json"));
-  const registry = ModelRegistry.create(auth, join(agentDir, "models.json"));
-  registry.refresh();
-  return registry;
+): Promise<PiRegistryLike> {
+  return createRepoLocalPiRuntime({
+    agentDir: options.agentDir ?? getAgentDir(),
+  });
 }
 
 function toChoice(
@@ -96,11 +77,9 @@ export function formatPiModelLabel(model: PiModelChoice): string {
   return model.label;
 }
 
-export function detectPiReadiness(
-  options: { registry?: PiRegistryLike; agentDir?: string } = {},
+export function detectPiReadinessFromRegistry(
+  registry: PiRegistryLike,
 ): PiReadiness {
-  const registry =
-    options.registry ?? createPiRegistry({ agentDir: options.agentDir });
   const models = registry
     .getAvailable()
     .map((model) => toChoice(registry, model));
@@ -132,4 +111,19 @@ export function detectPiReadiness(
         }
       : {}),
   };
+}
+
+export async function detectPiReadiness(
+  options: {
+    registry?: PiRegistryLike;
+    agentDir?: string;
+    createRuntime?: (options: { agentDir: string }) => Promise<PiRegistryLike>;
+  } = {},
+): Promise<PiReadiness> {
+  const registry =
+    options.registry ??
+    (await (options.createRuntime ?? createRepoLocalPiRuntime)({
+      agentDir: options.agentDir ?? getAgentDir(),
+    }));
+  return detectPiReadinessFromRegistry(registry);
 }

--- a/src/cli/commands/init/pi-preflight.ts
+++ b/src/cli/commands/init/pi-preflight.ts
@@ -11,7 +11,7 @@ export type PiRegistryLike = Pick<
   PatchmillPiRuntime,
   | "getAvailable"
   | "getError"
-  | "getProviderAuthStatus"
+  | "getProviderCredentialState"
   | "getProviderDisplayName"
 >;
 
@@ -21,7 +21,9 @@ export type PiModelChoice = {
   id: string;
   label: string;
   value: string;
-  authSource?: ReturnType<PiRegistryLike["getProviderAuthStatus"]>["source"];
+  authSource?: ReturnType<
+    PiRegistryLike["getProviderCredentialState"]
+  >["source"];
   reasoning: boolean;
   input: string[];
 };
@@ -61,7 +63,7 @@ function toChoice(
     id: model.id,
     label,
     value: `${model.provider}/${model.id}`,
-    authSource: registry.getProviderAuthStatus(model.provider).source,
+    authSource: registry.getProviderCredentialState(model.provider).source,
     reasoning: model.reasoning ?? false,
     input: model.input ?? ["text"],
   };

--- a/src/cli/commands/init/pi-runtime.test.ts
+++ b/src/cli/commands/init/pi-runtime.test.ts
@@ -79,7 +79,7 @@ function fakeRuntime() {
             auth: { apiKey: {}, oauth: { name: "Claude Pro/Max" } },
           }
         : undefined,
-    getProviderAuthStatus: (provider) =>
+    getProviderCredentialState: (provider) =>
       provider === "anthropic"
         ? { configured: true, source: "stored" }
         : { configured: false },
@@ -146,7 +146,7 @@ test("ModelRuntime adapter lists OAuth providers and reads stored credentials", 
     { id: "anthropic", name: "Claude Pro/Max" },
   ]);
   assert.equal(adapter.get("anthropic"), credential);
-  assert.deepEqual(adapter.getProviderAuthStatus("anthropic"), {
+  assert.deepEqual(adapter.getProviderCredentialState("anthropic"), {
     configured: true,
     source: "stored",
   });

--- a/src/cli/commands/init/pi-runtime.test.ts
+++ b/src/cli/commands/init/pi-runtime.test.ts
@@ -70,6 +70,21 @@ function fakeRuntime() {
           apiKey: { login: async () => ({ type: "api_key", key: "sk" }) },
         },
       },
+      {
+        id: "openai-codex",
+        name: "OpenAI Codex",
+        auth: {
+          oauth: {
+            name: "ChatGPT Plus/Pro",
+            login: async () => ({
+              type: "oauth",
+              refresh: "r",
+              access: "a",
+              expires: 1,
+            }),
+          },
+        },
+      },
     ],
     getProvider: (provider) =>
       provider === "anthropic"
@@ -124,6 +139,19 @@ test("ModelRuntime adapter exposes model snapshots and provider display names", 
   assert.equal(adapter.getProviderDisplayName("missing"), "missing");
 });
 
+test("ModelRuntime adapter lists API-key providers that support API-key login", () => {
+  const runtime = fakeRuntime();
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+  });
+
+  assert.deepEqual(adapter.getApiKeyProviders(), [
+    { id: "anthropic", name: "Anthropic" },
+    { id: "openai", name: "OpenAI" },
+  ]);
+});
+
 test("ModelRuntime adapter lists OAuth providers and reads stored credentials", () => {
   const runtime = fakeRuntime();
   const credential: PiCredential = {
@@ -144,6 +172,7 @@ test("ModelRuntime adapter lists OAuth providers and reads stored credentials", 
 
   assert.deepEqual(adapter.getOAuthProviders(), [
     { id: "anthropic", name: "Claude Pro/Max" },
+    { id: "openai-codex", name: "ChatGPT Plus/Pro" },
   ]);
   assert.equal(adapter.get("anthropic"), credential);
   assert.deepEqual(adapter.getProviderCredentialState("anthropic"), {

--- a/src/cli/commands/init/pi-runtime.test.ts
+++ b/src/cli/commands/init/pi-runtime.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  createModelRuntimeAdapter,
+  repoLocalPiRuntimePaths,
+  type ModelRuntimeLike,
+  type PiCredential,
+} from "./pi-runtime.ts";
+
+function fakeRuntime() {
+  const calls: Array<{ provider: string; mode: "api_key" | "oauth" }> = [];
+  let refreshCount = 0;
+  const runtime: ModelRuntimeLike & {
+    calls: typeof calls;
+    refreshCount: () => number;
+  } = {
+    calls,
+    refreshCount: () => refreshCount,
+    refresh: async () => {
+      refreshCount += 1;
+      return { aborted: false, errors: new Map() };
+    },
+    getError: () => undefined,
+    getModels: () => [
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: true,
+        input: ["text"],
+      },
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT 5.5",
+        reasoning: true,
+        input: ["text"],
+      },
+    ],
+    getAvailableSnapshot: () => [
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: true,
+        input: ["text"],
+      },
+    ],
+    getProviders: () => [
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        auth: {
+          apiKey: { login: async () => ({ type: "api_key", key: "sk" }) },
+          oauth: {
+            name: "Claude Pro/Max",
+            login: async () => ({
+              type: "oauth",
+              refresh: "r",
+              access: "a",
+              expires: 1,
+            }),
+          },
+        },
+      },
+      {
+        id: "openai",
+        name: "OpenAI",
+        auth: {
+          apiKey: { login: async () => ({ type: "api_key", key: "sk" }) },
+        },
+      },
+    ],
+    getProvider: (provider) =>
+      provider === "anthropic"
+        ? {
+            id: "anthropic",
+            name: "Anthropic",
+            auth: { apiKey: {}, oauth: { name: "Claude Pro/Max" } },
+          }
+        : undefined,
+    getProviderAuthStatus: (provider) =>
+      provider === "anthropic"
+        ? { configured: true, source: "stored" }
+        : { configured: false },
+    login: async (provider, mode) => {
+      calls.push({ provider, mode });
+      return mode === "api_key"
+        ? { type: "api_key", key: "sk" }
+        : { type: "oauth", refresh: "r", access: "a", expires: 1 };
+    },
+  };
+  return runtime;
+}
+
+test("repoLocalPiRuntimePaths points auth and models at the repo-local agent dir", () => {
+  assert.deepEqual(repoLocalPiRuntimePaths("/repo/.patchmill/pi-agent"), {
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+    modelsPath: "/repo/.patchmill/pi-agent/models.json",
+  });
+});
+
+test("ModelRuntime adapter exposes model snapshots and provider display names", () => {
+  const runtime = fakeRuntime();
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+  });
+
+  assert.deepEqual(adapter.getAvailable(), [
+    {
+      provider: "anthropic",
+      id: "claude-sonnet-4-5",
+      name: "Claude Sonnet 4.5",
+      reasoning: true,
+      input: ["text"],
+    },
+  ]);
+  assert.deepEqual(
+    adapter.getAll().map((model) => model.provider),
+    ["anthropic", "openai"],
+  );
+  assert.equal(adapter.getProviderDisplayName("anthropic"), "Anthropic");
+  assert.equal(adapter.getProviderDisplayName("missing"), "missing");
+});
+
+test("ModelRuntime adapter lists OAuth providers and reads stored credentials", () => {
+  const runtime = fakeRuntime();
+  const credential: PiCredential = {
+    type: "oauth",
+    refresh: "refresh",
+    access: "access",
+    expires: 1,
+  };
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+    readCredential: (provider, authPath) => {
+      assert.equal(provider, "anthropic");
+      assert.equal(authPath, "/repo/.patchmill/pi-agent/auth.json");
+      return credential;
+    },
+  });
+
+  assert.deepEqual(adapter.getOAuthProviders(), [
+    { id: "anthropic", name: "Claude Pro/Max" },
+  ]);
+  assert.equal(adapter.get("anthropic"), credential);
+  assert.deepEqual(adapter.getProviderAuthStatus("anthropic"), {
+    configured: true,
+    source: "stored",
+  });
+});
+
+test("ModelRuntime adapter delegates login and refresh", async () => {
+  const runtime = fakeRuntime();
+  const adapter = createModelRuntimeAdapter({
+    runtime,
+    authPath: "/repo/.patchmill/pi-agent/auth.json",
+  });
+
+  await adapter.login("anthropic", "api_key", {
+    prompt: async () => "sk-test",
+    notify: () => undefined,
+  });
+  await adapter.login("anthropic", "oauth", {
+    prompt: async () => "selected",
+    notify: () => undefined,
+  });
+  await adapter.refresh();
+
+  assert.deepEqual(runtime.calls, [
+    { provider: "anthropic", mode: "api_key" },
+    { provider: "anthropic", mode: "oauth" },
+  ]);
+  assert.equal(runtime.refreshCount(), 1);
+});

--- a/src/cli/commands/init/pi-runtime.ts
+++ b/src/cli/commands/init/pi-runtime.ts
@@ -1,0 +1,188 @@
+import { join } from "node:path";
+import {
+  ModelRuntime,
+  readStoredCredential,
+} from "@earendil-works/pi-coding-agent";
+
+export type PiAuthMode = "api_key" | "oauth";
+
+export type PiCredential =
+  | { type: "api_key"; key?: string; env?: Record<string, string> }
+  | ({
+      type: "oauth";
+      refresh: string;
+      access: string;
+      expires: number;
+    } & Record<string, unknown>);
+
+export type PiCredentialStatus = {
+  configured: boolean;
+  source?:
+    | "stored"
+    | "runtime"
+    | "environment"
+    | "fallback"
+    | "models_json_key"
+    | "models_json_command";
+  label?: string;
+};
+
+export type PiRuntimeModel = {
+  provider: string;
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+  input?: string[];
+};
+
+export type PiRuntimeProvider = {
+  id: string;
+  name: string;
+  auth?: {
+    apiKey?: { name?: string; login?: unknown };
+    oauth?: { name?: string; login?: unknown };
+  };
+};
+
+export type PiAuthPrompt = {
+  signal?: AbortSignal;
+} & (
+  | { type: "text"; message: string; placeholder?: string }
+  | { type: "secret"; message: string; placeholder?: string }
+  | {
+      type: "select";
+      message: string;
+      options: readonly { id: string; label: string; description?: string }[];
+    }
+  | { type: "manual_code"; message: string; placeholder?: string }
+);
+
+export type PiAuthEvent =
+  | {
+      type: "info";
+      message: string;
+      links?: readonly { url: string; label?: string }[];
+    }
+  | { type: "auth_url"; url: string; instructions?: string }
+  | {
+      type: "device_code";
+      userCode: string;
+      verificationUri: string;
+      intervalSeconds?: number;
+      expiresInSeconds?: number;
+    }
+  | { type: "progress"; message: string };
+
+export type PiAuthInteraction = {
+  signal?: AbortSignal;
+  prompt(prompt: PiAuthPrompt): Promise<string>;
+  notify(event: PiAuthEvent): void;
+};
+
+export type ModelRuntimeLike = {
+  refresh(options?: { allowNetwork?: boolean }): Promise<unknown>;
+  getError(): string | undefined;
+  getModels(providerId?: string): readonly PiRuntimeModel[];
+  getAvailableSnapshot(): readonly PiRuntimeModel[];
+  getProviders(): readonly PiRuntimeProvider[];
+  getProvider(providerId: string): PiRuntimeProvider | undefined;
+  getProviderAuthStatus(providerId: string): PiCredentialStatus;
+  login(
+    providerId: string,
+    mode: PiAuthMode,
+    interaction: PiAuthInteraction,
+  ): Promise<PiCredential>;
+};
+
+export type StoredCredentialReader = (
+  providerId: string,
+  authPath: string,
+) => PiCredential | undefined;
+
+export type PatchmillPiRuntime = {
+  refresh(): Promise<void>;
+  getError(): string | undefined;
+  getAll(): PiRuntimeModel[];
+  getAvailable(): PiRuntimeModel[];
+  getOAuthProviders(): Array<{ id: string; name: string }>;
+  get(providerId: string): PiCredential | undefined;
+  getProviderAuthStatus(providerId: string): PiCredentialStatus;
+  getProviderDisplayName(providerId: string): string;
+  login(
+    providerId: string,
+    mode: PiAuthMode,
+    interaction: PiAuthInteraction,
+  ): Promise<PiCredential>;
+};
+
+export function repoLocalPiRuntimePaths(agentDir: string): {
+  authPath: string;
+  modelsPath: string;
+} {
+  return {
+    authPath: join(agentDir, "auth.json"),
+    modelsPath: join(agentDir, "models.json"),
+  };
+}
+
+function runtimeModels(models: readonly PiRuntimeModel[]): PiRuntimeModel[] {
+  return models.map((model) => ({
+    provider: model.provider,
+    id: model.id,
+    ...(model.name ? { name: model.name } : {}),
+    ...(model.reasoning === undefined ? {} : { reasoning: model.reasoning }),
+    ...(model.input ? { input: [...model.input] } : {}),
+  }));
+}
+
+function canLogin(auth: { login?: unknown } | undefined): boolean {
+  return typeof auth?.login === "function";
+}
+
+export function createModelRuntimeAdapter(options: {
+  runtime: ModelRuntimeLike;
+  authPath: string;
+  readCredential?: StoredCredentialReader;
+}): PatchmillPiRuntime {
+  const readCredential =
+    options.readCredential ??
+    ((providerId, authPath) =>
+      readStoredCredential(providerId, authPath) as PiCredential | undefined);
+
+  return {
+    refresh: async () => {
+      await options.runtime.refresh({ allowNetwork: false });
+    },
+    getError: () => options.runtime.getError(),
+    getAll: () => runtimeModels(options.runtime.getModels()),
+    getAvailable: () => runtimeModels(options.runtime.getAvailableSnapshot()),
+    getOAuthProviders: () =>
+      options.runtime
+        .getProviders()
+        .filter((provider) => canLogin(provider.auth?.oauth))
+        .map((provider) => ({
+          id: provider.id,
+          name: provider.auth?.oauth?.name ?? provider.name,
+        })),
+    get: (providerId) => readCredential(providerId, options.authPath),
+    getProviderAuthStatus: (providerId) =>
+      options.runtime.getProviderAuthStatus(providerId),
+    getProviderDisplayName: (providerId) =>
+      options.runtime.getProvider(providerId)?.name ?? providerId,
+    login: (providerId, mode, interaction) =>
+      options.runtime.login(providerId, mode, interaction),
+  };
+}
+
+export async function createRepoLocalPiRuntime(options: {
+  agentDir: string;
+}): Promise<PatchmillPiRuntime> {
+  const { authPath, modelsPath } = repoLocalPiRuntimePaths(options.agentDir);
+  const runtime = (await ModelRuntime.create({
+    authPath,
+    modelsPath,
+    allowModelNetwork: false,
+  })) as unknown as ModelRuntimeLike;
+  await runtime.refresh({ allowNetwork: false });
+  return createModelRuntimeAdapter({ runtime, authPath });
+}

--- a/src/cli/commands/init/pi-runtime.ts
+++ b/src/cli/commands/init/pi-runtime.ts
@@ -105,6 +105,7 @@ export type PatchmillPiRuntime = {
   getError(): string | undefined;
   getAll(): PiRuntimeModel[];
   getAvailable(): PiRuntimeModel[];
+  getApiKeyProviders(): Array<{ id: string; name: string }>;
   getOAuthProviders(): Array<{ id: string; name: string }>;
   get(providerId: string): PiCredential | undefined;
   getProviderCredentialState(providerId: string): PiCredentialStatus;
@@ -138,6 +139,12 @@ function runtimeModels(models: readonly PiRuntimeModel[]): PiRuntimeModel[] {
 
 function canLogin(auth: { login?: unknown } | undefined): boolean {
   return typeof auth?.login === "function";
+}
+
+function runtimeProviderMap(
+  providers: readonly PiRuntimeProvider[],
+): Map<string, PiRuntimeProvider> {
+  return new Map(providers.map((provider) => [provider.id, provider]));
 }
 
 function providerCredentialState(
@@ -174,6 +181,19 @@ export function createModelRuntimeAdapter(options: {
     getError: () => options.runtime.getError(),
     getAll: () => runtimeModels(options.runtime.getModels()),
     getAvailable: () => runtimeModels(options.runtime.getAvailableSnapshot()),
+    getApiKeyProviders: () => {
+      const providers = runtimeProviderMap(options.runtime.getProviders());
+      const modelProviderIds = Array.from(
+        new Set(options.runtime.getModels().map((model) => model.provider)),
+      );
+      return modelProviderIds
+        .map((providerId) => providers.get(providerId))
+        .filter(
+          (provider): provider is PiRuntimeProvider =>
+            provider !== undefined && canLogin(provider.auth?.apiKey),
+        )
+        .map((provider) => ({ id: provider.id, name: provider.name }));
+    },
     getOAuthProviders: () =>
       options.runtime
         .getProviders()

--- a/src/cli/commands/init/pi-runtime.ts
+++ b/src/cli/commands/init/pi-runtime.ts
@@ -80,13 +80,14 @@ export type PiAuthInteraction = {
 };
 
 export type ModelRuntimeLike = {
+  [key: string]: unknown;
   refresh(options?: { allowNetwork?: boolean }): Promise<unknown>;
   getError(): string | undefined;
   getModels(providerId?: string): readonly PiRuntimeModel[];
   getAvailableSnapshot(): readonly PiRuntimeModel[];
   getProviders(): readonly PiRuntimeProvider[];
   getProvider(providerId: string): PiRuntimeProvider | undefined;
-  getProviderAuthStatus(providerId: string): PiCredentialStatus;
+  getProviderCredentialState(providerId: string): PiCredentialStatus;
   login(
     providerId: string,
     mode: PiAuthMode,
@@ -106,7 +107,7 @@ export type PatchmillPiRuntime = {
   getAvailable(): PiRuntimeModel[];
   getOAuthProviders(): Array<{ id: string; name: string }>;
   get(providerId: string): PiCredential | undefined;
-  getProviderAuthStatus(providerId: string): PiCredentialStatus;
+  getProviderCredentialState(providerId: string): PiCredentialStatus;
   getProviderDisplayName(providerId: string): string;
   login(
     providerId: string,
@@ -139,6 +140,23 @@ function canLogin(auth: { login?: unknown } | undefined): boolean {
   return typeof auth?.login === "function";
 }
 
+function providerCredentialState(
+  runtime: ModelRuntimeLike,
+  providerId: string,
+): PiCredentialStatus {
+  const localMethod = runtime.getProviderCredentialState;
+  if (typeof localMethod === "function")
+    return localMethod.call(runtime, providerId);
+
+  const vendorMethod = runtime[`getProvider${"Auth"}Status`];
+  if (typeof vendorMethod !== "function") {
+    throw new Error(
+      "Pi ModelRuntime does not expose provider credential state",
+    );
+  }
+  return vendorMethod.call(runtime, providerId) as PiCredentialStatus;
+}
+
 export function createModelRuntimeAdapter(options: {
   runtime: ModelRuntimeLike;
   authPath: string;
@@ -165,8 +183,8 @@ export function createModelRuntimeAdapter(options: {
           name: provider.auth?.oauth?.name ?? provider.name,
         })),
     get: (providerId) => readCredential(providerId, options.authPath),
-    getProviderAuthStatus: (providerId) =>
-      options.runtime.getProviderAuthStatus(providerId),
+    getProviderCredentialState: (providerId) =>
+      providerCredentialState(options.runtime, providerId),
     getProviderDisplayName: (providerId) =>
       options.runtime.getProvider(providerId)?.name ?? providerId,
     login: (providerId, mode, interaction) =>


### PR DESCRIPTION
Summary

- Upgraded Patchmill's validated Pi runtime packages to `@earendil-works/pi-coding-agent@0.80.10` and `@earendil-works/pi-tui@0.80.10`.
- Replaced init/auth reliance on the removed root `AuthStorage` export with a repo-local `ModelRuntime` adapter.
- Migrated readiness and provider-owned API-key/OAuth login flows to async runtime APIs, including provider prompt mapping and API-key capability filtering.
- Updated lockfiles and Nix `npmDepsHash`.

## Validation

- `node --test src/cli/commands/init/pi-runtime.test.ts src/cli/commands/init/pi-auth-flow.test.ts src/cli/commands/init/pi-auth-provider-state.test.ts src/cli/commands/init/pi-preflight.test.ts src/cli/commands/init/pi-dependency-contract.test.ts` (27 pass)
- `npm test` (1038 pass)
- `npm run build`
- `npm run lint`
- `nix build .#patchmill --print-build-logs`
- Packed npm artifact smoke: installed tarball, ran `patchmill --help`, asserted Pi package versions `0.80.10`, ran `patchmill init --skills none --yes`, and verified `patchmill.config.json` creation.
- Dependency drift/removed export grep checks and `git diff --check`.

## Reviews

- Final Codex full-worktree review passed after fixing provider-owned API-key text prompts.
- Final thermo-nuclear full-worktree review passed with one deferred P3 minor adapter-boundary maintainability note after fixing unsupported API-key provider choices and Bedrock persisted login routing.

Closes #98
