### PR TITLE
Fix todo terminal status compatibility

### DIFF
--- a/docs/plans/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate.md
+++ b/docs/plans/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate.md
@@ -1,0 +1,916 @@
+# Todo Terminal Status Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Patchmill-managed issue task todo terminal statuses consistent across the Pi todo tool, prompt guidance, progress tracking, and final handoff gates.
+
+**Architecture:** Introduce a shared todo-status helper that owns default terminal statuses, normalization, predicates, and Pi-extension environment serialization. Wire Patchmill task-contract readers, Pi invocation, prompts, and the bundled todo extension to that helper so the default workflow recognizes `closed`, `completed`, `complete`, and `done`, while custom task-contract `doneStatuses` remain authoritative when configured.
+
+**Tech Stack:** TypeScript, Node.js `node:test`, TypeBox/Pi tool schemas, Patchmill run-once policy and prompt code, bundled Pi extension runtime.
+
+## Global Constraints
+
+- Base the implementation on `docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md`.
+- Default Patchmill terminal statuses must be exactly `closed`, `completed`, `complete`, and `done`.
+- Status matching must trim surrounding whitespace and compare case-insensitively.
+- Existing todo files with `status: "complete"` must be treated as done without rewriting files.
+- Project overrides of `projectPolicy.pi.taskContract.doneStatuses` remain authoritative for Patchmill issue task todos.
+- The todo extension must default to the Patchmill default terminal set when no Patchmill environment is provided.
+- The Pi todo tool status schema must be constrained to the active status vocabulary: `open` plus the resolved done statuses.
+- UI close actions still write `closed`; reopen actions still write `open`.
+- Do not change todo file location, title matching, tags, locking, assignment, or garbage-collection policy except where terminal-status recognition already participates.
+- Do not change npm dependencies. If `package.json`, `package-lock.json`, or `npm-shrinkwrap.json` changes unexpectedly, stop and add a Nix build verification step per `AGENTS.md`.
+- Testing Value Gate: this is a production regression in status parsing, prompt contracts, and final handoff behavior, so automated tests are required.
+
+## File Structure
+
+- Create `src/policy/todo-statuses.ts`: shared default status list, normalization, done predicate, environment variable name, serialization, and parsing helpers.
+- Create `src/policy/todo-statuses.test.ts`: behavior tests for defaults, normalization, custom statuses, de-duplication, and invalid environment fallback.
+- Modify `src/policy/task-contract.ts`: import the shared default list and predicate; make `DEFAULT_PI_TASK_CONTRACT.doneStatuses` use the shared default.
+- Modify `src/policy/task-contract.test.ts` and `src/policy/defaults.test.ts`: update default expectations and add predicate normalization coverage.
+- Modify `src/cli/commands/run-once/issue-todos.ts`: rely on the normalized shared predicate through `issueTodoStatusDone`.
+- Modify `src/cli/commands/run-once/issue-todos.test.ts`: cover `complete`, whitespace/case normalization, progress advancement, and all default terminal statuses in the final gate.
+- Modify `src/cli/commands/run-once/pipeline-landing.test.ts`: add a final-handoff regression where all issue task todos are `complete` and `pr-created` succeeds.
+- Modify `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`: add or update a progress scenario proving `complete` advances implementation progress.
+- Modify `src/cli/commands/run-once/pi.ts`: pass the resolved done-status list to Pi with a JSON string-array environment variable.
+- Modify `src/cli/commands/run-once/pi.test.ts`: assert `PI_TODO_DONE_STATUSES` is passed and progress respects custom done statuses.
+- Modify `src/cli/commands/run-once/prompts.ts`: render accepted terminal statuses in plan and implementation todo guidance and prefer setting completed work to `closed`.
+- Modify `src/cli/commands/run-once/prompts.test.ts`: update default prompt assertions and add custom terminal-status prompt assertions.
+- Modify `extensions/todos.ts`: import the shared helper, resolve active done statuses from the environment, constrain the status parameter schema, and use the shared predicate for grouping, sorting, assignment clearing, claiming, and garbage collection.
+- Create `test-support/todos-extension.test.ts`: focused extension-harness tests for default `complete` closed grouping, claim blocking, schema vocabulary, and invalid environment fallback.
+
+---
+
+## Task 1: Shared todo-status helper and default task contract
+
+**Files:**
+
+- Create: `src/policy/todo-statuses.ts`
+- Create: `src/policy/todo-statuses.test.ts`
+- Modify: `src/policy/task-contract.ts`
+- Modify: `src/policy/task-contract.test.ts`
+- Modify: `src/policy/defaults.test.ts`
+
+**Interfaces:**
+
+- Consumes: current `PatchmillPiTaskContract.doneStatuses` arrays.
+- Produces: `DEFAULT_TODO_DONE_STATUSES`, `PI_TODO_DONE_STATUSES_ENV`, `normalizeTodoStatus`, `normalizeTodoDoneStatuses`, `todoStatusIsDone`, `serializeTodoDoneStatuses`, and `parseTodoDoneStatusesEnv` for later tasks.
+
+- [ ] **Step 1: Write failing shared-helper tests**
+
+Create `src/policy/todo-statuses.test.ts` with these tests:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_TODO_DONE_STATUSES,
+  parseTodoDoneStatusesEnv,
+  serializeTodoDoneStatuses,
+  todoStatusIsDone,
+} from "./todo-statuses.ts";
+
+test("default todo done statuses include compatibility aliases", () => {
+  assert.deepEqual(DEFAULT_TODO_DONE_STATUSES, [
+    "closed",
+    "completed",
+    "complete",
+    "done",
+  ]);
+});
+
+test("todoStatusIsDone trims and compares case-insensitively", () => {
+  assert.equal(todoStatusIsDone(" COMPLETE "), true);
+  assert.equal(todoStatusIsDone("Done"), true);
+  assert.equal(todoStatusIsDone("open"), false);
+  assert.equal(todoStatusIsDone(undefined), false);
+});
+
+test("custom done statuses are authoritative after normalization", () => {
+  assert.equal(todoStatusIsDone(" shipped ", ["SHIPPED"]), true);
+  assert.equal(todoStatusIsDone("complete", ["shipped"]), false);
+});
+
+test("todo done status env serialization parses valid arrays and falls back safely", () => {
+  assert.deepEqual(parseTodoDoneStatusesEnv(serializeTodoDoneStatuses([" Shipped ", "shipped", ""])), [
+    "shipped",
+  ]);
+  assert.deepEqual(parseTodoDoneStatusesEnv("not json"), DEFAULT_TODO_DONE_STATUSES);
+  assert.deepEqual(parseTodoDoneStatusesEnv(JSON.stringify([])), DEFAULT_TODO_DONE_STATUSES);
+  assert.deepEqual(parseTodoDoneStatusesEnv(JSON.stringify(["", "  "])), DEFAULT_TODO_DONE_STATUSES);
+  assert.deepEqual(parseTodoDoneStatusesEnv(JSON.stringify(["done", 3])), DEFAULT_TODO_DONE_STATUSES);
+});
+```
+
+Run:
+
+```sh
+node --test src/policy/todo-statuses.test.ts
+```
+
+Expected: fail because `src/policy/todo-statuses.ts` does not exist.
+
+- [ ] **Step 2: Implement the shared helper**
+
+Create `src/policy/todo-statuses.ts` with this behavior:
+
+```ts
+export const DEFAULT_TODO_DONE_STATUSES = [
+  "closed",
+  "completed",
+  "complete",
+  "done",
+] as const;
+
+export const PI_TODO_DONE_STATUSES_ENV = "PI_TODO_DONE_STATUSES";
+
+export function normalizeTodoStatus(status: string): string {
+  return status.trim().toLowerCase();
+}
+
+export function normalizeTodoDoneStatuses(
+  doneStatuses: readonly string[] = DEFAULT_TODO_DONE_STATUSES,
+): string[] {
+  const normalized: string[] = [];
+  for (const status of doneStatuses) {
+    const value = normalizeTodoStatus(status);
+    if (!value || normalized.includes(value)) continue;
+    normalized.push(value);
+  }
+  return normalized.length > 0
+    ? normalized
+    : [...DEFAULT_TODO_DONE_STATUSES];
+}
+
+export function todoStatusIsDone(
+  status: string | undefined,
+  doneStatuses: readonly string[] = DEFAULT_TODO_DONE_STATUSES,
+): boolean {
+  if (status === undefined) return false;
+  return normalizeTodoDoneStatuses(doneStatuses).includes(
+    normalizeTodoStatus(status),
+  );
+}
+
+export function serializeTodoDoneStatuses(
+  doneStatuses: readonly string[],
+): string {
+  return JSON.stringify(normalizeTodoDoneStatuses(doneStatuses));
+}
+
+export function parseTodoDoneStatusesEnv(value: string | undefined): string[] {
+  if (value === undefined || value.trim().length === 0) {
+    return [...DEFAULT_TODO_DONE_STATUSES];
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [...DEFAULT_TODO_DONE_STATUSES];
+    if (!parsed.every((entry): entry is string => typeof entry === "string")) {
+      return [...DEFAULT_TODO_DONE_STATUSES];
+    }
+    return normalizeTodoDoneStatuses(parsed);
+  } catch {
+    return [...DEFAULT_TODO_DONE_STATUSES];
+  }
+}
+```
+
+- [ ] **Step 3: Wire the task contract to the helper**
+
+In `src/policy/task-contract.ts`, import the helper and change the default and predicate:
+
+```ts
+import {
+  DEFAULT_TODO_DONE_STATUSES,
+  todoStatusIsDone,
+} from "./todo-statuses.ts";
+```
+
+Use:
+
+```ts
+doneStatuses: [...DEFAULT_TODO_DONE_STATUSES],
+```
+
+and:
+
+```ts
+export function issueTodoStatusDone(
+  contract: PatchmillPiTaskContract,
+  status: string | undefined,
+): boolean {
+  return todoStatusIsDone(status, contract.doneStatuses);
+}
+```
+
+- [ ] **Step 4: Update default policy tests**
+
+Update `src/policy/task-contract.test.ts` and `src/policy/defaults.test.ts` so default `doneStatuses` expectations are:
+
+```ts
+doneStatuses: ["closed", "completed", "complete", "done"],
+```
+
+Add this assertion to `src/policy/task-contract.test.ts` near the existing `issueTodoStatusDone` checks:
+
+```ts
+assert.equal(issueTodoStatusDone(DEFAULT_PI_TASK_CONTRACT, " Complete "), true);
+assert.equal(issueTodoStatusDone(DEFAULT_PI_TASK_CONTRACT, "DONE"), true);
+```
+
+- [ ] **Step 5: Run focused policy tests**
+
+Run:
+
+```sh
+node --test src/policy/todo-statuses.test.ts src/policy/task-contract.test.ts src/policy/defaults.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit the helper**
+
+Run:
+
+```sh
+git add src/policy/todo-statuses.ts src/policy/todo-statuses.test.ts src/policy/task-contract.ts src/policy/task-contract.test.ts src/policy/defaults.test.ts
+git commit -m "fix: share todo terminal status vocabulary"
+```
+
+Expected: one conventional commit containing only the shared-helper and default-contract changes.
+
+## Task 2: Issue todo progress and final handoff compatibility
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/issue-todos.ts`
+- Modify: `src/cli/commands/run-once/issue-todos.test.ts`
+- Modify: `src/cli/commands/run-once/pipeline-landing.test.ts`
+- Modify: `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`
+
+**Interfaces:**
+
+- Consumes: `issueTodoStatusDone(contract, status)` from Task 1.
+- Produces: issue todo readers, progress, and final gates that recognize default `complete` todos and custom configured statuses consistently.
+
+- [ ] **Step 1: Add issue-todo reader and gate tests for `complete`**
+
+In `src/cli/commands/run-once/issue-todos.test.ts`, add a test that writes issue #19 todos with statuses `" complete "`, `"COMPLETED"`, `"Done"`, and `"closed"`, then asserts all are done and the final gate accepts them:
+
+```ts
+test("issue todo readers treat every default terminal status as done", async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "agent-issue-complete-status-"));
+  await writeTodo(repoRoot, "a", "issue-19-task-01-first", " complete ");
+  await writeTodo(repoRoot, "b", "issue-19-task-02-second", "COMPLETED");
+  await writeTodo(repoRoot, "c", "issue-19-task-03-third", "Done");
+  await writeTodo(repoRoot, "d", "issue-19-task-04-fourth", "closed");
+
+  const tasks = await readIssueTodoTasks(repoRoot, 19);
+  assert.deepEqual(
+    tasks.map((task) => task.done),
+    [true, true, true, true],
+  );
+  assert.deepEqual(await issueTodoProgress(repoRoot, 19), {
+    current: 4,
+    total: 4,
+    label: "fourth",
+  });
+  await assertIssueTodosComplete(repoRoot, 19);
+});
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/issue-todos.test.ts
+```
+
+Expected before Task 1 integration is fully wired: fail on `complete` or normalized values. Expected after Task 1: pass.
+
+- [ ] **Step 2: Add a final handoff regression for `complete` todos**
+
+In `src/cli/commands/run-once/pipeline-landing.test.ts`, add a test based on `runOneIssue blocks completed handoff when issue task todos remain open`, but create two issue #24 task todos with status `"complete"`, return a `pr-created` Pi result, and assert the pipeline returns `pr-created` instead of blocked:
+
+```ts
+test("runOneIssue accepts pr-created handoff when issue task todos are complete", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const selected = issue(24, ["agent-ready", "bug"], "Accept complete todo status");
+  const existingPlanPath = join(
+    config.plansDir,
+    "2026-05-01-issue-24-accept-complete-todo-status.md",
+  );
+  const worktreePath = ".worktrees/patchmill-issue-24-accept-complete-todo-status";
+  const worktreeRoot = join(config.repoRoot, worktreePath);
+  await mkdir(worktreeRoot, { recursive: true });
+  await writeFile(existingPlanPath, "# plan\n", "utf8");
+  await writeTodo(worktreeRoot, "task-1", "issue-24-task-01-status-helper", "complete");
+  await writeTodo(worktreeRoot, "task-2", "issue-24-task-02-final-gate", "complete");
+
+  const runner = createMockRunner(async (call) => {
+    if (call.command === "tea" && call.args[0] === "issues" && call.args[1] === "list") {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return { code: 0, stdout: page === "1" ? issueListPayload([selected]) : "[]", stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "git" && call.args[0] === "worktree" && call.args[1] === "list") {
+      return { code: 0, stdout: `worktree ${worktreeRoot}\n`, stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "-C" && call.args[2] === "branch") {
+      return { code: 0, stdout: "agent/issue-24-accept-complete-todo-status\n", stderr: "" };
+    }
+    if (call.command === "git" && call.args[0] === "log") {
+      return { code: 0, stdout: "abc123 implementation\n", stderr: "" };
+    }
+    if (call.command === "tea" && call.args[0] === "labels" && call.args[1] === "list") {
+      return { code: 0, stdout: labelListPayload(), stderr: "" };
+    }
+    if (call.command === "tea" && (call.args[0] === "issues" || call.args[0] === "comment")) {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (call.command === "pi") {
+      return {
+        code: 0,
+        stdout: '{"status":"pr-created","prUrl":"https://forgejo.example/pr/24","branch":"agent/issue-24-accept-complete-todo-status","commits":["abc123"],"validation":["git diff --check ok"],"reviewSummary":"reviewed"}',
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${call.command} ${call.args.join(" ")}`);
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created", JSON.stringify(result));
+});
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pipeline-landing.test.ts
+```
+
+Expected: pass after Task 1 predicate wiring.
+
+- [ ] **Step 3: Add a progress regression for `complete` todos**
+
+In `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`, add or adapt a heartbeat/progress case so an issue worktree has task 1 status `"complete"` and task 2 status `"open"`. Assert the progress event for implementation reports task 2 instead of staying on task 1. Use the existing `collectProgressEvents` helper and the existing `writeTodo` helper in that file.
+
+Use assertions in this shape:
+
+```ts
+assert.equal(
+  events.some((event) =>
+    event.message.includes("implement task 2/2 second task"),
+  ),
+  true,
+);
+assert.equal(
+  events.some((event) =>
+    event.message.includes("implement task 1/2 first task"),
+  ),
+  false,
+);
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+```
+
+Expected: pass after Task 1 predicate wiring.
+
+- [ ] **Step 4: Confirm no extra issue-todo implementation is needed**
+
+Inspect `src/cli/commands/run-once/issue-todos.ts`. If it already delegates through `issueTodoStatusDone`, do not add duplicate normalization there. If any direct `doneStatuses.includes` call remains in run-once issue-todo code, replace it with `issueTodoStatusDone`.
+
+Run:
+
+```sh
+rg "doneStatuses\.includes|status\.toLowerCase\(\)" src/cli/commands/run-once/issue-todos.ts
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run focused run-once todo tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/issue-todos.test.ts src/cli/commands/run-once/pipeline-landing.test.ts src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit the final-gate and progress regression coverage**
+
+Run:
+
+```sh
+git add src/cli/commands/run-once/issue-todos.ts src/cli/commands/run-once/issue-todos.test.ts src/cli/commands/run-once/pipeline-landing.test.ts src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+git commit -m "fix: treat complete todos as done in handoff gates"
+```
+
+Expected: one conventional commit containing the run-once reader, gate, progress, and regression-test changes.
+
+## Task 3: Pi invocation environment and prompt guidance
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pi.ts`
+- Modify: `src/cli/commands/run-once/pi.test.ts`
+- Modify: `src/cli/commands/run-once/prompts.ts`
+- Modify: `src/cli/commands/run-once/prompts.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PI_TODO_DONE_STATUSES_ENV` and `serializeTodoDoneStatuses` from Task 1.
+- Produces: Pi child processes receive the same resolved terminal vocabulary as Patchmill, and generated prompts tell agents to set finished task todos to `closed` while listing all accepted terminal statuses.
+
+- [ ] **Step 1: Add failing Pi environment tests**
+
+In `src/cli/commands/run-once/pi.test.ts`, extend `runPiPrompt passes the configured todo root to Pi` or add a sibling test asserting the env contains the serialized done statuses:
+
+```ts
+test("runPiPrompt passes resolved todo done statuses to Pi", async () => {
+  const runner = createMockRunner((call) => {
+    assert.equal(call.env?.PI_TODO_DONE_STATUSES, JSON.stringify(["shipped"]));
+    return {
+      code: 0,
+      stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+      stderr: "",
+    };
+  });
+
+  await runPiPrompt(runner, "/repo", "prompt", {
+    stage: "pi-plan",
+    taskContract: {
+      ...DEFAULT_PI_TASK_CONTRACT,
+      doneStatuses: [" Shipped ", "shipped"],
+    },
+  });
+});
+```
+
+Also update `runPiPrompt passes the local Pi agent dir to Pi` to assert the default env:
+
+```ts
+assert.equal(
+  call.env?.PI_TODO_DONE_STATUSES,
+  JSON.stringify(["closed", "completed", "complete", "done"]),
+);
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pi.test.ts
+```
+
+Expected: fail because `PI_TODO_DONE_STATUSES` is not passed yet.
+
+- [ ] **Step 2: Pass the resolved terminal vocabulary to Pi**
+
+In `src/cli/commands/run-once/pi.ts`, import the helper:
+
+```ts
+import {
+  PI_TODO_DONE_STATUSES_ENV,
+  serializeTodoDoneStatuses,
+} from "../../../policy/todo-statuses.ts";
+```
+
+Change the `piAgentCommandEnv` call to include both todo env values:
+
+```ts
+env: piAgentCommandEnv(options?.piAgentDir ?? localPiAgentDir(cwd), {
+  PI_TODO_PATH:
+    options?.taskContract?.todoRoot ?? DEFAULT_PI_TASK_CONTRACT.todoRoot,
+  [PI_TODO_DONE_STATUSES_ENV]: serializeTodoDoneStatuses(
+    options?.taskContract?.doneStatuses ??
+      DEFAULT_PI_TASK_CONTRACT.doneStatuses,
+  ),
+}),
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pi.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Add prompt tests for default and custom terminal statuses**
+
+In `src/cli/commands/run-once/prompts.test.ts`, update implementation guidance assertions so they expect wording like:
+
+```ts
+assert.match(
+  prompt,
+  /Set a task todo status to `closed` only after code, tests, review, fixes, and verification/,
+);
+assert.match(
+  prompt,
+  /This contract treats `closed`, `completed`, `complete`, and `done` as terminal/,
+);
+```
+
+Add or update the custom task-contract prompt assertion near the existing custom contract tests:
+
+```ts
+assert.match(prompt, /This contract treats `shipped` as terminal/);
+assert.doesNotMatch(prompt, /`complete`, and `done` as terminal/);
+```
+
+Update plan-stage guidance assertions so the plan prompt names the status vocabulary and says to set plan-related task todos to `closed` after the plan commit:
+
+```ts
+assert.match(
+  prompt,
+  /After the plan document is committed, set the plan-related task todo status to `closed`/,
+);
+assert.match(
+  prompt,
+  /This contract treats `closed`, `completed`, `complete`, and `done` as terminal/,
+);
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/prompts.test.ts
+```
+
+Expected: fail until prompt rendering is updated.
+
+- [ ] **Step 4: Render terminal statuses in prompt guidance**
+
+In `src/cli/commands/run-once/prompts.ts`, add a helper near `renderConjoinedList`:
+
+```ts
+function renderTerminalStatuses(taskContract: PatchmillPiTaskContract): string {
+  return renderConjoinedList(
+    taskContract.doneStatuses.map((status) => `\`${status}\``),
+  );
+}
+```
+
+Add a shared line in `renderTaskContractTodoWorkflowLines`:
+
+```ts
+const terminalStatusLine = `- This contract treats ${renderTerminalStatuses(taskContract)} as terminal.`;
+```
+
+For plan-stage lines, replace the ambiguous completion sentence with:
+
+```ts
+terminalStatusLine,
+"- After the plan document is committed, set the plan-related task todo status to `closed` so they reflect the committed plan state.",
+```
+
+For implementation-stage lines, replace the ambiguous completion sentence with:
+
+```ts
+`- Set a task todo status to \`closed\` only after code, tests, review, fixes, and verification for that task are done.`,
+terminalStatusLine,
+```
+
+- [ ] **Step 5: Run focused Pi and prompt tests**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/run-once/prompts.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Pi environment and prompt changes**
+
+Run:
+
+```sh
+git add src/cli/commands/run-once/pi.ts src/cli/commands/run-once/pi.test.ts src/cli/commands/run-once/prompts.ts src/cli/commands/run-once/prompts.test.ts
+git commit -m "fix: pass todo terminal statuses to pi"
+```
+
+Expected: one conventional commit containing only Pi invocation and prompt guidance changes.
+
+## Task 4: Bundled todo extension status vocabulary
+
+**Files:**
+
+- Modify: `extensions/todos.ts`
+- Create: `test-support/todos-extension.test.ts`
+
+**Interfaces:**
+
+- Consumes: `parseTodoDoneStatusesEnv`, `todoStatusIsDone`, and `PI_TODO_DONE_STATUSES_ENV` from Task 1.
+- Produces: the bundled Pi `todo` tool and `/todos` UI use the same active terminal-status vocabulary as Patchmill for grouping, sorting, assignment clearing, claim blocking, garbage collection, and schema guidance.
+
+- [ ] **Step 1: Add a focused extension harness test**
+
+Create `test-support/todos-extension.test.ts` with a minimal mock Pi extension API. The test must register `extensions/todos.ts`, execute the registered `todo` tool in a temporary cwd, create one `complete` todo and one `open` todo, call `list-all`, and assert the `complete` todo is returned in the serialized `closed` group and cannot be claimed.
+
+Use this harness shape:
+
+```ts
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import todosExtension from "../extensions/todos.ts";
+import { PI_TODO_DONE_STATUSES_ENV } from "../src/policy/todo-statuses.ts";
+
+type RegisteredTool = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal,
+    onUpdate: () => void,
+    ctx: { cwd: string; sessionManager: { getSessionId: () => string } },
+  ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+};
+
+function registerTodoTool(): RegisteredTool {
+  let tool: RegisteredTool | undefined;
+  todosExtension({
+    on: () => undefined,
+    registerCommand: () => undefined,
+    registerTool: (registered: RegisteredTool) => {
+      tool = registered;
+    },
+  } as never);
+  assert.ok(tool);
+  return tool;
+}
+
+test("todo extension groups complete todos as closed and blocks claims", async () => {
+  const previous = process.env[PI_TODO_DONE_STATUSES_ENV];
+  delete process.env[PI_TODO_DONE_STATUSES_ENV];
+  try {
+    const tool = registerTodoTool();
+    const cwd = await mkdtemp(join(tmpdir(), "patchmill-todos-extension-"));
+    await mkdir(join(cwd, ".pi", "todos"), { recursive: true });
+    const ctx = { cwd, sessionManager: { getSessionId: () => "session-a" } };
+    const signal = new AbortController().signal;
+
+    const closedCreate = await tool.execute(
+      "call-1",
+      { action: "create", title: "finished", status: "complete" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    await tool.execute(
+      "call-2",
+      { action: "create", title: "still open", status: "open" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    const listed = await tool.execute(
+      "call-3",
+      { action: "list-all" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+
+    const closedTodo = JSON.parse(closedCreate.content[0].text) as { id: string };
+    const groups = JSON.parse(listed.content[0].text) as {
+      open: Array<{ title: string }>;
+      closed: Array<{ title: string }>;
+    };
+    assert.deepEqual(groups.closed.map((todo) => todo.title), ["finished"]);
+    assert.deepEqual(groups.open.map((todo) => todo.title), ["still open"]);
+
+    const claim = await tool.execute(
+      "call-4",
+      { action: "claim", id: closedTodo.id },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    assert.match(claim.content[0].text, /closed/);
+  } finally {
+    if (previous === undefined) delete process.env[PI_TODO_DONE_STATUSES_ENV];
+    else process.env[PI_TODO_DONE_STATUSES_ENV] = previous;
+  }
+});
+```
+
+Run:
+
+```sh
+node --test test-support/todos-extension.test.ts
+```
+
+Expected: fail because `complete` is currently open in extension grouping.
+
+- [ ] **Step 2: Resolve the active terminal vocabulary in the extension**
+
+In `extensions/todos.ts`, import helpers from the shared source:
+
+```ts
+import {
+  parseTodoDoneStatusesEnv,
+  PI_TODO_DONE_STATUSES_ENV,
+  todoStatusIsDone,
+} from "../src/policy/todo-statuses.ts";
+```
+
+Add module-level active status helpers:
+
+```ts
+function activeTodoDoneStatuses(): string[] {
+  return parseTodoDoneStatusesEnv(process.env[PI_TODO_DONE_STATUSES_ENV]);
+}
+
+function activeTodoStatusVocabulary(): string[] {
+  const statuses = ["open", ...activeTodoDoneStatuses()];
+  return statuses.filter((status, index) => statuses.indexOf(status) === index);
+}
+```
+
+Replace `isTodoClosed` with:
+
+```ts
+function isTodoClosed(status: string): boolean {
+  return todoStatusIsDone(status, activeTodoDoneStatuses());
+}
+```
+
+- [ ] **Step 3: Constrain the status parameter schema and update tool guidance**
+
+Replace the top-level static `TodoParams` with a function that builds parameters at registration time:
+
+```ts
+function todoParams() {
+  const statusVocabulary = activeTodoStatusVocabulary();
+  return Type.Object({
+    action: StringEnum([
+      "list",
+      "list-all",
+      "get",
+      "create",
+      "update",
+      "append",
+      "delete",
+      "claim",
+      "release",
+    ] as const),
+    id: Type.Optional(Type.String({ description: "Todo id (TODO-<hex> or raw hex filename)" })),
+    title: Type.Optional(Type.String({ description: "Short summary shown in lists" })),
+    status: Type.Optional(
+      StringEnum(statusVocabulary as [string, ...string[]], {
+        description: `Todo status. Use open for unfinished work. Prefer closed when work is complete. Terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`,
+      }),
+    ),
+    tags: Type.Optional(Type.Array(Type.String({ description: "Todo tag" }))),
+    body: Type.Optional(Type.String({ description: "Long-form details (markdown). Update replaces; append adds." })),
+    force: Type.Optional(Type.Boolean({ description: "Override another session's assignment" })),
+  });
+}
+```
+
+Change registration to:
+
+```ts
+parameters: todoParams(),
+```
+
+Update the registered tool description to include:
+
+```ts
+`Prefer status \`closed\` when work is complete. Accepted terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`
+```
+
+- [ ] **Step 4: Verify extension behavior and add schema/custom-env assertions**
+
+Extend `test-support/todos-extension.test.ts` with a second test that sets `process.env.PI_TODO_DONE_STATUSES` to `JSON.stringify(["shipped"])`, registers the tool, and asserts the description mentions `shipped` and a todo with status `shipped` appears in the closed group.
+
+Use this assertion shape:
+
+```ts
+assert.match(tool.description, /Accepted terminal statuses: shipped/);
+```
+
+Run:
+
+```sh
+node --test test-support/todos-extension.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Search for stale hard-coded terminal checks**
+
+Run:
+
+```sh
+rg '"closed", "done"|\["closed", "done"\]|status\.toLowerCase\(\)' extensions/todos.ts src
+```
+
+Expected: no stale todo terminal-status checks except tests that intentionally assert old behavior is gone. If `status.toLowerCase()` appears for unrelated display or non-terminal logic, verify it is not a todo completion check before keeping it.
+
+- [ ] **Step 6: Commit extension changes**
+
+Run:
+
+```sh
+git add extensions/todos.ts test-support/todos-extension.test.ts
+git commit -m "fix: align todo extension terminal statuses"
+```
+
+Expected: one conventional commit containing only extension status vocabulary and tests.
+
+## Task 5: Final validation and cleanup
+
+**Files:**
+
+- Read: `AGENTS.md`
+- Read: `docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md`
+- Verify: all files changed by Tasks 1-4
+
+**Interfaces:**
+
+- Consumes: all code and tests from Tasks 1-4.
+- Produces: final verification evidence that the todo tool, prompt guidance, UI grouping, progress tracking, and final handoff gate share one terminal-status vocabulary.
+
+- [ ] **Step 1: Run narrow affected tests**
+
+Run:
+
+```sh
+node --test src/policy/todo-statuses.test.ts src/policy/task-contract.test.ts src/policy/defaults.test.ts
+node --test src/cli/commands/run-once/issue-todos.test.ts
+node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/run-once/prompts.test.ts
+node --test src/cli/commands/run-once/pipeline-landing.test.ts src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+node --test test-support/todos-extension.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run repository validation**
+
+Run:
+
+```sh
+npm run lint
+npm test
+```
+
+Expected: both pass. `npm run lint` includes Markdown formatting checks, TypeScript linting for `src`, `bin`, and `test-support`, and Markdown linting. `npm test` runs the repository Node test suite.
+
+- [ ] **Step 3: Confirm dependency policy does not require Nix**
+
+Run:
+
+```sh
+git diff --name-only HEAD~4..HEAD | rg '(^|/)(package\.json|package-lock\.json|npm-shrinkwrap\.json)$' || true
+```
+
+Expected: no output. If the command prints a dependency file, run the repository Nix build before final handoff because `AGENTS.md` requires it when npm dependencies change.
+
+- [ ] **Step 4: Confirm shared vocabulary is used consistently**
+
+Run:
+
+```sh
+rg '"closed", "completed", "done"|"closed", "done"|doneStatuses\.includes|status\.toLowerCase\(\)' src extensions test-support
+```
+
+Expected: no stale terminal-status implementation remains. Test fixtures may still contain literal status examples; inspect any matches and ensure completion logic goes through `todoStatusIsDone` or the extension `isTodoClosed` wrapper.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```sh
+git status --short
+git diff --stat HEAD~4..HEAD
+git diff HEAD~4..HEAD -- src/policy src/cli/commands/run-once extensions/todos.ts test-support/todos-extension.test.ts
+```
+
+Expected: only issue #109 implementation files are changed, with no `.pi/todos` files staged or committed.
+
+- [ ] **Step 6: Commit final validation notes if code changed during validation**
+
+If validation required code or test fixes, commit those fixes with:
+
+```sh
+git add <fixed-files>
+git commit -m "fix: complete todo terminal status validation"
+```
+
+If no files changed during validation, do not create an empty commit.
+
+- [ ] **Step 7: Prepare final handoff evidence**
+
+Record the exact validation commands and pass/fail outcomes in the final response. No npm dependency changes are expected, so the Nix build is not required unless Step 3 printed a dependency file.

--- a/docs/plans/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate.md
+++ b/docs/plans/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate.md
@@ -1,43 +1,90 @@
 # Todo Terminal Status Compatibility Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make Patchmill-managed issue task todo terminal statuses consistent across the Pi todo tool, prompt guidance, progress tracking, and final handoff gates.
+**Goal:** Make Patchmill-managed issue task todo terminal statuses consistent
+across the Pi todo tool, prompt guidance, progress tracking, and final handoff
+gates.
 
-**Architecture:** Introduce a shared todo-status helper that owns default terminal statuses, normalization, predicates, and Pi-extension environment serialization. Wire Patchmill task-contract readers, Pi invocation, prompts, and the bundled todo extension to that helper so the default workflow recognizes `closed`, `completed`, `complete`, and `done`, while custom task-contract `doneStatuses` remain authoritative when configured.
+**Architecture:** Introduce a shared todo-status helper that owns default
+terminal statuses, normalization, predicates, and Pi-extension environment
+serialization. Wire Patchmill task-contract readers, Pi invocation, prompts, and
+the bundled todo extension to that helper so the default workflow recognizes
+`closed`, `completed`, `complete`, and `done`, while custom task-contract
+`doneStatuses` remain authoritative when configured.
 
-**Tech Stack:** TypeScript, Node.js `node:test`, TypeBox/Pi tool schemas, Patchmill run-once policy and prompt code, bundled Pi extension runtime.
+**Tech Stack:** TypeScript, Node.js `node:test`, TypeBox/Pi tool schemas,
+Patchmill run-once policy and prompt code, bundled Pi extension runtime.
 
 ## Global Constraints
 
-- Base the implementation on `docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md`.
-- Default Patchmill terminal statuses must be exactly `closed`, `completed`, `complete`, and `done`.
-- Status matching must trim surrounding whitespace and compare case-insensitively.
-- Existing todo files with `status: "complete"` must be treated as done without rewriting files.
-- Project overrides of `projectPolicy.pi.taskContract.doneStatuses` remain authoritative for Patchmill issue task todos.
-- The todo extension must default to the Patchmill default terminal set when no Patchmill environment is provided.
-- The Pi todo tool status schema must be constrained to the active status vocabulary: `open` plus the resolved done statuses.
+- Base the implementation on
+  `docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md`.
+- Default Patchmill terminal statuses must be exactly `closed`, `completed`,
+  `complete`, and `done`.
+- Status matching must trim surrounding whitespace and compare
+  case-insensitively.
+- Existing todo files with `status: "complete"` must be treated as done without
+  rewriting files.
+- Project overrides of `projectPolicy.pi.taskContract.doneStatuses` remain
+  authoritative for Patchmill issue task todos.
+- The todo extension must default to the Patchmill default terminal set when no
+  Patchmill environment is provided.
+- The Pi todo tool status schema must be constrained to the active status
+  vocabulary: `open` plus the resolved done statuses.
 - UI close actions still write `closed`; reopen actions still write `open`.
-- Do not change todo file location, title matching, tags, locking, assignment, or garbage-collection policy except where terminal-status recognition already participates.
-- Do not change npm dependencies. If `package.json`, `package-lock.json`, or `npm-shrinkwrap.json` changes unexpectedly, stop and add a Nix build verification step per `AGENTS.md`.
-- Testing Value Gate: this is a production regression in status parsing, prompt contracts, and final handoff behavior, so automated tests are required.
+- Do not change todo file location, title matching, tags, locking, assignment,
+  or garbage-collection policy except where terminal-status recognition already
+  participates.
+- Do not change npm dependencies. If `package.json`, `package-lock.json`, or
+  `npm-shrinkwrap.json` changes unexpectedly, stop and add a Nix build
+  verification step per `AGENTS.md`.
+- Testing Value Gate: this is a production regression in status parsing, prompt
+  contracts, and final handoff behavior, so automated tests are required.
 
 ## File Structure
 
-- Create `src/policy/todo-statuses.ts`: shared default status list, normalization, done predicate, environment variable name, serialization, and parsing helpers.
-- Create `src/policy/todo-statuses.test.ts`: behavior tests for defaults, normalization, custom statuses, de-duplication, and invalid environment fallback.
-- Modify `src/policy/task-contract.ts`: import the shared default list and predicate; make `DEFAULT_PI_TASK_CONTRACT.doneStatuses` use the shared default.
-- Modify `src/policy/task-contract.test.ts` and `src/policy/defaults.test.ts`: update default expectations and add predicate normalization coverage.
-- Modify `src/cli/commands/run-once/issue-todos.ts`: rely on the normalized shared predicate through `issueTodoStatusDone`.
-- Modify `src/cli/commands/run-once/issue-todos.test.ts`: cover `complete`, whitespace/case normalization, progress advancement, and all default terminal statuses in the final gate.
-- Modify `src/cli/commands/run-once/pipeline-landing.test.ts`: add a final-handoff regression where all issue task todos are `complete` and `pr-created` succeeds.
-- Modify `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`: add or update a progress scenario proving `complete` advances implementation progress.
-- Modify `src/cli/commands/run-once/pi.ts`: pass the resolved done-status list to Pi with a JSON string-array environment variable.
-- Modify `src/cli/commands/run-once/pi.test.ts`: assert `PI_TODO_DONE_STATUSES` is passed and progress respects custom done statuses.
-- Modify `src/cli/commands/run-once/prompts.ts`: render accepted terminal statuses in plan and implementation todo guidance and prefer setting completed work to `closed`.
-- Modify `src/cli/commands/run-once/prompts.test.ts`: update default prompt assertions and add custom terminal-status prompt assertions.
-- Modify `extensions/todos.ts`: import the shared helper, resolve active done statuses from the environment, constrain the status parameter schema, and use the shared predicate for grouping, sorting, assignment clearing, claiming, and garbage collection.
-- Create `test-support/todos-extension.test.ts`: focused extension-harness tests for default `complete` closed grouping, claim blocking, schema vocabulary, and invalid environment fallback.
+- Create `src/policy/todo-statuses.ts`: shared default status list,
+  normalization, done predicate, environment variable name, serialization, and
+  parsing helpers.
+- Create `src/policy/todo-statuses.test.ts`: behavior tests for defaults,
+  normalization, custom statuses, de-duplication, and invalid environment
+  fallback.
+- Modify `src/policy/task-contract.ts`: import the shared default list and
+  predicate; make `DEFAULT_PI_TASK_CONTRACT.doneStatuses` use the shared
+  default.
+- Modify `src/policy/task-contract.test.ts` and `src/policy/defaults.test.ts`:
+  update default expectations and add predicate normalization coverage.
+- Modify `src/cli/commands/run-once/issue-todos.ts`: rely on the normalized
+  shared predicate through `issueTodoStatusDone`.
+- Modify `src/cli/commands/run-once/issue-todos.test.ts`: cover `complete`,
+  whitespace/case normalization, progress advancement, and all default terminal
+  statuses in the final gate.
+- Modify `src/cli/commands/run-once/pipeline-landing.test.ts`: add a
+  final-handoff regression where all issue task todos are `complete` and
+  `pr-created` succeeds.
+- Modify `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`: add or
+  update a progress scenario proving `complete` advances implementation
+  progress.
+- Modify `src/cli/commands/run-once/pi.ts`: pass the resolved done-status list
+  to Pi with a JSON string-array environment variable.
+- Modify `src/cli/commands/run-once/pi.test.ts`: assert `PI_TODO_DONE_STATUSES`
+  is passed and progress respects custom done statuses.
+- Modify `src/cli/commands/run-once/prompts.ts`: render accepted terminal
+  statuses in plan and implementation todo guidance and prefer setting completed
+  work to `closed`.
+- Modify `src/cli/commands/run-once/prompts.test.ts`: update default prompt
+  assertions and add custom terminal-status prompt assertions.
+- Modify `extensions/todos.ts`: import the shared helper, resolve active done
+  statuses from the environment, constrain the status parameter schema, and use
+  the shared predicate for grouping, sorting, assignment clearing, claiming, and
+  garbage collection.
+- Create `test-support/todos-extension.test.ts`: focused extension-harness tests
+  for default `complete` closed grouping, claim blocking, schema vocabulary, and
+  invalid environment fallback.
 
 ---
 
@@ -54,7 +101,9 @@
 **Interfaces:**
 
 - Consumes: current `PatchmillPiTaskContract.doneStatuses` arrays.
-- Produces: `DEFAULT_TODO_DONE_STATUSES`, `PI_TODO_DONE_STATUSES_ENV`, `normalizeTodoStatus`, `normalizeTodoDoneStatuses`, `todoStatusIsDone`, `serializeTodoDoneStatuses`, and `parseTodoDoneStatusesEnv` for later tasks.
+- Produces: `DEFAULT_TODO_DONE_STATUSES`, `PI_TODO_DONE_STATUSES_ENV`,
+  `normalizeTodoStatus`, `normalizeTodoDoneStatuses`, `todoStatusIsDone`,
+  `serializeTodoDoneStatuses`, and `parseTodoDoneStatusesEnv` for later tasks.
 
 - [ ] **Step 1: Write failing shared-helper tests**
 
@@ -92,13 +141,28 @@ test("custom done statuses are authoritative after normalization", () => {
 });
 
 test("todo done status env serialization parses valid arrays and falls back safely", () => {
-  assert.deepEqual(parseTodoDoneStatusesEnv(serializeTodoDoneStatuses([" Shipped ", "shipped", ""])), [
-    "shipped",
-  ]);
-  assert.deepEqual(parseTodoDoneStatusesEnv("not json"), DEFAULT_TODO_DONE_STATUSES);
-  assert.deepEqual(parseTodoDoneStatusesEnv(JSON.stringify([])), DEFAULT_TODO_DONE_STATUSES);
-  assert.deepEqual(parseTodoDoneStatusesEnv(JSON.stringify(["", "  "])), DEFAULT_TODO_DONE_STATUSES);
-  assert.deepEqual(parseTodoDoneStatusesEnv(JSON.stringify(["done", 3])), DEFAULT_TODO_DONE_STATUSES);
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(
+      serializeTodoDoneStatuses([" Shipped ", "shipped", ""]),
+    ),
+    ["shipped"],
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv("not json"),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(JSON.stringify([])),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(JSON.stringify(["", "  "])),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(JSON.stringify(["done", 3])),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
 });
 ```
 
@@ -137,9 +201,7 @@ export function normalizeTodoDoneStatuses(
     if (!value || normalized.includes(value)) continue;
     normalized.push(value);
   }
-  return normalized.length > 0
-    ? normalized
-    : [...DEFAULT_TODO_DONE_STATUSES];
+  return normalized.length > 0 ? normalized : [...DEFAULT_TODO_DONE_STATUSES];
 }
 
 export function todoStatusIsDone(
@@ -177,7 +239,8 @@ export function parseTodoDoneStatusesEnv(value: string | undefined): string[] {
 
 - [ ] **Step 3: Wire the task contract to the helper**
 
-In `src/policy/task-contract.ts`, import the helper and change the default and predicate:
+In `src/policy/task-contract.ts`, import the helper and change the default and
+predicate:
 
 ```ts
 import {
@@ -205,13 +268,15 @@ export function issueTodoStatusDone(
 
 - [ ] **Step 4: Update default policy tests**
 
-Update `src/policy/task-contract.test.ts` and `src/policy/defaults.test.ts` so default `doneStatuses` expectations are:
+Update `src/policy/task-contract.test.ts` and `src/policy/defaults.test.ts` so
+default `doneStatuses` expectations are:
 
 ```ts
 doneStatuses: ["closed", "completed", "complete", "done"],
 ```
 
-Add this assertion to `src/policy/task-contract.test.ts` near the existing `issueTodoStatusDone` checks:
+Add this assertion to `src/policy/task-contract.test.ts` near the existing
+`issueTodoStatusDone` checks:
 
 ```ts
 assert.equal(issueTodoStatusDone(DEFAULT_PI_TASK_CONTRACT, " Complete "), true);
@@ -237,7 +302,8 @@ git add src/policy/todo-statuses.ts src/policy/todo-statuses.test.ts src/policy/
 git commit -m "fix: share todo terminal status vocabulary"
 ```
 
-Expected: one conventional commit containing only the shared-helper and default-contract changes.
+Expected: one conventional commit containing only the shared-helper and
+default-contract changes.
 
 ## Task 2: Issue todo progress and final handoff compatibility
 
@@ -251,15 +317,20 @@ Expected: one conventional commit containing only the shared-helper and default-
 **Interfaces:**
 
 - Consumes: `issueTodoStatusDone(contract, status)` from Task 1.
-- Produces: issue todo readers, progress, and final gates that recognize default `complete` todos and custom configured statuses consistently.
+- Produces: issue todo readers, progress, and final gates that recognize default
+  `complete` todos and custom configured statuses consistently.
 
 - [ ] **Step 1: Add issue-todo reader and gate tests for `complete`**
 
-In `src/cli/commands/run-once/issue-todos.test.ts`, add a test that writes issue #19 todos with statuses `" complete "`, `"COMPLETED"`, `"Done"`, and `"closed"`, then asserts all are done and the final gate accepts them:
+In `src/cli/commands/run-once/issue-todos.test.ts`, add a test that writes issue
+19 todos with statuses `" complete "`, `"COMPLETED"`, `"Done"`, and `"closed"`,
+then asserts all are done and the final gate accepts them:
 
 ```ts
 test("issue todo readers treat every default terminal status as done", async () => {
-  const repoRoot = await mkdtemp(join(tmpdir(), "agent-issue-complete-status-"));
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "agent-issue-complete-status-"),
+  );
   await writeTodo(repoRoot, "a", "issue-19-task-01-first", " complete ");
   await writeTodo(repoRoot, "b", "issue-19-task-02-second", "COMPLETED");
   await writeTodo(repoRoot, "c", "issue-19-task-03-third", "Done");
@@ -285,56 +356,106 @@ Run:
 node --test src/cli/commands/run-once/issue-todos.test.ts
 ```
 
-Expected before Task 1 integration is fully wired: fail on `complete` or normalized values. Expected after Task 1: pass.
+Expected before Task 1 integration is fully wired: fail on `complete` or
+normalized values. Expected after Task 1: pass.
 
 - [ ] **Step 2: Add a final handoff regression for `complete` todos**
 
-In `src/cli/commands/run-once/pipeline-landing.test.ts`, add a test based on `runOneIssue blocks completed handoff when issue task todos remain open`, but create two issue #24 task todos with status `"complete"`, return a `pr-created` Pi result, and assert the pipeline returns `pr-created` instead of blocked:
+In `src/cli/commands/run-once/pipeline-landing.test.ts`, add a test based on
+`runOneIssue blocks completed handoff when issue task todos remain open`, but
+create two issue #24 task todos with status `"complete"`, return a `pr-created`
+Pi result, and assert the pipeline returns `pr-created` instead of blocked:
 
 ```ts
 test("runOneIssue accepts pr-created handoff when issue task todos are complete", async () => {
   const config = await makeConfig({ dryRun: false, execute: true });
-  const selected = issue(24, ["agent-ready", "bug"], "Accept complete todo status");
+  const selected = issue(
+    24,
+    ["agent-ready", "bug"],
+    "Accept complete todo status",
+  );
   const existingPlanPath = join(
     config.plansDir,
     "2026-05-01-issue-24-accept-complete-todo-status.md",
   );
-  const worktreePath = ".worktrees/patchmill-issue-24-accept-complete-todo-status";
+  const worktreePath =
+    ".worktrees/patchmill-issue-24-accept-complete-todo-status";
   const worktreeRoot = join(config.repoRoot, worktreePath);
   await mkdir(worktreeRoot, { recursive: true });
   await writeFile(existingPlanPath, "# plan\n", "utf8");
-  await writeTodo(worktreeRoot, "task-1", "issue-24-task-01-status-helper", "complete");
-  await writeTodo(worktreeRoot, "task-2", "issue-24-task-02-final-gate", "complete");
+  await writeTodo(
+    worktreeRoot,
+    "task-1",
+    "issue-24-task-01-status-helper",
+    "complete",
+  );
+  await writeTodo(
+    worktreeRoot,
+    "task-2",
+    "issue-24-task-02-final-gate",
+    "complete",
+  );
 
   const runner = createMockRunner(async (call) => {
-    if (call.command === "tea" && call.args[0] === "issues" && call.args[1] === "list") {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
       const page = call.args[call.args.indexOf("--page") + 1];
-      return { code: 0, stdout: page === "1" ? issueListPayload([selected]) : "[]", stderr: "" };
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
     }
-    if (call.command === "git" && call.args[0] === "status") return { code: 0, stdout: "", stderr: "" };
-    if (call.command === "git" && call.args[0] === "worktree" && call.args[1] === "list") {
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "list"
+    ) {
       return { code: 0, stdout: `worktree ${worktreeRoot}\n`, stderr: "" };
     }
-    if (call.command === "git" && call.args[0] === "-C" && call.args[2] === "branch") {
-      return { code: 0, stdout: "agent/issue-24-accept-complete-todo-status\n", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "-C" &&
+      call.args[2] === "branch"
+    ) {
+      return {
+        code: 0,
+        stdout: "agent/issue-24-accept-complete-todo-status\n",
+        stderr: "",
+      };
     }
     if (call.command === "git" && call.args[0] === "log") {
       return { code: 0, stdout: "abc123 implementation\n", stderr: "" };
     }
-    if (call.command === "tea" && call.args[0] === "labels" && call.args[1] === "list") {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    ) {
       return { code: 0, stdout: labelListPayload(), stderr: "" };
     }
-    if (call.command === "tea" && (call.args[0] === "issues" || call.args[0] === "comment")) {
+    if (
+      call.command === "tea" &&
+      (call.args[0] === "issues" || call.args[0] === "comment")
+    ) {
       return { code: 0, stdout: "", stderr: "" };
     }
     if (call.command === "pi") {
       return {
         code: 0,
-        stdout: '{"status":"pr-created","prUrl":"https://forgejo.example/pr/24","branch":"agent/issue-24-accept-complete-todo-status","commits":["abc123"],"validation":["git diff --check ok"],"reviewSummary":"reviewed"}',
+        stdout:
+          '{"status":"pr-created","prUrl":"https://forgejo.example/pr/24","branch":"agent/issue-24-accept-complete-todo-status","commits":["abc123"],"validation":["git diff --check ok"],"reviewSummary":"reviewed"}',
         stderr: "",
       };
     }
-    throw new Error(`unexpected command: ${call.command} ${call.args.join(" ")}`);
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
   });
 
   const result = await runOneIssue(runner, config, { now: NOW });
@@ -353,7 +474,11 @@ Expected: pass after Task 1 predicate wiring.
 
 - [ ] **Step 3: Add a progress regression for `complete` todos**
 
-In `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`, add or adapt a heartbeat/progress case so an issue worktree has task 1 status `"complete"` and task 2 status `"open"`. Assert the progress event for implementation reports task 2 instead of staying on task 1. Use the existing `collectProgressEvents` helper and the existing `writeTodo` helper in that file.
+In `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`, add or adapt
+a heartbeat/progress case so an issue worktree has task 1 status `"complete"`
+and task 2 status `"open"`. Assert the progress event for implementation reports
+task 2 instead of staying on task 1. Use the existing `collectProgressEvents`
+helper and the existing `writeTodo` helper in that file.
 
 Use assertions in this shape:
 
@@ -382,7 +507,10 @@ Expected: pass after Task 1 predicate wiring.
 
 - [ ] **Step 4: Confirm no extra issue-todo implementation is needed**
 
-Inspect `src/cli/commands/run-once/issue-todos.ts`. If it already delegates through `issueTodoStatusDone`, do not add duplicate normalization there. If any direct `doneStatuses.includes` call remains in run-once issue-todo code, replace it with `issueTodoStatusDone`.
+Inspect `src/cli/commands/run-once/issue-todos.ts`. If it already delegates
+through `issueTodoStatusDone`, do not add duplicate normalization there. If any
+direct `doneStatuses.includes` call remains in run-once issue-todo code, replace
+it with `issueTodoStatusDone`.
 
 Run:
 
@@ -411,7 +539,8 @@ git add src/cli/commands/run-once/issue-todos.ts src/cli/commands/run-once/issue
 git commit -m "fix: treat complete todos as done in handoff gates"
 ```
 
-Expected: one conventional commit containing the run-once reader, gate, progress, and regression-test changes.
+Expected: one conventional commit containing the run-once reader, gate,
+progress, and regression-test changes.
 
 ## Task 3: Pi invocation environment and prompt guidance
 
@@ -424,12 +553,17 @@ Expected: one conventional commit containing the run-once reader, gate, progress
 
 **Interfaces:**
 
-- Consumes: `PI_TODO_DONE_STATUSES_ENV` and `serializeTodoDoneStatuses` from Task 1.
-- Produces: Pi child processes receive the same resolved terminal vocabulary as Patchmill, and generated prompts tell agents to set finished task todos to `closed` while listing all accepted terminal statuses.
+- Consumes: `PI_TODO_DONE_STATUSES_ENV` and `serializeTodoDoneStatuses` from
+  Task 1.
+- Produces: Pi child processes receive the same resolved terminal vocabulary as
+  Patchmill, and generated prompts tell agents to set finished task todos to
+  `closed` while listing all accepted terminal statuses.
 
 - [ ] **Step 1: Add failing Pi environment tests**
 
-In `src/cli/commands/run-once/pi.test.ts`, extend `runPiPrompt passes the configured todo root to Pi` or add a sibling test asserting the env contains the serialized done statuses:
+In `src/cli/commands/run-once/pi.test.ts`, extend
+`runPiPrompt passes the configured todo root to Pi` or add a sibling test
+asserting the env contains the serialized done statuses:
 
 ```ts
 test("runPiPrompt passes resolved todo done statuses to Pi", async () => {
@@ -452,7 +586,8 @@ test("runPiPrompt passes resolved todo done statuses to Pi", async () => {
 });
 ```
 
-Also update `runPiPrompt passes the local Pi agent dir to Pi` to assert the default env:
+Also update `runPiPrompt passes the local Pi agent dir to Pi` to assert the
+default env:
 
 ```ts
 assert.equal(
@@ -503,7 +638,8 @@ Expected: pass.
 
 - [ ] **Step 3: Add prompt tests for default and custom terminal statuses**
 
-In `src/cli/commands/run-once/prompts.test.ts`, update implementation guidance assertions so they expect wording like:
+In `src/cli/commands/run-once/prompts.test.ts`, update implementation guidance
+assertions so they expect wording like:
 
 ```ts
 assert.match(
@@ -516,14 +652,17 @@ assert.match(
 );
 ```
 
-Add or update the custom task-contract prompt assertion near the existing custom contract tests:
+Add or update the custom task-contract prompt assertion near the existing custom
+contract tests:
 
 ```ts
 assert.match(prompt, /This contract treats `shipped` as terminal/);
 assert.doesNotMatch(prompt, /`complete`, and `done` as terminal/);
 ```
 
-Update plan-stage guidance assertions so the plan prompt names the status vocabulary and says to set plan-related task todos to `closed` after the plan commit:
+Update plan-stage guidance assertions so the plan prompt names the status
+vocabulary and says to set plan-related task todos to `closed` after the plan
+commit:
 
 ```ts
 assert.match(
@@ -546,7 +685,8 @@ Expected: fail until prompt rendering is updated.
 
 - [ ] **Step 4: Render terminal statuses in prompt guidance**
 
-In `src/cli/commands/run-once/prompts.ts`, add a helper near `renderConjoinedList`:
+In `src/cli/commands/run-once/prompts.ts`, add a helper near
+`renderConjoinedList`:
 
 ```ts
 function renderTerminalStatuses(taskContract: PatchmillPiTaskContract): string {
@@ -595,7 +735,8 @@ git add src/cli/commands/run-once/pi.ts src/cli/commands/run-once/pi.test.ts src
 git commit -m "fix: pass todo terminal statuses to pi"
 ```
 
-Expected: one conventional commit containing only Pi invocation and prompt guidance changes.
+Expected: one conventional commit containing only Pi invocation and prompt
+guidance changes.
 
 ## Task 4: Bundled todo extension status vocabulary
 
@@ -606,12 +747,19 @@ Expected: one conventional commit containing only Pi invocation and prompt guida
 
 **Interfaces:**
 
-- Consumes: `parseTodoDoneStatusesEnv`, `todoStatusIsDone`, and `PI_TODO_DONE_STATUSES_ENV` from Task 1.
-- Produces: the bundled Pi `todo` tool and `/todos` UI use the same active terminal-status vocabulary as Patchmill for grouping, sorting, assignment clearing, claim blocking, garbage collection, and schema guidance.
+- Consumes: `parseTodoDoneStatusesEnv`, `todoStatusIsDone`, and
+  `PI_TODO_DONE_STATUSES_ENV` from Task 1.
+- Produces: the bundled Pi `todo` tool and `/todos` UI use the same active
+  terminal-status vocabulary as Patchmill for grouping, sorting, assignment
+  clearing, claim blocking, garbage collection, and schema guidance.
 
 - [ ] **Step 1: Add a focused extension harness test**
 
-Create `test-support/todos-extension.test.ts` with a minimal mock Pi extension API. The test must register `extensions/todos.ts`, execute the registered `todo` tool in a temporary cwd, create one `complete` todo and one `open` todo, call `list-all`, and assert the `complete` todo is returned in the serialized `closed` group and cannot be claimed.
+Create `test-support/todos-extension.test.ts` with a minimal mock Pi extension
+API. The test must register `extensions/todos.ts`, execute the registered `todo`
+tool in a temporary cwd, create one `complete` todo and one `open` todo, call
+`list-all`, and assert the `complete` todo is returned in the serialized
+`closed` group and cannot be claimed.
 
 Use this harness shape:
 
@@ -682,13 +830,21 @@ test("todo extension groups complete todos as closed and blocks claims", async (
       ctx,
     );
 
-    const closedTodo = JSON.parse(closedCreate.content[0].text) as { id: string };
+    const closedTodo = JSON.parse(closedCreate.content[0].text) as {
+      id: string;
+    };
     const groups = JSON.parse(listed.content[0].text) as {
       open: Array<{ title: string }>;
       closed: Array<{ title: string }>;
     };
-    assert.deepEqual(groups.closed.map((todo) => todo.title), ["finished"]);
-    assert.deepEqual(groups.open.map((todo) => todo.title), ["still open"]);
+    assert.deepEqual(
+      groups.closed.map((todo) => todo.title),
+      ["finished"],
+    );
+    assert.deepEqual(
+      groups.open.map((todo) => todo.title),
+      ["still open"],
+    );
 
     const claim = await tool.execute(
       "call-4",
@@ -748,7 +904,8 @@ function isTodoClosed(status: string): boolean {
 
 - [ ] **Step 3: Constrain the status parameter schema and update tool guidance**
 
-Replace the top-level static `TodoParams` with a function that builds parameters at registration time:
+Replace the top-level static `TodoParams` with a function that builds parameters
+at registration time:
 
 ```ts
 function todoParams() {
@@ -765,16 +922,27 @@ function todoParams() {
       "claim",
       "release",
     ] as const),
-    id: Type.Optional(Type.String({ description: "Todo id (TODO-<hex> or raw hex filename)" })),
-    title: Type.Optional(Type.String({ description: "Short summary shown in lists" })),
+    id: Type.Optional(
+      Type.String({ description: "Todo id (TODO-<hex> or raw hex filename)" }),
+    ),
+    title: Type.Optional(
+      Type.String({ description: "Short summary shown in lists" }),
+    ),
     status: Type.Optional(
       StringEnum(statusVocabulary as [string, ...string[]], {
         description: `Todo status. Use open for unfinished work. Prefer closed when work is complete. Terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`,
       }),
     ),
     tags: Type.Optional(Type.Array(Type.String({ description: "Todo tag" }))),
-    body: Type.Optional(Type.String({ description: "Long-form details (markdown). Update replaces; append adds." })),
-    force: Type.Optional(Type.Boolean({ description: "Override another session's assignment" })),
+    body: Type.Optional(
+      Type.String({
+        description:
+          "Long-form details (markdown). Update replaces; append adds.",
+      }),
+    ),
+    force: Type.Optional(
+      Type.Boolean({ description: "Override another session's assignment" }),
+    ),
   });
 }
 ```
@@ -788,12 +956,15 @@ parameters: todoParams(),
 Update the registered tool description to include:
 
 ```ts
-`Prefer status \`closed\` when work is complete. Accepted terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`
+`Prefer status \`closed\` when work is complete. Accepted terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`;
 ```
 
 - [ ] **Step 4: Verify extension behavior and add schema/custom-env assertions**
 
-Extend `test-support/todos-extension.test.ts` with a second test that sets `process.env.PI_TODO_DONE_STATUSES` to `JSON.stringify(["shipped"])`, registers the tool, and asserts the description mentions `shipped` and a todo with status `shipped` appears in the closed group.
+Extend `test-support/todos-extension.test.ts` with a second test that sets
+`process.env.PI_TODO_DONE_STATUSES` to `JSON.stringify(["shipped"])`, registers
+the tool, and asserts the description mentions `shipped` and a todo with status
+`shipped` appears in the closed group.
 
 Use this assertion shape:
 
@@ -817,7 +988,10 @@ Run:
 rg '"closed", "done"|\["closed", "done"\]|status\.toLowerCase\(\)' extensions/todos.ts src
 ```
 
-Expected: no stale todo terminal-status checks except tests that intentionally assert old behavior is gone. If `status.toLowerCase()` appears for unrelated display or non-terminal logic, verify it is not a todo completion check before keeping it.
+Expected: no stale todo terminal-status checks except tests that intentionally
+assert old behavior is gone. If `status.toLowerCase()` appears for unrelated
+display or non-terminal logic, verify it is not a todo completion check before
+keeping it.
 
 - [ ] **Step 6: Commit extension changes**
 
@@ -828,20 +1002,24 @@ git add extensions/todos.ts test-support/todos-extension.test.ts
 git commit -m "fix: align todo extension terminal statuses"
 ```
 
-Expected: one conventional commit containing only extension status vocabulary and tests.
+Expected: one conventional commit containing only extension status vocabulary
+and tests.
 
 ## Task 5: Final validation and cleanup
 
 **Files:**
 
 - Read: `AGENTS.md`
-- Read: `docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md`
+- Read:
+  `docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md`
 - Verify: all files changed by Tasks 1-4
 
 **Interfaces:**
 
 - Consumes: all code and tests from Tasks 1-4.
-- Produces: final verification evidence that the todo tool, prompt guidance, UI grouping, progress tracking, and final handoff gate share one terminal-status vocabulary.
+- Produces: final verification evidence that the todo tool, prompt guidance, UI
+  grouping, progress tracking, and final handoff gate share one terminal-status
+  vocabulary.
 
 - [ ] **Step 1: Run narrow affected tests**
 
@@ -866,7 +1044,9 @@ npm run lint
 npm test
 ```
 
-Expected: both pass. `npm run lint` includes Markdown formatting checks, TypeScript linting for `src`, `bin`, and `test-support`, and Markdown linting. `npm test` runs the repository Node test suite.
+Expected: both pass. `npm run lint` includes Markdown formatting checks,
+TypeScript linting for `src`, `bin`, and `test-support`, and Markdown linting.
+`npm test` runs the repository Node test suite.
 
 - [ ] **Step 3: Confirm dependency policy does not require Nix**
 
@@ -876,7 +1056,9 @@ Run:
 git diff --name-only HEAD~4..HEAD | rg '(^|/)(package\.json|package-lock\.json|npm-shrinkwrap\.json)$' || true
 ```
 
-Expected: no output. If the command prints a dependency file, run the repository Nix build before final handoff because `AGENTS.md` requires it when npm dependencies change.
+Expected: no output. If the command prints a dependency file, run the repository
+Nix build before final handoff because `AGENTS.md` requires it when npm
+dependencies change.
 
 - [ ] **Step 4: Confirm shared vocabulary is used consistently**
 
@@ -886,7 +1068,9 @@ Run:
 rg '"closed", "completed", "done"|"closed", "done"|doneStatuses\.includes|status\.toLowerCase\(\)' src extensions test-support
 ```
 
-Expected: no stale terminal-status implementation remains. Test fixtures may still contain literal status examples; inspect any matches and ensure completion logic goes through `todoStatusIsDone` or the extension `isTodoClosed` wrapper.
+Expected: no stale terminal-status implementation remains. Test fixtures may
+still contain literal status examples; inspect any matches and ensure completion
+logic goes through `todoStatusIsDone` or the extension `isTodoClosed` wrapper.
 
 - [ ] **Step 5: Review final diff**
 
@@ -898,9 +1082,11 @@ git diff --stat HEAD~4..HEAD
 git diff HEAD~4..HEAD -- src/policy src/cli/commands/run-once extensions/todos.ts test-support/todos-extension.test.ts
 ```
 
-Expected: only issue #109 implementation files are changed, with no `.pi/todos` files staged or committed.
+Expected: only issue #109 implementation files are changed, with no `.pi/todos`
+files staged or committed.
 
-- [ ] **Step 6: Commit final validation notes if code changed during validation**
+- [ ] **Step 6: Commit final validation notes if code changed during
+      validation**
 
 If validation required code or test fixes, commit those fixes with:
 
@@ -913,4 +1099,6 @@ If no files changed during validation, do not create an empty commit.
 
 - [ ] **Step 7: Prepare final handoff evidence**
 
-Record the exact validation commands and pass/fail outcomes in the final response. No npm dependency changes are expected, so the Nix build is not required unless Step 3 printed a dependency file.
+Record the exact validation commands and pass/fail outcomes in the final
+response. No npm dependency changes are expected, so the Nix build is not
+required unless Step 3 printed a dependency file.

--- a/docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md
+++ b/docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md
@@ -1,0 +1,191 @@
+# Issue #109 Todo Terminal Status Design
+
+**Date:** 2026-07-23 **Status:** Proposed; implementation pending
+
+## Problem
+
+Patchmill's bundled Pi `todo` tool can persist `status: "complete"`, but the
+status is not interpreted consistently. The todo extension treats only `closed`
+and `done` as closed, while the default Patchmill task contract treats `closed`,
+`completed`, and `done` as final-gate done statuses. As a result, an
+implementation agent can mark every issue task todo `complete`, receive a
+successful todo-tool response, and still have Patchmill reject `pr-created` or
+`merged` with `0/N complete`.
+
+The same mismatch can keep run progress on the first implementation task because
+progress reads the same task-contract done check.
+
+## Goals
+
+- Define one terminal-status vocabulary for Patchmill-managed issue task todos.
+- Treat existing default-workflow todos with `status: "complete"` as done.
+- Keep documented default terminal statuses `closed`, `completed`, and `done`.
+- Make agent-facing prompt guidance name the accepted terminal statuses.
+- Make the todo tool schema and UI grouping match the final handoff gate.
+- Preserve project task-contract overrides, including custom done statuses.
+- Test both the todo-status interpretation and final-gate/progress behavior.
+
+## Non-goals
+
+- Do not add a migration that rewrites existing todo files.
+- Do not support arbitrary natural-language completion statuses.
+- Do not change todo file location, title matching, tags, locking, assignment,
+  or garbage-collection policy except where terminal-status recognition already
+  participates in those flows.
+- Do not require changes to committed implementation plans or specs.
+
+## Decision
+
+Use compatibility recognition rather than write-time normalization.
+
+The default Patchmill terminal-status set becomes:
+
+```text
+closed, completed, complete, done
+```
+
+`closed` remains the preferred status for UI close actions and prompt examples.
+`done`, `completed`, and `complete` are accepted aliases so existing and natural
+agent outputs are handled safely. Status matching should trim surrounding
+whitespace and compare case-insensitively.
+
+For projects that configure `projectPolicy.pi.taskContract.doneStatuses`, the
+configured list remains authoritative for Patchmill issue task todos. Patchmill
+passes that resolved list to the bundled todo extension for each Pi invocation
+so the extension can present and group todos using the same terminal vocabulary
+as the final gate.
+
+## Affected components
+
+### Shared status vocabulary
+
+Add a small shared helper for todo status handling, for example
+`src/policy/todo-statuses.ts`, with:
+
+- `DEFAULT_TODO_DONE_STATUSES = ["closed", "completed", "complete", "done"]`;
+- a normalizer for trim/lowercase comparison;
+- a `todoStatusIsDone(status, doneStatuses)` predicate;
+- serialization/parsing helpers for passing the resolved status list to the Pi
+  extension environment.
+
+`DEFAULT_PI_TASK_CONTRACT.doneStatuses` should use the shared default list.
+`issueTodoStatusDone` should delegate to the shared predicate so
+`readIssueTodoTasks`, `issueTodoProgress`, and `assertIssueTodosComplete` all
+interpret statuses identically.
+
+If the Pi extension loader cannot safely import from `src/`, place the helper in
+a package-included location that both the CLI and `extensions/todos.ts` can
+import. The implementation must still keep a single source of truth.
+
+### Bundled todo extension
+
+Update `extensions/todos.ts` to derive its terminal-status set from the same
+helper, defaulting to the Patchmill default set when no Patchmill environment is
+provided.
+
+The extension should use that set for:
+
+- `isTodoClosed`;
+- clearing assignment when a todo becomes terminal;
+- sorting and search result ordering;
+- `list`, `list-all`, `/todos`, and rendered tool-result grouping;
+- UI close/reopen behavior, with close still writing `closed` and reopen still
+  writing `open`;
+- garbage collection of closed todos.
+
+Constrain the `status` parameter schema to the active status vocabulary when the
+extension registers the tool. The minimum non-terminal status is `open`; the
+terminal values are the resolved done-status list. The tool description should
+say to prefer `closed` when work is complete and list the accepted terminal
+statuses. This prevents `complete` from being an undocumented accident while
+still allowing project-specific done statuses when Patchmill supplies them.
+
+Existing todo files that already contain `complete` should not be rewritten, but
+under the default contract they must appear under closed todos and be ineligible
+for claim as open work.
+
+### Patchmill Pi invocation
+
+When `runPiPrompt` launches Pi, pass the resolved task contract's done statuses
+to the todo extension, alongside the existing todo-root environment. Use a stable
+format such as a JSON string array to avoid ambiguity around status names.
+
+Invalid or empty environment values should fall back to the shared default inside
+the extension. Config validation should continue to require
+`doneStatuses` to be an array of strings; implementation may additionally reject
+blank normalized statuses if not already covered.
+
+### Prompt guidance
+
+Update the task-contract prompt rendering in
+`src/cli/commands/run-once/prompts.ts` so plan and implementation prompts name
+the accepted terminal statuses.
+
+Plan-stage guidance should continue to say that plan-related task todos are
+closed only after the plan document is committed, but should specify the status
+vocabulary rather than saying only "complete" in prose.
+
+Implementation-stage guidance should replace ambiguous wording such as "Mark a
+task todo complete" with wording like:
+
+```text
+Set a task todo status to `closed` after code, tests, review, fixes, and
+verification for that task are done. This contract treats `closed`,
+`completed`, `complete`, and `done` as terminal.
+```
+
+For custom task contracts, render the configured done statuses instead of the
+default list.
+
+## Rejected alternatives
+
+### Normalize `complete` to `closed` on write
+
+This would make newly written default todos safe, but existing `complete` todo
+files would still need read-time compatibility. It would also hide the user's
+actual status value from tool responses, making debugging harder.
+
+### Add only `complete` to the final gate
+
+This would fix the final rejection but leave `/todos`, tool-result grouping,
+assignment clearing, garbage collection, and progress semantics inconsistent.
+
+### Hard-code a fixed enum in the todo extension
+
+A fixed enum would help the default workflow but would break existing Patchmill
+support for custom `doneStatuses` such as `shipped` or `verified`.
+
+## Verification strategy
+
+Apply Patchmill's Testing Value Gate: this is a production regression in status
+parsing, prompt contracts, and final handoff behavior, so automated tests are
+valuable.
+
+Add or update tests for:
+
+- shared status helper defaults, normalization, custom statuses, and invalid
+  environment fallback;
+- `DEFAULT_PI_TASK_CONTRACT.doneStatuses` including `complete`;
+- `readIssueTodoTasks` marking `complete` as done;
+- `issueTodoProgress` advancing past tasks marked `complete`;
+- `assertIssueTodosComplete` accepting all default terminal statuses;
+- the landing/final-handoff path accepting a `pr-created` or `merged` result
+  when all issue task todos are `complete`;
+- prompt rendering naming the default terminal statuses and custom contract
+  terminal statuses;
+- `runPiPrompt` passing the resolved done-status list to Pi;
+- todo-extension closed grouping and claim blocking for `complete` through the
+  shared status helper or a focused extension test.
+
+Run the narrow affected tests first, then the full run-once and project test
+suites:
+
+```text
+node --test src/policy/*.test.ts src/cli/commands/run-once/issue-todos.test.ts
+node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/run-once/prompts.test.ts
+node --test src/cli/commands/run-once/pipeline-landing.test.ts src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+npm test
+```
+
+No npm dependency changes are expected, so the Nix build is not required by the
+repository dependency-change policy.

--- a/docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md
+++ b/docs/specs/2026-07-23-issue-109-todo-status-is-accepted-but-fails-the-final-handoff-gate-design.md
@@ -107,11 +107,12 @@ for claim as open work.
 ### Patchmill Pi invocation
 
 When `runPiPrompt` launches Pi, pass the resolved task contract's done statuses
-to the todo extension, alongside the existing todo-root environment. Use a stable
-format such as a JSON string array to avoid ambiguity around status names.
+to the todo extension, alongside the existing todo-root environment. Use a
+stable format such as a JSON string array to avoid ambiguity around status
+names.
 
-Invalid or empty environment values should fall back to the shared default inside
-the extension. Config validation should continue to require
+Invalid or empty environment values should fall back to the shared default
+inside the extension. Config validation should continue to require
 `doneStatuses` to be an array of strings; implementation may additionally reject
 blank normalized statuses if not already covered.
 

--- a/extensions/todos.ts
+++ b/extensions/todos.ts
@@ -39,6 +39,7 @@ import { Type } from "typebox";
 import {
 	parseTodoDoneStatusesEnv,
 	PI_TODO_DONE_STATUSES_ENV,
+	todoCompletionStatus,
 	todoStatusIsDone,
 } from "../src/policy/todo-statuses.ts";
 import path from "node:path";
@@ -118,8 +119,13 @@ function activeTodoStatusVocabulary(): string[] {
 	return statuses.filter((status, index) => statuses.indexOf(status) === index);
 }
 
+export function todoCloseStatus(): string {
+	return todoCompletionStatus(activeTodoDoneStatuses());
+}
+
 function todoParams() {
 	const doneStatuses = activeTodoDoneStatuses();
+	const completionStatus = todoCloseStatus();
 	const statusVocabulary = activeTodoStatusVocabulary();
 	return Type.Object({
 		action: stringEnum([
@@ -139,7 +145,7 @@ function todoParams() {
 		title: Type.Optional(Type.String({ description: "Short summary shown in lists" })),
 		status: Type.Optional(
 			stringEnum(statusVocabulary, {
-				description: `Todo status. Use open for unfinished work. Prefer closed when work is complete. Terminal statuses: ${doneStatuses.join(", ")}.`,
+				description: `Todo status. Use open for unfinished work. Prefer \`${completionStatus}\` when work is complete. Terminal statuses: ${doneStatuses.join(", ")}.`,
 			}),
 		),
 		tags: Type.Optional(Type.Array(Type.String({ description: "Todo tag" }))),
@@ -1481,7 +1487,7 @@ export default function todosExtension(pi: ExtensionAPI) {
 			`Manage file-based todos in ${todosDirLabel} (list, list-all, get, create, update, append, delete, claim, release). ` +
 			"Title is the short summary; body is long-form markdown notes (update replaces, append adds). " +
 			"Todo ids are shown as TODO-<hex>; id parameters accept TODO-<hex> or the raw hex filename. " +
-			`Claim tasks before working on them to avoid conflicts. Prefer status \`closed\` when work is complete. Accepted terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`,
+			`Claim tasks before working on them to avoid conflicts. Prefer status \`${todoCloseStatus()}\` when work is complete. Accepted terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`,
 		parameters: todoParams(),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -1989,7 +1995,7 @@ export default function todosExtension(pi: ExtensionAPI) {
 						return "stay";
 					}
 
-					const nextStatus = action === "close" ? "closed" : "open";
+					const nextStatus = action === "close" ? todoCloseStatus() : "open";
 					const result = await updateTodoStatus(todosDir, record.id, nextStatus, ctx);
 					if ("error" in result) {
 						ctx.ui.notify(result.error, "error");

--- a/extensions/todos.ts
+++ b/extensions/todos.ts
@@ -35,8 +35,12 @@
  * naturally.
  */
 import { DynamicBorder, copyToClipboard, getMarkdownTheme, keyHint, type ExtensionAPI, type ExtensionContext, type Theme } from "@earendil-works/pi-coding-agent";
-import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
+import {
+	parseTodoDoneStatusesEnv,
+	PI_TODO_DONE_STATUSES_ENV,
+	todoStatusIsDone,
+} from "../src/policy/todo-statuses.ts";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
@@ -98,29 +102,53 @@ type KeybindingMatcher = {
 	matches: (keyData: string, keybindingId: string) => boolean;
 };
 
-const TodoParams = Type.Object({
-	action: StringEnum([
-		"list",
-		"list-all",
-		"get",
-		"create",
-		"update",
-		"append",
-		"delete",
-		"claim",
-		"release",
-	] as const),
-	id: Type.Optional(
-		Type.String({ description: "Todo id (TODO-<hex> or raw hex filename)" }),
-	),
-	title: Type.Optional(Type.String({ description: "Short summary shown in lists" })),
-	status: Type.Optional(Type.String({ description: "Todo status" })),
-	tags: Type.Optional(Type.Array(Type.String({ description: "Todo tag" }))),
-	body: Type.Optional(
-		Type.String({ description: "Long-form details (markdown). Update replaces; append adds." }),
-	),
-	force: Type.Optional(Type.Boolean({ description: "Override another session's assignment" })),
-});
+function stringEnum(
+	values: readonly string[],
+	options: Record<string, unknown> = {},
+) {
+	return Type.Unsafe({ type: "string", enum: [...values], ...options });
+}
+
+function activeTodoDoneStatuses(): string[] {
+	return parseTodoDoneStatusesEnv(process.env[PI_TODO_DONE_STATUSES_ENV]);
+}
+
+function activeTodoStatusVocabulary(): string[] {
+	const statuses = ["open", ...activeTodoDoneStatuses()];
+	return statuses.filter((status, index) => statuses.indexOf(status) === index);
+}
+
+function todoParams() {
+	const doneStatuses = activeTodoDoneStatuses();
+	const statusVocabulary = activeTodoStatusVocabulary();
+	return Type.Object({
+		action: stringEnum([
+			"list",
+			"list-all",
+			"get",
+			"create",
+			"update",
+			"append",
+			"delete",
+			"claim",
+			"release",
+		] as const),
+		id: Type.Optional(
+			Type.String({ description: "Todo id (TODO-<hex> or raw hex filename)" }),
+		),
+		title: Type.Optional(Type.String({ description: "Short summary shown in lists" })),
+		status: Type.Optional(
+			stringEnum(statusVocabulary, {
+				description: `Todo status. Use open for unfinished work. Prefer closed when work is complete. Terminal statuses: ${doneStatuses.join(", ")}.`,
+			}),
+		),
+		tags: Type.Optional(Type.Array(Type.String({ description: "Todo tag" }))),
+		body: Type.Optional(
+			Type.String({ description: "Long-form details (markdown). Update replaces; append adds." }),
+		),
+		force: Type.Optional(Type.Boolean({ description: "Override another session's assignment" })),
+	});
+}
 
 type TodoAction =
 	| "list"
@@ -182,7 +210,7 @@ function displayTodoId(id: string): string {
 }
 
 function isTodoClosed(status: string): boolean {
-	return ["closed", "done"].includes(status.toLowerCase());
+	return todoStatusIsDone(status, activeTodoDoneStatuses());
 }
 
 function clearAssignmentIfClosed(todo: TodoFrontMatter): void {
@@ -265,6 +293,7 @@ class TodoSelectorComponent extends Container implements Focusable {
 	private headerText: Text;
 	private hintText: Text;
 	private currentSessionId?: string;
+	private onQuickAction?: (todo: TodoFrontMatter, action: "work" | "refine") => void;
 
 	private _focused = false;
 	get focused(): boolean {
@@ -284,13 +313,14 @@ class TodoSelectorComponent extends Container implements Focusable {
 		onCancel: () => void,
 		initialSearchInput?: string,
 		currentSessionId?: string,
-		private onQuickAction?: (todo: TodoFrontMatter, action: "work" | "refine") => void,
+		onQuickAction?: (todo: TodoFrontMatter, action: "work" | "refine") => void,
 	) {
 		super();
 		this.tui = tui;
 		this.theme = theme;
 		this.keybindings = keybindings;
 		this.currentSessionId = currentSessionId;
+		this.onQuickAction = onQuickAction;
 		this.allTodos = todos;
 		this.filteredTodos = todos;
 		this.onSelectCallback = onSelect;
@@ -1451,8 +1481,8 @@ export default function todosExtension(pi: ExtensionAPI) {
 			`Manage file-based todos in ${todosDirLabel} (list, list-all, get, create, update, append, delete, claim, release). ` +
 			"Title is the short summary; body is long-form markdown notes (update replaces, append adds). " +
 			"Todo ids are shown as TODO-<hex>; id parameters accept TODO-<hex> or the raw hex filename. " +
-			"Claim tasks before working on them to avoid conflicts, and close them when complete.",
-		parameters: TodoParams,
+			`Claim tasks before working on them to avoid conflicts. Prefer status \`closed\` when work is complete. Accepted terminal statuses: ${activeTodoDoneStatuses().join(", ")}.`,
+		parameters: todoParams(),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const todosDir = getTodosDir(ctx.cwd);

--- a/src/cli/commands/run-once/issue-todos.test.ts
+++ b/src/cli/commands/run-once/issue-todos.test.ts
@@ -52,6 +52,28 @@ test("readIssueTodoTasks returns sorted implementation task labels", async () =>
   ]);
 });
 
+test("issue todo readers treat every default terminal status as done", async () => {
+  const repoRoot = await mkdtemp(
+    join(tmpdir(), "agent-issue-complete-status-"),
+  );
+  await writeTodo(repoRoot, "a", "issue-19-task-01-first", " complete ");
+  await writeTodo(repoRoot, "b", "issue-19-task-02-second", "COMPLETED");
+  await writeTodo(repoRoot, "c", "issue-19-task-03-third", "Done");
+  await writeTodo(repoRoot, "d", "issue-19-task-04-fourth", "closed");
+
+  const tasks = await readIssueTodoTasks(repoRoot, 19);
+  assert.deepEqual(
+    tasks.map((task) => task.done),
+    [true, true, true, true],
+  );
+  assert.deepEqual(await issueTodoProgress(repoRoot, 19), {
+    current: 4,
+    total: 4,
+    label: "fourth",
+  });
+  await assertIssueTodosComplete(repoRoot, 19);
+});
+
 test("issueTodoProgress includes the current task label", async () => {
   const repoRoot = await mkdtemp(join(tmpdir(), "agent-issue-progress-"));
   await writeTodo(repoRoot, "a", "issue-19-task-01-date-range-model", "closed");

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -206,10 +206,33 @@ test("runPiPrompt passes the configured todo root to Pi", async () => {
   });
 });
 
+test("runPiPrompt passes resolved todo done statuses to Pi", async () => {
+  const runner = createMockRunner((call) => {
+    assert.equal(call.env?.PI_TODO_DONE_STATUSES, JSON.stringify(["shipped"]));
+    return {
+      code: 0,
+      stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+      stderr: "",
+    };
+  });
+
+  await runPiPrompt(runner, "/repo", "prompt", {
+    stage: "pi-plan",
+    taskContract: {
+      ...DEFAULT_PI_TASK_CONTRACT,
+      doneStatuses: [" Shipped ", "shipped"],
+    },
+  });
+});
+
 test("runPiPrompt passes the local Pi agent dir to Pi", async () => {
   const runner = createMockRunner((call) => {
     assert.equal(call.env?.PI_CODING_AGENT_DIR, "/repo/.patchmill/pi-agent");
     assert.equal(call.env?.PI_TODO_PATH, DEFAULT_PI_TASK_CONTRACT.todoRoot);
+    assert.equal(
+      call.env?.PI_TODO_DONE_STATUSES,
+      JSON.stringify(["closed", "completed", "complete", "done"]),
+    );
     return {
       code: 0,
       stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -5,6 +5,10 @@ import {
   DEFAULT_PI_TASK_CONTRACT,
   type PatchmillPiTaskContract,
 } from "../../../policy/task-contract.ts";
+import {
+  PI_TODO_DONE_STATUSES_ENV,
+  serializeTodoDoneStatuses,
+} from "../../../policy/todo-statuses.ts";
 import { localPiAgentDir } from "../init/pi-agent-settings.ts";
 import {
   piAgentCommandEnv,
@@ -504,6 +508,10 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
             PI_TODO_PATH:
               options?.taskContract?.todoRoot ??
               DEFAULT_PI_TASK_CONTRACT.todoRoot,
+            [PI_TODO_DONE_STATUSES_ENV]: serializeTodoDoneStatuses(
+              options?.taskContract?.doneStatuses ??
+                DEFAULT_PI_TASK_CONTRACT.doneStatuses,
+            ),
           }),
         },
       );

--- a/src/cli/commands/run-once/pipeline-landing.test.ts
+++ b/src/cli/commands/run-once/pipeline-landing.test.ts
@@ -168,6 +168,102 @@ test("runOneIssue blocks completed handoff when issue task todos remain open", a
   );
 });
 
+test("runOneIssue accepts pr-created handoff when issue task todos are complete", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const selected = issue(
+    24,
+    ["agent-ready", "bug"],
+    "Accept complete todo status",
+  );
+  const existingPlanPath = join(
+    config.plansDir,
+    "2026-05-01-issue-24-accept-complete-todo-status.md",
+  );
+  const worktreePath =
+    ".worktrees/patchmill-issue-24-accept-complete-todo-status";
+  const worktreeRoot = join(config.repoRoot, worktreePath);
+  await mkdir(worktreeRoot, { recursive: true });
+  await writeFile(existingPlanPath, "# plan\n", "utf8");
+  await writeTodo(
+    worktreeRoot,
+    "task-1",
+    "issue-24-task-01-status-helper",
+    "complete",
+  );
+  await writeTodo(
+    worktreeRoot,
+    "task-2",
+    "issue-24-task-02-final-gate",
+    "complete",
+  );
+
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "list"
+    ) {
+      return { code: 0, stdout: `worktree ${worktreeRoot}\n`, stderr: "" };
+    }
+    if (
+      call.command === "git" &&
+      call.args[0] === "-C" &&
+      call.args[2] === "branch"
+    ) {
+      return {
+        code: 0,
+        stdout: "agent/issue-24-accept-complete-todo-status\n",
+        stderr: "",
+      };
+    }
+    if (call.command === "git" && call.args[0] === "log") {
+      return { code: 0, stdout: "abc123 implementation\n", stderr: "" };
+    }
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    ) {
+      return { code: 0, stdout: labelListPayload(), stderr: "" };
+    }
+    if (
+      call.command === "tea" &&
+      (call.args[0] === "issues" || call.args[0] === "comment")
+    ) {
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (call.command === "pi") {
+      return {
+        code: 0,
+        stdout:
+          '{"status":"pr-created","prUrl":"https://forgejo.example/pr/24","branch":"agent/issue-24-accept-complete-todo-status","commits":["abc123"],"validation":["git diff --check ok"],"reviewSummary":"reviewed"}',
+        stderr: "",
+      };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created", JSON.stringify(result));
+});
+
 test("runOneIssue accepts direct squash-landed implementation results when skills.landing is configured", async () => {
   const config = await makeConfig({
     dryRun: false,

--- a/src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+++ b/src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
@@ -237,7 +237,7 @@ test("runOneIssue emits visible implementation subtask step labels", async () =>
         worktreeRoot,
         "task-1",
         "issue-15-task-01-date-range-model",
-        "closed",
+        "complete",
       );
       await writeTodo(
         worktreeRoot,

--- a/src/cli/commands/run-once/prompts.test.ts
+++ b/src/cli/commands/run-once/prompts.test.ts
@@ -980,7 +980,7 @@ test("task contract overrides drive todo instructions in plan and implementation
           "checkpoint details",
           "latest validation",
         ],
-        doneStatuses: ["shipped"],
+        doneStatuses: [" Shipped ", "shipped"],
         planTaskHeadingPattern: "### Step <number> - <label>",
         openTaskTodosBlockFinalHandoff: false,
       },
@@ -1013,6 +1013,7 @@ test("task contract overrides drive todo instructions in plan and implementation
   );
   assert.match(planPrompt, /work-42-step-<two-digit-number>-<slug>/);
   assert.match(planPrompt, /This contract treats `shipped` as terminal/);
+  assert.doesNotMatch(planPrompt, /` Shipped `|`shipped` and `shipped`/);
   assert.match(
     planPrompt,
     /After the plan document is committed, set the plan-related task todo status to `shipped`/,
@@ -1033,6 +1034,10 @@ test("task contract overrides drive todo instructions in plan and implementation
   assert.match(
     implementationPrompt,
     /This contract treats `shipped` as terminal/,
+  );
+  assert.doesNotMatch(
+    implementationPrompt,
+    /` Shipped `|`shipped` and `shipped`/,
   );
   assert.match(
     implementationPrompt,

--- a/src/cli/commands/run-once/prompts.test.ts
+++ b/src/cli/commands/run-once/prompts.test.ts
@@ -174,7 +174,11 @@ test("buildPlanCreationPrompt includes issue context, workflow rules, and result
   );
   assert.match(
     prompt,
-    /After the plan document is committed, mark the plan-related task todos complete/,
+    /After the plan document is committed, set the plan-related task todo status to `closed`/,
+  );
+  assert.match(
+    prompt,
+    /This contract treats `closed`, `completed`, `complete`, and `done` as terminal/,
   );
   assert.match(prompt, /Number: #42/);
   assert.match(prompt, /Title: Add once runner helpers/);
@@ -467,7 +471,11 @@ test("buildImplementationPrompt includes plan-first execution, review loop, vali
   );
   assert.match(
     prompt,
-    /Mark a task todo complete only after code, tests, review, fixes, and verification/,
+    /Set a task todo status to `closed` only after code, tests, review, fixes, and verification/,
+  );
+  assert.match(
+    prompt,
+    /This contract treats `closed`, `completed`, `complete`, and `done` as terminal/,
   );
   assert.match(
     prompt,
@@ -1004,6 +1012,7 @@ test("task contract overrides drive todo instructions in plan and implementation
     /Each task todo body must include: purpose, plan checklist item, and checkpoint details/,
   );
   assert.match(planPrompt, /work-42-step-<two-digit-number>-<slug>/);
+  assert.match(planPrompt, /This contract treats `shipped` as terminal/);
   assert.match(
     implementationPrompt,
     /Store issue task todos under `\.patchmill\/todos`/,
@@ -1017,6 +1026,14 @@ test("task contract overrides drive todo instructions in plan and implementation
     /Each task todo body must include: purpose, plan checklist item, checkpoint details, and latest validation/,
   );
   assert.match(implementationPrompt, /work-42-step-<two-digit-number>-<slug>/);
+  assert.match(
+    implementationPrompt,
+    /This contract treats `shipped` as terminal/,
+  );
+  assert.doesNotMatch(
+    implementationPrompt,
+    /`complete`, and `done` as terminal/,
+  );
   assert.match(
     implementationPrompt,
     /Open issue task todos do not block final handoff for this project/,

--- a/src/cli/commands/run-once/prompts.test.ts
+++ b/src/cli/commands/run-once/prompts.test.ts
@@ -1014,6 +1014,10 @@ test("task contract overrides drive todo instructions in plan and implementation
   assert.match(planPrompt, /work-42-step-<two-digit-number>-<slug>/);
   assert.match(planPrompt, /This contract treats `shipped` as terminal/);
   assert.match(
+    planPrompt,
+    /After the plan document is committed, set the plan-related task todo status to `shipped`/,
+  );
+  assert.match(
     implementationPrompt,
     /Store issue task todos under `\.patchmill\/todos`/,
   );
@@ -1029,6 +1033,10 @@ test("task contract overrides drive todo instructions in plan and implementation
   assert.match(
     implementationPrompt,
     /This contract treats `shipped` as terminal/,
+  );
+  assert.match(
+    implementationPrompt,
+    /Set a task todo status to `shipped` only after code, tests, review, fixes, and verification/,
   );
   assert.doesNotMatch(
     implementationPrompt,

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -1,6 +1,9 @@
 import type { GitWorktreeStrategyConfig } from "../../../git/types.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
-import { todoCompletionStatus } from "../../../policy/todo-statuses.ts";
+import {
+  normalizeTodoDoneStatuses,
+  todoCompletionStatus,
+} from "../../../policy/todo-statuses.ts";
 import {
   DEFAULT_PATCHMILL_SKILLS,
   type PatchmillSkillsConfig,
@@ -316,7 +319,9 @@ function renderTaskTodoBodyRequirements(requirements: string[]): string {
 
 function renderTerminalStatuses(taskContract: PatchmillPiTaskContract): string {
   return renderConjoinedList(
-    taskContract.doneStatuses.map((status) => `\`${status}\``),
+    normalizeTodoDoneStatuses(taskContract.doneStatuses).map(
+      (status) => `\`${status}\``,
+    ),
   );
 }
 

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -313,6 +313,12 @@ function renderTaskTodoBodyRequirements(requirements: string[]): string {
   return renderConjoinedList(requirements);
 }
 
+function renderTerminalStatuses(taskContract: PatchmillPiTaskContract): string {
+  return renderConjoinedList(
+    taskContract.doneStatuses.map((status) => `\`${status}\``),
+  );
+}
+
 function renderTaskContractTodoWorkflowLines(
   taskContract: PatchmillPiTaskContract,
   stage: "plan" | "implementation",
@@ -324,6 +330,7 @@ function renderTaskContractTodoWorkflowLines(
   );
   const todoTitleGlob = renderIssueTodoTitleGlob(taskContract, issueNumber);
   const todoTags = renderTaskTodoTags(taskContract, issueNumber);
+  const terminalStatusLine = `- This contract treats ${renderTerminalStatuses(taskContract)} as terminal.`;
   const sharedLines = [
     `- Store issue task todos under \`${taskContract.todoRoot}\`.`,
     ...(todoTags.length > 0 ? [`- Tag each task todo with ${todoTags}.`] : []),
@@ -342,7 +349,8 @@ function renderTaskContractTodoWorkflowLines(
             `- Each task todo body must include: ${renderTaskTodoBodyRequirements(taskContract.planTodoBodyRequirements)}.`,
           ]
         : []),
-      "- After the plan document is committed, mark the plan-related task todos complete so they reflect the committed plan state.",
+      terminalStatusLine,
+      "- After the plan document is committed, set the plan-related task todo status to `closed` so they reflect the committed plan state.",
     ];
   }
 
@@ -363,7 +371,8 @@ function renderTaskContractTodoWorkflowLines(
       : []),
     "- Do not create a single broad implementation todo.",
     "- Claim or update the current task todo before doing work on that task.",
-    "- Mark a task todo complete only after code, tests, review, fixes, and verification for that task are done.",
+    "- Set a task todo status to `closed` only after code, tests, review, fixes, and verification for that task are done.",
+    terminalStatusLine,
   ];
 
   if (taskContract.openTaskTodosBlockFinalHandoff) {

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -1,5 +1,6 @@
 import type { GitWorktreeStrategyConfig } from "../../../git/types.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
+import { todoCompletionStatus } from "../../../policy/todo-statuses.ts";
 import {
   DEFAULT_PATCHMILL_SKILLS,
   type PatchmillSkillsConfig,
@@ -331,6 +332,7 @@ function renderTaskContractTodoWorkflowLines(
   const todoTitleGlob = renderIssueTodoTitleGlob(taskContract, issueNumber);
   const todoTags = renderTaskTodoTags(taskContract, issueNumber);
   const terminalStatusLine = `- This contract treats ${renderTerminalStatuses(taskContract)} as terminal.`;
+  const completionStatus = todoCompletionStatus(taskContract.doneStatuses);
   const sharedLines = [
     `- Store issue task todos under \`${taskContract.todoRoot}\`.`,
     ...(todoTags.length > 0 ? [`- Tag each task todo with ${todoTags}.`] : []),
@@ -350,7 +352,7 @@ function renderTaskContractTodoWorkflowLines(
           ]
         : []),
       terminalStatusLine,
-      "- After the plan document is committed, set the plan-related task todo status to `closed` so they reflect the committed plan state.",
+      `- After the plan document is committed, set the plan-related task todo status to \`${completionStatus}\` so they reflect the committed plan state.`,
     ];
   }
 
@@ -371,7 +373,7 @@ function renderTaskContractTodoWorkflowLines(
       : []),
     "- Do not create a single broad implementation todo.",
     "- Claim or update the current task todo before doing work on that task.",
-    "- Set a task todo status to `closed` only after code, tests, review, fixes, and verification for that task are done.",
+    `- Set a task todo status to \`${completionStatus}\` only after code, tests, review, fixes, and verification for that task are done.`,
     terminalStatusLine,
   ];
 

--- a/src/policy/defaults.test.ts
+++ b/src/policy/defaults.test.ts
@@ -35,7 +35,7 @@ test("DEFAULT_PATCHMILL_POLICY stays generic", () => {
       "checkpoint details",
       "the latest last error or validation notes",
     ],
-    doneStatuses: ["closed", "completed", "done"],
+    doneStatuses: ["closed", "completed", "complete", "done"],
     planTaskHeadingPattern: "## Task <number>: <label>",
     openTaskTodosBlockFinalHandoff: true,
   });

--- a/src/policy/task-contract.test.ts
+++ b/src/policy/task-contract.test.ts
@@ -34,7 +34,7 @@ test("DEFAULT_PI_TASK_CONTRACT preserves the current Pi task conventions", () =>
       "checkpoint details",
       "the latest last error or validation notes",
     ],
-    doneStatuses: ["closed", "completed", "done"],
+    doneStatuses: ["closed", "completed", "complete", "done"],
     planTaskHeadingPattern: "## Task <number>: <label>",
     openTaskTodosBlockFinalHandoff: true,
   });
@@ -70,6 +70,11 @@ test("task contract helpers render and compile default issue todo patterns", () 
     true,
   );
   assert.equal(issueTodoStatusDone(DEFAULT_PI_TASK_CONTRACT, "open"), false);
+  assert.equal(
+    issueTodoStatusDone(DEFAULT_PI_TASK_CONTRACT, " Complete "),
+    true,
+  );
+  assert.equal(issueTodoStatusDone(DEFAULT_PI_TASK_CONTRACT, "DONE"), true);
 });
 
 test("task contract helpers compile default and custom plan heading patterns", () => {

--- a/src/policy/task-contract.ts
+++ b/src/policy/task-contract.ts
@@ -1,4 +1,8 @@
 import { isAbsolute, join } from "node:path";
+import {
+  DEFAULT_TODO_DONE_STATUSES,
+  todoStatusIsDone,
+} from "./todo-statuses.ts";
 
 export type PatchmillPiTaskContract = {
   todoRoot: string;
@@ -27,7 +31,7 @@ export const DEFAULT_PI_TASK_CONTRACT: PatchmillPiTaskContract = {
     "checkpoint details",
     "the latest last error or validation notes",
   ],
-  doneStatuses: ["closed", "completed", "done"],
+  doneStatuses: [...DEFAULT_TODO_DONE_STATUSES],
   planTaskHeadingPattern: "## Task <number>: <label>",
   openTaskTodosBlockFinalHandoff: true,
 };
@@ -125,7 +129,7 @@ export function issueTodoStatusDone(
   contract: PatchmillPiTaskContract,
   status: string | undefined,
 ): boolean {
-  return status !== undefined && contract.doneStatuses.includes(status);
+  return todoStatusIsDone(status, contract.doneStatuses);
 }
 
 export function compilePlanTaskHeadingPattern(

--- a/src/policy/todo-statuses.test.ts
+++ b/src/policy/todo-statuses.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_TODO_DONE_STATUSES,
+  parseTodoDoneStatusesEnv,
+  serializeTodoDoneStatuses,
+  todoStatusIsDone,
+} from "./todo-statuses.ts";
+
+test("default todo done statuses include compatibility aliases", () => {
+  assert.deepEqual(DEFAULT_TODO_DONE_STATUSES, [
+    "closed",
+    "completed",
+    "complete",
+    "done",
+  ]);
+});
+
+test("todoStatusIsDone trims and compares case-insensitively", () => {
+  assert.equal(todoStatusIsDone(" COMPLETE "), true);
+  assert.equal(todoStatusIsDone("Done"), true);
+  assert.equal(todoStatusIsDone("open"), false);
+  assert.equal(todoStatusIsDone(undefined), false);
+});
+
+test("custom done statuses are authoritative after normalization", () => {
+  assert.equal(todoStatusIsDone(" shipped ", ["SHIPPED"]), true);
+  assert.equal(todoStatusIsDone("complete", ["shipped"]), false);
+});
+
+test("todo done status env serialization parses valid arrays and falls back safely", () => {
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(
+      serializeTodoDoneStatuses([" Shipped ", "shipped", ""]),
+    ),
+    ["shipped"],
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv("not json"),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(JSON.stringify([])),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(JSON.stringify(["", "  "])),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+  assert.deepEqual(
+    parseTodoDoneStatusesEnv(JSON.stringify(["done", 3])),
+    DEFAULT_TODO_DONE_STATUSES,
+  );
+});

--- a/src/policy/todo-statuses.ts
+++ b/src/policy/todo-statuses.ts
@@ -1,0 +1,57 @@
+export const DEFAULT_TODO_DONE_STATUSES = [
+  "closed",
+  "completed",
+  "complete",
+  "done",
+] as const;
+
+export const PI_TODO_DONE_STATUSES_ENV = "PI_TODO_DONE_STATUSES";
+
+export function normalizeTodoStatus(status: string): string {
+  return status.trim().toLowerCase();
+}
+
+export function normalizeTodoDoneStatuses(
+  doneStatuses: readonly string[] = DEFAULT_TODO_DONE_STATUSES,
+): string[] {
+  const normalized: string[] = [];
+  for (const status of doneStatuses) {
+    const value = normalizeTodoStatus(status);
+    if (!value || normalized.includes(value)) continue;
+    normalized.push(value);
+  }
+  return normalized.length > 0 ? normalized : [...DEFAULT_TODO_DONE_STATUSES];
+}
+
+export function todoStatusIsDone(
+  status: string | undefined,
+  doneStatuses: readonly string[] = DEFAULT_TODO_DONE_STATUSES,
+): boolean {
+  if (status === undefined) return false;
+  return normalizeTodoDoneStatuses(doneStatuses).includes(
+    normalizeTodoStatus(status),
+  );
+}
+
+export function serializeTodoDoneStatuses(
+  doneStatuses: readonly string[],
+): string {
+  return JSON.stringify(normalizeTodoDoneStatuses(doneStatuses));
+}
+
+export function parseTodoDoneStatusesEnv(value: string | undefined): string[] {
+  if (value === undefined || value.trim().length === 0) {
+    return [...DEFAULT_TODO_DONE_STATUSES];
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) return [...DEFAULT_TODO_DONE_STATUSES];
+    if (!parsed.every((entry): entry is string => typeof entry === "string")) {
+      return [...DEFAULT_TODO_DONE_STATUSES];
+    }
+    return normalizeTodoDoneStatuses(parsed);
+  } catch {
+    return [...DEFAULT_TODO_DONE_STATUSES];
+  }
+}

--- a/src/policy/todo-statuses.ts
+++ b/src/policy/todo-statuses.ts
@@ -23,6 +23,13 @@ export function normalizeTodoDoneStatuses(
   return normalized.length > 0 ? normalized : [...DEFAULT_TODO_DONE_STATUSES];
 }
 
+export function todoCompletionStatus(
+  doneStatuses: readonly string[] = DEFAULT_TODO_DONE_STATUSES,
+): string {
+  const normalized = normalizeTodoDoneStatuses(doneStatuses);
+  return normalized.includes("closed") ? "closed" : (normalized[0] ?? "closed");
+}
+
 export function todoStatusIsDone(
   status: string | undefined,
   doneStatuses: readonly string[] = DEFAULT_TODO_DONE_STATUSES,

--- a/test-support/todos-extension.test.ts
+++ b/test-support/todos-extension.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import todosExtension from "../extensions/todos.ts";
+import { PI_TODO_DONE_STATUSES_ENV } from "../src/policy/todo-statuses.ts";
+
+type RegisteredTool = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal,
+    onUpdate: () => void,
+    ctx: {
+      cwd: string;
+      sessionManager: {
+        getSessionId: () => string;
+        getSessionFile: () => string;
+      };
+    },
+  ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+};
+
+function registerTodoTool(): RegisteredTool {
+  let tool: RegisteredTool | undefined;
+  todosExtension({
+    on: () => undefined,
+    registerCommand: () => undefined,
+    registerTool: (registered: RegisteredTool) => {
+      tool = registered;
+    },
+  } as never);
+  assert.ok(tool);
+  return tool;
+}
+
+test("todo extension groups complete todos as closed and blocks claims", async () => {
+  const previous = process.env[PI_TODO_DONE_STATUSES_ENV];
+  delete process.env[PI_TODO_DONE_STATUSES_ENV];
+  try {
+    const tool = registerTodoTool();
+    const schema = tool.parameters as {
+      properties?: { status?: { enum?: string[] } };
+    };
+    assert.deepEqual(schema.properties?.status?.enum, [
+      "open",
+      "closed",
+      "completed",
+      "complete",
+      "done",
+    ]);
+    const cwd = await mkdtemp(join(tmpdir(), "patchmill-todos-extension-"));
+    await mkdir(join(cwd, ".pi", "todos"), { recursive: true });
+    const ctx = {
+      cwd,
+      sessionManager: {
+        getSessionId: () => "session-a",
+        getSessionFile: () => "session-a.json",
+      },
+    };
+    const signal = new AbortController().signal;
+
+    const closedCreate = await tool.execute(
+      "call-1",
+      { action: "create", title: "finished", status: "complete" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    await tool.execute(
+      "call-2",
+      { action: "create", title: "still open", status: "open" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    const listed = await tool.execute(
+      "call-3",
+      { action: "list-all" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+
+    const closedTodo = JSON.parse(closedCreate.content[0]?.text ?? "") as {
+      id: string;
+    };
+    const groups = JSON.parse(listed.content[0]?.text ?? "") as {
+      open: Array<{ title: string }>;
+      closed: Array<{ title: string }>;
+    };
+    assert.deepEqual(
+      groups.closed.map((todo) => todo.title),
+      ["finished"],
+    );
+    assert.deepEqual(
+      groups.open.map((todo) => todo.title),
+      ["still open"],
+    );
+
+    const claim = await tool.execute(
+      "call-4",
+      { action: "claim", id: closedTodo.id },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    assert.match(claim.content[0]?.text ?? "", /closed/);
+  } finally {
+    if (previous === undefined) delete process.env[PI_TODO_DONE_STATUSES_ENV];
+    else process.env[PI_TODO_DONE_STATUSES_ENV] = previous;
+  }
+});
+
+test("todo extension uses configured terminal statuses in its guidance and grouping", async () => {
+  const previous = process.env[PI_TODO_DONE_STATUSES_ENV];
+  process.env[PI_TODO_DONE_STATUSES_ENV] = JSON.stringify(["shipped"]);
+  try {
+    const tool = registerTodoTool();
+    assert.match(tool.description, /Accepted terminal statuses: shipped/);
+    const schema = tool.parameters as {
+      properties?: { status?: { enum?: string[] } };
+    };
+    assert.deepEqual(schema.properties?.status?.enum, ["open", "shipped"]);
+
+    const cwd = await mkdtemp(
+      join(tmpdir(), "patchmill-custom-todos-extension-"),
+    );
+    const ctx = {
+      cwd,
+      sessionManager: {
+        getSessionId: () => "session-a",
+        getSessionFile: () => "session-a.json",
+      },
+    };
+    const signal = new AbortController().signal;
+    await tool.execute(
+      "call-1",
+      { action: "create", title: "shipped work", status: "shipped" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    const listed = await tool.execute(
+      "call-2",
+      { action: "list-all" },
+      signal,
+      () => undefined,
+      ctx,
+    );
+    const groups = JSON.parse(listed.content[0]?.text ?? "") as {
+      closed: Array<{ title: string }>;
+    };
+    assert.deepEqual(
+      groups.closed.map((todo) => todo.title),
+      ["shipped work"],
+    );
+  } finally {
+    if (previous === undefined) delete process.env[PI_TODO_DONE_STATUSES_ENV];
+    else process.env[PI_TODO_DONE_STATUSES_ENV] = previous;
+  }
+});

--- a/test-support/todos-extension.test.ts
+++ b/test-support/todos-extension.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import todosExtension from "../extensions/todos.ts";
+import todosExtension, { todoCloseStatus } from "../extensions/todos.ts";
 import { PI_TODO_DONE_STATUSES_ENV } from "../src/policy/todo-statuses.ts";
 
 type RegisteredTool = {
@@ -43,6 +43,7 @@ test("todo extension groups complete todos as closed and blocks claims", async (
   delete process.env[PI_TODO_DONE_STATUSES_ENV];
   try {
     const tool = registerTodoTool();
+    assert.equal(todoCloseStatus(), "closed");
     const schema = tool.parameters as {
       properties?: { status?: { enum?: string[] } };
     };
@@ -121,11 +122,20 @@ test("todo extension uses configured terminal statuses in its guidance and group
   process.env[PI_TODO_DONE_STATUSES_ENV] = JSON.stringify(["shipped"]);
   try {
     const tool = registerTodoTool();
+    assert.match(
+      tool.description,
+      /Prefer status `shipped` when work is complete/,
+    );
     assert.match(tool.description, /Accepted terminal statuses: shipped/);
+    assert.equal(todoCloseStatus(), "shipped");
     const schema = tool.parameters as {
       properties?: { status?: { enum?: string[] } };
     };
     assert.deepEqual(schema.properties?.status?.enum, ["open", "shipped"]);
+    assert.match(
+      schema.properties?.status?.description ?? "",
+      /Prefer `shipped` when work is complete/,
+    );
 
     const cwd = await mkdtemp(
       join(tmpdir(), "patchmill-custom-todos-extension-"),


### PR DESCRIPTION
Summary

- Added shared normalized todo terminal-status handling for Patchmill issue task todos.
- Propagated resolved terminal statuses into Pi, prompt guidance, final handoff/progress paths, and the bundled todo extension.
- Covered default `complete` compatibility and custom terminal-status contracts.

## Validation

- node --test src/policy/todo-statuses.test.ts src/policy/task-contract.test.ts src/policy/defaults.test.ts
- node --test src/cli/commands/run-once/issue-todos.test.ts
- node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/run-once/prompts.test.ts
- node --test src/cli/commands/run-once/pipeline-landing.test.ts src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
- node --test test-support/todos-extension.test.ts
- npm run lint
- npm test

## Reviews

- Final Codex full-worktree review: passed with no findings.
- Final thermo-nuclear full-worktree review: two findings fixed; final re-review passed.
- Final validation-readiness review: passed all required commands.

Closes #109
