### PR TITLE
feat: automate Pi dependency upgrade PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,23 +30,7 @@ jobs:
         run: npm test
 
       - name: Smoke test npm package install
-        run: |
-          package_tgz="$(npm pack --silent)"
-          smoke_dir="$(mktemp -d)"
-          npm_cache="$(mktemp -d)"
-          cleanup() {
-            rm -rf "$GITHUB_WORKSPACE/dist" "$GITHUB_WORKSPACE/$package_tgz" "$smoke_dir" "$npm_cache"
-          }
-          trap cleanup EXIT
-          mkdir -p "$smoke_dir/home" "$smoke_dir/config" "$smoke_dir/project"
-          cd "$smoke_dir/project"
-          npm init -y >/dev/null
-          npm_config_cache="$npm_cache" npm install "$GITHUB_WORKSPACE/$package_tgz"
-          ./node_modules/.bin/patchmill --help >/dev/null
-          HOME="$smoke_dir/home" \
-            XDG_CONFIG_HOME="$smoke_dir/config" \
-            ./node_modules/.bin/patchmill init >/dev/null
-          test -f .patchmill/skills/patchmill-issue-triage/SKILL.md
+        run: node scripts/smoke-packed-artifact.mjs
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/pi-dependency-upgrade.yml
+++ b/.github/workflows/pi-dependency-upgrade.yml
@@ -1,0 +1,143 @@
+name: Pi dependency upgrade
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      target-version:
+        description: "Version to apply to both Pi runtime packages"
+        required: false
+        type: string
+      pi-coding-agent-version:
+        description: "Explicit @earendil-works/pi-coding-agent version"
+        required: false
+        type: string
+      pi-tui-version:
+        description: "Explicit @earendil-works/pi-tui version"
+        required: false
+        type: string
+      validate-only:
+        description: "Validate selected versions without creating a PR"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pi-dependency-upgrade
+  cancel-in-progress: false
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Update Pi dependency metadata
+        id: update
+        env:
+          TARGET_VERSION: ${{ inputs.target-version }}
+          PI_CODING_AGENT_VERSION: ${{ inputs.pi-coding-agent-version }}
+          PI_TUI_VERSION: ${{ inputs.pi-tui-version }}
+          VALIDATE_ONLY: ${{ inputs.validate-only || false }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp
+          args=(--summary-json .tmp/pi-deps-summary.json)
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            args+=(--mode manual)
+            [[ -n "${TARGET_VERSION:-}" ]] && args+=(--target-version "$TARGET_VERSION")
+            [[ -n "${PI_CODING_AGENT_VERSION:-}" ]] && args+=(--pi-coding-agent-version "$PI_CODING_AGENT_VERSION")
+            [[ -n "${PI_TUI_VERSION:-}" ]] && args+=(--pi-tui-version "$PI_TUI_VERSION")
+            [[ "$VALIDATE_ONLY" == "true" ]] && args+=(--validate-only)
+          else
+            args+=(--mode scheduled)
+          fi
+          node scripts/update-pi-deps.mjs "${args[@]}"
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require("node:fs");
+          const summary = JSON.parse(fs.readFileSync(".tmp/pi-deps-summary.json", "utf8"));
+          const target = summary.targets["@earendil-works/pi-coding-agent"];
+          console.log(`no_update=${summary.noUpdate ? "true" : "false"}`);
+          console.log(`validate_only=${summary.validateOnly ? "true" : "false"}`);
+          console.log(`target_version=${target}`);
+          NODE
+
+      - name: Reinstall updated dependencies
+        if: steps.update.outputs.no_update != 'true'
+        run: npm ci
+
+      - name: Run Pi compatibility contract
+        if: steps.update.outputs.no_update != 'true'
+        run: node --test src/cli/commands/init/pi-dependency-contract.test.ts
+
+      - name: Run Node tests
+        if: steps.update.outputs.no_update != 'true'
+        run: npm test
+
+      - name: Run packed artifact smoke test
+        if: steps.update.outputs.no_update != 'true'
+        run: node scripts/smoke-packed-artifact.mjs
+
+      - name: Run lint
+        if: steps.update.outputs.no_update != 'true'
+        run: npm run lint
+
+      - name: Verify Nix npm dependency hash
+        if: steps.update.outputs.no_update != 'true'
+        run: |
+          scripts/update-npm-deps-hash.sh
+          if ! git diff --exit-code -- nix/package.nix; then
+            echo "::error file=nix/package.nix::npmDepsHash is stale after Pi dependency update."
+            exit 1
+          fi
+
+      - name: Build Nix package
+        if: steps.update.outputs.no_update != 'true'
+        run: nix build .#patchmill --print-build-logs
+
+      - name: Render pull request body
+        if: >-
+          steps.update.outputs.no_update != 'true' &&
+          steps.update.outputs.validate_only != 'true'
+        run: |
+          node -e 'import("./scripts/pi-dependency-upgrade-lib.mjs").then(({renderPullRequestBody}) => { const fs = require("node:fs"); const summary = JSON.parse(fs.readFileSync(".tmp/pi-deps-summary.json", "utf8")); fs.writeFileSync(".tmp/pi-deps-pr-body.md", renderPullRequestBody(summary)); })'
+
+      - name: Create or update Pi dependency upgrade PR
+        if: >-
+          steps.update.outputs.no_update != 'true' &&
+          steps.update.outputs.validate_only != 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/pi-deps-${{ steps.update.outputs.target_version }}
+          delete-branch: true
+          title:
+            "chore(deps): update Pi runtime packages to ${{
+            steps.update.outputs.target_version }}"
+          body-path: .tmp/pi-deps-pr-body.md
+          commit-message:
+            "chore(deps): update Pi runtime packages to ${{
+            steps.update.outputs.target_version }}"
+          labels: dependencies, automated-pr

--- a/.github/workflows/pi-dependency-upgrade.yml
+++ b/.github/workflows/pi-dependency-upgrade.yml
@@ -109,8 +109,9 @@ jobs:
       - name: Verify Nix npm dependency hash
         if: steps.update.outputs.no_update != 'true'
         run: |
+          cp nix/package.nix .tmp/nix-package.nix.before-hash
           scripts/update-npm-deps-hash.sh
-          if ! git diff --exit-code -- nix/package.nix; then
+          if ! cmp --silent .tmp/nix-package.nix.before-hash nix/package.nix; then
             echo "::error file=nix/package.nix::npmDepsHash is stale after Pi dependency update."
             exit 1
           fi
@@ -133,6 +134,11 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.PATCHMILL_AUTOMATION_TOKEN }}
+          add-paths: |
+            package.json
+            package-lock.json
+            npm-shrinkwrap.json
+            nix/package.nix
           branch: automation/pi-deps-${{ steps.update.outputs.target_version }}
           delete-branch: true
           title:

--- a/.github/workflows/pi-dependency-upgrade.yml
+++ b/.github/workflows/pi-dependency-upgrade.yml
@@ -127,13 +127,23 @@ jobs:
         run: |
           node -e 'import("./scripts/pi-dependency-upgrade-lib.mjs").then(({renderPullRequestBody}) => { const fs = require("node:fs"); const summary = JSON.parse(fs.readFileSync(".tmp/pi-deps-summary.json", "utf8")); fs.writeFileSync(".tmp/pi-deps-pr-body.md", renderPullRequestBody(summary)); })'
 
+      - name: Create automation bot token
+        id: app-token
+        if: >-
+          steps.update.outputs.no_update != 'true' &&
+          steps.update.outputs.validate_only != 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_BOT_PRIVATE_KEY }}
+
       - name: Create or update Pi dependency upgrade PR
         if: >-
           steps.update.outputs.no_update != 'true' &&
           steps.update.outputs.validate_only != 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PATCHMILL_AUTOMATION_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: |
             package.json
             package-lock.json

--- a/.github/workflows/pi-dependency-upgrade.yml
+++ b/.github/workflows/pi-dependency-upgrade.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -131,6 +132,7 @@ jobs:
           steps.update.outputs.validate_only != 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.PATCHMILL_AUTOMATION_TOKEN }}
           branch: automation/pi-deps-${{ steps.update.outputs.target_version }}
           delete-branch: true
           title:

--- a/docs/pi-dependency-upgrades.md
+++ b/docs/pi-dependency-upgrades.md
@@ -18,6 +18,16 @@ node scripts/update-pi-deps.mjs \
 
 Omit `--skip-nix-hash` when preparing real dependency changes.
 
+## Repository automation token
+
+Configure the repository secret `PATCHMILL_AUTOMATION_TOKEN` with a fine-grained
+personal access token for a dedicated automation account that can create
+branches and pull requests. The workflow uses it only after all upgrade
+validations pass, so the resulting review-gated PR can trigger normal pull
+request checks; GitHub Actions' default `GITHUB_TOKEN` does not trigger those
+workflows. Checkout does not persist this token while dependency validation
+runs.
+
 ## Required local checks for a real upgrade
 
 ```bash

--- a/docs/pi-dependency-upgrades.md
+++ b/docs/pi-dependency-upgrades.md
@@ -18,15 +18,15 @@ node scripts/update-pi-deps.mjs \
 
 Omit `--skip-nix-hash` when preparing real dependency changes.
 
-## Repository automation token
+## Repository automation credentials
 
-Configure the repository secret `PATCHMILL_AUTOMATION_TOKEN` with a fine-grained
-personal access token for a dedicated automation account that can create
-branches and pull requests. The workflow uses it only after all upgrade
-validations pass, so the resulting review-gated PR can trigger normal pull
-request checks; GitHub Actions' default `GITHUB_TOKEN` does not trigger those
-workflows. Checkout does not persist this token while dependency validation
-runs.
+Configure the repository secrets `RELEASE_PLEASE_BOT_APP_ID` and
+`RELEASE_PLEASE_BOT_PRIVATE_KEY` for a GitHub App that can create branches and
+pull requests. The workflow mints a short-lived installation token only after
+all upgrade validations pass, so the resulting review-gated PR can trigger
+normal pull request checks; GitHub Actions' default `GITHUB_TOKEN` does not
+trigger those workflows. Checkout does not persist credentials while dependency
+validation runs.
 
 ## Required local checks for a real upgrade
 

--- a/docs/pi-dependency-upgrades.md
+++ b/docs/pi-dependency-upgrades.md
@@ -1,0 +1,32 @@
+# Pi Dependency Upgrades
+
+Patchmill keeps `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`
+on exact pins. The `Pi dependency upgrade` workflow discovers matching newer npm
+`latest` versions on a schedule and opens a review-gated PR after compatibility,
+packed-artifact, npm, and Nix validation pass.
+
+## Manual validation
+
+```bash
+node scripts/update-pi-deps.mjs \
+  --mode manual \
+  --target-version 0.80.10 \
+  --validate-only \
+  --skip-nix-hash \
+  --summary-json .tmp/pi-deps-summary.json
+```
+
+Omit `--skip-nix-hash` when preparing real dependency changes.
+
+## Required local checks for a real upgrade
+
+```bash
+node --test src/cli/commands/init/pi-dependency-contract.test.ts
+npm test
+node scripts/smoke-packed-artifact.mjs
+npm run lint
+scripts/update-npm-deps-hash.sh
+nix build .#patchmill --print-build-logs
+```
+
+The workflow does not auto-merge or publish Pi dependency upgrades.

--- a/docs/plans/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation.md
+++ b/docs/plans/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation.md
@@ -1,0 +1,1026 @@
+# Automate Pi Dependency Upgrade PRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automate review-gated PRs that upgrade Patchmill's tightly coupled Pi
+runtime dependencies only after metadata, compatibility, packed-artifact, and
+Nix validation succeed.
+
+**Architecture:** Put repository-specific upgrade logic in versioned Node
+scripts that can run locally and from GitHub Actions. Keep pure
+target-resolution and metadata-validation behavior unit-tested, make the runtime
+compatibility test read the current exact pins, and reuse one packed-artifact
+smoke script from CI and the upgrade workflow.
+
+**Tech Stack:** Node.js 24 in CI, TypeScript ESM tests through `node --test`,
+JavaScript `.mjs` repository scripts, npm lockfile/shrinkwrap, Prettier, GitHub
+Actions, Nix `buildNpmPackage`, `peter-evans/create-pull-request@v7`.
+
+## Global Constraints
+
+- `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` remain exact
+  dependency pins in `package.json`; do not widen them to ranges.
+- Scheduled mode only prepares an upgrade when both packages expose the same
+  newer `latest` version than the current pins; divergent scheduled latest
+  versions are a non-zero failure before editing files.
+- Manual mode may accept explicit package versions and must call out any
+  non-matching pair in the generated summary/PR body.
+- Generated upgrade PRs update `package.json`, `package-lock.json`,
+  `npm-shrinkwrap.json`, and `nix/package.nix` `npmDepsHash` when the dependency
+  graph changes.
+- Upgrade validation must run the Pi compatibility contract, full Node tests,
+  linting, packed-artifact smoke checks, `scripts/update-npm-deps-hash.sh`, and
+  `nix build .#patchmill --print-build-logs`.
+- Because npm dependencies change in generated upgrade PRs, rerun the Nix build
+  as required by `AGENTS.md`.
+- The automation opens or updates a normal review PR only; it must not
+  auto-merge, auto-publish, or bypass failed compatibility checks.
+- Do not add tests that merely assert workflow YAML, dependency versions,
+  lockfile text, static config values, documentation text, or one-off script
+  structure. Use direct validation such as Prettier, dry-runs, existing test
+  suites, and Nix builds for those.
+- Do not commit `.pi/todos` or other local operator state.
+
+---
+
+## File Structure
+
+- Create `scripts/pi-dependency-upgrade-lib.mjs`: pure helpers for Pi package
+  constants, exact-pin checks, npm `latest` discovery, target selection,
+  lockfile validation, JSON I/O, and PR-summary rendering.
+- Create `scripts/pi-dependency-upgrade-lib.test.mjs`: behavior tests for target
+  selection, exact-pin failures, lockfile mismatch diagnostics, and PR-summary
+  text.
+- Create `scripts/update-pi-deps.mjs`: CLI wrapper that discovers/accepts target
+  versions, updates package pins, regenerates both lockfiles, formats generated
+  JSON, validates metadata, optionally updates `npmDepsHash`, and writes a
+  machine-readable summary for workflows.
+- Modify `package.json`: add `scripts/*.test.mjs` to the `npm test` command so
+  script helper tests run with the normal suite.
+- Modify `src/cli/commands/init/pi-dependency-contract.test.ts`: derive expected
+  Pi versions from exact root `package.json` pins while keeping capability
+  assertions for `ModelRuntime`, `ModelRegistry`, `readStoredCredential`, and
+  `getAgentDir`.
+- Create `scripts/smoke-packed-artifact.mjs`: reusable packed npm artifact smoke
+  script for `patchmill --help`, `patchmill init`, installed skill presence, and
+  resolved Pi package version assertions.
+- Modify `.github/workflows/ci.yml`: replace the inline npm packed smoke shell
+  block with the reusable script.
+- Create `.github/workflows/pi-dependency-upgrade.yml`: scheduled/manual update
+  workflow that validates changes and opens or updates the review PR.
+
+---
+
+### Task 1: Add unit-tested Pi upgrade helper library
+
+**Files:**
+
+- Create: `scripts/pi-dependency-upgrade-lib.mjs`
+- Create: `scripts/pi-dependency-upgrade-lib.test.mjs`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Consumes: package metadata objects, lockfile objects, npm registry metadata,
+  current package pins, and optional manual target versions.
+- Produces: `PI_PACKAGES`, `isExactVersion(spec)`, `readJson(path)`,
+  `writeJson(path, value)`, `getRootPins(packageJson)`,
+  `fetchLatestVersion(packageName, fetchImpl)`, `resolveUpgradeTarget(options)`,
+  `assertLockfilesMatchTargets({ packageJson, packageLock, shrinkwrap, targets })`,
+  and `renderPullRequestBody(summary)` for later scripts.
+
+- [ ] **Step 1: Create the helper library with pure validation and target
+      selection functions**
+
+  Create `scripts/pi-dependency-upgrade-lib.mjs` with these exported names and
+  behavior:
+
+  ```js
+  import { readFile, writeFile } from "node:fs/promises";
+
+  export const PI_PACKAGES = [
+    "@earendil-works/pi-coding-agent",
+    "@earendil-works/pi-tui",
+  ];
+
+  export function isExactVersion(spec) {
+    return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      spec,
+    );
+  }
+
+  export async function readJson(path) {
+    return JSON.parse(await readFile(path, "utf8"));
+  }
+
+  export async function writeJson(path, value) {
+    await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+  }
+
+  export function getRootPins(packageJson) {
+    const dependencies = packageJson.dependencies ?? {};
+    return Object.fromEntries(
+      PI_PACKAGES.map((name) => {
+        const spec = dependencies[name];
+        if (!isExactVersion(spec ?? "")) {
+          throw new Error(
+            `${name} must be an exact version; found ${spec ?? "missing"}`,
+          );
+        }
+        return [name, spec];
+      }),
+    );
+  }
+  ```
+
+  Add the remaining exports in the same file:
+  - `fetchLatestVersion(packageName, fetchImpl = fetch)` calls
+    `https://registry.npmjs.org/${encodeURIComponent(packageName).replace("%40", "@")}`,
+    requires an OK response, requires `dist-tags.latest`, and throws
+    `${packageName}: npm latest dist-tag not found` if missing.
+  - `compareVersions(a, b)` handles numeric `major.minor.patch` comparison and
+    ignores pre-release ordering beyond treating different strings with equal
+    numeric components as equal for scheduled discovery.
+  - `resolveUpgradeTarget({ mode, currentPins, latestVersions, manualVersions })`
+    returns `{ noUpdate, targets, warnings }`.
+  - In scheduled mode, if latest versions differ, throw
+    `Scheduled Pi upgrade requires matching latest versions: @earendil-works/pi-coding-agent=<version>, @earendil-works/pi-tui=<version>`.
+  - In scheduled mode, if the shared latest version is not newer than both
+    current pins, return `noUpdate: true` with current pins as `targets`.
+  - In manual mode, require explicit versions for both packages and add warning
+    text when they differ.
+  - `assertLockfilesMatchTargets` verifies root dependencies and each
+    `packages["node_modules/<name>"].version` entry in both lockfiles. Its
+    errors must include file label, package name, expected version, and actual
+    value.
+  - `renderPullRequestBody(summary)` returns markdown listing target versions,
+    warnings, changed files, and validation commands.
+
+- [ ] **Step 2: Add focused behavior tests for the helper library**
+
+  Create `scripts/pi-dependency-upgrade-lib.test.mjs` with `node:test` cases
+  equivalent to:
+
+  ```js
+  import assert from "node:assert/strict";
+  import { test } from "node:test";
+  import {
+    assertLockfilesMatchTargets,
+    getRootPins,
+    renderPullRequestBody,
+    resolveUpgradeTarget,
+  } from "./pi-dependency-upgrade-lib.mjs";
+
+  const currentPins = {
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
+  };
+
+  test("scheduled mode selects a newer shared latest version", () => {
+    const result = resolveUpgradeTarget({
+      mode: "scheduled",
+      currentPins,
+      latestVersions: {
+        "@earendil-works/pi-coding-agent": "0.80.11",
+        "@earendil-works/pi-tui": "0.80.11",
+      },
+    });
+
+    assert.equal(result.noUpdate, false);
+    assert.deepEqual(result.targets, {
+      "@earendil-works/pi-coding-agent": "0.80.11",
+      "@earendil-works/pi-tui": "0.80.11",
+    });
+  });
+
+  test("scheduled mode fails before edits when latest versions diverge", () => {
+    assert.throws(
+      () =>
+        resolveUpgradeTarget({
+          mode: "scheduled",
+          currentPins,
+          latestVersions: {
+            "@earendil-works/pi-coding-agent": "0.80.12",
+            "@earendil-works/pi-tui": "0.80.11",
+          },
+        }),
+      /requires matching latest versions.*pi-coding-agent=0.80.12.*pi-tui=0.80.11/,
+    );
+  });
+  ```
+
+  Include additional tests for: no-update scheduled mode, manual non-matching
+  warning, non-exact root pins, lockfile mismatch error text, and PR body
+  validation-command rendering.
+
+- [ ] **Step 3: Include script helper tests in the normal Node test suite**
+
+  Modify `package.json` so the `test` script becomes:
+
+  ```json
+  "test": "node --test \"bin/*.test.ts\" \"src/**/*.test.ts\" \"test-support/*.test.ts\" \"scripts/*.test.mjs\""
+  ```
+
+  Do not change npm dependencies for this task.
+
+- [ ] **Step 4: Run the new helper tests**
+
+  Run:
+
+  ```bash
+  node --test scripts/pi-dependency-upgrade-lib.test.mjs
+  ```
+
+  Expected: PASS. Failures should name the helper behavior that regressed.
+
+- [ ] **Step 5: Run the normal test entrypoint to prove the new test pattern is
+      included**
+
+  Run:
+
+  ```bash
+  npm test
+  ```
+
+  Expected: PASS, including `scripts/pi-dependency-upgrade-lib.test.mjs`.
+
+- [ ] **Step 6: Commit the helper library and tests**
+
+  Run:
+
+  ```bash
+  git add package.json scripts/pi-dependency-upgrade-lib.mjs scripts/pi-dependency-upgrade-lib.test.mjs
+  git commit -m "feat: add pi dependency upgrade helpers"
+  ```
+
+---
+
+### Task 2: Add the Pi dependency update CLI
+
+**Files:**
+
+- Create: `scripts/update-pi-deps.mjs`
+- Modify: `scripts/pi-dependency-upgrade-lib.mjs` only if Task 1 exposed an
+  integration gap.
+- Modify during generated upgrade runs: `package.json`, `package-lock.json`,
+  `npm-shrinkwrap.json`, `nix/package.nix`.
+
+**Interfaces:**
+
+- Consumes: Task 1 helpers, npm registry metadata, current package files, and
+  CLI flags.
+- Produces: a local/workflow command that updates exact Pi pins, regenerates
+  both npm metadata files, refreshes the Nix npm dependency hash unless
+  explicitly skipped, validates versions, and writes a JSON summary.
+
+- [ ] **Step 1: Implement CLI argument parsing and summary output contract**
+
+  Create `scripts/update-pi-deps.mjs` with flags:
+
+  ```text
+  --mode scheduled|manual
+  --pi-coding-agent-version <version>
+  --pi-tui-version <version>
+  --target-version <version>
+  --summary-json <path>
+  --validate-only
+  --skip-nix-hash
+  ```
+
+  Parsing rules:
+  - Default `--mode` is `scheduled`.
+  - `--target-version` sets both Pi package targets for manual runs.
+  - Explicit per-package flags override `--target-version`.
+  - `--validate-only` validates current files against selected targets without
+    writing package metadata.
+  - `--skip-nix-hash` is only for local dry-runs and tests where Nix is
+    unavailable; the workflow must not use it.
+
+  The script should always write summary JSON when `--summary-json` is provided:
+
+  ```json
+  {
+    "noUpdate": false,
+    "validateOnly": false,
+    "targets": {
+      "@earendil-works/pi-coding-agent": "0.80.11",
+      "@earendil-works/pi-tui": "0.80.11"
+    },
+    "warnings": [],
+    "changedFiles": [
+      "package.json",
+      "package-lock.json",
+      "npm-shrinkwrap.json",
+      "nix/package.nix"
+    ],
+    "validationCommands": [
+      "node --test src/cli/commands/init/pi-dependency-contract.test.ts",
+      "npm test",
+      "node scripts/smoke-packed-artifact.mjs",
+      "npm run lint",
+      "scripts/update-npm-deps-hash.sh",
+      "nix build .#patchmill --print-build-logs"
+    ]
+  }
+  ```
+
+- [ ] **Step 2: Implement candidate discovery and pre-edit validation**
+
+  Use `readJson`, `getRootPins`, `fetchLatestVersion`, and
+  `resolveUpgradeTarget` from Task 1. Log the current pins and selected targets
+  before editing. If scheduled mode returns `noUpdate: true`, write the summary,
+  print `No Pi dependency update available`, and exit 0 without modifying files.
+
+  Expected divergent-latest failure text:
+
+  ```text
+  Scheduled Pi upgrade requires matching latest versions: @earendil-works/pi-coding-agent=0.x.y, @earendil-works/pi-tui=0.a.b
+  ```
+
+- [ ] **Step 3: Implement package and lockfile updates**
+
+  When not `--validate-only`, update root `package.json` dependencies to the
+  exact target strings, then regenerate both npm metadata files with this
+  sequence from the repository root:
+
+  ```js
+  await run("npm", ["install", "--package-lock-only", "--ignore-scripts"]);
+  await copyFile("npm-shrinkwrap.json", shrinkwrapTempPath);
+  await rm("npm-shrinkwrap.json");
+  await run("npm", ["install", "--package-lock-only", "--ignore-scripts"]);
+  await copyFile(shrinkwrapTempPath, "npm-shrinkwrap.json");
+  await run("npx", [
+    "prettier",
+    "--write",
+    "package.json",
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+  ]);
+  ```
+
+  Wrap `child_process.spawn` in a `run(command, args)` helper that prints the
+  command before execution and throws `Command failed: <command> <args>` on
+  non-zero exit. If npm resolution fails, rethrow with the target package names
+  and requested versions in the error message.
+
+- [ ] **Step 4: Validate updated metadata and refresh the Nix hash**
+
+  Re-read `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`; call
+  `assertLockfilesMatchTargets`. Unless `--skip-nix-hash` or `--validate-only`
+  is set, run:
+
+  ```bash
+  scripts/update-npm-deps-hash.sh
+  ```
+
+  Then compute `changedFiles` from:
+
+  ```bash
+  git diff --name-only -- package.json package-lock.json npm-shrinkwrap.json nix/package.nix
+  ```
+
+  Include the changed-file list in the JSON summary and human-readable log.
+
+- [ ] **Step 5: Dry-run validate the CLI against current pins without editing**
+
+  Run:
+
+  ```bash
+  node scripts/update-pi-deps.mjs \
+    --mode manual \
+    --target-version 0.80.10 \
+    --validate-only \
+    --skip-nix-hash \
+    --summary-json .tmp/pi-deps-validate-summary.json
+  git diff --exit-code -- package.json package-lock.json npm-shrinkwrap.json nix/package.nix
+  node -e 'console.log(JSON.parse(require("node:fs").readFileSync(".tmp/pi-deps-validate-summary.json", "utf8")).targets)'
+  ```
+
+  Expected: exit 0; `git diff --exit-code` reports no metadata changes; the
+  summary targets are both `0.80.10`.
+
+- [ ] **Step 6: Commit the update CLI**
+
+  Run:
+
+  ```bash
+  git add scripts/update-pi-deps.mjs scripts/pi-dependency-upgrade-lib.mjs
+  git commit -m "feat: automate pi dependency metadata updates"
+  ```
+
+---
+
+### Task 3: Make Pi compatibility assertions follow exact root pins
+
+**Files:**
+
+- Modify: `src/cli/commands/init/pi-dependency-contract.test.ts`
+
+**Interfaces:**
+
+- Consumes: exact Pi dependency pins from root `package.json` and resolved
+  package metadata from installed Pi packages.
+- Produces: compatibility failures that identify the package name, resolved
+  version, expected pin, and missing Pi capability.
+
+- [ ] **Step 1: Replace the hard-coded expected version with root-pin lookup**
+
+  Modify `src/cli/commands/init/pi-dependency-contract.test.ts` so it includes:
+
+  ```ts
+  const PI_PACKAGES = [
+    "@earendil-works/pi-coding-agent",
+    "@earendil-works/pi-tui",
+  ] as const;
+
+  const ROOT_PACKAGE_JSON = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../../../package.json",
+  );
+
+  function isExactVersion(spec: string | undefined): spec is string {
+    return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      spec ?? "",
+    );
+  }
+
+  function rootPiPins(): Record<(typeof PI_PACKAGES)[number], string> {
+    const rootPackage = JSON.parse(
+      readFileSync(ROOT_PACKAGE_JSON, "utf8"),
+    ) as PackageJson;
+    const dependencies = rootPackage.dependencies ?? {};
+    const pins = {} as Record<(typeof PI_PACKAGES)[number], string>;
+
+    for (const name of PI_PACKAGES) {
+      const spec = dependencies[name];
+      assert.equal(
+        isExactVersion(spec),
+        true,
+        `${name} must be pinned to an exact version in package.json; found ${spec ?? "missing"}`,
+      );
+      pins[name] = spec;
+    }
+
+    return pins;
+  }
+  ```
+
+  Remove `const EXPECTED_PI_VERSION = "0.80.10";`.
+
+- [ ] **Step 2: Update the version test assertions with actionable messages**
+
+  Replace the version test body with:
+
+  ```ts
+  test("resolved Pi packages use the package.json exact pins", () => {
+    const pins = rootPiPins();
+
+    for (const name of PI_PACKAGES) {
+      const resolved = packageJson(name);
+      assert.equal(
+        resolved.version,
+        pins[name],
+        `${name} resolved ${resolved.version} but package.json pins ${pins[name]}`,
+      );
+    }
+  });
+  ```
+
+  Keep the existing export-capability tests unchanged so missing exports still
+  fail with messages such as
+  `@earendil-works/pi-coding-agent must export ModelRuntime`.
+
+- [ ] **Step 3: Run the focused compatibility contract test**
+
+  Run:
+
+  ```bash
+  node --test src/cli/commands/init/pi-dependency-contract.test.ts
+  ```
+
+  Expected: PASS with current `0.80.10` pins. If it fails, the output must name
+  the mismatched package or missing export.
+
+- [ ] **Step 4: Run the normal Node test suite**
+
+  Run:
+
+  ```bash
+  npm test
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit the compatibility test update**
+
+  Run:
+
+  ```bash
+  git add src/cli/commands/init/pi-dependency-contract.test.ts
+  git commit -m "test: derive pi compatibility versions from exact pins"
+  ```
+
+---
+
+### Task 4: Move packed npm artifact smoke checks into a reusable script
+
+**Files:**
+
+- Create: `scripts/smoke-packed-artifact.mjs`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+
+- Consumes: root package pins, `npm pack` output, a temporary npm project, and
+  the installed `patchmill` binary.
+- Produces: one command that verifies packed artifact installability,
+  `patchmill --help`, non-interactive `patchmill init`, installed Patchmill
+  skill presence, and resolved Pi versions.
+
+- [ ] **Step 1: Create the smoke script**
+
+  Create `scripts/smoke-packed-artifact.mjs` with these behaviors:
+
+  ```js
+  import { mkdtemp, readFile, rm } from "node:fs/promises";
+  import { existsSync } from "node:fs";
+  import { tmpdir } from "node:os";
+  import { dirname, join } from "node:path";
+  import { fileURLToPath } from "node:url";
+  import { createRequire } from "node:module";
+  import { spawn } from "node:child_process";
+  import { getRootPins, PI_PACKAGES } from "./pi-dependency-upgrade-lib.mjs";
+
+  const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+  function run(command, args, options = {}) {
+    console.log(`$ ${[command, ...args].join(" ")}`);
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, { stdio: "inherit", ...options });
+      child.on("exit", (code) => {
+        if (code === 0) resolve();
+        else
+          reject(
+            new Error(`Command failed (${code}): ${command} ${args.join(" ")}`),
+          );
+      });
+      child.on("error", reject);
+    });
+  }
+  ```
+
+  Complete the script so it:
+  - creates one temporary directory with `home`, `config`, `npm-cache`, and
+    `project` subdirectories;
+  - runs `npm pack --silent` from `rootDir` and records the tarball path;
+  - runs `npm init -y` and installs the tarball into the temporary project with
+    `npm_config_cache` pointed at the isolated cache;
+  - runs `./node_modules/.bin/patchmill --help`;
+  - runs `patchmill init` with isolated `HOME` and `XDG_CONFIG_HOME`;
+  - asserts `.patchmill/skills/patchmill-issue-triage/SKILL.md` exists;
+  - resolves each Pi package's `package.json` from the installed project using
+    `createRequire(join(projectDir, "package.json"))` and compares the installed
+    version to `getRootPins(root package.json)`;
+  - on mismatch, throws
+    `<package> resolved <actual> from <path> but package.json pins <expected>`;
+  - cleans the temporary directory and packed tarball on exit unless
+    `PATCHMILL_KEEP_SMOKE_ARTIFACTS=1` is set.
+
+- [ ] **Step 2: Replace the CI inline npm smoke block with the reusable script**
+
+  In `.github/workflows/ci.yml`, replace the `Smoke test npm package install`
+  shell block with:
+
+  ```yaml
+  - name: Smoke test npm package install
+    run: node scripts/smoke-packed-artifact.mjs
+  ```
+
+  Do not add a test that asserts this YAML text. The Testing Value Gate rejects
+  that kind of static workflow-content test; use direct formatting and the
+  script's own runtime smoke command instead.
+
+- [ ] **Step 3: Run the packed-artifact smoke script locally**
+
+  Run:
+
+  ```bash
+  node scripts/smoke-packed-artifact.mjs
+  ```
+
+  Expected: PASS. The log should show `npm pack`, package install,
+  `patchmill --help`, and `patchmill init`; failures should include the command
+  or Pi package version that failed.
+
+- [ ] **Step 4: Run focused formatting checks for the script and workflow**
+
+  Run:
+
+  ```bash
+  npx prettier --check scripts/smoke-packed-artifact.mjs .github/workflows/ci.yml
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Commit the reusable smoke script and CI update**
+
+  Run:
+
+  ```bash
+  git add scripts/smoke-packed-artifact.mjs .github/workflows/ci.yml
+  git commit -m "ci: reuse packed artifact smoke validation"
+  ```
+
+---
+
+### Task 5: Add the scheduled/manual Pi dependency upgrade workflow
+
+**Files:**
+
+- Create: `.github/workflows/pi-dependency-upgrade.yml`
+
+**Interfaces:**
+
+- Consumes: `scripts/update-pi-deps.mjs`, `scripts/smoke-packed-artifact.mjs`,
+  GitHub Actions workflow inputs, repository credentials, Node 24, and Nix.
+- Produces: scheduled/manual validation and, unless validate-only or no-update,
+  a review-gated PR branch named `automation/pi-deps-<version>`.
+
+- [ ] **Step 1: Create the workflow triggers, permissions, and inputs**
+
+  Create `.github/workflows/pi-dependency-upgrade.yml` beginning with:
+
+  ```yaml
+  name: Pi dependency upgrade
+
+  on:
+    schedule:
+      - cron: "17 6 * * 1"
+    workflow_dispatch:
+      inputs:
+        target-version:
+          description: "Version to apply to both Pi runtime packages"
+          required: false
+          type: string
+        pi-coding-agent-version:
+          description: "Explicit @earendil-works/pi-coding-agent version"
+          required: false
+          type: string
+        pi-tui-version:
+          description: "Explicit @earendil-works/pi-tui version"
+          required: false
+          type: string
+        validate-only:
+          description: "Validate selected versions without creating a PR"
+          required: false
+          default: false
+          type: boolean
+
+  permissions:
+    contents: write
+    pull-requests: write
+
+  concurrency:
+    group: pi-dependency-upgrade
+    cancel-in-progress: false
+  ```
+
+- [ ] **Step 2: Add checkout, Node, npm, and Nix setup steps**
+
+  Add a single `upgrade` job on `ubuntu-latest` with:
+
+  ```yaml
+  steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+      with:
+        ref: main
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+  ```
+
+- [ ] **Step 3: Run the update script and expose workflow outputs**
+
+  Add a step with `id: update` that builds CLI args from dispatch inputs, runs
+  the script, and writes outputs from summary JSON:
+
+  ```yaml
+  - name: Update Pi dependency metadata
+    id: update
+    env:
+      TARGET_VERSION: ${{ inputs.target-version }}
+      PI_CODING_AGENT_VERSION: ${{ inputs.pi-coding-agent-version }}
+      PI_TUI_VERSION: ${{ inputs.pi-tui-version }}
+      VALIDATE_ONLY: ${{ inputs.validate-only || false }}
+    run: |
+      set -euo pipefail
+      mkdir -p .tmp
+      args=(--summary-json .tmp/pi-deps-summary.json)
+      if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+        args+=(--mode manual)
+        [[ -n "${TARGET_VERSION:-}" ]] && args+=(--target-version "$TARGET_VERSION")
+        [[ -n "${PI_CODING_AGENT_VERSION:-}" ]] && args+=(--pi-coding-agent-version "$PI_CODING_AGENT_VERSION")
+        [[ -n "${PI_TUI_VERSION:-}" ]] && args+=(--pi-tui-version "$PI_TUI_VERSION")
+        [[ "$VALIDATE_ONLY" == "true" ]] && args+=(--validate-only)
+      else
+        args+=(--mode scheduled)
+      fi
+      node scripts/update-pi-deps.mjs "${args[@]}"
+      node <<'NODE' >> "$GITHUB_OUTPUT"
+      const fs = require("node:fs");
+      const summary = JSON.parse(fs.readFileSync(".tmp/pi-deps-summary.json", "utf8"));
+      const target = summary.targets["@earendil-works/pi-coding-agent"];
+      console.log(`no_update=${summary.noUpdate ? "true" : "false"}`);
+      console.log(`validate_only=${summary.validateOnly ? "true" : "false"}`);
+      console.log(`target_version=${target}`);
+      NODE
+  ```
+
+- [ ] **Step 4: Reinstall and run validations when an update is selected**
+
+  Add validation steps guarded by
+  `if: steps.update.outputs.no_update != 'true'`:
+
+  ```yaml
+  - name: Reinstall updated dependencies
+    if: steps.update.outputs.no_update != 'true'
+    run: npm ci
+
+  - name: Run Pi compatibility contract
+    if: steps.update.outputs.no_update != 'true'
+    run: node --test src/cli/commands/init/pi-dependency-contract.test.ts
+
+  - name: Run Node tests
+    if: steps.update.outputs.no_update != 'true'
+    run: npm test
+
+  - name: Run packed artifact smoke test
+    if: steps.update.outputs.no_update != 'true'
+    run: node scripts/smoke-packed-artifact.mjs
+
+  - name: Run lint
+    if: steps.update.outputs.no_update != 'true'
+    run: npm run lint
+
+  - name: Verify Nix npm dependency hash
+    if: steps.update.outputs.no_update != 'true'
+    run: |
+      scripts/update-npm-deps-hash.sh
+      if ! git diff --exit-code -- nix/package.nix; then
+        echo "::error file=nix/package.nix::npmDepsHash is stale after Pi dependency update."
+        exit 1
+      fi
+
+  - name: Build Nix package
+    if: steps.update.outputs.no_update != 'true'
+    run: nix build .#patchmill --print-build-logs
+  ```
+
+- [ ] **Step 5: Open or update a review-gated PR when validation succeeds**
+
+  Add a PR-body step and create-pull-request step guarded by
+  `no_update != 'true'` and `validate_only != 'true'`:
+
+  ```yaml
+  - name: Render pull request body
+    if:
+      steps.update.outputs.no_update != 'true' &&
+      steps.update.outputs.validate_only != 'true'
+    run: |
+      node -e 'import("./scripts/pi-dependency-upgrade-lib.mjs").then(({renderPullRequestBody}) => { const fs = require("node:fs"); const summary = JSON.parse(fs.readFileSync(".tmp/pi-deps-summary.json", "utf8")); fs.writeFileSync(".tmp/pi-deps-pr-body.md", renderPullRequestBody(summary)); })'
+
+  - name: Create or update Pi dependency upgrade PR
+    if:
+      steps.update.outputs.no_update != 'true' &&
+      steps.update.outputs.validate_only != 'true'
+    uses: peter-evans/create-pull-request@v7
+    with:
+      branch: automation/pi-deps-${{ steps.update.outputs.target_version }}
+      delete-branch: true
+      title:
+        "chore(deps): update Pi runtime packages to ${{
+        steps.update.outputs.target_version }}"
+      body-path: .tmp/pi-deps-pr-body.md
+      commit-message:
+        "chore(deps): update Pi runtime packages to ${{
+        steps.update.outputs.target_version }}"
+      labels: dependencies, automated-pr
+  ```
+
+  The workflow must not include an auto-merge or publish step.
+
+- [ ] **Step 6: Directly validate workflow formatting and no-update/manual
+      paths**
+
+  Run:
+
+  ```bash
+  npx prettier --check .github/workflows/pi-dependency-upgrade.yml
+  node scripts/update-pi-deps.mjs \
+    --mode manual \
+    --target-version 0.80.10 \
+    --validate-only \
+    --skip-nix-hash \
+    --summary-json .tmp/pi-deps-workflow-validate.json
+  ```
+
+  Expected: Prettier passes; the validate-only command exits 0 without editing
+  package metadata. Do not add a workflow-YAML content test; this is static CI
+  configuration and direct verification is more valuable.
+
+- [ ] **Step 7: Commit the workflow**
+
+  Run:
+
+  ```bash
+  git add .github/workflows/pi-dependency-upgrade.yml
+  git commit -m "ci: automate pi dependency upgrade prs"
+  ```
+
+---
+
+### Task 6: Run final integration validation and document operator usage
+
+**Files:**
+
+- Modify:
+  `docs/specs/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation-design.md`
+  only if implementation discoveries require a design correction.
+- Create: `docs/pi-dependency-upgrades.md`
+- Modify: `README.md` only if the repository already links to automation docs in
+  the touched section.
+
+**Interfaces:**
+
+- Consumes: all tasks above.
+- Produces: final validation evidence and concise operator documentation for
+  manual dispatch, validate-only mode, and local script usage.
+
+- [ ] **Step 1: Apply the Testing Value Gate before adding docs-only tests**
+
+  Do not add automated tests for documentation text. The documentation explains
+  operator commands and is verified through markdown linting plus the actual
+  commands below.
+
+- [ ] **Step 2: Add operator documentation**
+
+  Create `docs/pi-dependency-upgrades.md` with these sections:
+
+  ````markdown
+  # Pi Dependency Upgrades
+
+  Patchmill keeps `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`
+  on exact pins. The `Pi dependency upgrade` workflow discovers matching newer
+  npm `latest` versions on a schedule and opens a review-gated PR after
+  compatibility, packed-artifact, npm, and Nix validation pass.
+
+  ## Manual validation
+
+  ```bash
+  node scripts/update-pi-deps.mjs \
+    --mode manual \
+    --target-version 0.80.10 \
+    --validate-only \
+    --skip-nix-hash \
+    --summary-json .tmp/pi-deps-summary.json
+  ```
+
+  Omit `--skip-nix-hash` when preparing real dependency changes.
+
+  ## Required local checks for a real upgrade
+
+  ```bash
+  node --test src/cli/commands/init/pi-dependency-contract.test.ts
+  npm test
+  node scripts/smoke-packed-artifact.mjs
+  npm run lint
+  scripts/update-npm-deps-hash.sh
+  nix build .#patchmill --print-build-logs
+  ```
+
+  The workflow does not auto-merge or publish Pi dependency upgrades.
+  ````
+
+- [ ] **Step 3: Run focused checks**
+
+  Run:
+
+  ```bash
+  node --test scripts/pi-dependency-upgrade-lib.test.mjs src/cli/commands/init/pi-dependency-contract.test.ts
+  node scripts/update-pi-deps.mjs \
+    --mode manual \
+    --target-version 0.80.10 \
+    --validate-only \
+    --skip-nix-hash \
+    --summary-json .tmp/pi-deps-final-validate.json
+  node scripts/smoke-packed-artifact.mjs
+  ```
+
+  Expected: all commands pass. The update script should leave package metadata
+  unchanged in validate-only mode.
+
+- [ ] **Step 4: Run full repository validation required for npm/Nix-sensitive
+      changes**
+
+  Run:
+
+  ```bash
+  npm test
+  npm run lint
+  scripts/update-npm-deps-hash.sh
+  git diff --exit-code -- nix/package.nix
+  nix build .#patchmill --print-build-logs
+  ```
+
+  Expected: all commands pass; `git diff --exit-code -- nix/package.nix` reports
+  no stale hash changes after the update script. These commands satisfy the
+  `AGENTS.md` requirement for npm dependency changes in generated upgrade PRs
+  and validate that this automation has not broken the current package graph.
+
+- [ ] **Step 5: Inspect final diff for scope and security posture**
+
+  Run:
+
+  ```bash
+  git diff --stat
+  rg "auto-merge|automerge|npm publish|release" .github/workflows/pi-dependency-upgrade.yml scripts/update-pi-deps.mjs
+  ```
+
+  Expected: the diff is limited to the files named in this plan, and any matches
+  confirm the workflow does not auto-merge or publish.
+
+- [ ] **Step 6: Commit documentation and final validation notes**
+
+  Run:
+
+  ```bash
+  git add docs/pi-dependency-upgrades.md README.md docs/specs/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation-design.md
+  git commit -m "docs: document pi dependency upgrade automation"
+  ```
+
+  If `README.md` or the spec did not change, omit those paths from `git add`.
+
+---
+
+## Final Validation Commands
+
+Run these before opening the implementation PR:
+
+```bash
+node --test scripts/pi-dependency-upgrade-lib.test.mjs src/cli/commands/init/pi-dependency-contract.test.ts
+node scripts/update-pi-deps.mjs \
+  --mode manual \
+  --target-version 0.80.10 \
+  --validate-only \
+  --skip-nix-hash \
+  --summary-json .tmp/pi-deps-final-validate.json
+node scripts/smoke-packed-artifact.mjs
+npm test
+npm run lint
+scripts/update-npm-deps-hash.sh
+git diff --exit-code -- nix/package.nix
+nix build .#patchmill --print-build-logs
+```
+
+## Testing Value Gate Decisions
+
+- Add automated tests for `scripts/pi-dependency-upgrade-lib.mjs` because target
+  resolution, exact-pin validation, lockfile mismatch diagnostics, and PR body
+  rendering are reusable behavior that can regress meaningfully.
+- Keep `src/cli/commands/init/pi-dependency-contract.test.ts` as automated
+  coverage because it proves runtime package resolution and Pi SDK capabilities,
+  not static dependency text.
+- Do not add automated tests for workflow YAML, dependency version strings,
+  lockfile contents, or docs. Validate those with Prettier, script dry-runs,
+  existing CI commands, and Nix builds.
+- Do not add a separate automated test for the packed smoke script's internal
+  shell structure. Its value comes from running the script against a real packed
+  tarball.
+
+## Self-Review Notes
+
+- Spec coverage: candidate discovery, exact metadata updates, Nix hash refresh,
+  compatibility assertions, packed-artifact smoke checks, scheduled/manual PR
+  automation, actionable failure logs, review-gated posture, and no-auto-publish
+  constraints are each mapped to tasks above.
+- Placeholder scan: no step relies on unspecified future work; each command and
+  expected outcome is stated directly.
+- Interface consistency: Task 2 and Task 5 consume the helper exports introduced
+  in Task 1; Task 4 consumes `getRootPins` and `PI_PACKAGES`; final validation
+  uses commands created by earlier tasks.

--- a/docs/specs/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation-design.md
+++ b/docs/specs/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation-design.md
@@ -1,0 +1,255 @@
+# Automate Pi dependency upgrade PRs with compatibility validation
+
+## Summary
+
+Patchmill should automate review-gated upgrade PRs for its tightly coupled Pi
+runtime dependencies, `@earendil-works/pi-coding-agent` and
+`@earendil-works/pi-tui`, while preserving exact pins and the compatibility
+boundary established by the Pi `0.80.10` upgrade.
+
+The automation will discover newer Pi package versions, update all generated
+package metadata consistently, refresh the Nix npm dependency hash when needed,
+and run the same compatibility and packed-artifact smoke checks that protect
+published Patchmill releases. It will open or update a pull request for human
+review; it will not auto-merge, publish, or bypass failing compatibility checks.
+
+## Current state
+
+- `package.json` pins both Pi runtime packages exactly at `0.80.10`.
+- `package-lock.json` and `npm-shrinkwrap.json` publish the resolved dependency
+  graph.
+- `nix/package.nix` uses `buildNpmPackage` with an `npmDepsHash` maintained by
+  `scripts/update-npm-deps-hash.sh`.
+- CI already runs Node tests, linting, packed npm install smoke checks, Nix hash
+  validation, and Nix install smoke checks.
+- `src/cli/commands/init/pi-dependency-contract.test.ts` asserts the validated Pi
+  version and the Pi runtime exports Patchmill depends on.
+
+## Goals
+
+- Scheduled and manual CI can prepare or validate a Pi dependency upgrade PR
+  without hand-editing package metadata.
+- Upgrade PRs update exact pins in `package.json`, resolved entries in
+  `package-lock.json` and `npm-shrinkwrap.json`, and `nix/package.nix`
+  `npmDepsHash` when the dependency graph changes.
+- Upgrade PRs run Pi compatibility tests and packed-artifact smoke checks before
+  review.
+- Smoke checks run from a packed tarball and cover `patchmill --help`,
+  `patchmill init`, installed skill presence, and resolved Pi package versions.
+- Failures identify the package, target version, or Pi capability check that
+  failed.
+- The workflow remains review-gated: no auto-publish and no auto-merge.
+
+## Non-goals
+
+- Do not implement or redesign Patchmill's Pi compatibility boundary itself.
+- Do not change upstream `@earendil-works/*` APIs or vendor upstream internals.
+- Do not widen Pi dependency ranges; exact pins remain the release boundary.
+- Do not add tests that only assert static workflow YAML or lockfile text.
+
+## Design options considered
+
+### Option A: Dependabot-only version PRs
+
+Dependabot can detect npm updates and open PRs, but it will not know how to keep
+Patchmill's `npm-shrinkwrap.json`, Nix `npmDepsHash`, compatibility assertions,
+and packed-artifact smoke checks synchronized. This would still require manual
+repair on every Pi upgrade.
+
+### Option B: Scheduled GitHub Actions workflow with Patchmill-owned scripts
+
+A scheduled/manual workflow runs repository scripts that discover the target Pi
+versions, update package metadata, refresh the Nix hash, validate the result,
+and create or update a PR branch. This keeps the repository-specific upgrade
+contract in versioned code and makes failures actionable in CI logs.
+
+### Option C: External release bot
+
+An external bot could run the same logic outside GitHub Actions, but it would add
+new credentials and operational surface area without improving validation. The
+repository already has the needed CI, Nix, and PR automation primitives.
+
+**Decision:** Use Option B. Keep the core logic in repository scripts so it can
+run locally, under `workflow_dispatch`, on a schedule, and on PR validation.
+
+## Proposed behavior
+
+### Candidate discovery
+
+Add a Patchmill-owned update script, for example `scripts/update-pi-deps.mjs`,
+that accepts either explicit target versions or a discovery mode:
+
+- Scheduled mode queries npm registry metadata for the `latest` dist-tag of both
+  Pi packages.
+- Manual mode accepts explicit package versions through workflow inputs for
+  rollback or pre-release validation.
+- Scheduled mode only prepares an upgrade when both packages have a newer shared
+  `latest` version than the current exact pins. If latest versions diverge, the
+  script exits non-zero before editing files and logs both package names and
+  dist-tag versions.
+- Manual mode may accept different explicit versions, but the PR body must call
+  out the non-matching pair so reviewers can decide whether it is intentional.
+- If no newer candidate exists, scheduled mode exits successfully without
+  opening a PR.
+
+The script should verify that the root `package.json` dependencies are exact
+semver strings before proceeding. A range such as `^0.80.10` is an error because
+it weakens Patchmill's compatibility boundary.
+
+### Metadata update
+
+The update script should codify the proven manual upgrade workflow:
+
+1. Set `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` in
+   `package.json` to exact target versions.
+2. Regenerate `npm-shrinkwrap.json` and `package-lock.json` with npm in
+   lockfile-only, ignore-scripts mode.
+3. Format `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` with
+   Prettier.
+4. Validate that root dependencies and each lockfile's `node_modules/<package>`
+   entries resolve to the requested versions.
+5. Run `scripts/update-npm-deps-hash.sh` after lockfile changes so
+   `nix/package.nix` records the correct `npmDepsHash`.
+
+The script should print a concise summary of changed files and target versions.
+If npm cannot resolve either target version, the error should include the package
+name and requested version.
+
+### Compatibility assertions
+
+Keep `src/cli/commands/init/pi-dependency-contract.test.ts` as the primary Pi
+runtime boundary test, but make the expected version derive from the exact root
+`package.json` pins instead of requiring a hand-edited constant on every upgrade.
+The test should fail with messages such as:
+
+- `@earendil-works/pi-coding-agent resolved 0.x.y but package.json pins 0.a.b`;
+- `@earendil-works/pi-tui resolved 0.x.y but package.json pins 0.a.b`;
+- `@earendil-works/pi-coding-agent must export ModelRuntime`.
+
+This keeps version assertions tied to the PR's proposed pins while preserving
+capability checks for Patchmill's current Pi SDK usage.
+
+### Packed-artifact smoke script
+
+Move the packed npm artifact smoke behavior into a reusable script, for example
+`scripts/smoke-packed-artifact.mjs` or `scripts/smoke-packed-artifact.sh`, and
+have CI call it. The script should:
+
+1. run `npm pack --silent` from the repository;
+2. install the tarball in a temporary npm project with isolated `HOME`,
+   `XDG_CONFIG_HOME`, and npm cache;
+3. run `./node_modules/.bin/patchmill --help`;
+4. run `./node_modules/.bin/patchmill init` non-interactively in the temporary
+   project;
+5. assert an installed Patchmill skill file exists;
+6. resolve `@earendil-works/pi-coding-agent/package.json` and
+   `@earendil-works/pi-tui/package.json` from the installed package and compare
+   their versions to the root package pins.
+
+Version mismatch failures should include the package name, expected pin, actual
+resolved version, and installed package path when available.
+
+### GitHub Actions workflow
+
+Add `.github/workflows/pi-dependency-upgrade.yml` with:
+
+- `schedule`, for example weekly;
+- `workflow_dispatch` with optional target versions and a validate-only mode;
+- `permissions: contents: write, pull-requests: write` for PR creation;
+- concurrency keyed to the Pi dependency upgrade branch.
+
+The workflow should:
+
+1. check out `main`;
+2. set up Node 24 and run `npm ci`;
+3. discover or accept target Pi versions;
+4. run the update script;
+5. stop successfully if there are no changes;
+6. install Nix and run `scripts/update-npm-deps-hash.sh`;
+7. run targeted Pi compatibility tests, full `npm test`, the packed-artifact
+   smoke script, `npm run lint`, and `nix build .#patchmill --print-build-logs`;
+8. create or update a branch such as `automation/pi-deps-<version>`;
+9. open or update a PR with a generated body containing target versions, changed
+   metadata files, and validation results.
+
+The PR should have a clear title such as
+`chore(deps): update Pi runtime packages to <version>` and should not request
+release publication or auto-merge. If validation fails, the workflow should fail
+without updating a successful PR body; logs remain the source of actionable
+failure details.
+
+### CI validation on upgrade PRs
+
+Update the existing CI workflow to call the reusable packed-artifact smoke script
+instead of duplicating shell logic. The normal PR checks will then validate both
+manually opened and automation-created Pi upgrade PRs.
+
+The Nix job should continue to run `scripts/update-npm-deps-hash.sh` and fail if
+`nix/package.nix` changes, ensuring contributors cannot forget the hash update.
+
+## Affected components
+
+- New: Pi dependency update script under `scripts/`.
+- New: reusable packed-artifact smoke script under `scripts/`.
+- New: scheduled/manual workflow `.github/workflows/pi-dependency-upgrade.yml`.
+- Modified: `.github/workflows/ci.yml` to call the reusable smoke script.
+- Modified: `src/cli/commands/init/pi-dependency-contract.test.ts` to derive
+  expected versions from exact root package pins.
+- Modified during generated PRs: `package.json`, `package-lock.json`,
+  `npm-shrinkwrap.json`, and `nix/package.nix` when the dependency graph changes.
+
+## Error handling and logs
+
+The scripts should prefer explicit validation errors over silent drift:
+
+- no update available: log current and latest versions, exit 0;
+- divergent scheduled latest versions: log both package versions, exit non-zero
+  before editing;
+- non-exact root pins: log the offending package and dependency spec;
+- npm resolution failure: log package and requested target version;
+- lockfile mismatch: log file, package, expected version, and actual version;
+- Nix hash failure without a parseable mismatch: preserve and print the existing
+  `scripts/update-npm-deps-hash.sh` diagnostic;
+- compatibility failure: rely on the Pi contract test's package/export-specific
+  assertion messages;
+- packed smoke failure: log the command being run, package path, expected Pi
+  versions, and actual resolved versions.
+
+## Verification strategy
+
+Implementation should use automated tests for reusable parsing and validation
+logic because those checks prove behavior and can fail for meaningful future
+regressions. It should avoid tests that merely duplicate workflow YAML.
+
+Recommended verification for the implementation plan:
+
+- unit-test the version discovery/update helpers with fixture package files and
+  mocked npm metadata;
+- unit-test exact-pin and lockfile-version validation failures;
+- run the Pi dependency contract test:
+  `node --test src/cli/commands/init/pi-dependency-contract.test.ts`;
+- run full Node tests: `npm test`;
+- run the packed-artifact smoke script from a local tarball;
+- run lint: `npm run lint`;
+- because npm metadata can change in generated PRs, run
+  `scripts/update-npm-deps-hash.sh` and `nix build .#patchmill --print-build-logs`;
+- manually dispatch the new workflow in validate-only mode before relying on the
+  schedule.
+
+## Rollout
+
+1. Land the automation scripts and workflow without changing the current Pi
+   versions.
+2. Manually dispatch validate-only mode against the current pins to prove the
+   workflow does not require an actual newer version.
+3. Manually dispatch with explicit current versions or a harmless fixture path if
+   supported by the implementation to exercise the no-op and validation paths.
+4. Let the next scheduled run create a real upgrade PR when npm publishes newer
+   compatible Pi packages.
+
+## Security and review posture
+
+The workflow should only use npm registry metadata and repository code. It must
+not execute commands from issue or PR text. Generated PRs remain normal review
+artifacts, and failing compatibility or smoke checks block merge through the
+existing branch protection rather than through an auto-merge policy.

--- a/docs/specs/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation-design.md
+++ b/docs/specs/2026-07-23-issue-96-automate-pi-dependency-upgrade-prs-with-compatibility-validation-design.md
@@ -22,8 +22,8 @@ review; it will not auto-merge, publish, or bypass failing compatibility checks.
   `scripts/update-npm-deps-hash.sh`.
 - CI already runs Node tests, linting, packed npm install smoke checks, Nix hash
   validation, and Nix install smoke checks.
-- `src/cli/commands/init/pi-dependency-contract.test.ts` asserts the validated Pi
-  version and the Pi runtime exports Patchmill depends on.
+- `src/cli/commands/init/pi-dependency-contract.test.ts` asserts the validated
+  Pi version and the Pi runtime exports Patchmill depends on.
 
 ## Goals
 
@@ -65,9 +65,9 @@ contract in versioned code and makes failures actionable in CI logs.
 
 ### Option C: External release bot
 
-An external bot could run the same logic outside GitHub Actions, but it would add
-new credentials and operational surface area without improving validation. The
-repository already has the needed CI, Nix, and PR automation primitives.
+An external bot could run the same logic outside GitHub Actions, but it would
+add new credentials and operational surface area without improving validation.
+The repository already has the needed CI, Nix, and PR automation primitives.
 
 **Decision:** Use Option B. Keep the core logic in repository scripts so it can
 run locally, under `workflow_dispatch`, on a schedule, and on PR validation.
@@ -112,15 +112,15 @@ The update script should codify the proven manual upgrade workflow:
    `nix/package.nix` records the correct `npmDepsHash`.
 
 The script should print a concise summary of changed files and target versions.
-If npm cannot resolve either target version, the error should include the package
-name and requested version.
+If npm cannot resolve either target version, the error should include the
+package name and requested version.
 
 ### Compatibility assertions
 
 Keep `src/cli/commands/init/pi-dependency-contract.test.ts` as the primary Pi
 runtime boundary test, but make the expected version derive from the exact root
-`package.json` pins instead of requiring a hand-edited constant on every upgrade.
-The test should fail with messages such as:
+`package.json` pins instead of requiring a hand-edited constant on every
+upgrade. The test should fail with messages such as:
 
 - `@earendil-works/pi-coding-agent resolved 0.x.y but package.json pins 0.a.b`;
 - `@earendil-works/pi-tui resolved 0.x.y but package.json pins 0.a.b`;
@@ -180,9 +180,9 @@ failure details.
 
 ### CI validation on upgrade PRs
 
-Update the existing CI workflow to call the reusable packed-artifact smoke script
-instead of duplicating shell logic. The normal PR checks will then validate both
-manually opened and automation-created Pi upgrade PRs.
+Update the existing CI workflow to call the reusable packed-artifact smoke
+script instead of duplicating shell logic. The normal PR checks will then
+validate both manually opened and automation-created Pi upgrade PRs.
 
 The Nix job should continue to run `scripts/update-npm-deps-hash.sh` and fail if
 `nix/package.nix` changes, ensuring contributors cannot forget the hash update.
@@ -196,7 +196,8 @@ The Nix job should continue to run `scripts/update-npm-deps-hash.sh` and fail if
 - Modified: `src/cli/commands/init/pi-dependency-contract.test.ts` to derive
   expected versions from exact root package pins.
 - Modified during generated PRs: `package.json`, `package-lock.json`,
-  `npm-shrinkwrap.json`, and `nix/package.nix` when the dependency graph changes.
+  `npm-shrinkwrap.json`, and `nix/package.nix` when the dependency graph
+  changes.
 
 ## Error handling and logs
 
@@ -232,7 +233,8 @@ Recommended verification for the implementation plan:
 - run the packed-artifact smoke script from a local tarball;
 - run lint: `npm run lint`;
 - because npm metadata can change in generated PRs, run
-  `scripts/update-npm-deps-hash.sh` and `nix build .#patchmill --print-build-logs`;
+  `scripts/update-npm-deps-hash.sh` and
+  `nix build .#patchmill --print-build-logs`;
 - manually dispatch the new workflow in validate-only mode before relying on the
   schedule.
 
@@ -242,8 +244,9 @@ Recommended verification for the implementation plan:
    versions.
 2. Manually dispatch validate-only mode against the current pins to prove the
    workflow does not require an actual newer version.
-3. Manually dispatch with explicit current versions or a harmless fixture path if
-   supported by the implementation to exercise the no-op and validation paths.
+3. Manually dispatch with explicit current versions or a harmless fixture path
+   if supported by the implementation to exercise the no-op and validation
+   paths.
 4. Let the next scheduled run create a real upgrade PR when npm publishes newer
    compatible Pi packages.
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
-    "test": "node --test \"bin/*.test.ts\" \"src/**/*.test.ts\" \"test-support/*.test.ts\"",
+    "test": "node --test \"bin/*.test.ts\" \"src/**/*.test.ts\" \"test-support/*.test.ts\" \"scripts/*.test.mjs\"",
     "test:coverage": "node --test --experimental-test-coverage --test-coverage-include='bin/**/*.ts' --test-coverage-include='src/**/*.ts' --test-coverage-include='test-support/**/*.ts' --test-coverage-exclude='**/*.test.ts' \"bin/*.test.ts\" \"src/**/*.test.ts\" \"test-support/*.test.ts\"",
     "test:cli": "node --test bin/*.test.ts src/cli/main.test.ts",
     "test:triage": "node --test src/cli/commands/triage/*.test.ts",

--- a/scripts/pi-dependency-upgrade-lib.mjs
+++ b/scripts/pi-dependency-upgrade-lib.mjs
@@ -1,0 +1,164 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+export const PI_PACKAGES = [
+  "@earendil-works/pi-coding-agent",
+  "@earendil-works/pi-tui",
+];
+
+export function isExactVersion(spec) {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(spec);
+}
+
+export async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+export async function writeJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function getRootPins(packageJson) {
+  const dependencies = packageJson.dependencies ?? {};
+  return Object.fromEntries(
+    PI_PACKAGES.map((name) => {
+      const spec = dependencies[name];
+      if (!isExactVersion(spec ?? "")) {
+        throw new Error(
+          `${name} must be an exact version; found ${spec ?? "missing"}`,
+        );
+      }
+      return [name, spec];
+    }),
+  );
+}
+
+export async function fetchLatestVersion(packageName, fetchImpl = fetch) {
+  const encodedName = encodeURIComponent(packageName).replace("%40", "@");
+  const response = await fetchImpl(`https://registry.npmjs.org/${encodedName}`);
+  if (!response.ok) {
+    throw new Error(
+      `${packageName}: npm registry request failed (${response.status})`,
+    );
+  }
+
+  const latest = (await response.json())?.["dist-tags"]?.latest;
+  if (!latest) {
+    throw new Error(`${packageName}: npm latest dist-tag not found`);
+  }
+  return latest;
+}
+
+export function compareVersions(a, b) {
+  const parse = (version) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+    if (!match) throw new Error(`Invalid version: ${version}`);
+    return match.slice(1).map(Number);
+  };
+  const left = parse(a);
+  const right = parse(b);
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+export function resolveUpgradeTarget({
+  mode,
+  currentPins,
+  latestVersions,
+  manualVersions,
+}) {
+  if (mode === "scheduled") {
+    const [codingAgent, tui] = PI_PACKAGES.map(
+      (name) => latestVersions?.[name],
+    );
+    if (codingAgent !== tui) {
+      throw new Error(
+        `Scheduled Pi upgrade requires matching latest versions: ${PI_PACKAGES[0]}=${codingAgent}, ${PI_PACKAGES[1]}=${tui}`,
+      );
+    }
+    const noUpdate = PI_PACKAGES.every(
+      (name) => compareVersions(codingAgent, currentPins[name]) <= 0,
+    );
+    return {
+      noUpdate,
+      targets: noUpdate
+        ? currentPins
+        : Object.fromEntries(PI_PACKAGES.map((name) => [name, codingAgent])),
+      warnings: [],
+    };
+  }
+
+  if (mode !== "manual") throw new Error(`Unsupported upgrade mode: ${mode}`);
+  const targets = Object.fromEntries(
+    PI_PACKAGES.map((name) => {
+      const version = manualVersions?.[name];
+      if (!isExactVersion(version ?? "")) {
+        throw new Error(
+          `${name} manual version must be an exact version; found ${version ?? "missing"}`,
+        );
+      }
+      return [name, version];
+    }),
+  );
+  const warnings =
+    targets[PI_PACKAGES[0]] === targets[PI_PACKAGES[1]]
+      ? []
+      : [
+          `Pi package versions differ: ${PI_PACKAGES[0]}=${targets[PI_PACKAGES[0]]}, ${PI_PACKAGES[1]}=${targets[PI_PACKAGES[1]]}`,
+        ];
+  return { noUpdate: false, targets, warnings };
+}
+
+function assertLockfileMatchesTargets(lockfile, label, targets) {
+  const rootDependencies = lockfile.packages?.[""]?.dependencies ?? {};
+  for (const name of PI_PACKAGES) {
+    const expected = targets[name];
+    const rootActual = rootDependencies[name];
+    if (rootActual !== expected) {
+      throw new Error(
+        `${label}: ${name} expected ${expected}, root dependency is ${rootActual ?? "missing"}`,
+      );
+    }
+    const resolvedActual = lockfile.packages?.[`node_modules/${name}`]?.version;
+    if (resolvedActual !== expected) {
+      throw new Error(
+        `${label}: ${name} expected ${expected}, resolved version is ${resolvedActual ?? "missing"}`,
+      );
+    }
+  }
+}
+
+export function assertLockfilesMatchTargets({
+  packageJson,
+  packageLock,
+  shrinkwrap,
+  targets,
+}) {
+  const pins = getRootPins(packageJson);
+  for (const name of PI_PACKAGES) {
+    if (pins[name] !== targets[name]) {
+      throw new Error(
+        `package.json: ${name} expected ${targets[name]}, dependency is ${pins[name]}`,
+      );
+    }
+  }
+  assertLockfileMatchesTargets(packageLock, "package-lock.json", targets);
+  assertLockfileMatchesTargets(shrinkwrap, "npm-shrinkwrap.json", targets);
+}
+
+export function renderPullRequestBody(summary) {
+  const versions = PI_PACKAGES.map(
+    (name) => `- \`${name}\`: \`${summary.targets[name]}\``,
+  ).join("\n");
+  const warnings = summary.warnings?.length
+    ? `\n## Warnings\n\n${summary.warnings.map((warning) => `- ${warning}`).join("\n")}\n`
+    : "";
+  const changedFiles =
+    (summary.changedFiles ?? []).map((file) => `- \`${file}\``).join("\n") ||
+    "- No metadata changes";
+  const validation = (summary.validationCommands ?? [])
+    .map((command) => `- \`${command}\``)
+    .join("\n");
+  return `## Pi runtime dependency upgrade\n\n### Target versions\n\n${versions}${warnings}\n## Changed files\n\n${changedFiles}\n\n## Validation\n\n${validation}\n\nThis PR is review-gated and does not auto-merge or publish.\n`;
+}

--- a/scripts/pi-dependency-upgrade-lib.mjs
+++ b/scripts/pi-dependency-upgrade-lib.mjs
@@ -77,8 +77,8 @@ export function resolveUpgradeTarget({
         `Scheduled Pi upgrade requires matching latest versions: ${PI_PACKAGES[0]}=${codingAgent}, ${PI_PACKAGES[1]}=${tui}`,
       );
     }
-    const noUpdate = PI_PACKAGES.every(
-      (name) => compareVersions(codingAgent, currentPins[name]) <= 0,
+    const noUpdate = !PI_PACKAGES.every(
+      (name) => compareVersions(codingAgent, currentPins[name]) > 0,
     );
     return {
       noUpdate,

--- a/scripts/pi-dependency-upgrade-lib.test.mjs
+++ b/scripts/pi-dependency-upgrade-lib.test.mjs
@@ -54,6 +54,21 @@ test("scheduled mode does not update equal or older numeric versions", () => {
   assert.deepEqual(result.targets, currentPins);
 });
 
+test("scheduled mode requires a newer version than both current pins", () => {
+  const pins = {
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.12",
+  };
+  const result = resolveUpgradeTarget({
+    mode: "scheduled",
+    currentPins: pins,
+    latestVersions: newerVersions,
+  });
+
+  assert.equal(result.noUpdate, true);
+  assert.deepEqual(result.targets, pins);
+});
+
 test("manual mode warns when Pi package versions differ", () => {
   const result = resolveUpgradeTarget({
     mode: "manual",

--- a/scripts/pi-dependency-upgrade-lib.test.mjs
+++ b/scripts/pi-dependency-upgrade-lib.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  assertLockfilesMatchTargets,
+  getRootPins,
+  renderPullRequestBody,
+  resolveUpgradeTarget,
+} from "./pi-dependency-upgrade-lib.mjs";
+
+const currentPins = {
+  "@earendil-works/pi-coding-agent": "0.80.10",
+  "@earendil-works/pi-tui": "0.80.10",
+};
+
+const newerVersions = {
+  "@earendil-works/pi-coding-agent": "0.80.11",
+  "@earendil-works/pi-tui": "0.80.11",
+};
+
+test("scheduled mode selects a newer shared latest version", () => {
+  const result = resolveUpgradeTarget({
+    mode: "scheduled",
+    currentPins,
+    latestVersions: newerVersions,
+  });
+
+  assert.equal(result.noUpdate, false);
+  assert.deepEqual(result.targets, newerVersions);
+});
+
+test("scheduled mode fails before edits when latest versions diverge", () => {
+  assert.throws(
+    () =>
+      resolveUpgradeTarget({
+        mode: "scheduled",
+        currentPins,
+        latestVersions: {
+          "@earendil-works/pi-coding-agent": "0.80.12",
+          "@earendil-works/pi-tui": "0.80.11",
+        },
+      }),
+    /requires matching latest versions.*pi-coding-agent=0.80.12.*pi-tui=0.80.11/,
+  );
+});
+
+test("scheduled mode does not update equal or older numeric versions", () => {
+  const result = resolveUpgradeTarget({
+    mode: "scheduled",
+    currentPins,
+    latestVersions: currentPins,
+  });
+
+  assert.equal(result.noUpdate, true);
+  assert.deepEqual(result.targets, currentPins);
+});
+
+test("manual mode warns when Pi package versions differ", () => {
+  const result = resolveUpgradeTarget({
+    mode: "manual",
+    currentPins,
+    manualVersions: {
+      "@earendil-works/pi-coding-agent": "0.80.11",
+      "@earendil-works/pi-tui": "0.80.12",
+    },
+  });
+
+  assert.equal(result.warnings.length, 1);
+  assert.match(result.warnings[0], /versions differ/);
+});
+
+test("root Pi pins must be exact versions", () => {
+  assert.throws(
+    () =>
+      getRootPins({
+        dependencies: {
+          "@earendil-works/pi-coding-agent": "^0.80.10",
+          "@earendil-works/pi-tui": "0.80.10",
+        },
+      }),
+    /pi-coding-agent must be an exact version; found \^0.80.10/,
+  );
+});
+
+test("lockfile validation identifies file, package, expected, and actual versions", () => {
+  const validLockfile = {
+    packages: {
+      "": { dependencies: currentPins },
+      "node_modules/@earendil-works/pi-coding-agent": { version: "0.80.10" },
+      "node_modules/@earendil-works/pi-tui": { version: "0.80.10" },
+    },
+  };
+  const invalidShrinkwrap = structuredClone(validLockfile);
+  invalidShrinkwrap.packages["node_modules/@earendil-works/pi-tui"].version =
+    "0.80.9";
+
+  assert.throws(
+    () =>
+      assertLockfilesMatchTargets({
+        packageJson: { dependencies: currentPins },
+        packageLock: validLockfile,
+        shrinkwrap: invalidShrinkwrap,
+        targets: currentPins,
+      }),
+    /npm-shrinkwrap.json: @earendil-works\/pi-tui expected 0.80.10, resolved version is 0.80.9/,
+  );
+});
+
+test("PR body renders target versions and validation commands", () => {
+  const body = renderPullRequestBody({
+    targets: currentPins,
+    warnings: ["Versions differ for a manual upgrade"],
+    changedFiles: ["package.json"],
+    validationCommands: ["npm test"],
+  });
+
+  assert.match(body, /@earendil-works\/pi-coding-agent.*0.80.10/);
+  assert.match(body, /Versions differ for a manual upgrade/);
+  assert.match(body, /`package.json`/);
+  assert.match(body, /`npm test`/);
+});

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getRootPins, PI_PACKAGES } from "./pi-dependency-upgrade-lib.mjs";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function run(command, args, options = {}) {
+  console.log(`$ ${[command, ...args].join(" ")}`);
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit", ...options });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(`Command failed (${code}): ${command} ${args.join(" ")}`),
+        );
+    });
+    child.on("error", reject);
+  });
+}
+
+async function main() {
+  const smokeDir = await mkdtemp(join(tmpdir(), "patchmill-smoke-"));
+  const homeDir = join(smokeDir, "home");
+  const configDir = join(smokeDir, "config");
+  const cacheDir = join(smokeDir, "npm-cache");
+  const projectDir = join(smokeDir, "project");
+  let tarballPath;
+  await Promise.all(
+    [homeDir, configDir, cacheDir, projectDir].map((path) => mkdir(path)),
+  );
+  const environment = {
+    ...process.env,
+    HOME: homeDir,
+    XDG_CONFIG_HOME: configDir,
+    npm_config_cache: cacheDir,
+  };
+
+  try {
+    const tarballName = await new Promise((resolve, reject) => {
+      const child = spawn("npm", ["pack", "--silent"], {
+        cwd: rootDir,
+        env: environment,
+      });
+      let stdout = "";
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+        process.stdout.write(chunk);
+      });
+      child.stderr.pipe(process.stderr);
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        if (code === 0) resolve(stdout.trim());
+        else reject(new Error(`Command failed (${code}): npm pack --silent`));
+      });
+    });
+    tarballPath = join(rootDir, tarballName);
+
+    await run("npm", ["init", "-y"], { cwd: projectDir, env: environment });
+    await run("npm", ["install", tarballPath], {
+      cwd: projectDir,
+      env: environment,
+    });
+    await run("./node_modules/.bin/patchmill", ["--help"], {
+      cwd: projectDir,
+      env: environment,
+    });
+    await run("./node_modules/.bin/patchmill", ["init"], {
+      cwd: projectDir,
+      env: environment,
+    });
+
+    const skillPath = join(
+      projectDir,
+      ".patchmill/skills/patchmill-issue-triage/SKILL.md",
+    );
+    if (!existsSync(skillPath)) {
+      throw new Error(`Installed Patchmill skill is missing: ${skillPath}`);
+    }
+
+    const rootPins = getRootPins(
+      JSON.parse(await readFile(join(rootDir, "package.json"), "utf8")),
+    );
+    const projectRequire = createRequire(join(projectDir, "package.json"));
+    const nodeModulesDir = dirname(
+      dirname(projectRequire.resolve("patchmill/package.json")),
+    );
+    for (const name of PI_PACKAGES) {
+      const packagePath = join(nodeModulesDir, name, "package.json");
+      if (!existsSync(packagePath)) {
+        throw new Error(
+          `Could not locate package.json for ${name}: ${packagePath}`,
+        );
+      }
+      const resolved = JSON.parse(await readFile(packagePath, "utf8"));
+      if (resolved.version !== rootPins[name]) {
+        throw new Error(
+          `${name} resolved ${resolved.version} from ${packagePath} but package.json pins ${rootPins[name]}`,
+        );
+      }
+      console.log(`${name} resolved ${resolved.version} from ${packagePath}`);
+    }
+  } finally {
+    if (process.env.PATCHMILL_KEEP_SMOKE_ARTIFACTS !== "1") {
+      await Promise.all([
+        rm(smokeDir, { recursive: true, force: true }),
+        ...(tarballPath ? [rm(tarballPath, { force: true })] : []),
+        rm(join(rootDir, "dist"), { recursive: true, force: true }),
+      ]);
+    } else {
+      console.log(`Keeping smoke artifacts in ${smokeDir}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/update-pi-deps.mjs
+++ b/scripts/update-pi-deps.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PI_PACKAGES,
+  assertLockfilesMatchTargets,
+  fetchLatestVersion,
+  getRootPins,
+  readJson,
+  resolveUpgradeTarget,
+  writeJson,
+} from "./pi-dependency-upgrade-lib.mjs";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const packagePaths = {
+  packageJson: join(rootDir, "package.json"),
+  packageLock: join(rootDir, "package-lock.json"),
+  shrinkwrap: join(rootDir, "npm-shrinkwrap.json"),
+};
+const validationCommands = [
+  "node --test src/cli/commands/init/pi-dependency-contract.test.ts",
+  "npm test",
+  "node scripts/smoke-packed-artifact.mjs",
+  "npm run lint",
+  "scripts/update-npm-deps-hash.sh",
+  "nix build .#patchmill --print-build-logs",
+];
+
+function parseArgs(args) {
+  const options = {
+    mode: "scheduled",
+    manualVersions: {},
+    skipNixHash: false,
+    validateOnly: false,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const value = () => {
+      index += 1;
+      if (!args[index]) throw new Error(`${argument} requires a value`);
+      return args[index];
+    };
+    switch (argument) {
+      case "--mode":
+        options.mode = value();
+        break;
+      case "--target-version":
+        options.targetVersion = value();
+        break;
+      case "--pi-coding-agent-version":
+        options.manualVersions[PI_PACKAGES[0]] = value();
+        break;
+      case "--pi-tui-version":
+        options.manualVersions[PI_PACKAGES[1]] = value();
+        break;
+      case "--summary-json":
+        options.summaryJson = value();
+        break;
+      case "--validate-only":
+        options.validateOnly = true;
+        break;
+      case "--skip-nix-hash":
+        options.skipNixHash = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!["scheduled", "manual"].includes(options.mode)) {
+    throw new Error(
+      `--mode must be scheduled or manual; found ${options.mode}`,
+    );
+  }
+  if (options.targetVersion) {
+    for (const name of PI_PACKAGES) {
+      options.manualVersions[name] ??= options.targetVersion;
+    }
+  }
+  return options;
+}
+
+function run(command, args) {
+  console.log(`$ ${[command, ...args].join(" ")}`);
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: rootDir, stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Command failed: ${command} ${args.join(" ")}`));
+    });
+  });
+}
+
+async function changedMetadataFiles() {
+  const output = await new Promise((resolve, reject) => {
+    const child = spawn(
+      "git",
+      [
+        "diff",
+        "--name-only",
+        "--",
+        "package.json",
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+        "nix/package.nix",
+      ],
+      { cwd: rootDir },
+    );
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error("Unable to inspect changed package metadata"));
+    });
+  });
+  return output.trim() ? output.trim().split("\n") : [];
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const packageJson = await readJson(packagePaths.packageJson);
+  const currentPins = getRootPins(packageJson);
+  const latestVersions =
+    options.mode === "scheduled"
+      ? Object.fromEntries(
+          await Promise.all(
+            PI_PACKAGES.map(async (name) => [
+              name,
+              await fetchLatestVersion(name),
+            ]),
+          ),
+        )
+      : undefined;
+  const resolved = resolveUpgradeTarget({
+    mode: options.mode,
+    currentPins,
+    latestVersions,
+    manualVersions: options.manualVersions,
+  });
+  const summary = {
+    noUpdate: resolved.noUpdate,
+    validateOnly: options.validateOnly,
+    targets: resolved.targets,
+    warnings: resolved.warnings,
+    changedFiles: [],
+    validationCommands,
+  };
+
+  console.log(
+    `Current Pi pins: ${PI_PACKAGES.map((name) => `${name}=${currentPins[name]}`).join(", ")}`,
+  );
+  console.log(
+    `Selected Pi targets: ${PI_PACKAGES.map((name) => `${name}=${resolved.targets[name]}`).join(", ")}`,
+  );
+
+  if (!resolved.noUpdate && !options.validateOnly) {
+    packageJson.dependencies ??= {};
+    for (const name of PI_PACKAGES)
+      packageJson.dependencies[name] = resolved.targets[name];
+    await writeJson(packagePaths.packageJson, packageJson);
+
+    const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-"));
+    const temporaryShrinkwrap = join(tempDir, "npm-shrinkwrap.json");
+    try {
+      try {
+        await run("npm", [
+          "install",
+          "--package-lock-only",
+          "--ignore-scripts",
+        ]);
+        await copyFile(packagePaths.shrinkwrap, temporaryShrinkwrap);
+        await rm(packagePaths.shrinkwrap);
+        await run("npm", [
+          "install",
+          "--package-lock-only",
+          "--ignore-scripts",
+        ]);
+        await copyFile(temporaryShrinkwrap, packagePaths.shrinkwrap);
+        await run("npx", [
+          "prettier",
+          "--write",
+          "package.json",
+          "package-lock.json",
+          "npm-shrinkwrap.json",
+        ]);
+      } catch (error) {
+        const requested = PI_PACKAGES.map(
+          (name) => `${name}=${resolved.targets[name]}`,
+        ).join(", ");
+        throw new Error(
+          `Unable to resolve requested Pi dependency versions (${requested}): ${error.message}`,
+        );
+      }
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  const [updatedPackageJson, packageLock, shrinkwrap] = await Promise.all([
+    readJson(packagePaths.packageJson),
+    readJson(packagePaths.packageLock),
+    readJson(packagePaths.shrinkwrap),
+  ]);
+  assertLockfilesMatchTargets({
+    packageJson: updatedPackageJson,
+    packageLock,
+    shrinkwrap,
+    targets: resolved.targets,
+  });
+
+  if (!resolved.noUpdate && !options.validateOnly && !options.skipNixHash) {
+    await run("scripts/update-npm-deps-hash.sh", []);
+  }
+  summary.changedFiles = await changedMetadataFiles();
+  console.log(
+    `Changed metadata files: ${summary.changedFiles.join(", ") || "none"}`,
+  );
+  if (resolved.noUpdate) console.log("No Pi dependency update available");
+  if (options.summaryJson) await writeJson(options.summaryJson, summary);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/update-pi-deps.mjs
+++ b/scripts/update-pi-deps.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +19,10 @@ const packagePaths = {
   packageJson: join(rootDir, "package.json"),
   packageLock: join(rootDir, "package-lock.json"),
   shrinkwrap: join(rootDir, "npm-shrinkwrap.json"),
+};
+const trackedMetadataPaths = {
+  ...packagePaths,
+  nixPackage: join(rootDir, "nix/package.nix"),
 };
 const validationCommands = [
   "node --test src/cli/commands/init/pi-dependency-contract.test.ts",
@@ -177,32 +181,23 @@ function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-async function changedMetadataFiles() {
-  const output = await new Promise((resolve, reject) => {
-    const child = spawn(
-      "git",
-      [
-        "diff",
-        "--name-only",
-        "--",
-        "package.json",
-        "package-lock.json",
-        "npm-shrinkwrap.json",
-        "nix/package.nix",
-      ],
-      { cwd: rootDir },
-    );
-    let stdout = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk;
-    });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve(stdout);
-      else reject(new Error("Unable to inspect changed package metadata"));
-    });
-  });
-  return output.trim() ? output.trim().split("\n") : [];
+async function snapshotMetadataFiles() {
+  return Object.fromEntries(
+    await Promise.all(
+      Object.entries(trackedMetadataPaths).map(async ([name, path]) => [
+        name,
+        await readFile(path),
+      ]),
+    ),
+  );
+}
+
+async function changedMetadataFiles(snapshot) {
+  if (!snapshot) return [];
+  const current = await snapshotMetadataFiles();
+  return Object.entries(trackedMetadataPaths)
+    .filter(([name]) => !snapshot[name].equals(current[name]))
+    .map(([, path]) => path.slice(rootDir.length + 1));
 }
 
 async function main() {
@@ -219,10 +214,12 @@ async function main() {
     changedFiles: [],
     validationCommands,
   };
+  let metadataSnapshot;
 
   try {
     Object.assign(options, parseArgs(args));
     summary.validateOnly = options.validateOnly;
+    metadataSnapshot = await snapshotMetadataFiles();
     const packageJson = await readJson(packagePaths.packageJson);
     const currentPins = getRootPins(packageJson);
     const latestVersions =
@@ -274,7 +271,7 @@ async function main() {
     if (!resolved.noUpdate && !options.validateOnly && !options.skipNixHash) {
       await run("scripts/update-npm-deps-hash.sh", []);
     }
-    summary.changedFiles = await changedMetadataFiles();
+    summary.changedFiles = await changedMetadataFiles(metadataSnapshot);
     console.log(
       `Changed metadata files: ${summary.changedFiles.join(", ") || "none"}`,
     );
@@ -283,9 +280,9 @@ async function main() {
   } catch (error) {
     summary.error = errorMessage(error);
     try {
-      summary.changedFiles = await changedMetadataFiles();
+      summary.changedFiles = await changedMetadataFiles(metadataSnapshot);
     } catch {
-      // Preserve the primary failure when Git cannot report changed metadata.
+      // Preserve the primary failure when metadata comparison also fails.
     }
     try {
       await writeSummary(options, summary);

--- a/scripts/update-pi-deps.mjs
+++ b/scripts/update-pi-deps.mjs
@@ -29,6 +29,15 @@ const validationCommands = [
   "nix build .#patchmill --print-build-logs",
 ];
 
+function summaryPathFromArgs(args) {
+  for (let index = args.length - 2; index >= 0; index -= 1) {
+    if (args[index] === "--summary-json" && !args[index + 1].startsWith("--")) {
+      return args[index + 1];
+    }
+  }
+  return undefined;
+}
+
 function parseArgs(args) {
   const options = {
     mode: "scheduled",
@@ -197,7 +206,11 @@ async function changedMetadataFiles() {
 }
 
 async function main() {
-  const options = parseArgs(process.argv.slice(2));
+  const args = process.argv.slice(2);
+  const options = {
+    summaryJson: summaryPathFromArgs(args),
+    validateOnly: false,
+  };
   const summary = {
     noUpdate: false,
     validateOnly: options.validateOnly,
@@ -208,6 +221,8 @@ async function main() {
   };
 
   try {
+    Object.assign(options, parseArgs(args));
+    summary.validateOnly = options.validateOnly;
     const packageJson = await readJson(packagePaths.packageJson);
     const currentPins = getRootPins(packageJson);
     const latestVersions =

--- a/scripts/update-pi-deps.mjs
+++ b/scripts/update-pi-deps.mjs
@@ -94,6 +94,70 @@ function run(command, args) {
   });
 }
 
+async function updatePackageMetadata(packageJson, targets) {
+  const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-"));
+  const originalPaths = Object.fromEntries(
+    Object.keys(packagePaths).map((name) => [
+      name,
+      join(tempDir, `${name}.json`),
+    ]),
+  );
+  const requested = PI_PACKAGES.map((name) => `${name}=${targets[name]}`).join(
+    ", ",
+  );
+  let originalsSaved = false;
+
+  try {
+    await Promise.all(
+      Object.entries(packagePaths).map(([name, path]) =>
+        copyFile(path, originalPaths[name]),
+      ),
+    );
+    originalsSaved = true;
+
+    packageJson.dependencies ??= {};
+    for (const name of PI_PACKAGES)
+      packageJson.dependencies[name] = targets[name];
+    await writeJson(packagePaths.packageJson, packageJson);
+
+    await run("npm", ["install", "--package-lock-only", "--ignore-scripts"]);
+    const updatedShrinkwrap = join(tempDir, "updated-shrinkwrap.json");
+    await copyFile(packagePaths.shrinkwrap, updatedShrinkwrap);
+    await rm(packagePaths.shrinkwrap);
+    await run("npm", ["install", "--package-lock-only", "--ignore-scripts"]);
+    await copyFile(updatedShrinkwrap, packagePaths.shrinkwrap);
+    await run("npx", [
+      "prettier",
+      "--write",
+      "package.json",
+      "package-lock.json",
+      "npm-shrinkwrap.json",
+    ]);
+  } catch (error) {
+    let restoreError;
+    if (originalsSaved) {
+      try {
+        await Promise.all(
+          Object.entries(packagePaths).map(([name, path]) =>
+            copyFile(originalPaths[name], path),
+          ),
+        );
+      } catch (failure) {
+        restoreError = failure;
+      }
+    }
+    const message = `Unable to resolve requested Pi dependency versions (${requested}): ${error.message}`;
+    if (restoreError) {
+      throw new Error(
+        `${message}; additionally failed to restore original metadata: ${restoreError.message}`,
+      );
+    }
+    throw new Error(message);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
 async function changedMetadataFiles() {
   const output = await new Promise((resolve, reject) => {
     const child = spawn(
@@ -160,46 +224,7 @@ async function main() {
   );
 
   if (!resolved.noUpdate && !options.validateOnly) {
-    packageJson.dependencies ??= {};
-    for (const name of PI_PACKAGES)
-      packageJson.dependencies[name] = resolved.targets[name];
-    await writeJson(packagePaths.packageJson, packageJson);
-
-    const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-"));
-    const temporaryShrinkwrap = join(tempDir, "npm-shrinkwrap.json");
-    try {
-      try {
-        await run("npm", [
-          "install",
-          "--package-lock-only",
-          "--ignore-scripts",
-        ]);
-        await copyFile(packagePaths.shrinkwrap, temporaryShrinkwrap);
-        await rm(packagePaths.shrinkwrap);
-        await run("npm", [
-          "install",
-          "--package-lock-only",
-          "--ignore-scripts",
-        ]);
-        await copyFile(temporaryShrinkwrap, packagePaths.shrinkwrap);
-        await run("npx", [
-          "prettier",
-          "--write",
-          "package.json",
-          "package-lock.json",
-          "npm-shrinkwrap.json",
-        ]);
-      } catch (error) {
-        const requested = PI_PACKAGES.map(
-          (name) => `${name}=${resolved.targets[name]}`,
-        ).join(", ");
-        throw new Error(
-          `Unable to resolve requested Pi dependency versions (${requested}): ${error.message}`,
-        );
-      }
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
+    await updatePackageMetadata(packageJson, resolved.targets);
   }
 
   const [updatedPackageJson, packageLock, shrinkwrap] = await Promise.all([

--- a/scripts/update-pi-deps.mjs
+++ b/scripts/update-pi-deps.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -158,6 +158,16 @@ async function updatePackageMetadata(packageJson, targets) {
   }
 }
 
+async function writeSummary(options, summary) {
+  if (!options.summaryJson) return;
+  await mkdir(dirname(options.summaryJson), { recursive: true });
+  await writeJson(options.summaryJson, summary);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function changedMetadataFiles() {
   const output = await new Promise((resolve, reject) => {
     const child = spawn(
@@ -188,66 +198,89 @@ async function changedMetadataFiles() {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const packageJson = await readJson(packagePaths.packageJson);
-  const currentPins = getRootPins(packageJson);
-  const latestVersions =
-    options.mode === "scheduled"
-      ? Object.fromEntries(
-          await Promise.all(
-            PI_PACKAGES.map(async (name) => [
-              name,
-              await fetchLatestVersion(name),
-            ]),
-          ),
-        )
-      : undefined;
-  const resolved = resolveUpgradeTarget({
-    mode: options.mode,
-    currentPins,
-    latestVersions,
-    manualVersions: options.manualVersions,
-  });
   const summary = {
-    noUpdate: resolved.noUpdate,
+    noUpdate: false,
     validateOnly: options.validateOnly,
-    targets: resolved.targets,
-    warnings: resolved.warnings,
+    targets: {},
+    warnings: [],
     changedFiles: [],
     validationCommands,
   };
 
-  console.log(
-    `Current Pi pins: ${PI_PACKAGES.map((name) => `${name}=${currentPins[name]}`).join(", ")}`,
-  );
-  console.log(
-    `Selected Pi targets: ${PI_PACKAGES.map((name) => `${name}=${resolved.targets[name]}`).join(", ")}`,
-  );
+  try {
+    const packageJson = await readJson(packagePaths.packageJson);
+    const currentPins = getRootPins(packageJson);
+    const latestVersions =
+      options.mode === "scheduled"
+        ? Object.fromEntries(
+            await Promise.all(
+              PI_PACKAGES.map(async (name) => [
+                name,
+                await fetchLatestVersion(name),
+              ]),
+            ),
+          )
+        : undefined;
+    const resolved = resolveUpgradeTarget({
+      mode: options.mode,
+      currentPins,
+      latestVersions,
+      manualVersions: options.manualVersions,
+    });
+    Object.assign(summary, {
+      noUpdate: resolved.noUpdate,
+      targets: resolved.targets,
+      warnings: resolved.warnings,
+    });
 
-  if (!resolved.noUpdate && !options.validateOnly) {
-    await updatePackageMetadata(packageJson, resolved.targets);
+    console.log(
+      `Current Pi pins: ${PI_PACKAGES.map((name) => `${name}=${currentPins[name]}`).join(", ")}`,
+    );
+    console.log(
+      `Selected Pi targets: ${PI_PACKAGES.map((name) => `${name}=${resolved.targets[name]}`).join(", ")}`,
+    );
+
+    if (!resolved.noUpdate && !options.validateOnly) {
+      await updatePackageMetadata(packageJson, resolved.targets);
+    }
+
+    const [updatedPackageJson, packageLock, shrinkwrap] = await Promise.all([
+      readJson(packagePaths.packageJson),
+      readJson(packagePaths.packageLock),
+      readJson(packagePaths.shrinkwrap),
+    ]);
+    assertLockfilesMatchTargets({
+      packageJson: updatedPackageJson,
+      packageLock,
+      shrinkwrap,
+      targets: resolved.targets,
+    });
+
+    if (!resolved.noUpdate && !options.validateOnly && !options.skipNixHash) {
+      await run("scripts/update-npm-deps-hash.sh", []);
+    }
+    summary.changedFiles = await changedMetadataFiles();
+    console.log(
+      `Changed metadata files: ${summary.changedFiles.join(", ") || "none"}`,
+    );
+    if (resolved.noUpdate) console.log("No Pi dependency update available");
+    await writeSummary(options, summary);
+  } catch (error) {
+    summary.error = errorMessage(error);
+    try {
+      summary.changedFiles = await changedMetadataFiles();
+    } catch {
+      // Preserve the primary failure when Git cannot report changed metadata.
+    }
+    try {
+      await writeSummary(options, summary);
+    } catch (summaryError) {
+      console.error(
+        `Unable to write failure summary: ${errorMessage(summaryError)}`,
+      );
+    }
+    throw error;
   }
-
-  const [updatedPackageJson, packageLock, shrinkwrap] = await Promise.all([
-    readJson(packagePaths.packageJson),
-    readJson(packagePaths.packageLock),
-    readJson(packagePaths.shrinkwrap),
-  ]);
-  assertLockfilesMatchTargets({
-    packageJson: updatedPackageJson,
-    packageLock,
-    shrinkwrap,
-    targets: resolved.targets,
-  });
-
-  if (!resolved.noUpdate && !options.validateOnly && !options.skipNixHash) {
-    await run("scripts/update-npm-deps-hash.sh", []);
-  }
-  summary.changedFiles = await changedMetadataFiles();
-  console.log(
-    `Changed metadata files: ${summary.changedFiles.join(", ") || "none"}`,
-  );
-  if (resolved.noUpdate) console.log("No Pi dependency update available");
-  if (options.summaryJson) await writeJson(options.summaryJson, summary);
 }
 
 main().catch((error) => {

--- a/scripts/update-pi-deps.test.mjs
+++ b/scripts/update-pi-deps.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { spawn } from "node:child_process";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptPath = join(rootDir, "scripts/update-pi-deps.mjs");
+
+function runUpdateScript(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: rootDir,
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => resolve({ code, stderr }));
+  });
+}
+
+test("update CLI creates parent directories for successful summaries", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-test-"));
+  const summaryPath = join(tempDir, "nested", "summary.json");
+
+  try {
+    const result = await runUpdateScript([
+      "--mode",
+      "manual",
+      "--target-version",
+      "0.80.10",
+      "--validate-only",
+      "--skip-nix-hash",
+      "--summary-json",
+      summaryPath,
+    ]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+    assert.equal(summary.validateOnly, true);
+    assert.equal(summary.noUpdate, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("update CLI records actionable failures in the summary", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-test-"));
+  const summaryPath = join(tempDir, "nested", "summary.json");
+
+  try {
+    const result = await runUpdateScript([
+      "--mode",
+      "manual",
+      "--pi-coding-agent-version",
+      "0.80.10",
+      "--summary-json",
+      summaryPath,
+    ]);
+
+    assert.equal(result.code, 1);
+    assert.match(
+      result.stderr,
+      /pi-tui manual version must be an exact version/,
+    );
+    const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+    assert.equal(summary.validateOnly, false);
+    assert.deepEqual(summary.targets, {});
+    assert.deepEqual(summary.changedFiles, []);
+    assert.match(
+      summary.error,
+      /pi-tui manual version must be an exact version/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/update-pi-deps.test.mjs
+++ b/scripts/update-pi-deps.test.mjs
@@ -48,6 +48,27 @@ test("update CLI creates parent directories for successful summaries", async () 
   }
 });
 
+test("update CLI records parse failures in the summary", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-test-"));
+  const summaryPath = join(tempDir, "nested", "summary.json");
+
+  try {
+    const result = await runUpdateScript([
+      "--summary-json",
+      summaryPath,
+      "--mode",
+      "invalid",
+    ]);
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /--mode must be scheduled or manual/);
+    const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+    assert.match(summary.error, /--mode must be scheduled or manual/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("update CLI records actionable failures in the summary", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-test-"));
   const summaryPath = join(tempDir, "nested", "summary.json");

--- a/scripts/update-pi-deps.test.mjs
+++ b/scripts/update-pi-deps.test.mjs
@@ -9,10 +9,11 @@ import { spawn } from "node:child_process";
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const scriptPath = join(rootDir, "scripts/update-pi-deps.mjs");
 
-function runUpdateScript(args) {
+function runUpdateScript(args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [scriptPath, ...args], {
       cwd: rootDir,
+      ...options,
     });
     let stderr = "";
     child.stderr.on("data", (chunk) => {
@@ -23,26 +24,30 @@ function runUpdateScript(args) {
   });
 }
 
-test("update CLI creates parent directories for successful summaries", async () => {
+test("update CLI works without Git on PATH", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "patchmill-pi-deps-test-"));
   const summaryPath = join(tempDir, "nested", "summary.json");
 
   try {
-    const result = await runUpdateScript([
-      "--mode",
-      "manual",
-      "--target-version",
-      "0.80.10",
-      "--validate-only",
-      "--skip-nix-hash",
-      "--summary-json",
-      summaryPath,
-    ]);
+    const result = await runUpdateScript(
+      [
+        "--mode",
+        "manual",
+        "--target-version",
+        "0.80.10",
+        "--validate-only",
+        "--skip-nix-hash",
+        "--summary-json",
+        summaryPath,
+      ],
+      { env: { ...process.env, PATH: tempDir } },
+    );
 
     assert.equal(result.code, 0, result.stderr);
     const summary = JSON.parse(await readFile(summaryPath, "utf8"));
     assert.equal(summary.validateOnly, true);
     assert.equal(summary.noUpdate, false);
+    assert.deepEqual(summary.changedFiles, []);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/src/cli/commands/init/pi-dependency-contract.test.ts
+++ b/src/cli/commands/init/pi-dependency-contract.test.ts
@@ -5,7 +5,15 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import * as piCodingAgent from "@earendil-works/pi-coding-agent";
 
-const EXPECTED_PI_VERSION = "0.80.10";
+const PI_PACKAGES = [
+  "@earendil-works/pi-coding-agent",
+  "@earendil-works/pi-tui",
+] as const;
+
+const ROOT_PACKAGE_JSON = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../package.json",
+);
 
 const REQUIRED_INIT_RUNTIME_EXPORTS = [
   "ModelRuntime",
@@ -18,6 +26,32 @@ type PackageJson = {
   version: string;
   dependencies?: Record<string, string>;
 };
+
+function isExactVersion(spec: string | undefined): spec is string {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+    spec ?? "",
+  );
+}
+
+function rootPiPins(): Record<(typeof PI_PACKAGES)[number], string> {
+  const rootPackage = JSON.parse(
+    readFileSync(ROOT_PACKAGE_JSON, "utf8"),
+  ) as PackageJson;
+  const dependencies = rootPackage.dependencies ?? {};
+  const pins = {} as Record<(typeof PI_PACKAGES)[number], string>;
+
+  for (const name of PI_PACKAGES) {
+    const spec = dependencies[name];
+    assert.equal(
+      isExactVersion(spec),
+      true,
+      `${name} must be pinned to an exact version in package.json; found ${spec ?? "missing"}`,
+    );
+    pins[name] = spec;
+  }
+
+  return pins;
+}
 
 function packageJson(name: string): PackageJson {
   let packageDir = dirname(fileURLToPath(import.meta.resolve(name)));
@@ -39,15 +73,17 @@ function packageJson(name: string): PackageJson {
   throw new Error(`Could not locate package.json for ${name}`);
 }
 
-test("resolved Pi packages use the validated exact version", () => {
-  assert.equal(
-    packageJson("@earendil-works/pi-coding-agent").version,
-    EXPECTED_PI_VERSION,
-  );
-  assert.equal(
-    packageJson("@earendil-works/pi-tui").version,
-    EXPECTED_PI_VERSION,
-  );
+test("resolved Pi packages use the package.json exact pins", () => {
+  const pins = rootPiPins();
+
+  for (const name of PI_PACKAGES) {
+    const resolved = packageJson(name);
+    assert.equal(
+      resolved.version,
+      pins[name],
+      `${name} resolved ${resolved.version} but package.json pins ${pins[name]}`,
+    );
+  }
 });
 
 test("resolved pi-coding-agent exports the runtime symbols used by patchmill init", () => {


### PR DESCRIPTION
Summary

- Added unit-tested Pi dependency upgrade helpers and CLI automation for exact pins, lockfiles, Nix hash refresh, and machine-readable summaries.
- Added reusable packed-artifact smoke validation and scheduled/manual review-gated Pi dependency upgrade workflow.
- Updated Pi compatibility assertions to follow root package pins and documented operator usage.

## Validation

- node --test scripts/pi-dependency-upgrade-lib.test.mjs scripts/update-pi-deps.test.mjs src/cli/commands/init/pi-dependency-contract.test.ts
- node scripts/update-pi-deps.mjs --mode manual --target-version 0.80.10 --validate-only --skip-nix-hash --summary-json .tmp/pi-deps-final-validate.json
- node scripts/smoke-packed-artifact.mjs
- npm test
- npm run lint
- scripts/update-npm-deps-hash.sh
- git diff --exit-code -- nix/package.nix
- nix build .#patchmill --print-build-logs

## Reviews

- Final Codex full-worktree review passed after accepted fixes for workflow credentials, transactional metadata restore, summary output, and CLI parse-failure summaries.
- Final thermo-nuclear full-worktree review passed after accepted fixes for gitless validation, Nix hash idempotence checks, and generated PR add-path restrictions.
- Final validation-readiness review ran all required commands and passed.

## Notes for maintainers

- The scheduled workflow requires repository secret `PATCHMILL_AUTOMATION_TOKEN` so generated dependency PRs can trigger normal PR checks.
- The workflow remains review-gated and does not auto-merge or publish Pi dependency upgrades.

Closes #96
