### PR TITLE
Add run-once cost breakdown to PR summaries

### DIFF
--- a/docs/plans/2026-07-19-run-once-pr-cost-summary.md
+++ b/docs/plans/2026-07-19-run-once-pr-cost-summary.md
@@ -1,0 +1,1812 @@
+# Run-once PR Cost Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Calculate deduplicated per-stage and per-model Pi usage for the
+current successful `run-once` execution and publish it as an idempotent cost
+section in GitHub and Forgejo/Gitea PR bodies.
+
+**Architecture:** Use a pure aggregation core to parse and deduplicate in-memory
+Pi session files, a filesystem shell to take a stable snapshot of the durable
+session tree, and a pure Markdown renderer to upsert the generated block. Add
+narrow GitHub and Forgejo PR-body adapters, persist validated reports in run
+state for recovery, and let the finish stage publish nonfatally before the
+existing handoff sequence.
+
+**Tech Stack:** TypeScript on Node.js, `node:test`, `node:assert/strict`, Pi
+session JSONL, existing `CommandRunner`, `gh`, `tea`, Prettier, ESLint, and
+Markdownlint.
+
+## Global Constraints
+
+- Follow `docs/specs/2026-07-19-run-once-pr-cost-summary-design.md` exactly.
+- Report only the current `run-once` execution that produced `pr-created`; never
+  accumulate earlier issue runs.
+- Prompt tokens equal `usage.input + usage.cacheRead + usage.cacheWrite`.
+- Output tokens equal `usage.output`.
+- Estimated USD cost equals recorded `usage.cost.total`; never recalculate from
+  current prices.
+- Deduplicate copied parent history globally by stable session-entry ID and
+  attribute it to the earliest session file.
+- Group rows by stage and recorded model; add a stage subtotal only when a stage
+  used multiple models.
+- Include parent and child/subagent JSONL files under the current durable
+  session root.
+- Treat aggregation, marker, URL, host-read, and host-update failures as
+  warnings; a valid PR handoff remains successful.
+- Preserve all PR body bytes outside the generated marker block.
+- Support both GitHub through `gh` and Forgejo/Gitea through `tea` in the
+  initial implementation.
+- Do not add dependencies, pricing configuration, a feature toggle, a fallback
+  issue comment, or a direct-land report.
+- Do not expose prompts, message content, tool calls, credentials, or session
+  paths in the PR.
+- Keep new production modules focused; prefer the pure-core/filesystem-shell
+  split below rather than adding parsing or host commands to `pipeline.ts`.
+
+---
+
+## File structure
+
+### New files
+
+- `src/cli/commands/run-once/run-cost.ts` — report types, strict JSONL
+  accounting parser, global entry-ID deduplication, stage/model aggregation, and
+  persisted-report validation.
+- `src/cli/commands/run-once/run-cost.test.ts` — pure parser, deduplication,
+  grouping, validation, and failure tests.
+- `src/cli/commands/run-once/run-cost-files.ts` — recursive durable-session
+  discovery, session ordering, pre/post manifest stability, and
+  filesystem-to-core orchestration.
+- `src/cli/commands/run-once/run-cost-files.test.ts` — real temporary-tree and
+  injected changing-manifest tests.
+- `src/cli/commands/run-once/pr-cost-summary.ts` — pure Markdown rendering,
+  escaping, marker validation, append, and replacement.
+- `src/cli/commands/run-once/pr-cost-summary.test.ts` — table, subtotal,
+  formatting, escaping, and idempotent body-preservation tests.
+- `src/host/pull-request-reference.ts` — provider-specific PR-number extraction
+  and canonical URL comparison.
+- `src/host/pull-request-reference.test.ts` — GitHub/Forgejo URL acceptance and
+  malformed URL rejection.
+- `src/host/github-pr-body.ts` — structured GitHub PR-body reads and
+  temporary-body-file edits.
+- `src/host/github-pr-body.test.ts` — GitHub command, payload, URL validation,
+  multiline body, and cleanup tests.
+- `src/host/forgejo-pr-body.ts` — structured Forgejo API reads and multiline
+  `tea pulls edit` updates.
+- `src/host/forgejo-pr-body.test.ts` — Forgejo command context, payload, URL
+  validation, and update tests.
+- `src/cli/commands/run-once/pipeline-run-cost.ts` — fresh-versus-resumed report
+  resolution and nonfatal aggregation warnings.
+- `src/cli/commands/run-once/pipeline-run-cost.test.ts` — fresh, resumed,
+  legacy, merged, and failure-path tests.
+- `src/cli/commands/run-once/pr-cost-publication.ts` — host read, pure upsert,
+  conditional host update, and updated/unchanged result.
+- `src/cli/commands/run-once/pr-cost-publication.test.ts` — changed and
+  already-current publication tests.
+
+### Modified files
+
+- `src/host/types.ts` — add `PullRequestBodyHostProvider` and
+  `RunOnceHostProvider` capabilities.
+- `src/host/github-gh.ts` — delegate PR-body methods to `github-pr-body.ts`.
+- `src/host/github-gh.test.ts` — verify the concrete provider exposes the GitHub
+  PR-body behavior.
+- `src/host/forgejo-tea.ts` — delegate PR-body methods to `forgejo-pr-body.ts`.
+- `src/host/forgejo-tea.test.ts` — verify the concrete provider exposes the
+  Forgejo PR-body behavior.
+- `src/host/factory.ts` — add `createRunOnceHostProvider()` without broadening
+  all issue-host consumers.
+- `src/host/factory.test.ts` — verify both configured providers satisfy the
+  run-once capability.
+- `src/cli/commands/run-once/types.ts` — persist `RunCostReport`, add
+  `prCostSummaryUpdated`, and carry the optional report through run-state
+  updates.
+- `src/cli/commands/run-once/run-state.ts` — merge, clear, and serialize the
+  implementation-associated report.
+- `src/cli/commands/run-once/run-state.test.ts` — report persistence,
+  preservation, clearing, and checkpoint tests.
+- `src/cli/commands/run-once/pipeline-lifecycle.ts` — treat cost publication as
+  a resume-only side effect.
+- `src/cli/commands/run-once/pipeline-lifecycle.test.ts` — checkpoint filtering
+  coverage.
+- `src/cli/commands/run-once/progress.ts` — add the `warning` progress level.
+- `src/cli/commands/run-once/pipeline.ts` — create the run-once host, resolve a
+  fresh or persisted report, and pass it to finish.
+- `src/cli/commands/run-once/pipeline-finish.ts` — persist the report, publish
+  before visual-evidence handoff, checkpoint success, and warn nonfatally.
+- `src/cli/commands/run-once/pipeline-finish-scenarios.test.ts` — publication,
+  recovery, idempotency, warning, and merged-skip scenarios.
+- `test-support/run-once/mock-runner.ts` — add a helper that writes priced Pi
+  session entries for integration tests.
+
+---
+
+### Task 1: Build the pure run-cost aggregation core
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/run-cost.ts`
+- Create: `src/cli/commands/run-once/run-cost.test.ts`
+
+**Interfaces:**
+
+- Consumes: in-memory `RunCostSessionFile[]` values with `relativePath`,
+  `startedAtMs`, and complete JSONL `content`.
+- Produces: `RunCostModelUsage`, `RunCostStageUsage`, `RunCostReport`,
+  `RunCostSessionFile`, `RunCostReportError`, `aggregateRunCost(files)`, and
+  `parseRunCostReport(value)`.
+- Later tasks rely on `aggregateRunCost()` for filesystem snapshots and
+  `parseRunCostReport()` for resumed run state.
+
+- [ ] **Step 1: Write the failing happy-path and copied-history tests**
+
+Create `run-cost.test.ts` with compact session builders and one test that proves
+prompt-token math, global deduplication, earliest-stage attribution, two
+implementation models, and totals:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import { aggregateRunCost, type RunCostSessionFile } from "./run-cost.ts";
+
+type Usage = {
+  input: number;
+  cacheRead: number;
+  cacheWrite: number;
+  output: number;
+  cost: { total: number };
+};
+
+function assistant(
+  id: string,
+  model: string,
+  usage: Usage,
+): Record<string, unknown> {
+  return {
+    type: "message",
+    id,
+    timestamp: "2026-07-19T12:00:00.000Z",
+    message: { role: "assistant", model, usage, content: [] },
+  };
+}
+
+function sessionFile(
+  relativePath: string,
+  startedAtMs: number,
+  entries: Record<string, unknown>[],
+): RunCostSessionFile {
+  return {
+    relativePath,
+    startedAtMs,
+    content: `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+  };
+}
+
+const planning = assistant("entry-plan", "gpt-5.5", {
+  input: 10,
+  cacheRead: 20,
+  cacheWrite: 30,
+  output: 4,
+  cost: { total: 0.1 },
+});
+
+const implementationGpt = assistant("entry-impl-gpt", "gpt-5.5", {
+  input: 50,
+  cacheRead: 50,
+  cacheWrite: 50,
+  output: 20,
+  cost: { total: 0.3 },
+});
+
+const implementationTerra = assistant("entry-impl-terra", "gpt-5.6-terra", {
+  input: 100,
+  cacheRead: 200,
+  cacheWrite: 0,
+  output: 10,
+  cost: { total: 0.4 },
+});
+
+test("aggregateRunCost deduplicates copied history and groups stage models", () => {
+  const report = aggregateRunCost([
+    sessionFile("pi-plan/invocation-a/parent.jsonl", 1, [planning]),
+    sessionFile("pi-implementation/invocation-b/child.jsonl", 2, [
+      planning,
+      implementationGpt,
+      implementationTerra,
+    ]),
+  ]);
+
+  assert.deepEqual(report, {
+    stages: [
+      {
+        stage: "pi-plan",
+        models: [
+          {
+            model: "gpt-5.5",
+            promptTokens: 60,
+            outputTokens: 4,
+            estimatedCostUsd: 0.1,
+          },
+        ],
+        promptTokens: 60,
+        outputTokens: 4,
+        estimatedCostUsd: 0.1,
+      },
+      {
+        stage: "pi-implementation",
+        models: [
+          {
+            model: "gpt-5.5",
+            promptTokens: 150,
+            outputTokens: 20,
+            estimatedCostUsd: 0.3,
+          },
+          {
+            model: "gpt-5.6-terra",
+            promptTokens: 300,
+            outputTokens: 10,
+            estimatedCostUsd: 0.4,
+          },
+        ],
+        promptTokens: 450,
+        outputTokens: 30,
+        estimatedCostUsd: 0.7,
+      },
+    ],
+    promptTokens: 510,
+    outputTokens: 34,
+    estimatedCostUsd: 0.8,
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the missing module failure**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/run-cost.test.ts
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `./run-cost.ts`.
+
+- [ ] **Step 3: Implement the report types and strict unique-entry reducer**
+
+Create `run-cost.ts` with this exact public surface:
+
+```ts
+export type RunCostModelUsage = {
+  model: string;
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type RunCostStageUsage = {
+  stage: string;
+  models: RunCostModelUsage[];
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type RunCostReport = {
+  stages: RunCostStageUsage[];
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+
+export type RunCostSessionFile = {
+  relativePath: string;
+  startedAtMs: number;
+  content: string;
+};
+
+export class RunCostReportError extends Error {
+  readonly name = "RunCostReportError";
+}
+
+export function aggregateRunCost(files: RunCostSessionFile[]): RunCostReport;
+export function parseRunCostReport(value: unknown): RunCostReport | undefined;
+```
+
+Implement `aggregateRunCost()` with the following concrete flow:
+
+```ts
+const orderedFiles = [...files].sort(
+  (left, right) =>
+    left.startedAtMs - right.startedAtMs ||
+    left.relativePath.localeCompare(right.relativePath),
+);
+const uniqueEntries = new Map<
+  string,
+  {
+    fingerprint: string;
+    stage: string;
+    model: string;
+    promptTokens: number;
+    outputTokens: number;
+    estimatedCostUsd: number;
+  }
+>();
+
+for (const file of orderedFiles) {
+  const stage = file.relativePath.split(/[\\/]/u)[0] || "unknown";
+  for (const [lineIndex, rawLine] of file.content.split(/\r?\n/u).entries()) {
+    if (rawLine.trim().length === 0) continue;
+    let entry: unknown;
+    try {
+      entry = JSON.parse(rawLine);
+    } catch (error) {
+      throw new RunCostReportError(
+        `Malformed Pi session JSON in ${file.relativePath}:${lineIndex + 1}`,
+        { cause: error },
+      );
+    }
+    const usage = assistantUsage(entry, file.relativePath, lineIndex + 1);
+    if (!usage) continue;
+    const existing = uniqueEntries.get(usage.id);
+    if (existing && existing.fingerprint !== usage.fingerprint) {
+      throw new RunCostReportError(`Conflicting Pi session entry ${usage.id}`);
+    }
+    if (!existing) uniqueEntries.set(usage.id, { ...usage, stage });
+  }
+}
+
+if (uniqueEntries.size === 0) {
+  throw new RunCostReportError("No assistant usage records found");
+}
+```
+
+Define `assistantUsage()` in the same file so that it:
+
+- returns `undefined` only for non-assistant entries;
+- requires a non-empty string `entry.id` for assistant entries;
+- maps a missing/blank model to `Unknown model`;
+- requires finite non-negative `input`, `cacheRead`, `cacheWrite`, `output`, and
+  `cost.total` values;
+- computes `promptTokens` by adding all three prompt fields; and
+- fingerprints `{ model, promptTokens, outputTokens, estimatedCostUsd }` with
+  `JSON.stringify()`.
+
+Reduce unique entries into nested `Map<string, Map<string, RunCostModelUsage>>`
+values. Emit known stages in this order and append unknown stages lexically:
+
+```ts
+const STAGE_ORDER = [
+  "pi-artifact-extraction",
+  "pi-plan",
+  "pi-development-environment",
+  "pi-implementation",
+] as const;
+```
+
+Sort models lexically, derive each stage total from model values, and derive the
+report total from stage values without rounding.
+
+Implement `parseRunCostReport()` as a strict, non-throwing validator for
+persisted JSON. It returns `undefined` unless every stage/model/total field has
+the exact object/array/string/finite-non-negative-number shape above. Recompute
+each stage total from its model rows and the report total from its stage rows;
+return `undefined` when any persisted total disagrees with those derived values.
+
+- [ ] **Step 4: Run the focused test and verify the aggregation passes**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/run-cost.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 5: Add failure and persisted-report validation tests**
+
+Add tests with exact assertions for:
+
+```ts
+test("aggregateRunCost rejects conflicting copies of one entry id", () => {
+  const changed = assistant("entry-plan", "gpt-5.5", {
+    input: 10,
+    cacheRead: 20,
+    cacheWrite: 30,
+    output: 4,
+    cost: { total: 9.9 },
+  });
+  assert.throws(
+    () =>
+      aggregateRunCost([
+        sessionFile("pi-plan/a.jsonl", 1, [planning]),
+        sessionFile("pi-implementation/b.jsonl", 2, [changed]),
+      ]),
+    /Conflicting Pi session entry entry-plan/u,
+  );
+});
+
+test("aggregateRunCost rejects malformed and incomplete assistant usage", () => {
+  assert.throws(
+    () =>
+      aggregateRunCost([
+        {
+          relativePath: "pi-plan/a.jsonl",
+          startedAtMs: 1,
+          content: "{not-json}\n",
+        },
+      ]),
+    /Malformed Pi session JSON/u,
+  );
+  assert.throws(
+    () =>
+      aggregateRunCost([
+        sessionFile("pi-plan/a.jsonl", 1, [
+          { type: "message", id: "bad", message: { role: "assistant" } },
+        ]),
+      ]),
+    /usage/u,
+  );
+});
+
+test("parseRunCostReport accepts valid zero cost and rejects malformed state", () => {
+  const zeroReport = {
+    stages: [
+      {
+        stage: "pi-plan",
+        models: [
+          {
+            model: "local-model",
+            promptTokens: 0,
+            outputTokens: 0,
+            estimatedCostUsd: 0,
+          },
+        ],
+        promptTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0,
+      },
+    ],
+    promptTokens: 0,
+    outputTokens: 0,
+    estimatedCostUsd: 0,
+  };
+  assert.deepEqual(parseRunCostReport(zeroReport), zeroReport);
+  assert.equal(
+    parseRunCostReport({ ...zeroReport, promptTokens: -1 }),
+    undefined,
+  );
+});
+```
+
+Also cover missing IDs, `NaN`/negative usage, unknown model fallback, unknown
+stage ordering, and model lexical ordering.
+
+- [ ] **Step 6: Run the focused tests and type-aware project checks**
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/run-cost.test.ts
+npm run lint:ts
+npm run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 7: Commit the pure aggregation core**
+
+```sh
+git add src/cli/commands/run-once/run-cost.ts src/cli/commands/run-once/run-cost.test.ts
+git commit -m "feat(run-once): aggregate Pi session cost"
+```
+
+---
+
+### Task 2: Add the stable durable-session filesystem shell
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/run-cost-files.ts`
+- Create: `src/cli/commands/run-once/run-cost-files.test.ts`
+
+**Interfaces:**
+
+- Consumes: `aggregateRunCost()` and `RunCostSessionFile` from Task 1.
+- Produces: `RunCostIo`, `nodeRunCostIo`, and
+  `summarizeRunCost(piSessionPath, io?)`.
+- Task 7 calls `summarizeRunCost()` only for a fresh `pr-created`
+  implementation.
+
+- [ ] **Step 1: Write failing real-tree and changing-manifest tests**
+
+Create `run-cost-files.test.ts`. Use a real temporary tree for normal discovery
+and an injected `RunCostIo` for deterministic concurrent-change simulation:
+
+```ts
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { summarizeRunCost, type RunCostIo } from "./run-cost-files.ts";
+
+async function withTempRoot(
+  fn: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "patchmill-run-cost-test-"));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("summarizeRunCost recursively reads every stable JSONL file", async () => {
+  await withTempRoot(async (root) => {
+    const dir = join(root, "pi-implementation", "invocation-a", "--repo--");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "2026-07-19T12-00-00-000Z_session.jsonl"),
+      [
+        JSON.stringify({
+          type: "session",
+          id: "session-a",
+          timestamp: "2026-07-19T12:00:00.000Z",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "entry-a",
+          message: {
+            role: "assistant",
+            model: "gpt-5.5",
+            usage: {
+              input: 10,
+              cacheRead: 20,
+              cacheWrite: 30,
+              output: 4,
+              cost: { total: 0.1 },
+            },
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const report = await summarizeRunCost(root);
+    assert.equal(report.promptTokens, 60);
+    assert.equal(report.outputTokens, 4);
+    assert.equal(report.estimatedCostUsd, 0.1);
+  });
+});
+
+test("summarizeRunCost rejects a session tree that changes after reading", async () => {
+  let listing = 0;
+  const io: RunCostIo = {
+    async listJsonlFiles() {
+      listing += 1;
+      return listing === 1
+        ? ["/root/a.jsonl"]
+        : ["/root/a.jsonl", "/root/b.jsonl"];
+    },
+    async stat() {
+      return { size: 1, mtimeMs: 1 };
+    },
+    async readFile() {
+      return "";
+    },
+  };
+  await assert.rejects(
+    () => summarizeRunCost("/root", io),
+    /Pi session files changed while calculating run cost/u,
+  );
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing module failure**
+
+```sh
+node --test src/cli/commands/run-once/run-cost-files.test.ts
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `run-cost-files.ts`.
+
+- [ ] **Step 3: Implement recursive discovery, ordering, and manifest
+      comparison**
+
+Create this public I/O boundary:
+
+```ts
+export type RunCostFileInfo = { size: number; mtimeMs: number };
+
+export type RunCostIo = {
+  listJsonlFiles(root: string): Promise<string[]>;
+  stat(path: string): Promise<RunCostFileInfo>;
+  readFile(path: string): Promise<string>;
+};
+
+export const nodeRunCostIo: RunCostIo;
+
+export async function summarizeRunCost(
+  piSessionPath: string,
+  io: RunCostIo = nodeRunCostIo,
+): Promise<RunCostReport>;
+```
+
+Implement `nodeRunCostIo.listJsonlFiles()` with recursive
+`readdir(..., { withFileTypes: true })`, include only regular `.jsonl` files,
+and sort absolute paths lexically.
+
+In `summarizeRunCost()`:
+
+1. List paths and stat each path into a pre-read manifest keyed by absolute
+   path.
+2. Read every file.
+3. Derive `startedAtMs` from the first valid `type: "session"` timestamp.
+   Otherwise parse the safe filename prefix before `_` by converting
+   `YYYY-MM-DDTHH-MM-SS-mmmZ` back to `YYYY-MM-DDTHH:MM:SS.mmmZ`; otherwise use
+   the pre-read `mtimeMs`.
+4. Convert each path to a normalized relative path with
+   `relative(piSessionPath, path)`.
+5. List and stat again.
+6. Compare path, size, and `mtimeMs` exactly; throw
+   `RunCostReportError("Pi session files changed while calculating run cost")`
+   on any difference.
+7. Call `aggregateRunCost()` with the captured contents.
+
+Do not retry or wait for detached writers.
+
+- [ ] **Step 4: Run filesystem and aggregation tests**
+
+```sh
+node --test \
+  src/cli/commands/run-once/run-cost.test.ts \
+  src/cli/commands/run-once/run-cost-files.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 5: Add fallback-order and unreadable-root cases**
+
+Add tests proving:
+
+- the session-entry timestamp wins over filename and `mtimeMs`;
+- filename timestamp wins when the session entry lacks a usable timestamp;
+- `mtimeMs` is the final deterministic fallback;
+- equal timestamps break ties by relative path through Task 1 ordering; and
+- an unreadable/missing root rejects with the filesystem error for Task 7 to
+  convert into a warning.
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/run-cost-files.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 6: Commit the filesystem shell**
+
+```sh
+git add \
+  src/cli/commands/run-once/run-cost-files.ts \
+  src/cli/commands/run-once/run-cost-files.test.ts
+git commit -m "feat(run-once): read durable session cost"
+```
+
+---
+
+### Task 3: Render and safely upsert the generated PR section
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/pr-cost-summary.ts`
+- Create: `src/cli/commands/run-once/pr-cost-summary.test.ts`
+
+**Interfaces:**
+
+- Consumes: validated `RunCostReport` from Task 1.
+- Produces: `renderRunCostSection(report)` and
+  `upsertRunCostSection(body, report)`.
+- Task 7 uses only `upsertRunCostSection()` through the publication helper.
+
+- [ ] **Step 1: Write the failing table and idempotent-upsert tests**
+
+Create a report fixture with one planning model and two implementation models,
+then assert the complete rendered block:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RunCostReport } from "./run-cost.ts";
+import {
+  renderRunCostSection,
+  upsertRunCostSection,
+} from "./pr-cost-summary.ts";
+
+const report: RunCostReport = {
+  stages: [
+    {
+      stage: "pi-plan",
+      models: [
+        {
+          model: "gpt-5.5",
+          promptTokens: 294103,
+          outputTokens: 1290,
+          estimatedCostUsd: 0.486239,
+        },
+      ],
+      promptTokens: 294103,
+      outputTokens: 1290,
+      estimatedCostUsd: 0.486239,
+    },
+    {
+      stage: "pi-implementation",
+      models: [
+        {
+          model: "gpt-5.5",
+          promptTokens: 302448,
+          outputTokens: 3960,
+          estimatedCostUsd: 0.5452,
+        },
+        {
+          model: "gpt-5.6-terra",
+          promptTokens: 1282348,
+          outputTokens: 9539,
+          estimatedCostUsd: 0.8364,
+        },
+      ],
+      promptTokens: 1584796,
+      outputTokens: 13499,
+      estimatedCostUsd: 1.3816,
+    },
+  ],
+  promptTokens: 1878899,
+  outputTokens: 14789,
+  estimatedCostUsd: 1.867839,
+};
+
+test("renderRunCostSection renders model rows, subtotal, total, and note", () => {
+  const markdown = renderRunCostSection(report);
+  assert.match(markdown, /<!-- patchmill-run-cost:start -->/u);
+  assert.match(
+    markdown,
+    /\| Planning \| gpt-5\.5 \| 294,103 \| 1,290 \| \$0\.4862 \|/u,
+  );
+  assert.match(
+    markdown,
+    /\| \*\*Implementation subtotal\*\* \|  \| \*\*1,584,796\*\* \| \*\*13,499\*\* \| \*\*\$1\.3816\*\* \|/u,
+  );
+  assert.match(markdown, /\*\*\$1\.8678\*\*/u);
+  assert.match(markdown, /Prompt tokens include uncached input/u);
+  assert.match(markdown, /<!-- patchmill-run-cost:end -->/u);
+});
+
+test("upsertRunCostSection appends once and then replaces idempotently", () => {
+  const original = "Summary\n\n- Existing body.\n\nCloses #104\n";
+  const appended = upsertRunCostSection(original, report);
+  assert.equal(appended.startsWith(original), true);
+  assert.equal(upsertRunCostSection(appended, report), appended);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the missing module failure**
+
+```sh
+node --test src/cli/commands/run-once/pr-cost-summary.test.ts
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `pr-cost-summary.ts`.
+
+- [ ] **Step 3: Implement deterministic rendering and marker validation**
+
+Use these exact markers and exports:
+
+```ts
+const START_MARKER = "<!-- patchmill-run-cost:start -->";
+const END_MARKER = "<!-- patchmill-run-cost:end -->";
+
+export class PrCostSummaryError extends Error {
+  readonly name = "PrCostSummaryError";
+}
+
+export function renderRunCostSection(report: RunCostReport): string;
+export function upsertRunCostSection(
+  body: string,
+  report: RunCostReport,
+): string;
+```
+
+Implement these private helpers:
+
+```ts
+const TOKEN_FORMAT = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  useGrouping: true,
+});
+
+function escapeCell(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replace(/[\r\n]+/gu, " ")
+    .trim();
+}
+
+function stageLabel(stage: string): string {
+  const known: Record<string, string> = {
+    "pi-artifact-extraction": "Artifact extraction",
+    "pi-plan": "Planning",
+    "pi-development-environment": "Development environment",
+    "pi-implementation": "Implementation",
+  };
+  const fallback = stage.replace(/^pi-/u, "").replace(/[-_]+/gu, " ").trim();
+  const label = known[stage] ?? (fallback || "Unknown stage");
+  return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
+}
+
+function tokens(value: number): string {
+  return TOKEN_FORMAT.format(value);
+}
+
+function usd(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+```
+
+Render one row for every stage/model pair, a bold stage subtotal only when
+`models.length > 1`, and one bold final total. End with the exact explanatory
+note from the design.
+
+For upsert:
+
+- count occurrences of each marker;
+- append when both counts are zero, preserving the original body as an exact
+  prefix;
+- replace from the start marker through the end marker when each count is one
+  and ordered correctly; and
+- throw `PrCostSummaryError("Malformed Patchmill run-cost markers")` for every
+  other shape.
+
+- [ ] **Step 4: Add body-protection and escaping cases**
+
+Add tests that assert:
+
+```ts
+assert.throws(
+  () => upsertRunCostSection("body\n<!-- patchmill-run-cost:start -->", report),
+  /Malformed Patchmill run-cost markers/u,
+);
+assert.throws(
+  () =>
+    upsertRunCostSection(
+      "<!-- patchmill-run-cost:end -->\n<!-- patchmill-run-cost:start -->",
+      report,
+    ),
+  /Malformed Patchmill run-cost markers/u,
+);
+```
+
+Also verify duplicate markers reject, replacement preserves the exact prefix and
+suffix, a model named `bad|model\nrow` cannot add a table row, unknown stages
+use the specified fallback, single-model stages have no subtotal, and valid zero
+cost renders `$0.0000`.
+
+- [ ] **Step 5: Run renderer tests and formatting**
+
+```sh
+node --test src/cli/commands/run-once/pr-cost-summary.test.ts
+npx prettier --check \
+  src/cli/commands/run-once/pr-cost-summary.ts \
+  src/cli/commands/run-once/pr-cost-summary.test.ts
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 6: Commit the pure PR-body transformation**
+
+```sh
+git add \
+  src/cli/commands/run-once/pr-cost-summary.ts \
+  src/cli/commands/run-once/pr-cost-summary.test.ts
+git commit -m "feat(run-once): render PR cost summary"
+```
+
+---
+
+### Task 4: Add GitHub PR-body read and update support
+
+**Files:**
+
+- Create: `src/host/pull-request-reference.ts`
+- Create: `src/host/pull-request-reference.test.ts`
+- Create: `src/host/github-pr-body.ts`
+- Create: `src/host/github-pr-body.test.ts`
+- Modify: `src/host/github-gh.ts`
+- Modify: `src/host/github-gh.test.ts`
+
+**Interfaces:**
+
+- Produces: `pullRequestNumber(prUrl, pathSegment)`,
+  `sameCanonicalUrl(left, right)`, `readGitHubPullRequestBody(options, prUrl)`,
+  and `updateGitHubPullRequestBody(options, prUrl, body)`.
+- Task 5 reuses the URL helper for Forgejo.
+- Task 5 adds the formal host capability after both concrete adapters exist.
+
+- [ ] **Step 1: Write failing PR-reference tests**
+
+Create `pull-request-reference.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  pullRequestNumber,
+  sameCanonicalUrl,
+} from "./pull-request-reference.ts";
+
+test("pullRequestNumber accepts provider-specific PR paths", () => {
+  assert.equal(
+    pullRequestNumber("https://github.com/acme/repo/pull/42", "pull"),
+    42,
+  );
+  assert.equal(
+    pullRequestNumber("https://git.example/acme/repo/pulls/43", "pulls"),
+    43,
+  );
+});
+
+test("pullRequestNumber rejects malformed and mismatched paths", () => {
+  assert.throws(
+    () => pullRequestNumber("not-a-url", "pull"),
+    /Invalid pull request URL/u,
+  );
+  assert.throws(
+    () => pullRequestNumber("https://github.com/acme/repo/pulls/42", "pull"),
+    /Invalid pull request URL/u,
+  );
+});
+
+test("sameCanonicalUrl ignores only a trailing slash", () => {
+  assert.equal(
+    sameCanonicalUrl(
+      "https://github.com/acme/repo/pull/42",
+      "https://github.com/acme/repo/pull/42/",
+    ),
+    true,
+  );
+  assert.equal(
+    sameCanonicalUrl(
+      "https://github.com/acme/repo/pull/42",
+      "https://github.com/other/repo/pull/42",
+    ),
+    false,
+  );
+});
+```
+
+- [ ] **Step 2: Implement strict PR-number extraction and canonical comparison**
+
+`pullRequestNumber()` must parse with `new URL()`, reject
+credentials/query/hash, require at least
+`owner/repo/<segment>/<positive integer>`, and reject trailing path components.
+`sameCanonicalUrl()` should compare protocol, lower-cased host, normalized
+pathname without a trailing slash, empty search, and empty hash.
+
+Run:
+
+```sh
+node --test src/host/pull-request-reference.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 3: Write failing GitHub adapter tests**
+
+Create a recorded `CommandRunner` and test these exact behaviors:
+
+```ts
+const read = await readGitHubPullRequestBody(
+  { runner, repoRoot: "/repo" },
+  "https://github.com/acme/repo/pull/42",
+);
+assert.equal(read, "Summary\n");
+assert.deepEqual(calls[0], {
+  command: "gh",
+  args: ["pr", "view", "42", "--json", "body,url"],
+  cwd: "/repo",
+  env: { GH_REPO: undefined },
+});
+```
+
+The runner response for that call is:
+
+```ts
+{
+  code: 0,
+  stdout: JSON.stringify({
+    body: "Summary\n",
+    url: "https://github.com/acme/repo/pull/42",
+  }),
+  stderr: "",
+}
+```
+
+For update, inspect the path following `--body-file` inside the fake runner,
+assert its contents equal the exact multiline body, return success, then assert
+the temporary directory no longer exists after the function resolves.
+
+Add rejection tests for nonzero `gh`, invalid JSON, non-string `body`/`url`, and
+a returned URL for another repository.
+
+- [ ] **Step 4: Implement the focused GitHub adapter**
+
+Create this options type and exports in `github-pr-body.ts`:
+
+```ts
+import type { CommandRunner } from "../cli/commands/triage/types.ts";
+
+export type GitHubPrBodyOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+};
+
+export async function readGitHubPullRequestBody(
+  options: GitHubPrBodyOptions,
+  prUrl: string,
+): Promise<string>;
+
+export async function updateGitHubPullRequestBody(
+  options: GitHubPrBodyOptions,
+  prUrl: string,
+  body: string,
+): Promise<void>;
+```
+
+Read with:
+
+```ts
+const number = pullRequestNumber(prUrl, "pull");
+const result = await options.runner.run(
+  "gh",
+  ["pr", "view", String(number), "--json", "body,url"],
+  { cwd: options.repoRoot, env: { GH_REPO: undefined } },
+);
+```
+
+Parse `{ body, url }`, require both strings, and require
+`sameCanonicalUrl(prUrl, url)`. Include command output in nonzero-result errors.
+
+Update by creating `mkdtemp(join(tmpdir(), "patchmill-pr-body-"))`, writing
+`body.md`, and running:
+
+```ts
+await options.runner.run(
+  "gh",
+  ["pr", "edit", String(number), "--body-file", bodyPath],
+  { cwd: options.repoRoot, env: { GH_REPO: undefined } },
+);
+```
+
+Delete the entire temporary directory in `finally` with
+`rm(..., { recursive: true, force: true })` on success and failure.
+
+- [ ] **Step 5: Delegate from the concrete GitHub provider**
+
+Add these methods to `GitHubGhHostProvider`:
+
+```ts
+readPullRequestBody(prUrl: string): Promise<string> {
+  return readGitHubPullRequestBody(this.options, prUrl);
+}
+
+updatePullRequestBody(prUrl: string, body: string): Promise<void> {
+  return updateGitHubPullRequestBody(this.options, prUrl, body);
+}
+```
+
+Extend `github-gh.test.ts` with one provider-level read and update assertion so
+future refactors cannot drop the delegation.
+
+- [ ] **Step 6: Run GitHub host tests**
+
+```sh
+node --test \
+  src/host/pull-request-reference.test.ts \
+  src/host/github-pr-body.test.ts \
+  src/host/github-gh.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 7: Commit GitHub PR-body support**
+
+```sh
+git add \
+  src/host/pull-request-reference.ts \
+  src/host/pull-request-reference.test.ts \
+  src/host/github-pr-body.ts \
+  src/host/github-pr-body.test.ts \
+  src/host/github-gh.ts \
+  src/host/github-gh.test.ts
+git commit -m "feat(host): update GitHub PR bodies"
+```
+
+---
+
+### Task 5: Add Forgejo PR-body support and the run-once host capability
+
+**Files:**
+
+- Create: `src/host/forgejo-pr-body.ts`
+- Create: `src/host/forgejo-pr-body.test.ts`
+- Modify: `src/host/types.ts`
+- Modify: `src/host/github-gh.ts`
+- Modify: `src/host/forgejo-tea.ts`
+- Modify: `src/host/forgejo-tea.test.ts`
+- Modify: `src/host/factory.ts`
+- Modify: `src/host/factory.test.ts`
+
+**Interfaces:**
+
+- Consumes: URL helpers from Task 4 and `withTeaContext()` from
+  `src/host/forgejo-tea-context.ts`.
+- Produces: `readForgejoPullRequestBody()`, `updateForgejoPullRequestBody()`,
+  `PullRequestBodyHostProvider`, `RunOnceHostProvider`, and
+  `createRunOnceHostProvider()`.
+- Task 7 switches only run-once to the new factory; triage and labels retain
+  `IssueHostProvider`.
+
+- [ ] **Step 1: Write failing Forgejo adapter tests**
+
+Create tests using a `repoRoot` fixture whose origin is
+`git@git.example:acme/repo.git` so `withTeaContext()` emits `--repo acme/repo`.
+
+The read assertion should require this semantic command, including the
+configured login:
+
+```ts
+[
+  "api",
+  "/repos/{owner}/{repo}/pulls/42",
+  "--repo",
+  "acme/repo",
+  "--login",
+  "robot",
+];
+```
+
+Return:
+
+```ts
+{
+  code: 0,
+  stdout: JSON.stringify({
+    body: "Summary\n",
+    html_url: "https://git.example/acme/repo/pulls/42",
+  }),
+  stderr: "",
+}
+```
+
+Assert update uses `tea pulls edit 42 --description <actual multiline body>`
+with the same repo/login context. Add errors for invalid JSON, malformed
+body/`html_url`, mismatched URL, and nonzero commands.
+
+- [ ] **Step 2: Implement the Forgejo adapter**
+
+Create this public surface:
+
+```ts
+export type ForgejoPrBodyOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  login?: string;
+};
+
+export async function readForgejoPullRequestBody(
+  options: ForgejoPrBodyOptions,
+  prUrl: string,
+): Promise<string>;
+
+export async function updateForgejoPullRequestBody(
+  options: ForgejoPrBodyOptions,
+  prUrl: string,
+  body: string,
+): Promise<void>;
+```
+
+Use `pullRequestNumber(prUrl, "pulls")`. Build both command arrays with
+`withTeaContext(args, options.repoRoot, options.login)` and run them with
+`cwd: options.repoRoot`.
+
+Read through:
+
+```ts
+["api", `/repos/{owner}/{repo}/pulls/${number}`];
+```
+
+Update through:
+
+```ts
+["pulls", "edit", String(number), "--description", body];
+```
+
+Parse structured read output, require string `body` and `html_url`, and validate
+`html_url` with `sameCanonicalUrl()` before returning the body.
+
+- [ ] **Step 3: Delegate from `ForgejoTeaHostProvider`**
+
+Add:
+
+```ts
+readPullRequestBody(prUrl: string): Promise<string> {
+  return readForgejoPullRequestBody(this.options, prUrl);
+}
+
+updatePullRequestBody(prUrl: string, body: string): Promise<void> {
+  return updateForgejoPullRequestBody(this.options, prUrl, body);
+}
+```
+
+Add provider-level delegation coverage in `forgejo-tea.test.ts`.
+
+- [ ] **Step 4: Add the narrow run-once host capability**
+
+In `src/host/types.ts`, add:
+
+```ts
+export type PullRequestBodyHostProvider = {
+  readPullRequestBody(prUrl: string): Promise<string>;
+  updatePullRequestBody(prUrl: string, body: string): Promise<void>;
+};
+
+export type RunOnceHostProvider = IssueHostProvider &
+  PullRequestBodyHostProvider;
+```
+
+Update both concrete class `implements` clauses to include
+`PullRequestBodyHostProvider`.
+
+In `factory.ts`, leave `createIssueHostProvider()` unchanged and add:
+
+```ts
+export function createRunOnceHostProvider(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  host: PatchmillHostConfig;
+}): RunOnceHostProvider {
+  return createHostProvider(options);
+}
+```
+
+Extend `factory.test.ts` for both provider IDs and assert both PR-body methods
+are functions.
+
+- [ ] **Step 5: Run all host tests and build**
+
+```sh
+node --test \
+  src/host/pull-request-reference.test.ts \
+  src/host/github-pr-body.test.ts \
+  src/host/forgejo-pr-body.test.ts \
+  src/host/github-gh.test.ts \
+  src/host/forgejo-tea.test.ts \
+  src/host/factory.test.ts
+npm run build
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 6: Commit cross-host run-once PR capability**
+
+```sh
+git add \
+  src/host/forgejo-pr-body.ts \
+  src/host/forgejo-pr-body.test.ts \
+  src/host/types.ts \
+  src/host/github-gh.ts \
+  src/host/forgejo-tea.ts \
+  src/host/forgejo-tea.test.ts \
+  src/host/factory.ts \
+  src/host/factory.test.ts
+git commit -m "feat(host): update Forgejo PR bodies"
+```
+
+---
+
+### Task 6: Persist the report and publication checkpoint in run state
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/types.ts`
+- Modify: `src/cli/commands/run-once/run-state.ts`
+- Modify: `src/cli/commands/run-once/run-state.test.ts`
+- Modify: `src/cli/commands/run-once/pipeline-lifecycle.ts`
+- Modify: `src/cli/commands/run-once/pipeline-lifecycle.test.ts`
+
+**Interfaces:**
+
+- Consumes: `RunCostReport` from Task 1.
+- Produces: optional `runCostReport` fields on state/update and the
+  `prCostSummaryUpdated` checkpoint.
+- Task 7 reads `existingState.runCostReport`, passes the report to finish, and
+  records the checkpoint.
+
+- [ ] **Step 1: Write failing run-state report and checkpoint tests**
+
+Add a shared valid report fixture and verify a `pr-created` update persists it:
+
+```ts
+const runCostReport: RunCostReport = {
+  stages: [
+    {
+      stage: "pi-implementation",
+      models: [
+        {
+          model: "gpt-5.5",
+          promptTokens: 60,
+          outputTokens: 4,
+          estimatedCostUsd: 0.1,
+        },
+      ],
+      promptTokens: 60,
+      outputTokens: 4,
+      estimatedCostUsd: 0.1,
+    },
+  ],
+  promptTokens: 60,
+  outputTokens: 4,
+  estimatedCostUsd: 0.1,
+};
+```
+
+Write state with `implementationStatus: "pr-created"`, `runCostReport`, and
+`checkpoints: { implementationCompleted: true }`; read it back and deep-equal
+the report.
+
+Then write `checkpoints: { prCostSummaryUpdated: true }` and assert both the
+top-level report and merged checkpoint remain.
+
+Add a new implementation update without `runCostReport` and assert stale report
+data is cleared. Add a `merged` implementation update and assert both `prUrl`
+and `runCostReport` are absent.
+
+- [ ] **Step 2: Run focused state tests and verify the type/behavior failure**
+
+```sh
+node --test \
+  src/cli/commands/run-once/run-state.test.ts \
+  src/cli/commands/run-once/pipeline-lifecycle.test.ts
+```
+
+Expected: FAIL because the report field/checkpoint is not represented or
+persisted.
+
+- [ ] **Step 3: Extend types and merge semantics**
+
+Import `RunCostReport` as a type in `types.ts`. Add `"prCostSummaryUpdated"` to
+`AgentIssueRunCheckpoint` and `runCostReport?: RunCostReport` to both
+`AgentIssueRunState` and `AgentIssueRunStateUpdate`.
+
+In `mergeRunState()`:
+
+- include `"runCostReport"` in `hasImplementationUpdate`;
+- select the new report from the update when implementation fields change;
+- preserve the existing report for unrelated checkpoint/label updates;
+- clear it for `implementationStatus: "merged"` or a fresh implementation update
+  that omits the report; and
+- delete `next.runCostReport` when undefined.
+
+The core assignment should be:
+
+```ts
+const runCostReport =
+  update.implementationStatus === "merged"
+    ? undefined
+    : hasImplementationUpdate
+      ? update.runCostReport
+      : existingImplementation?.runCostReport;
+```
+
+Add `runCostReport` to the `next` object and cleanup section.
+
+- [ ] **Step 4: Mark publication as a resume-only side effect**
+
+Add `"prCostSummaryUpdated"` to `RESUME_ONLY_SIDE_EFFECT_CHECKPOINTS` in
+`pipeline-lifecycle.ts`.
+
+Extend `pipeline-lifecycle.test.ts` to assert:
+
+- resumable state retains `prCostSummaryUpdated`; and
+- non-resumable checkpoint filtering removes it with the other side-effect
+  checkpoints.
+
+- [ ] **Step 5: Run focused tests, lint, and build**
+
+```sh
+node --test \
+  src/cli/commands/run-once/run-state.test.ts \
+  src/cli/commands/run-once/pipeline-lifecycle.test.ts
+npm run lint:ts
+npm run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Commit resumable cost state**
+
+```sh
+git add \
+  src/cli/commands/run-once/types.ts \
+  src/cli/commands/run-once/run-state.ts \
+  src/cli/commands/run-once/run-state.test.ts \
+  src/cli/commands/run-once/pipeline-lifecycle.ts \
+  src/cli/commands/run-once/pipeline-lifecycle.test.ts
+git commit -m "feat(run-once): persist run cost reports"
+```
+
+---
+
+### Task 7: Resolve, publish, checkpoint, and recover the PR cost summary
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/pipeline-run-cost.ts`
+- Create: `src/cli/commands/run-once/pipeline-run-cost.test.ts`
+- Create: `src/cli/commands/run-once/pr-cost-publication.ts`
+- Create: `src/cli/commands/run-once/pr-cost-publication.test.ts`
+- Modify: `src/cli/commands/run-once/progress.ts`
+- Modify: `src/cli/commands/run-once/pipeline.ts`
+- Modify: `src/cli/commands/run-once/pipeline-finish.ts`
+- Modify: `src/cli/commands/run-once/pipeline-finish-scenarios.test.ts`
+- Modify: `test-support/run-once/mock-runner.ts`
+
+**Interfaces:**
+
+- Consumes: `summarizeRunCost()`, `parseRunCostReport()`,
+  `upsertRunCostSection()`, `RunOnceHostProvider`, and persisted state from
+  Tasks 1–6.
+- Produces: `resolvePipelineRunCost()`, `publishPrRunCost()`, warning progress,
+  finish-stage persistence/publication, and the final integration behavior.
+
+- [ ] **Step 1: Write failing fresh/resumed report resolution tests**
+
+Create `pipeline-run-cost.test.ts` with an injected calculator and warning
+collector. Use this interface:
+
+```ts
+export type ResolvePipelineRunCostOptions = {
+  implementationKind: "implemented" | "already-implemented";
+  implementationStatus: "pr-created" | "merged";
+  piSessionPath?: string;
+  persistedReport?: unknown;
+  calculate?: (piSessionPath: string) => Promise<RunCostReport>;
+  warn(message: string, error?: unknown): void | Promise<void>;
+};
+
+export async function resolvePipelineRunCost(
+  options: ResolvePipelineRunCostOptions,
+): Promise<RunCostReport | undefined>;
+```
+
+Tests must assert:
+
+- fresh `pr-created` calls `calculate(piSessionPath)` and returns its report;
+- resumed `pr-created` returns `parseRunCostReport(persistedReport)` without
+  calculating;
+- resumed legacy state with no report warns and returns `undefined`;
+- malformed persisted state warns and returns `undefined`;
+- fresh calculation rejection warns and returns `undefined`; and
+- `merged` returns `undefined` without calculating or warning.
+
+- [ ] **Step 2: Implement nonfatal report resolution**
+
+Use `summarizeRunCost` as the default calculator. Use fixed, testable warning
+messages:
+
+```ts
+"Patchmill could not calculate the PR run-cost summary";
+"Patchmill cannot publish a run-cost summary from legacy or invalid saved state";
+```
+
+Require `piSessionPath` for a fresh PR result; treat absence as the calculate
+warning. Never calculate from the current session path for `already-implemented`
+state.
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pipeline-run-cost.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 3: Write failing publication tests**
+
+Create `pr-cost-publication.test.ts` around this interface:
+
+```ts
+export async function publishPrRunCost(options: {
+  host: PullRequestBodyHostProvider;
+  prUrl: string;
+  report: RunCostReport;
+}): Promise<"updated" | "unchanged">;
+```
+
+Use a fake host to prove:
+
+- changed body calls `updatePullRequestBody()` once with the original content
+  plus the generated section and returns `updated`;
+- already-current body does not call update and returns `unchanged`; and
+- marker errors and host errors reject for the finish stage to catch.
+
+- [ ] **Step 4: Implement the focused publication helper**
+
+Implementation:
+
+```ts
+export async function publishPrRunCost({
+  host,
+  prUrl,
+  report,
+}: {
+  host: PullRequestBodyHostProvider;
+  prUrl: string;
+  report: RunCostReport;
+}): Promise<"updated" | "unchanged"> {
+  const currentBody = await host.readPullRequestBody(prUrl);
+  const nextBody = upsertRunCostSection(currentBody, report);
+  if (nextBody === currentBody) return "unchanged";
+  await host.updatePullRequestBody(prUrl, nextBody);
+  return "updated";
+}
+```
+
+Run:
+
+```sh
+node --test src/cli/commands/run-once/pr-cost-publication.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 5: Add priced-session support to the run-once mock runner**
+
+Add a new helper without changing the existing `writePiSessionMessage()`
+contract:
+
+```ts
+export async function writePiPricedSessionMessage(
+  call: Call,
+  input: {
+    id: string;
+    model: string;
+    input: number;
+    cacheRead: number;
+    cacheWrite: number;
+    output: number;
+    estimatedCostUsd: number;
+  },
+): Promise<void>;
+```
+
+It should locate `--session-dir`, write beneath `--repo--`, include a valid
+session timestamp, and write one assistant entry with the complete usage object
+and `cost.total`. Accept an optional array overload only if an integration test
+needs multiple models in the same file; do not weaken existing helper types.
+
+- [ ] **Step 6: Write failing finish-stage publication and recovery scenarios**
+
+In `pipeline-finish-scenarios.test.ts`, add scenarios next to the existing
+complete `pr-created` coverage:
+
+1. **Fresh report publication** — provide a valid `RunCostReport`; have the
+   configured host read `Summary\n\nCloses #45\n`; assert the update contains
+   the marker block, state contains `runCostReport`, and state checkpoint
+   `prCostSummaryUpdated` is true.
+2. **Already-current retry** — return a body containing the exact generated
+   block; assert no edit command occurs but the checkpoint becomes true.
+3. **Host update failure** — return nonzero from the edit; assert the final
+   result remains `pr-created`, a progress event has `level: "warning"`, the
+   report remains in state, and `prCostSummaryUpdated` is absent.
+4. **Malformed markers** — return one unmatched marker; assert the same nonfatal
+   warning behavior and unchanged body.
+5. **Merged result** — assert no PR-body read or update occurs and no report is
+   persisted.
+6. **Resumed implementation** — seed `implementationCompleted` and
+   `runCostReport`; assert no Pi call or fresh calculation is needed and
+   publication uses the saved report.
+
+Use exact event message text:
+
+```ts
+"Patchmill could not update the PR run-cost summary";
+```
+
+- [ ] **Step 7: Wire the run-once host and report resolution in `pipeline.ts`**
+
+Replace only the run-once factory call:
+
+```ts
+const host = createRunOnceHostProvider({
+  runner,
+  repoRoot: config.repoRoot,
+  host: config.host,
+});
+```
+
+After `runPipelineImplementationStage()` returns a successful result, resolve
+the report before calling finish:
+
+```ts
+const runCostReport = await resolvePipelineRunCost({
+  implementationKind: implementationStage.kind,
+  implementationStatus: implementationStage.result.status,
+  piSessionPath: runOptions.piSessionPath,
+  persistedReport: existingState?.runCostReport,
+  warn: (message, error) =>
+    progress(runOptions, "warning", "run-cost", message, {
+      issueNumber: issue.number,
+      data: error instanceof Error ? error.message : String(error ?? ""),
+      consoleMessage: `Warning: ${message}`,
+    }),
+});
+```
+
+Pass `runCostReport` into `runPipelineFinishStage()`.
+
+- [ ] **Step 8: Persist and publish in `pipeline-finish.ts`**
+
+Change the finish-stage host type to `RunOnceHostProvider` and add
+`runCostReport?: RunCostReport` to `PipelineFinishStageOptions`.
+
+Include `runCostReport` in the first implementation-completed state write and in
+the later visual-evidence state rewrite so the latter cannot clear it.
+
+Immediately after the first state write and before visual-evidence validation,
+add:
+
+```ts
+if (
+  implemented.status === "pr-created" &&
+  options.runCostReport &&
+  !checkpoints.prCostSummaryUpdated
+) {
+  try {
+    const publication = await publishPrRunCost({
+      host,
+      prUrl: implemented.prUrl,
+      report: options.runCostReport,
+    });
+    await writeRunState(
+      config.runStateDir,
+      {
+        issueNumber: issue.number,
+        status: "implementing",
+        checkpoints: { prCostSummaryUpdated: true },
+      },
+      timestamp,
+    );
+    checkpoints.prCostSummaryUpdated = true;
+    await emitProgress(
+      runOptions,
+      "info",
+      "run-cost",
+      `PR run-cost summary ${publication}`,
+      {
+        issueNumber: issue.number,
+        data: options.runCostReport,
+      },
+    );
+  } catch (error) {
+    await emitProgress(
+      runOptions,
+      "warning",
+      "run-cost",
+      "Patchmill could not update the PR run-cost summary",
+      {
+        issueNumber: issue.number,
+        data: error instanceof Error ? error.message : String(error),
+        consoleMessage:
+          "Warning: Patchmill could not update the PR run-cost summary",
+      },
+    );
+  }
+}
+```
+
+Add `"warning"` to `AgentIssueProgressEvent["level"]` in `progress.ts`. Do not
+map it to an error or blocker.
+
+- [ ] **Step 9: Run focused run-once integration tests**
+
+```sh
+node --test \
+  src/cli/commands/run-once/run-cost.test.ts \
+  src/cli/commands/run-once/run-cost-files.test.ts \
+  src/cli/commands/run-once/pr-cost-summary.test.ts \
+  src/cli/commands/run-once/pipeline-run-cost.test.ts \
+  src/cli/commands/run-once/pr-cost-publication.test.ts \
+  src/cli/commands/run-once/run-state.test.ts \
+  src/cli/commands/run-once/pipeline-lifecycle.test.ts \
+  src/cli/commands/run-once/pipeline-finish-scenarios.test.ts
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 10: Run the full project verification required by the spec**
+
+```sh
+npm test
+npm run lint
+npm run format:check
+npm run build
+```
+
+Expected: every command exits 0. If `package.json`, `package-lock.json`, or
+`npm-shrinkwrap.json` changed unexpectedly, stop, revert that dependency drift,
+and rerun verification. No Nix build is required when those files remain
+unchanged.
+
+- [ ] **Step 11: Review the final diff against privacy and scope constraints**
+
+Run:
+
+```sh
+git diff --check
+git status --short
+git diff --stat
+git diff -- \
+  src/cli/commands/run-once \
+  src/host \
+  test-support/run-once/mock-runner.ts
+```
+
+Confirm from the diff that:
+
+- only aggregate model names, token totals, and estimated cost reach the PR;
+- PR body content outside markers is preserved;
+- no prompt/session content is emitted;
+- direct-land paths skip publication;
+- all reporting exceptions are caught before handoff completion; and
+- no dependency or lock file changed.
+
+- [ ] **Step 12: Commit the integrated pipeline behavior**
+
+```sh
+git add \
+  src/cli/commands/run-once/pipeline-run-cost.ts \
+  src/cli/commands/run-once/pipeline-run-cost.test.ts \
+  src/cli/commands/run-once/pr-cost-publication.ts \
+  src/cli/commands/run-once/pr-cost-publication.test.ts \
+  src/cli/commands/run-once/progress.ts \
+  src/cli/commands/run-once/pipeline.ts \
+  src/cli/commands/run-once/pipeline-finish.ts \
+  src/cli/commands/run-once/pipeline-finish-scenarios.test.ts \
+  test-support/run-once/mock-runner.ts
+git commit -m "feat(run-once): publish PR cost summaries"
+```
+
+---
+
+## Final acceptance checklist
+
+- [ ] The report uses only the current successful run's durable Pi session root.
+- [ ] Copied parent entries count once globally by stable entry ID.
+- [ ] Earliest session attribution preserves the originating stage.
+- [ ] Prompt/output token and recorded-cost calculations match the approved
+      formulas.
+- [ ] Multi-model stages render model rows plus one subtotal.
+- [ ] The generated block is marker-delimited, escaped, deterministic, and
+      idempotent.
+- [ ] GitHub and Forgejo adapters validate the current repository PR before
+      editing.
+- [ ] The report and publication checkpoint survive finish-stage recovery.
+- [ ] Legacy state without a report remains resumable and emits only a warning.
+- [ ] Aggregation and host failures leave `pr-created` successful.
+- [ ] Direct-land and non-PR results perform no PR-body operations.
+- [ ] Focused tests, full tests, lint, format check, and build all exit 0.
+- [ ] No dependency or lock file changed.

--- a/docs/specs/2026-07-19-run-once-pr-cost-summary-design.md
+++ b/docs/specs/2026-07-19-run-once-pr-cost-summary-design.md
@@ -1,0 +1,507 @@
+# Run-once PR cost summary design
+
+## Context
+
+Patchmill preserves durable Pi session JSONL for each selected-issue `run-once`
+execution under a path such as:
+
+```text
+.patchmill/runs/issue-104/run-2026-07-19T15-14-56-391Z-pi-sessions/
+  pi-plan/
+  pi-development-environment/
+  pi-implementation/
+```
+
+Each assistant message records its provider, model, token usage, and Pi's
+calculated cost. A typical usage object includes:
+
+- `input` — uncached input tokens;
+- `cacheRead` — tokens read from the provider cache;
+- `cacheWrite` — tokens written to the provider cache;
+- `output` — output tokens; and
+- `cost.total` — Pi's estimated USD cost for that response.
+
+Patchmill currently observes output tokens for console progress, but it does not
+calculate a complete run cost or add cost information to the pull request.
+
+The implementation Pi session creates or updates the pull request before it
+returns its final `pr-created` JSON. The complete implementation cost is
+therefore unavailable when the agent first writes the PR body. Patchmill must
+calculate the report after the Pi invocation exits and then update the existing
+PR body.
+
+A recursive sum of every assistant message in every JSONL file would be wrong.
+Child and subagent sessions can copy parent session history into their own JSONL
+files while preserving session-entry IDs. Patchmill must deduplicate those
+copied entries before summing tokens or cost.
+
+## Decision
+
+For every successful `pr-created` run, Patchmill should calculate a report from
+the current run's durable Pi session tree and insert an idempotent, generated
+section into the existing PR body.
+
+The report should:
+
+- include all Pi stages present in the current `run-once` execution;
+- include parent and child/subagent sessions;
+- deduplicate copied session history;
+- group usage by stage and model;
+- show prompt tokens, output tokens, and estimated USD cost;
+- add a stage subtotal when a stage used multiple models;
+- show a total for the complete current run;
+- support GitHub through `gh` and Forgejo/Gitea through `tea`; and
+- treat reporting failures as warnings that do not invalidate a successful PR
+  handoff.
+
+The report describes the current `run-once` execution that produced the
+`pr-created` result. It is not cumulative across earlier approval runs, failed
+runs, or other attempts for the same issue.
+
+## Goals
+
+- Give reviewers a concise view of the model usage required to produce the PR.
+- Use Pi's recorded historical cost rather than current model pricing.
+- Include subagent usage without double-counting copied parent history.
+- Preserve the existing PR body outside Patchmill's generated section.
+- Make retries and resumed finish stages idempotent.
+- Keep cost parsing, Markdown rendering, host I/O, and pipeline orchestration in
+  separate, focused units.
+- Avoid exposing prompts, tool arguments, session paths, or other session
+  content in the PR.
+
+## Non-goals
+
+- Do not calculate an operator's exact invoice or subscription charge.
+- Do not recompute historical cost from token counts and current pricing.
+- Do not aggregate costs across multiple `run-once` executions for an issue.
+- Do not add a cost report to direct-landed changes that have no PR.
+- Do not post a fallback issue comment when the PR body cannot be updated.
+- Do not add configuration for currencies, custom price tables, report layout,
+  or opt-in/opt-out behavior in the initial implementation.
+- Do not expose cache-token columns separately; cache reads and writes are part
+  of the prompt-token total.
+- Do not wait indefinitely for detached subagents after Pi has returned a
+  successful final result.
+
+## Terminology and calculations
+
+### Prompt tokens
+
+The report's **Prompt tokens** value is:
+
+```text
+usage.input + usage.cacheRead + usage.cacheWrite
+```
+
+This keeps the PR table compact while accounting for all tokens used to build a
+provider request. The note below the table should state this definition.
+
+### Output tokens
+
+The report's **Output tokens** value is Pi's recorded `usage.output`. Reasoning
+usage is not displayed as a separate column.
+
+### Estimated cost
+
+The report's **Estimated cost (USD)** value is Pi's recorded `usage.cost.total`.
+It reflects Pi's configured model pricing and may differ from subscription
+charges, negotiated rates, credits, or the operator's final invoice.
+
+Patchmill should sum costs at full JavaScript numeric precision and round only
+when rendering. Displayed costs use four decimal places.
+
+## Components and responsibilities
+
+### Run-cost aggregation
+
+Add a focused run-once module with one narrow public operation conceptually
+shaped as:
+
+```ts
+summarizeRunCost(piSessionPath: string): Promise<RunCostReport>
+```
+
+The module owns recursive JSONL discovery, stable snapshot validation, session
+entry parsing, deduplication, stage/model aggregation, and report validation. It
+does not know about Markdown or issue-host commands.
+
+A report should have a domain shape equivalent to:
+
+```ts
+type RunCostModelUsage = {
+  model: string;
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+
+type RunCostStageUsage = {
+  stage: string;
+  models: RunCostModelUsage[];
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+
+type RunCostReport = {
+  stages: RunCostStageUsage[];
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+```
+
+The implementation may use stricter branded or readonly types, but it should
+keep one validated representation shared by run state and rendering.
+
+### PR cost-section rendering
+
+Add a separate pure module that:
+
+- renders a validated `RunCostReport` as Markdown;
+- inserts the generated block when no markers exist; and
+- replaces the existing generated block when exactly one valid marker pair
+  exists.
+
+This module should not perform filesystem or host I/O.
+
+### Pull-request host capability
+
+Add a narrow pull-request-body capability at the host boundary, conceptually:
+
+```ts
+type PullRequestBodyHost = {
+  readPullRequestBody(prUrl: string): Promise<string>;
+  updatePullRequestBody(prUrl: string, body: string): Promise<void>;
+};
+```
+
+The run-once host used by the pipeline should provide both the existing issue
+operations and this capability. Repository setup providers do not need it.
+
+### Pipeline orchestration
+
+The pipeline should decide when to calculate, persist, and publish the report.
+It should not parse JSONL or construct host-specific commands directly.
+
+## Session discovery and deduplication
+
+### File manifest
+
+Before parsing, recursively discover every `.jsonl` file under the current
+`piSessionPath`. For each file, record:
+
+- its path relative to the run session root;
+- the stage represented by the first relative path component;
+- file size and modification time; and
+- the session start timestamp from the file's first valid `session` entry.
+
+If a valid session-entry timestamp is unavailable, use the ISO timestamp prefix
+in the JSONL filename. If that is also unavailable, use the manifest
+modification time. Break remaining ties by relative path so attribution is
+deterministic.
+
+After parsing, rebuild the manifest. A new, removed, resized, or modified file
+means the session tree changed while being read. In that case the report is not
+safe to publish.
+
+A successful `pr-created` result is expected only after required subagents have
+finished. Snapshot validation protects against concurrent writes during
+aggregation, but Patchmill should not add an unbounded wait for detached
+workers.
+
+### Relevant entries
+
+Only entries satisfying all of the following contribute usage:
+
+- the JSONL entry has `type: "message"`;
+- `entry.message.role` is `"assistant"`;
+- the entry has a non-empty stable string `id`;
+- `message.usage.input`, `cacheRead`, `cacheWrite`, and `output` are finite,
+  non-negative numbers;
+- `message.usage.cost.total` is a finite, non-negative number; and
+- the message model is a usable string, or can be represented as
+  `Unknown model`.
+
+A valid recorded zero is meaningful and must remain zero. A session tree with no
+assistant usage produces no report rather than a fabricated `$0.0000` report.
+Any assistant entry that lacks the required ID or accounting fields invalidates
+the complete report instead of being silently omitted. Non-assistant entries do
+not require usage fields and are ignored for accounting.
+
+### Global deduplication
+
+Deduplicate across the entire current run, not only within individual files or
+stages.
+
+Use the stable session-entry `id` as the key. When an ID occurs in multiple
+files:
+
+1. Compare the accounting fields that affect the report, including model, token
+   counts, and total cost.
+2. If the copies conflict, reject the report as internally inconsistent.
+3. If they match, count the entry once.
+4. Attribute it to the earliest session file containing that ID, using the
+   session start ordering from the manifest.
+
+Attributing the earliest copy preserves the stage where the response originated
+when a later child session copies parent history.
+
+### Aggregation and ordering
+
+Aggregate each unique response first by stage and then by model. Sum stage and
+run totals from the same unique response records rather than summing already
+rounded display rows.
+
+Known stages should appear in workflow order:
+
+1. artifact extraction;
+2. planning;
+3. development environment; and
+4. implementation.
+
+Absent stages are omitted. Unknown future stages follow known stages in lexical
+order and are labelled by stripping a leading `pi-`, replacing hyphens and
+underscores with spaces, and capitalizing the first word. Models are grouped by
+the trimmed recorded `message.model` string and use deterministic lexical order
+within a stage.
+
+## PR Markdown contract
+
+Use exact HTML markers:
+
+```md
+<!-- patchmill-run-cost:start -->
+<!-- patchmill-run-cost:end -->
+```
+
+The generated section should have this shape:
+
+```md
+<!-- patchmill-run-cost:start -->
+
+## Patchmill run cost
+
+| Stage                       | Model         | Prompt tokens | Output tokens | Estimated cost (USD) |
+| --------------------------- | ------------- | ------------: | ------------: | -------------------: |
+| Planning                    | gpt-5.5       |       294,103 |         1,290 |              $0.4862 |
+| Development environment     | gpt-5.5       |       181,450 |           940 |              $0.2147 |
+| Implementation              | gpt-5.5       |       302,448 |         3,960 |              $0.5452 |
+| Implementation              | gpt-5.6-terra |     1,282,348 |         9,539 |              $0.8364 |
+| **Implementation subtotal** |               | **1,584,796** |    **13,499** |          **$1.3816** |
+| **Total**                   |               | **2,060,349** |    **15,729** |          **$2.0825** |
+
+_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an
+estimate based on Pi's recorded model pricing and includes parent and subagent
+sessions._
+
+<!-- patchmill-run-cost:end -->
+```
+
+Rendering rules:
+
+- Render one row per stage/model pair.
+- Render a stage subtotal only when that stage contains more than one model.
+- Render exact integer token counts with comma thousands separators.
+- Render USD with a dollar sign and exactly four decimal places.
+- Escape model and fallback stage labels so they cannot break Markdown table
+  cells or inject additional lines.
+- Keep known stage labels human-readable.
+
+### Marker safety
+
+The updater should follow these rules:
+
+- No markers: append the generated block with appropriate blank-line separation.
+- Exactly one start marker followed by exactly one end marker: replace the
+  inclusive generated region.
+- A missing mate, reversed pair, or multiple occurrence of either marker: reject
+  the update and warn.
+
+All existing body content outside the generated block must remain byte-for-byte
+unchanged. When appending, the original body remains an exact prefix of the new
+body.
+
+## Host-provider behavior
+
+Before reading or editing, adapters should validate that the returned PR URL is
+a supported PR URL for the configured repository. An unparseable or mismatched
+URL is a nonfatal reporting error.
+
+### GitHub
+
+The GitHub adapter should:
+
+- read the body using structured `gh pr view` JSON output;
+- update it using `gh pr edit` with a temporary body file so multiline Markdown
+  and body size do not depend on shell quoting; and
+- remove the temporary file in success and failure paths.
+
+The command should target the validated configured repository and PR number or
+validated URL explicitly.
+
+### Forgejo/Gitea
+
+The Forgejo adapter should:
+
+- extract the numeric pull index from the validated PR URL;
+- read the PR through structured `tea api` JSON because the installed `tea`
+  version does not expose a `pulls view` command;
+- update the description using `tea pulls edit <index> --description <body>`
+  with the configured repository context; and
+- pass the body as one real multiline argument rather than literal `\\n` text.
+
+Both adapters should parse structured output defensively and surface command,
+shape, authentication, permission, and network errors to pipeline orchestration.
+
+## Pipeline and run-state flow
+
+For a current execution that returns `pr-created`:
+
+1. The implementation Pi invocation and its session observation shutdown finish.
+2. Patchmill attempts to calculate the report from the current execution's
+   `piSessionPath`, converting an aggregation failure into a warning and an
+   absent report.
+3. Patchmill persists the implementation result and, when available, the
+   validated report in run state.
+4. When no report is available, Patchmill skips publication and continues the
+   existing finish sequence.
+5. Otherwise, Patchmill reads the latest PR body through the configured host
+   provider.
+6. Patchmill applies the pure marker upsert.
+7. If the transformed body differs, Patchmill updates the PR.
+8. Patchmill records a `prCostSummaryUpdated` checkpoint after either a
+   successful update or confirmation that the existing generated block is
+   already current.
+9. Existing visual-evidence validation, issue handoff, label changes, and
+   cleanup continue.
+
+Persisting the report before host publication supports recovery. If Patchmill
+crashes after implementation, a resumed finish stage uses the saved report
+instead of trying to calculate from the resumed invocation's different session
+root. If Patchmill crashes after editing the PR but before recording the
+checkpoint, marker replacement makes the retry idempotent.
+
+Legacy run-state files may contain a saved `pr-created` result without a cost
+report. Resume loading must accept those states. If the original session root is
+not available from that state, Patchmill should warn and continue rather than
+invent or recalculate a report from the new execution.
+
+Direct-landed `merged` results and all non-PR outcomes skip aggregation and host
+PR operations.
+
+## Progress and failure behavior
+
+Cost reporting is supplementary metadata. It must not convert a valid
+`pr-created` implementation into a blocked or failed handoff.
+
+On successful publication, emit a concise progress event indicating that the PR
+cost summary was updated. The durable run log may include structured report
+totals for diagnostics, but console output should remain concise.
+
+For any of the following, emit a warning, leave the PR unchanged, do not record
+the publication checkpoint, and continue normal handoff:
+
+- missing or unreadable session root;
+- malformed nonblank JSONL;
+- missing or invalid relevant usage fields;
+- missing stable IDs on relevant entries;
+- conflicting copies of one entry ID;
+- session files changing during aggregation;
+- no assistant usage records;
+- malformed or duplicated PR markers;
+- malformed or mismatched PR URL;
+- host body read or parse failure; or
+- host body update, authentication, permission, or network failure.
+
+No fallback issue comment should be posted. The validated report remains in run
+state when calculation succeeded but host publication failed.
+
+## Testing strategy
+
+These tests prove production behavior and pass the project's Testing Value Gate.
+
+### Run-cost aggregation tests
+
+Use compact temporary JSONL trees to verify:
+
+- one stage and one model;
+- multiple stages in workflow order;
+- multiple models within implementation;
+- prompt-token calculation from input plus both cache fields;
+- output-token and cost totals;
+- global deduplication of parent history copied into child and grandchild files;
+- attribution to the earliest session file;
+- rejection of conflicting copies with the same ID;
+- full-precision accumulation before rendering;
+- valid zero usage and cost;
+- unknown model and stage fallbacks;
+- no usage records;
+- malformed JSONL and invalid usage fields; and
+- pre-read/post-read manifest changes.
+
+### Markdown tests
+
+Verify:
+
+- stage/model rows and deterministic ordering;
+- subtotals only for multi-model stages;
+- total row, token formatting, and four-decimal USD formatting;
+- Markdown escaping for model and stage labels;
+- append behavior with exact original-body prefix preservation;
+- replacement behavior with exact outside-body preservation;
+- idempotent repeated upserts; and
+- rejection of missing, reversed, or duplicate markers.
+
+### Host adapter tests
+
+Extend the existing command-runner tests to verify:
+
+- GitHub structured body reads and body-file edits;
+- GitHub temporary-file cleanup on success and failure;
+- Forgejo structured API body reads and multiline description edits;
+- explicit configured repository targeting;
+- PR URL parsing and repository mismatch rejection; and
+- malformed command output and nonzero command results.
+
+### Pipeline and recovery tests
+
+Verify:
+
+- a `pr-created` result calculates and persists the report before publication;
+- the body update occurs before the existing handoff completion sequence;
+- successful publication records `prCostSummaryUpdated`;
+- a crash/retry replaces rather than duplicates the section;
+- a resumed finish stage uses the persisted report;
+- legacy state without a report remains loadable;
+- aggregation and host failures warn but preserve successful handoff;
+- failed publication does not record the checkpoint or post a fallback comment;
+  and
+- merged and non-PR results do not read or edit PR bodies.
+
+### Verification commands
+
+Run focused tests first, then:
+
+```sh
+npm test
+npm run lint
+npm run format:check
+npm run build
+```
+
+No dependency change is expected, so the dependency-triggered Nix build is not
+required. Documentation text should be checked through the existing Markdown
+lint/format commands rather than new tests that assert prose.
+
+## Security and privacy
+
+The generated section contains only aggregate model names, token counts, and
+estimated cost. It must not include prompts, assistant text, tool calls, file
+paths, repository-local session locations, provider credentials, or raw session
+records.
+
+Treat model and stage strings as untrusted Markdown input and escape them before
+rendering. Validate PR URLs against the configured repository before allowing an
+adapter to modify a remote PR.

--- a/src/cli/commands/run-once/pipeline-finish-run-cost.test.ts
+++ b/src/cli/commands/run-once/pipeline-finish-run-cost.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile } from "node:fs/promises";
+import test from "node:test";
+import type { RunOnceHostProvider } from "../../../host/types.ts";
+import { collectProgressEvents } from "../../../../test-support/run-once/assertions.ts";
+import { issue } from "../../../../test-support/run-once/issue-fixtures.ts";
+import { makeConfig } from "../../../../test-support/run-once/pipeline-fixtures.ts";
+import { resolvePipelineRunCost } from "./pipeline-run-cost.ts";
+import { runPipelineFinishStage } from "./pipeline-finish.ts";
+import { renderRunCostSection } from "./pr-cost-summary.ts";
+import { runStatePath, writeRunState } from "./run-state.ts";
+import type { RunCostReport } from "./run-cost.ts";
+
+const NOW = "2026-07-24T12:00:00.000Z";
+const REPORT: RunCostReport = {
+  stages: [
+    {
+      stage: "pi-implementation",
+      models: [
+        {
+          model: "gpt-5.5",
+          promptTokens: 60,
+          outputTokens: 4,
+          estimatedCostUsd: 0.1,
+        },
+      ],
+      promptTokens: 60,
+      outputTokens: 4,
+      estimatedCostUsd: 0.1,
+    },
+  ],
+  promptTokens: 60,
+  outputTokens: 4,
+  estimatedCostUsd: 0.1,
+};
+
+function hostWithBody(
+  body: string,
+  failUpdate = false,
+): {
+  host: RunOnceHostProvider;
+  updates: string[];
+} {
+  const updates: string[] = [];
+  return {
+    updates,
+    host: {
+      id: "forgejo-tea",
+      displayName: "Forgejo",
+      async checkCli() {
+        return { ok: true, message: "ready" };
+      },
+      missingLabelRemediation() {
+        return "";
+      },
+      async listOpenIssues() {
+        return [];
+      },
+      async viewIssue() {
+        throw new Error("not used");
+      },
+      async hydrateIssueComments(issues) {
+        return issues;
+      },
+      async trustedTriageCommentAuthors() {
+        return [];
+      },
+      async listLabels() {
+        return [];
+      },
+      async createLabel() {},
+      async applyLabels() {},
+      async commentIssue() {},
+      async readPullRequestBody() {
+        return body;
+      },
+      async updatePullRequestBody(_prUrl, updated) {
+        if (failUpdate) throw new Error("host update failed");
+        updates.push(updated);
+      },
+    },
+  };
+}
+
+async function finishWithCost(options: {
+  body: string;
+  report?: RunCostReport;
+  failUpdate?: boolean;
+}) {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  await mkdir(config.runStateDir, { recursive: true });
+  await writeRunState(
+    config.runStateDir,
+    { issueNumber: 45, title: "Cost summary", status: "implementing" },
+    NOW,
+  );
+  const { host, updates } = hostWithBody(options.body, options.failUpdate);
+  const { events, progress } = collectProgressEvents();
+  const checkpoints: Record<string, boolean | undefined> = {};
+  const result = await runPipelineFinishStage({
+    runner: {
+      async run() {
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+    host,
+    config,
+    issue: issue(45, ["in-progress"], "Cost summary"),
+    labels: ["in-progress"],
+    readyLabel: "agent-ready",
+    inProgressLabel: "in-progress",
+    doneLabel: "completed-by-bot",
+    needsInfoLabel: "needs-info",
+    checkpoints,
+    implemented: {
+      status: "pr-created",
+      prUrl: "https://forgejo.example/acme/repo/pulls/45",
+      branch: "agent/issue-45-cost-summary",
+      commits: ["abc123"],
+      validation: ["npm test"],
+    },
+    runCostReport: options.report,
+    specPath: undefined,
+    specCommit: undefined,
+    planPath: "docs/plans/cost-summary.md",
+    planCommit: "plan123",
+    branch: "agent/issue-45-cost-summary",
+    worktreePath: ".worktrees/patchmill-issue-45-cost-summary",
+    timestamp: NOW,
+    runOptions: { progress },
+    runStep: async (_label, fn) => fn(),
+  });
+  if (result.kind === "unexpected") throw result.error;
+  const state = JSON.parse(
+    await readFile(runStatePath(config.runStateDir, 45), "utf8"),
+  ) as { checkpoints?: Record<string, boolean>; runCostReport?: RunCostReport };
+  return { result, state, checkpoints, events, updates };
+}
+
+test("finish publishes one cost section and checkpoints a successful update", async () => {
+  const finished = await finishWithCost({ body: "Summary\n", report: REPORT });
+
+  assert.equal(finished.result.kind, "finished");
+  assert.equal(finished.updates.length, 1);
+  assert.match(finished.updates[0], /patchmill-run-cost:start/u);
+  assert.deepEqual(finished.state.runCostReport, REPORT);
+  assert.equal(finished.state.checkpoints?.prCostSummaryUpdated, true);
+});
+
+test("finish treats malformed markers and host update failures as nonfatal warnings", async () => {
+  for (const options of [
+    { body: "Summary\n<!-- patchmill-run-cost:start -->", failUpdate: false },
+    { body: "Summary\n", failUpdate: true },
+  ]) {
+    const finished = await finishWithCost({ ...options, report: REPORT });
+
+    assert.equal(finished.result.kind, "finished");
+    assert.equal(
+      finished.result.kind === "finished" && finished.result.result.status,
+      "pr-created",
+    );
+    assert.equal(finished.updates.length, 0);
+    assert.deepEqual(finished.state.runCostReport, REPORT);
+    assert.equal(finished.state.checkpoints?.prCostSummaryUpdated, undefined);
+    assert.ok(
+      finished.events.some(
+        (event) =>
+          event.level === "warning" &&
+          event.message ===
+            "Patchmill could not update the PR run-cost summary",
+      ),
+    );
+  }
+});
+
+test("finish checkpoints an already-current section without adding a duplicate", async () => {
+  const body = `Summary\n\n${renderRunCostSection(REPORT)}`;
+  const finished = await finishWithCost({ body, report: REPORT });
+
+  assert.equal(finished.result.kind, "finished");
+  assert.deepEqual(finished.updates, []);
+  assert.equal(finished.state.checkpoints?.prCostSummaryUpdated, true);
+});
+
+test("a resumed finish publishes the validated saved report without recalculating", async () => {
+  let calculated = false;
+  const report = await resolvePipelineRunCost({
+    implementationKind: "already-implemented",
+    implementationStatus: "pr-created",
+    persistedReport: REPORT,
+    calculate: async () => {
+      calculated = true;
+      return REPORT;
+    },
+    warn() {},
+  });
+  const finished = await finishWithCost({ body: "Summary\n", report });
+
+  assert.equal(calculated, false);
+  assert.equal(finished.updates.length, 1);
+  assert.equal(finished.state.checkpoints?.prCostSummaryUpdated, true);
+});

--- a/src/cli/commands/run-once/pipeline-finish-scenarios.test.ts
+++ b/src/cli/commands/run-once/pipeline-finish-scenarios.test.ts
@@ -16,6 +16,7 @@ import {
   createMockRunner,
   promptPath,
   workflowPiCalls,
+  writePiPricedSessionMessage,
 } from "../../../../test-support/run-once/mock-runner.ts";
 import { makeConfig } from "../../../../test-support/run-once/pipeline-fixtures.ts";
 import {
@@ -42,6 +43,125 @@ const LANDING_SKILLS = {
 };
 
 const cleanupHook = "./scripts/cleanup.sh";
+
+test("runOneIssue calculates and publishes a fresh priced implementation session", async () => {
+  const config = await makeConfig({ dryRun: false, execute: true });
+  const selected = issue(47, ["plan-approved"], "Publish fresh run cost");
+  const planPath = "docs/plans/2026-05-09-issue-47-publish-fresh-run-cost.md";
+  const prUrl = "https://forgejo.example/acme/repo/pulls/47";
+  await writeFile(join(config.repoRoot, planPath), "# plan\n", "utf8");
+  const runner = createMockRunner(async (call) => {
+    if (
+      call.command === "tea" &&
+      call.args[0] === "issues" &&
+      call.args[1] === "list"
+    ) {
+      const page = call.args[call.args.indexOf("--page") + 1];
+      return {
+        code: 0,
+        stdout: page === "1" ? issueListPayload([selected]) : "[]",
+        stderr: "",
+      };
+    }
+    if (
+      call.command === "tea" &&
+      call.args[0] === "labels" &&
+      call.args[1] === "list"
+    )
+      return { code: 0, stdout: labelListPayload(), stderr: "" };
+    if (call.command === "tea" && call.args[0] === "api") {
+      assert.equal(call.args[1], "/repos/{owner}/{repo}/pulls/47");
+      return {
+        code: 0,
+        stdout: JSON.stringify({ body: "Summary\n", html_url: prUrl }),
+        stderr: "",
+      };
+    }
+    if (
+      call.command === "tea" &&
+      call.args[0] === "pulls" &&
+      call.args[1] === "edit"
+    ) {
+      const description = call.args[call.args.indexOf("--description") + 1];
+      assert.match(description ?? "", /patchmill-run-cost:start/u);
+      assert.match(description ?? "", /\$0\.1250/u);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (call.command === "tea") return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "git" && call.args[0] === "status")
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "git" && call.args[0] === "show-ref")
+      return { code: 1, stdout: "", stderr: "" };
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      (call.args[1] === "list" || call.args[1] === "add")
+    )
+      return { code: 0, stdout: "", stderr: "" };
+    if (call.command === "pi") {
+      await writePiPricedSessionMessage(call, {
+        id: "fresh-priced-entry",
+        model: "gpt-5.5",
+        input: 10,
+        cacheRead: 20,
+        cacheWrite: 30,
+        output: 4,
+        estimatedCostUsd: 0.125,
+      });
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          status: "pr-created",
+          prUrl,
+          branch: "agent/issue-47-publish-fresh-run-cost",
+          commits: ["abc123"],
+          validation: ["npm test"],
+        }),
+        stderr: "",
+      };
+    }
+    throw new Error(
+      `unexpected command: ${call.command} ${call.args.join(" ")}`,
+    );
+  });
+
+  const result = await runOneIssue(runner, config, { now: NOW });
+
+  assert.equal(result.status, "pr-created");
+  assert.equal((await workflowPiCalls(runner.calls)).length, 1);
+  const state = JSON.parse(
+    await readFile(runStatePath(config.runStateDir, 47), "utf8"),
+  ) as {
+    checkpoints?: Record<string, boolean>;
+    runCostReport?: {
+      promptTokens: number;
+      outputTokens: number;
+      estimatedCostUsd: number;
+    };
+  };
+  assert.deepEqual(state.runCostReport, {
+    stages: [
+      {
+        stage: "pi-implementation",
+        models: [
+          {
+            model: "gpt-5.5",
+            promptTokens: 60,
+            outputTokens: 4,
+            estimatedCostUsd: 0.125,
+          },
+        ],
+        promptTokens: 60,
+        outputTokens: 4,
+        estimatedCostUsd: 0.125,
+      },
+    ],
+    promptTokens: 60,
+    outputTokens: 4,
+    estimatedCostUsd: 0.125,
+  });
+  assert.equal(state.checkpoints?.prCostSummaryUpdated, true);
+});
 
 test("runOneIssue reuses existing implementation result on resume without rerunning pi", async () => {
   const config = await makeConfig({

--- a/src/cli/commands/run-once/pipeline-finish.ts
+++ b/src/cli/commands/run-once/pipeline-finish.ts
@@ -19,7 +19,9 @@ import type {
   CommandRunner,
   IssueSummary,
 } from "./types.ts";
-import type { IssueHostProvider } from "../../../host/types.ts";
+import type { RunOnceHostProvider } from "../../../host/types.ts";
+import type { RunCostReport } from "./run-cost.ts";
+import { publishPrRunCost } from "./pr-cost-publication.ts";
 import type { PipelineSuccessfulImplementationResult } from "./pipeline-implementation.ts";
 
 export type PipelineFinishStageResult =
@@ -28,7 +30,7 @@ export type PipelineFinishStageResult =
 
 export type PipelineFinishStageOptions = {
   runner: CommandRunner;
-  host: IssueHostProvider;
+  host: RunOnceHostProvider;
   config: AgentIssueConfig;
   issue: IssueSummary;
   labels: string[];
@@ -38,6 +40,7 @@ export type PipelineFinishStageOptions = {
   needsInfoLabel: string;
   checkpoints: Record<string, boolean | undefined>;
   implemented: PipelineSuccessfulImplementationResult;
+  runCostReport?: RunCostReport;
   specPath: string | undefined;
   specCommit: string | undefined;
   planPath: string | undefined;
@@ -100,6 +103,7 @@ export async function runPipelineFinishStage(
         validation: implemented.validation,
         reviewSummary: implemented.reviewSummary,
         landingDecision: implemented.landingDecision,
+        runCostReport: options.runCostReport,
         visualEvidence:
           implemented.status === "pr-created"
             ? implemented.visualEvidence
@@ -110,6 +114,50 @@ export async function runPipelineFinishStage(
       timestamp,
     );
     checkpoints.implementationCompleted = true;
+
+    if (
+      implemented.status === "pr-created" &&
+      options.runCostReport &&
+      !checkpoints.prCostSummaryUpdated
+    ) {
+      try {
+        const publication = await publishPrRunCost({
+          host,
+          prUrl: implemented.prUrl,
+          report: options.runCostReport,
+        });
+        await writeRunState(
+          config.runStateDir,
+          {
+            issueNumber: issue.number,
+            status: "implementing",
+            checkpoints: { prCostSummaryUpdated: true },
+          },
+          timestamp,
+        );
+        checkpoints.prCostSummaryUpdated = true;
+        await emitProgress(
+          runOptions,
+          "info",
+          "run-cost",
+          `PR run-cost summary ${publication}`,
+          { issueNumber: issue.number, data: options.runCostReport },
+        );
+      } catch (error) {
+        await emitProgress(
+          runOptions,
+          "warning",
+          "run-cost",
+          "Patchmill could not update the PR run-cost summary",
+          {
+            issueNumber: issue.number,
+            data: error instanceof Error ? error.message : String(error),
+            consoleMessage:
+              "Warning: Patchmill could not update the PR run-cost summary",
+          },
+        );
+      }
+    }
 
     if (
       implemented.status === "pr-created" &&
@@ -146,6 +194,7 @@ export async function runPipelineFinishStage(
           validation: implemented.validation,
           reviewSummary: implemented.reviewSummary,
           landingDecision: implemented.landingDecision,
+          runCostReport: options.runCostReport,
           visualEvidence: validatedEvidence,
           checkpoints: { visualEvidenceValidated: true },
         },

--- a/src/cli/commands/run-once/pipeline-implementation-scenarios.test.ts
+++ b/src/cli/commands/run-once/pipeline-implementation-scenarios.test.ts
@@ -254,6 +254,7 @@ test("runOneIssue creates a missing plan, then creates a worktree and runs Pi fr
       "finding plan",
       "creating plan with pi",
       "running implementation with pi",
+      "Patchmill could not calculate the PR run-cost summary",
       "PR created: https://forgejo.example/pr/15",
       "removed local worktree .worktrees/patchmill-issue-15-ship-automation-pipeline",
       "deleted local branch agent/issue-15-ship-automation-pipeline",

--- a/src/cli/commands/run-once/pipeline-lifecycle.ts
+++ b/src/cli/commands/run-once/pipeline-lifecycle.ts
@@ -78,6 +78,7 @@ const RESUME_ONLY_SIDE_EFFECT_CHECKPOINTS = new Set<
   "planReadyCommentPosted",
   "worktreeReady",
   "implementationCompleted",
+  "prCostSummaryUpdated",
   "visualEvidenceValidated",
   "handoffCommentPosted",
   "doneLabelEnsured",

--- a/src/cli/commands/run-once/pipeline-run-cost.test.ts
+++ b/src/cli/commands/run-once/pipeline-run-cost.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolvePipelineRunCost } from "./pipeline-run-cost.ts";
+import type { RunCostReport } from "./run-cost.ts";
+
+const report: RunCostReport = {
+  stages: [
+    {
+      stage: "pi-implementation",
+      models: [
+        {
+          model: "gpt-5.5",
+          promptTokens: 6,
+          outputTokens: 4,
+          estimatedCostUsd: 0.1,
+        },
+      ],
+      promptTokens: 6,
+      outputTokens: 4,
+      estimatedCostUsd: 0.1,
+    },
+  ],
+  promptTokens: 6,
+  outputTokens: 4,
+  estimatedCostUsd: 0.1,
+};
+
+test("resolvePipelineRunCost resumes from a persisted report without recalculating", async () => {
+  let calculated = false;
+  const warnings: string[] = [];
+  const result = await resolvePipelineRunCost({
+    implementationKind: "already-implemented",
+    implementationStatus: "pr-created",
+    persistedReport: report,
+    calculate: async () => {
+      calculated = true;
+      return report;
+    },
+    warn(message) {
+      warnings.push(message);
+    },
+  });
+
+  assert.deepEqual(result, report);
+  assert.equal(calculated, false);
+  assert.deepEqual(warnings, []);
+});
+
+test("resolvePipelineRunCost warns without calculating legacy resumptions", async () => {
+  const warnings: string[] = [];
+  const result = await resolvePipelineRunCost({
+    implementationKind: "already-implemented",
+    implementationStatus: "pr-created",
+    calculate: async () => {
+      assert.fail("legacy resume must not calculate from a new session");
+    },
+    warn(message) {
+      warnings.push(message);
+    },
+  });
+
+  assert.equal(result, undefined);
+  assert.deepEqual(warnings, [
+    "Patchmill cannot publish a run-cost summary from legacy or invalid saved state",
+  ]);
+});

--- a/src/cli/commands/run-once/pipeline-run-cost.ts
+++ b/src/cli/commands/run-once/pipeline-run-cost.ts
@@ -1,0 +1,36 @@
+import { summarizeRunCost } from "./run-cost-files.ts";
+import { parseRunCostReport, type RunCostReport } from "./run-cost.ts";
+export type ResolvePipelineRunCostOptions = {
+  implementationKind: "implemented" | "already-implemented";
+  implementationStatus: "pr-created" | "merged";
+  piSessionPath?: string;
+  persistedReport?: unknown;
+  calculate?: (piSessionPath: string) => Promise<RunCostReport>;
+  warn(message: string, error?: unknown): void | Promise<void>;
+};
+export async function resolvePipelineRunCost(
+  options: ResolvePipelineRunCostOptions,
+): Promise<RunCostReport | undefined> {
+  if (options.implementationStatus !== "pr-created") return undefined;
+  if (options.implementationKind === "already-implemented") {
+    const report = parseRunCostReport(options.persistedReport);
+    if (!report)
+      await options.warn(
+        "Patchmill cannot publish a run-cost summary from legacy or invalid saved state",
+      );
+    return report;
+  }
+  if (!options.piSessionPath) {
+    await options.warn("Patchmill could not calculate the PR run-cost summary");
+    return undefined;
+  }
+  try {
+    return await (options.calculate ?? summarizeRunCost)(options.piSessionPath);
+  } catch (error) {
+    await options.warn(
+      "Patchmill could not calculate the PR run-cost summary",
+      error,
+    );
+    return undefined;
+  }
+}

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { localPiAgentDir } from "../init/pi-agent-settings.ts";
 
-import { createIssueHostProvider } from "../../../host/factory.ts";
+import { createRunOnceHostProvider } from "../../../host/factory.ts";
 import { planLabelChange } from "../triage/labels.ts";
 import { materializeIssueArtifactSources } from "./artifact-source-materialization.ts";
 import { runArtifactSourceStage } from "./artifact-source-stage.ts";
@@ -64,6 +64,7 @@ import {
 import { blockIssue, unexpectedFailure } from "./pipeline-failures.ts";
 import { runPipelineImplementationStage } from "./pipeline-implementation.ts";
 import { runPipelineFinishStage } from "./pipeline-finish.ts";
+import { resolvePipelineRunCost } from "./pipeline-run-cost.ts";
 import {
   runPiSessionPath,
   type AgentIssueProgressEvent,
@@ -102,7 +103,7 @@ export async function runOneIssue(
   config: AgentIssueConfig,
   options: RunOneIssueOptions = {},
 ): Promise<AgentIssuePipelineResult> {
-  const host = createIssueHostProvider({
+  const host = createRunOnceHostProvider({
     runner,
     repoRoot: config.repoRoot,
     host: config.host,
@@ -618,6 +619,19 @@ export async function runOneIssue(
     labels = implementationStage.labels;
     checkpoints.worktreeReady = true;
 
+    const runCostReport = await resolvePipelineRunCost({
+      implementationKind: implementationStage.kind,
+      implementationStatus: implementationStage.result.status,
+      piSessionPath: runOptions.piSessionPath,
+      persistedReport: existingState?.runCostReport,
+      warn: (message, error) =>
+        progress(runOptions, "warning", "run-cost", message, {
+          issueNumber: issue.number,
+          data: error instanceof Error ? error.message : String(error ?? ""),
+          consoleMessage: `Warning: ${message}`,
+        }),
+    });
+
     const finishStage = await runPipelineFinishStage({
       runner,
       host,
@@ -630,6 +644,7 @@ export async function runOneIssue(
       needsInfoLabel: needsInfo,
       checkpoints,
       implemented: implementationStage.result,
+      runCostReport,
       specPath,
       specCommit,
       planPath,

--- a/src/cli/commands/run-once/pr-cost-publication.test.ts
+++ b/src/cli/commands/run-once/pr-cost-publication.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PullRequestBodyHostProvider } from "../../../host/types.ts";
+import { publishPrRunCost } from "./pr-cost-publication.ts";
+import { renderRunCostSection } from "./pr-cost-summary.ts";
+import type { RunCostReport } from "./run-cost.ts";
+
+const report: RunCostReport = {
+  stages: [
+    {
+      stage: "pi-plan",
+      models: [
+        {
+          model: "gpt-5.5",
+          promptTokens: 6,
+          outputTokens: 4,
+          estimatedCostUsd: 0.1,
+        },
+      ],
+      promptTokens: 6,
+      outputTokens: 4,
+      estimatedCostUsd: 0.1,
+    },
+  ],
+  promptTokens: 6,
+  outputTokens: 4,
+  estimatedCostUsd: 0.1,
+};
+
+test("publishPrRunCost updates a changed body and skips an already-current body", async () => {
+  const updates: string[] = [];
+  const host: PullRequestBodyHostProvider = {
+    async readPullRequestBody() {
+      return "Summary\n";
+    },
+    async updatePullRequestBody(_, body) {
+      updates.push(body);
+    },
+  };
+  assert.equal(
+    await publishPrRunCost({
+      host,
+      prUrl: "https://github.com/acme/repo/pull/42",
+      report,
+    }),
+    "updated",
+  );
+  assert.equal(updates.length, 1);
+  assert.ok(updates[0]!.startsWith("Summary\n"));
+
+  const currentHost: PullRequestBodyHostProvider = {
+    async readPullRequestBody() {
+      return `Summary\n\n${renderRunCostSection(report)}`;
+    },
+    async updatePullRequestBody() {
+      assert.fail("already-current body must not be edited");
+    },
+  };
+  assert.equal(
+    await publishPrRunCost({
+      host: currentHost,
+      prUrl: "https://github.com/acme/repo/pull/42",
+      report,
+    }),
+    "unchanged",
+  );
+});

--- a/src/cli/commands/run-once/pr-cost-publication.ts
+++ b/src/cli/commands/run-once/pr-cost-publication.ts
@@ -1,0 +1,14 @@
+import type { PullRequestBodyHostProvider } from "../../../host/types.ts";
+import { upsertRunCostSection } from "./pr-cost-summary.ts";
+import type { RunCostReport } from "./run-cost.ts";
+export async function publishPrRunCost(options: {
+  host: PullRequestBodyHostProvider;
+  prUrl: string;
+  report: RunCostReport;
+}): Promise<"updated" | "unchanged"> {
+  const body = await options.host.readPullRequestBody(options.prUrl);
+  const next = upsertRunCostSection(body, options.report);
+  if (next === body) return "unchanged";
+  await options.host.updatePullRequestBody(options.prUrl, next);
+  return "updated";
+}

--- a/src/cli/commands/run-once/pr-cost-summary.test.ts
+++ b/src/cli/commands/run-once/pr-cost-summary.test.ts
@@ -37,6 +37,30 @@ test("renders escaped aggregate rows and replaces an existing generated region",
   assert.ok(result.endsWith("after"));
   assert.equal(upsertRunCostSection(result, report), result);
 });
+test("does not emit injected markers from table cells on retry", () => {
+  const maliciousReport = {
+    ...report,
+    stages: [
+      {
+        ...report.stages[0],
+        models: [
+          {
+            ...report.stages[0].models[0],
+            model: "<!-- patchmill-run-cost:start -->",
+          },
+        ],
+      },
+    ],
+  };
+
+  const once = upsertRunCostSection("Summary\n", maliciousReport);
+  assert.equal(upsertRunCostSection(once, maliciousReport), once);
+  assert.equal(
+    once.includes("| Implementation | <!-- patchmill-run-cost:start --> |"),
+    false,
+  );
+});
+
 test("rejects unsafe marker shapes", () => {
   assert.throws(
     () => upsertRunCostSection("<!-- patchmill-run-cost:start -->", report),

--- a/src/cli/commands/run-once/pr-cost-summary.test.ts
+++ b/src/cli/commands/run-once/pr-cost-summary.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PrCostSummaryError,
+  renderRunCostSection,
+  upsertRunCostSection,
+} from "./pr-cost-summary.ts";
+const report = {
+  stages: [
+    {
+      stage: "pi-implementation",
+      models: [
+        {
+          model: "bad|model\nrow",
+          promptTokens: 10,
+          outputTokens: 2,
+          estimatedCostUsd: 0,
+        },
+      ],
+      promptTokens: 10,
+      outputTokens: 2,
+      estimatedCostUsd: 0,
+    },
+  ],
+  promptTokens: 10,
+  outputTokens: 2,
+  estimatedCostUsd: 0,
+};
+test("renders escaped aggregate rows and replaces an existing generated region", () => {
+  const rendered = renderRunCostSection(report);
+  assert.match(rendered, /bad\\\|model row/u);
+  assert.match(rendered, /\$0\.0000/u);
+  const body =
+    "before\n<!-- patchmill-run-cost:start -->old<!-- patchmill-run-cost:end -->after";
+  const result = upsertRunCostSection(body, report);
+  assert.ok(result.startsWith("before\n"));
+  assert.ok(result.endsWith("after"));
+  assert.equal(upsertRunCostSection(result, report), result);
+});
+test("rejects unsafe marker shapes", () => {
+  assert.throws(
+    () => upsertRunCostSection("<!-- patchmill-run-cost:start -->", report),
+    PrCostSummaryError,
+  );
+});

--- a/src/cli/commands/run-once/pr-cost-summary.ts
+++ b/src/cli/commands/run-once/pr-cost-summary.ts
@@ -12,6 +12,8 @@ function escapeCell(value: string): string {
   return value
     .replaceAll("\\", "\\\\")
     .replaceAll("|", "\\|")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
     .replace(/[\r\n]+/gu, " ")
     .trim();
 }

--- a/src/cli/commands/run-once/pr-cost-summary.ts
+++ b/src/cli/commands/run-once/pr-cost-summary.ts
@@ -1,0 +1,89 @@
+import type { RunCostReport } from "./run-cost.ts";
+const START_MARKER = "<!-- patchmill-run-cost:start -->";
+const END_MARKER = "<!-- patchmill-run-cost:end -->";
+const TOKEN_FORMAT = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  useGrouping: true,
+});
+export class PrCostSummaryError extends Error {
+  readonly name = "PrCostSummaryError";
+}
+function escapeCell(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replace(/[\r\n]+/gu, " ")
+    .trim();
+}
+function stageLabel(stage: string): string {
+  const known: Record<string, string> = {
+    "pi-artifact-extraction": "Artifact extraction",
+    "pi-plan": "Planning",
+    "pi-development-environment": "Development environment",
+    "pi-implementation": "Implementation",
+  };
+  const fallback = stage.replace(/^pi-/u, "").replace(/[-_]+/gu, " ").trim();
+  const label = known[stage] ?? (fallback || "Unknown stage");
+  return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
+}
+function row(
+  stage: string,
+  model: string,
+  prompt: number,
+  output: number,
+  cost: number,
+): string {
+  return `| ${stage} | ${model} | ${TOKEN_FORMAT.format(prompt)} | ${TOKEN_FORMAT.format(output)} | $${cost.toFixed(4)} |`;
+}
+export function renderRunCostSection(report: RunCostReport): string {
+  const rows = report.stages.flatMap((stage) => {
+    const stageRows = stage.models.map((model) =>
+      row(
+        escapeCell(stageLabel(stage.stage)),
+        escapeCell(model.model),
+        model.promptTokens,
+        model.outputTokens,
+        model.estimatedCostUsd,
+      ),
+    );
+    if (stage.models.length > 1)
+      stageRows.push(
+        `| **${escapeCell(stageLabel(stage.stage))} subtotal** |  | **${TOKEN_FORMAT.format(stage.promptTokens)}** | **${TOKEN_FORMAT.format(stage.outputTokens)}** | **$${stage.estimatedCostUsd.toFixed(4)}** |`,
+      );
+    return stageRows;
+  });
+  return [
+    START_MARKER,
+    "",
+    "## Patchmill run cost",
+    "",
+    "| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |",
+    "| ----- | ----- | ------------: | ------------: | -------------------: |",
+    ...rows,
+    `| **Total** |  | **${TOKEN_FORMAT.format(report.promptTokens)}** | **${TOKEN_FORMAT.format(report.outputTokens)}** | **$${report.estimatedCostUsd.toFixed(4)}** |`,
+    "",
+    "_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._",
+    "",
+    END_MARKER,
+  ].join("\n");
+}
+function occurrences(body: string, marker: string): number {
+  return body.split(marker).length - 1;
+}
+export function upsertRunCostSection(
+  body: string,
+  report: RunCostReport,
+): string {
+  const starts = occurrences(body, START_MARKER),
+    ends = occurrences(body, END_MARKER),
+    section = renderRunCostSection(report);
+  if (starts === 0 && ends === 0)
+    return `${body}${body.length === 0 || body.endsWith("\n\n") ? "" : body.endsWith("\n") ? "\n" : "\n\n"}${section}`;
+  if (starts !== 1 || ends !== 1)
+    throw new PrCostSummaryError("Malformed Patchmill run-cost markers");
+  const start = body.indexOf(START_MARKER),
+    end = body.indexOf(END_MARKER);
+  if (end < start)
+    throw new PrCostSummaryError("Malformed Patchmill run-cost markers");
+  return `${body.slice(0, start)}${section}${body.slice(end + END_MARKER.length)}`;
+}

--- a/src/cli/commands/run-once/progress.ts
+++ b/src/cli/commands/run-once/progress.ts
@@ -16,7 +16,7 @@ export type AgentIssueStepEvent =
 
 export type AgentIssueProgressEvent = {
   time: string;
-  level: "info" | "heartbeat" | "error" | "debug";
+  level: "info" | "warning" | "heartbeat" | "error" | "debug";
   stage: string;
   message: string;
   consoleMessage?: string;

--- a/src/cli/commands/run-once/run-cost-files.test.ts
+++ b/src/cli/commands/run-once/run-cost-files.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { summarizeRunCost, type RunCostIo } from "./run-cost-files.ts";
+
+function assistant(id: string): string {
+  return JSON.stringify({
+    type: "message",
+    id,
+    message: {
+      role: "assistant",
+      model: "gpt-5.5",
+      usage: {
+        input: 1,
+        cacheRead: 2,
+        cacheWrite: 3,
+        output: 4,
+        cost: { total: 0.1 },
+      },
+    },
+  });
+}
+
+function ioFor(
+  files: Record<string, { content: string; mtimeMs: number }>,
+): RunCostIo {
+  const paths = Object.keys(files);
+  return {
+    async listJsonlFiles() {
+      return paths;
+    },
+    async stat(path) {
+      const file = files[path];
+      if (!file) throw new Error(`missing ${path}`);
+      return { size: file.content.length, mtimeMs: file.mtimeMs };
+    },
+    async readFile(path) {
+      const file = files[path];
+      if (!file) throw new Error(`missing ${path}`);
+      return file.content;
+    },
+  };
+}
+
+test("summarizeRunCost uses filename timestamps before mtime when session timestamps are invalid", async () => {
+  const report = await summarizeRunCost(
+    "/sessions",
+    ioFor({
+      "/sessions/pi-plan/2026-07-19T12-00-00-000Z_plan.jsonl": {
+        content: `${JSON.stringify({ type: "session", timestamp: "invalid" })}\n${assistant("copied")}\n`,
+        mtimeMs: 10,
+      },
+      "/sessions/pi-implementation/2026-07-19T11-00-00-000Z_implementation.jsonl":
+        {
+          content: `${JSON.stringify({ type: "session", timestamp: "invalid" })}\n${assistant("copied")}\n`,
+          mtimeMs: 20,
+        },
+    }),
+  );
+
+  assert.deepEqual(
+    report.stages.map((stage) => stage.stage),
+    ["pi-implementation"],
+  );
+});
+
+test("summarizeRunCost prioritizes valid session timestamps over filename timestamps", async () => {
+  const report = await summarizeRunCost(
+    "/sessions",
+    ioFor({
+      "/sessions/pi-plan/2026-07-19T11-00-00-000Z_plan.jsonl": {
+        content: `${JSON.stringify({ type: "session", timestamp: "2026-07-19T12:00:00.000Z" })}\n${assistant("copied")}\n`,
+        mtimeMs: 1,
+      },
+      "/sessions/pi-implementation/2026-07-19T13-00-00-000Z_implementation.jsonl":
+        {
+          content: `${JSON.stringify({ type: "session", timestamp: "2026-07-19T10:00:00.000Z" })}\n${assistant("copied")}\n`,
+          mtimeMs: 20,
+        },
+    }),
+  );
+
+  assert.deepEqual(
+    report.stages.map((stage) => stage.stage),
+    ["pi-implementation"],
+  );
+});
+
+test("summarizeRunCost uses mtime only when session and filename timestamps are unavailable", async () => {
+  const report = await summarizeRunCost(
+    "/sessions",
+    ioFor({
+      "/sessions/pi-plan/no-timestamp_plan.jsonl": {
+        content: `${JSON.stringify({ type: "session", timestamp: "invalid" })}\n${assistant("copied")}\n`,
+        mtimeMs: 20,
+      },
+      "/sessions/pi-implementation/no-timestamp_implementation.jsonl": {
+        content: `${JSON.stringify({ type: "session", timestamp: "invalid" })}\n${assistant("copied")}\n`,
+        mtimeMs: 10,
+      },
+    }),
+  );
+
+  assert.deepEqual(
+    report.stages.map((stage) => stage.stage),
+    ["pi-implementation"],
+  );
+});
+
+test("summarizeRunCost rejects a session manifest that changes after reading", async () => {
+  let listings = 0;
+  const io: RunCostIo = {
+    async listJsonlFiles() {
+      listings += 1;
+      return listings === 1
+        ? ["/sessions/a.jsonl"]
+        : ["/sessions/a.jsonl", "/sessions/b.jsonl"];
+    },
+    async stat() {
+      return { size: 1, mtimeMs: 1 };
+    },
+    async readFile() {
+      return "";
+    },
+  };
+
+  await assert.rejects(
+    () => summarizeRunCost("/sessions", io),
+    /Pi session files changed while calculating run cost/u,
+  );
+});

--- a/src/cli/commands/run-once/run-cost-files.test.ts
+++ b/src/cli/commands/run-once/run-cost-files.test.ts
@@ -106,6 +106,30 @@ test("summarizeRunCost uses mtime only when session and filename timestamps are 
   );
 });
 
+test("summarizeRunCost parses captured JSONL before checking the post-read manifest", async () => {
+  let listings = 0;
+  const io: RunCostIo = {
+    async listJsonlFiles() {
+      listings += 1;
+      return listings === 1
+        ? ["/sessions/a.jsonl"]
+        : ["/sessions/a.jsonl", "/sessions/b.jsonl"];
+    },
+    async stat() {
+      return { size: 1, mtimeMs: 1 };
+    },
+    async readFile() {
+      return "{not-json}\n";
+    },
+  };
+
+  await assert.rejects(
+    () => summarizeRunCost("/sessions", io),
+    /Malformed Pi session JSON/u,
+  );
+  assert.equal(listings, 1);
+});
+
 test("summarizeRunCost rejects a session manifest that changes after reading", async () => {
   let listings = 0;
   const io: RunCostIo = {
@@ -119,7 +143,7 @@ test("summarizeRunCost rejects a session manifest that changes after reading", a
       return { size: 1, mtimeMs: 1 };
     },
     async readFile() {
-      return "";
+      return `${assistant("entry-a")}\n`;
     },
   };
 

--- a/src/cli/commands/run-once/run-cost-files.ts
+++ b/src/cli/commands/run-once/run-cost-files.ts
@@ -45,7 +45,9 @@ function startedAt(content: string, path: string, fallback: number): number {
       /* aggregation reports nonblank malformed JSON */
     }
   }
-  const match = /^(\d{4}-\d\d-\d\dT\d\d-\d\d-\d\d\dZ)_/u.exec(basename(path));
+  const match = /^(\d{4}-\d\d-\d\dT\d\d-\d\d-\d\d-\d\d\dZ)_/u.exec(
+    basename(path),
+  );
   if (match) {
     const time = Date.parse(
       match[1].replace(/T(\d\d)-(\d\d)-(\d\d)-(\d\d\d)Z/u, "T$1:$2:$3.$4Z"),

--- a/src/cli/commands/run-once/run-cost-files.ts
+++ b/src/cli/commands/run-once/run-cost-files.ts
@@ -87,6 +87,7 @@ export async function summarizeRunCost(
       content,
     });
   }
+  const report = aggregateRunCost(files);
   const afterPaths = await io.listJsonlFiles(piSessionPath);
   const after = new Map(
     await Promise.all(
@@ -97,5 +98,5 @@ export async function summarizeRunCost(
     throw new RunCostReportError(
       "Pi session files changed while calculating run cost",
     );
-  return aggregateRunCost(files);
+  return report;
 }

--- a/src/cli/commands/run-once/run-cost-files.ts
+++ b/src/cli/commands/run-once/run-cost-files.ts
@@ -1,0 +1,99 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, join, relative } from "node:path";
+import {
+  aggregateRunCost,
+  RunCostReportError,
+  type RunCostReport,
+  type RunCostSessionFile,
+} from "./run-cost.ts";
+export type RunCostFileInfo = { size: number; mtimeMs: number };
+export type RunCostIo = {
+  listJsonlFiles(root: string): Promise<string[]>;
+  stat(path: string): Promise<RunCostFileInfo>;
+  readFile(path: string): Promise<string>;
+};
+async function list(root: string): Promise<string[]> {
+  const result: string[] = [];
+  async function visit(dir: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile() && entry.name.endsWith(".jsonl"))
+        result.push(path);
+    }
+  }
+  await visit(root);
+  return result.sort((a, b) => a.localeCompare(b));
+}
+export const nodeRunCostIo: RunCostIo = {
+  listJsonlFiles: list,
+  stat: async (path) => {
+    const info = await stat(path);
+    return { size: info.size, mtimeMs: info.mtimeMs };
+  },
+  readFile: (path) => readFile(path, "utf8"),
+};
+function startedAt(content: string, path: string, fallback: number): number {
+  for (const line of content.split(/\r?\n/u)) {
+    try {
+      const entry = JSON.parse(line) as { type?: unknown; timestamp?: unknown };
+      if (entry.type === "session" && typeof entry.timestamp === "string") {
+        const time = Date.parse(entry.timestamp);
+        if (!Number.isNaN(time)) return time;
+      }
+    } catch {
+      /* aggregation reports nonblank malformed JSON */
+    }
+  }
+  const match = /^(\d{4}-\d\d-\d\dT\d\d-\d\d-\d\d\dZ)_/u.exec(basename(path));
+  if (match) {
+    const time = Date.parse(
+      match[1].replace(/T(\d\d)-(\d\d)-(\d\d)-(\d\d\d)Z/u, "T$1:$2:$3.$4Z"),
+    );
+    if (!Number.isNaN(time)) return time;
+  }
+  return fallback;
+}
+function same(
+  left: Map<string, RunCostFileInfo>,
+  right: Map<string, RunCostFileInfo>,
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every(([path, info]) => {
+      const other = right.get(path);
+      return other?.size === info.size && other.mtimeMs === info.mtimeMs;
+    })
+  );
+}
+export async function summarizeRunCost(
+  piSessionPath: string,
+  io: RunCostIo = nodeRunCostIo,
+): Promise<RunCostReport> {
+  const paths = await io.listJsonlFiles(piSessionPath);
+  const before = new Map(
+    await Promise.all(
+      paths.map(async (path) => [path, await io.stat(path)] as const),
+    ),
+  );
+  const files: RunCostSessionFile[] = [];
+  for (const path of paths) {
+    const content = await io.readFile(path);
+    files.push({
+      relativePath: relative(piSessionPath, path),
+      startedAtMs: startedAt(content, path, before.get(path)!.mtimeMs),
+      content,
+    });
+  }
+  const afterPaths = await io.listJsonlFiles(piSessionPath);
+  const after = new Map(
+    await Promise.all(
+      afterPaths.map(async (path) => [path, await io.stat(path)] as const),
+    ),
+  );
+  if (!same(before, after))
+    throw new RunCostReportError(
+      "Pi session files changed while calculating run cost",
+    );
+  return aggregateRunCost(files);
+}

--- a/src/cli/commands/run-once/run-cost.test.ts
+++ b/src/cli/commands/run-once/run-cost.test.ts
@@ -66,3 +66,43 @@ test("rejects conflicting accounting and invalid persisted totals", () => {
     undefined,
   );
 });
+
+test("rejects empty persisted reports while accepting recorded zero usage", () => {
+  const zeroModel = {
+    model: "local-model",
+    promptTokens: 0,
+    outputTokens: 0,
+    estimatedCostUsd: 0,
+  };
+  const zeroStage = {
+    stage: "pi-plan",
+    models: [zeroModel],
+    promptTokens: 0,
+    outputTokens: 0,
+    estimatedCostUsd: 0,
+  };
+  const zeroReport = {
+    stages: [zeroStage],
+    promptTokens: 0,
+    outputTokens: 0,
+    estimatedCostUsd: 0,
+  };
+
+  assert.equal(
+    parseRunCostReport({
+      stages: [],
+      promptTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+    }),
+    undefined,
+  );
+  assert.equal(
+    parseRunCostReport({
+      ...zeroReport,
+      stages: [{ ...zeroStage, models: [] }],
+    }),
+    undefined,
+  );
+  assert.deepEqual(parseRunCostReport(zeroReport), zeroReport);
+});

--- a/src/cli/commands/run-once/run-cost.test.ts
+++ b/src/cli/commands/run-once/run-cost.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { aggregateRunCost, parseRunCostReport } from "./run-cost.ts";
+const entry = (id: string, model: string, input: number, cost: number) => ({
+  type: "message",
+  id,
+  message: {
+    role: "assistant",
+    model,
+    usage: {
+      input,
+      cacheRead: 2,
+      cacheWrite: 3,
+      output: 4,
+      cost: { total: cost },
+    },
+  },
+});
+test("aggregates copied session history once at its earliest stage", () => {
+  const planning = entry("a", "gpt", 1, 0.1);
+  const report = aggregateRunCost([
+    {
+      relativePath: "pi-plan/a.jsonl",
+      startedAtMs: 1,
+      content: `${JSON.stringify(planning)}\n`,
+    },
+    {
+      relativePath: "pi-implementation/b.jsonl",
+      startedAtMs: 2,
+      content: `${JSON.stringify(planning)}\n${JSON.stringify(entry("b", "terra", 5, 0.2))}\n`,
+    },
+  ]);
+  assert.deepEqual(
+    report.stages.map((stage) => [stage.stage, stage.promptTokens]),
+    [
+      ["pi-plan", 6],
+      ["pi-implementation", 10],
+    ],
+  );
+  assert.equal(report.estimatedCostUsd, 0.30000000000000004);
+});
+test("rejects conflicting accounting and invalid persisted totals", () => {
+  assert.throws(
+    () =>
+      aggregateRunCost([
+        {
+          relativePath: "pi-plan/a",
+          startedAtMs: 1,
+          content: `${JSON.stringify(entry("a", "gpt", 1, 1))}\n`,
+        },
+        {
+          relativePath: "pi-plan/b",
+          startedAtMs: 2,
+          content: `${JSON.stringify(entry("a", "gpt", 1, 2))}\n`,
+        },
+      ]),
+    /Conflicting/u,
+  );
+  assert.equal(
+    parseRunCostReport({
+      stages: [],
+      promptTokens: 1,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+    }),
+    undefined,
+  );
+});

--- a/src/cli/commands/run-once/run-cost.ts
+++ b/src/cli/commands/run-once/run-cost.ts
@@ -184,6 +184,7 @@ export function parseRunCostReport(value: unknown): RunCostReport | undefined {
   if (
     !raw ||
     !Array.isArray(raw.stages) ||
+    raw.stages.length === 0 ||
     !validNumber(raw.promptTokens) ||
     !validNumber(raw.outputTokens) ||
     !validNumber(raw.estimatedCostUsd)
@@ -196,6 +197,7 @@ export function parseRunCostReport(value: unknown): RunCostReport | undefined {
       !stage ||
       typeof stage.stage !== "string" ||
       !Array.isArray(stage.models) ||
+      stage.models.length === 0 ||
       !validNumber(stage.promptTokens) ||
       !validNumber(stage.outputTokens) ||
       !validNumber(stage.estimatedCostUsd)

--- a/src/cli/commands/run-once/run-cost.ts
+++ b/src/cli/commands/run-once/run-cost.ts
@@ -1,0 +1,233 @@
+export type RunCostModelUsage = {
+  model: string;
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+export type RunCostStageUsage = {
+  stage: string;
+  models: RunCostModelUsage[];
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+export type RunCostReport = {
+  stages: RunCostStageUsage[];
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+export type RunCostSessionFile = {
+  relativePath: string;
+  startedAtMs: number;
+  content: string;
+};
+
+export class RunCostReportError extends Error {
+  readonly name = "RunCostReportError";
+}
+
+const STAGE_ORDER = [
+  "pi-artifact-extraction",
+  "pi-plan",
+  "pi-development-environment",
+  "pi-implementation",
+] as const;
+type Usage = {
+  id: string;
+  fingerprint: string;
+  model: string;
+  promptTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+};
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+function amount(value: unknown, field: string, path: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0)
+    throw new RunCostReportError(`Invalid assistant usage ${field} in ${path}`);
+  return value;
+}
+function assistantUsage(entry: unknown, path: string): Usage | undefined {
+  const item = record(entry);
+  const message = record(item?.message);
+  if (item?.type !== "message" || message?.role !== "assistant")
+    return undefined;
+  if (typeof item.id !== "string" || item.id.trim().length === 0)
+    throw new RunCostReportError(
+      `Assistant entry missing stable id in ${path}`,
+    );
+  const usage = record(message.usage);
+  const cost = record(usage?.cost);
+  if (!usage || !cost)
+    throw new RunCostReportError(`Invalid assistant usage in ${path}`);
+  const input = amount(usage.input, "input", path);
+  const cacheRead = amount(usage.cacheRead, "cacheRead", path);
+  const cacheWrite = amount(usage.cacheWrite, "cacheWrite", path);
+  const outputTokens = amount(usage.output, "output", path);
+  const estimatedCostUsd = amount(cost.total, "cost.total", path);
+  const model =
+    typeof message.model === "string" && message.model.trim()
+      ? message.model.trim()
+      : "Unknown model";
+  const promptTokens = input + cacheRead + cacheWrite;
+  return {
+    id: item.id,
+    model,
+    promptTokens,
+    outputTokens,
+    estimatedCostUsd,
+    fingerprint: JSON.stringify({
+      model,
+      promptTokens,
+      outputTokens,
+      estimatedCostUsd,
+    }),
+  };
+}
+function total(
+  rows: readonly RunCostModelUsage[],
+): Omit<RunCostModelUsage, "model"> {
+  return rows.reduce(
+    (sum, row) => ({
+      promptTokens: sum.promptTokens + row.promptTokens,
+      outputTokens: sum.outputTokens + row.outputTokens,
+      estimatedCostUsd: sum.estimatedCostUsd + row.estimatedCostUsd,
+    }),
+    { promptTokens: 0, outputTokens: 0, estimatedCostUsd: 0 },
+  );
+}
+export function aggregateRunCost(files: RunCostSessionFile[]): RunCostReport {
+  const entries = new Map<string, Usage & { stage: string }>();
+  for (const file of [...files].sort(
+    (a, b) =>
+      a.startedAtMs - b.startedAtMs ||
+      a.relativePath.localeCompare(b.relativePath),
+  )) {
+    const stage = file.relativePath.split(/[\\/]/u)[0] || "unknown";
+    for (const [index, line] of file.content.split(/\r?\n/u).entries()) {
+      if (!line.trim()) continue;
+      let entry: unknown;
+      try {
+        entry = JSON.parse(line);
+      } catch (cause) {
+        throw new RunCostReportError(
+          `Malformed Pi session JSON in ${file.relativePath}:${index + 1}`,
+          { cause },
+        );
+      }
+      const usage = assistantUsage(entry, `${file.relativePath}:${index + 1}`);
+      if (!usage) continue;
+      const old = entries.get(usage.id);
+      if (old && old.fingerprint !== usage.fingerprint)
+        throw new RunCostReportError(
+          `Conflicting Pi session entry ${usage.id}`,
+        );
+      if (!old) entries.set(usage.id, { ...usage, stage });
+    }
+  }
+  if (!entries.size)
+    throw new RunCostReportError("No assistant usage records found");
+  const groups = new Map<string, Map<string, RunCostModelUsage>>();
+  for (const entry of entries.values()) {
+    const models =
+      groups.get(entry.stage) ?? new Map<string, RunCostModelUsage>();
+    const prior = models.get(entry.model) ?? {
+      model: entry.model,
+      promptTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+    };
+    models.set(entry.model, {
+      model: entry.model,
+      promptTokens: prior.promptTokens + entry.promptTokens,
+      outputTokens: prior.outputTokens + entry.outputTokens,
+      estimatedCostUsd: prior.estimatedCostUsd + entry.estimatedCostUsd,
+    });
+    groups.set(entry.stage, models);
+  }
+  const stages = [...groups.keys()]
+    .sort((a, b) => {
+      const ai = STAGE_ORDER.indexOf(a as (typeof STAGE_ORDER)[number]);
+      const bi = STAGE_ORDER.indexOf(b as (typeof STAGE_ORDER)[number]);
+      return (
+        (ai < 0 ? STAGE_ORDER.length : ai) -
+          (bi < 0 ? STAGE_ORDER.length : bi) || a.localeCompare(b)
+      );
+    })
+    .map((stage) => {
+      const models = [...groups.get(stage)!.values()].sort((a, b) =>
+        a.model.localeCompare(b.model),
+      );
+      return { stage, models, ...total(models) };
+    });
+  return { stages, ...total(stages) };
+}
+function validNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+function sameTotals(
+  left: Omit<RunCostModelUsage, "model">,
+  right: Omit<RunCostModelUsage, "model">,
+): boolean {
+  return (
+    left.promptTokens === right.promptTokens &&
+    left.outputTokens === right.outputTokens &&
+    left.estimatedCostUsd === right.estimatedCostUsd
+  );
+}
+export function parseRunCostReport(value: unknown): RunCostReport | undefined {
+  const raw = record(value);
+  if (
+    !raw ||
+    !Array.isArray(raw.stages) ||
+    !validNumber(raw.promptTokens) ||
+    !validNumber(raw.outputTokens) ||
+    !validNumber(raw.estimatedCostUsd)
+  )
+    return undefined;
+  const stages: RunCostStageUsage[] = [];
+  for (const rawStage of raw.stages) {
+    const stage = record(rawStage);
+    if (
+      !stage ||
+      typeof stage.stage !== "string" ||
+      !Array.isArray(stage.models) ||
+      !validNumber(stage.promptTokens) ||
+      !validNumber(stage.outputTokens) ||
+      !validNumber(stage.estimatedCostUsd)
+    )
+      return undefined;
+    const models: RunCostModelUsage[] = [];
+    for (const rawModel of stage.models) {
+      const model = record(rawModel);
+      if (
+        !model ||
+        typeof model.model !== "string" ||
+        !validNumber(model.promptTokens) ||
+        !validNumber(model.outputTokens) ||
+        !validNumber(model.estimatedCostUsd)
+      )
+        return undefined;
+      models.push({
+        model: model.model,
+        promptTokens: model.promptTokens,
+        outputTokens: model.outputTokens,
+        estimatedCostUsd: model.estimatedCostUsd,
+      });
+    }
+    const totals = total(models);
+    if (
+      !sameTotals(totals, stage as Omit<RunCostStageUsage, "stage" | "models">)
+    )
+      return undefined;
+    stages.push({ stage: stage.stage, models, ...totals });
+  }
+  const totals = total(stages);
+  return sameTotals(totals, raw as Omit<RunCostReport, "stages">)
+    ? { stages, ...totals }
+    : undefined;
+}

--- a/src/cli/commands/run-once/run-state.test.ts
+++ b/src/cli/commands/run-once/run-state.test.ts
@@ -149,6 +149,51 @@ test("writeRunState preserves issue details, timestamps, and last error across s
   assert.deepEqual(reread, finished);
 });
 
+test("writeRunState preserves a persisted cost report when checkpointing its publication", async () => {
+  const runStateDir = await mkdtemp(
+    join(tmpdir(), "patchmill-run-cost-state-"),
+  );
+  const runCostReport = {
+    stages: [
+      {
+        stage: "pi-implementation",
+        models: [
+          {
+            model: "gpt-5.5",
+            promptTokens: 6,
+            outputTokens: 4,
+            estimatedCostUsd: 0.1,
+          },
+        ],
+        promptTokens: 6,
+        outputTokens: 4,
+        estimatedCostUsd: 0.1,
+      },
+    ],
+    promptTokens: 6,
+    outputTokens: 4,
+    estimatedCostUsd: 0.1,
+  };
+  await writeRunState(runStateDir, {
+    issueNumber: 45,
+    title: "Resume cost publication",
+    status: "implementing",
+    implementationStatus: "pr-created",
+    prUrl: "https://github.com/acme/repo/pull/45",
+    runCostReport,
+    checkpoints: { implementationCompleted: true },
+  });
+
+  const state = await writeRunState(runStateDir, {
+    issueNumber: 45,
+    status: "implementing",
+    checkpoints: { prCostSummaryUpdated: true },
+  });
+
+  assert.deepEqual(state.runCostReport, runCostReport);
+  assert.equal(state.checkpoints.prCostSummaryUpdated, true);
+});
+
 test("writeRunState merges checkpoint updates", async () => {
   const repoRoot = await mkdtemp(
     join(tmpdir(), "agent-issue-run-state-checkpoints-"),

--- a/src/cli/commands/run-once/run-state.ts
+++ b/src/cli/commands/run-once/run-state.ts
@@ -98,6 +98,7 @@ function mergeRunState(
     "validation",
     "reviewSummary",
     "landingDecision",
+    "runCostReport",
     "visualEvidence",
   ].some((key) => Object.hasOwn(update, key));
   const implementationStatus = hasImplementationUpdate
@@ -127,6 +128,12 @@ function mergeRunState(
   const landingDecision = hasImplementationUpdate
     ? update.landingDecision
     : existingImplementation?.landingDecision;
+  const runCostReport =
+    update.implementationStatus === "merged"
+      ? undefined
+      : hasImplementationUpdate
+        ? update.runCostReport
+        : existingImplementation?.runCostReport;
   const visualEvidence = hasImplementationUpdate
     ? update.visualEvidence
     : existingImplementation?.visualEvidence;
@@ -176,6 +183,7 @@ function mergeRunState(
     validation,
     reviewSummary,
     landingDecision,
+    runCostReport,
     visualEvidence,
     handoffCommentPosted: handoffCommentPosted ? true : undefined,
     failureCommentKeys,
@@ -222,6 +230,9 @@ function mergeRunState(
   }
   if (landingDecision === undefined) {
     delete next.landingDecision;
+  }
+  if (runCostReport === undefined) {
+    delete next.runCostReport;
   }
   if (visualEvidence === undefined) {
     delete next.visualEvidence;

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -4,6 +4,7 @@ import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import type { PatchmillLabelCatalog } from "../../../policy/label-catalog.ts";
 import type { WorkflowApprovalPolicy } from "../../../workflow/approval-policy.ts";
 import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
+import type { RunCostReport } from "./run-cost.ts";
 
 export type {
   CommandResult,
@@ -104,6 +105,7 @@ export type AgentIssueRunCheckpoint =
   | "readyLabelRestored"
   | "worktreeReady"
   | "implementationCompleted"
+  | "prCostSummaryUpdated"
   | "visualEvidenceValidated"
   | "handoffCommentPosted"
   | "doneLabelEnsured"
@@ -131,6 +133,7 @@ export type AgentIssueRunState = {
   validation?: string[];
   reviewSummary?: string;
   landingDecision?: string;
+  runCostReport?: RunCostReport;
   visualEvidence?: AgentIssueVisualEvidence[];
   handoffCommentPosted?: boolean;
   failureCommentKeys?: string[];
@@ -164,6 +167,7 @@ export type AgentIssueRunStateUpdate = {
   validation?: string[];
   reviewSummary?: string;
   landingDecision?: string;
+  runCostReport?: RunCostReport;
   visualEvidence?: AgentIssueVisualEvidence[];
   handoffCommentPosted?: boolean;
   failureCommentKeys?: string[];

--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -5,6 +5,7 @@ import { GitHubGhHostProvider } from "./github-gh.ts";
 import type {
   IssueHostProvider,
   RepositorySetupHostProvider,
+  RunOnceHostProvider,
 } from "./types.ts";
 
 function createHostProvider(options: {
@@ -40,5 +41,13 @@ export function createIssueHostProvider(options: {
   repoRoot: string;
   host: PatchmillHostConfig;
 }): IssueHostProvider {
+  return createHostProvider(options);
+}
+
+export function createRunOnceHostProvider(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  host: PatchmillHostConfig;
+}): RunOnceHostProvider {
   return createHostProvider(options);
 }

--- a/src/host/forgejo-pr-body.test.ts
+++ b/src/host/forgejo-pr-body.test.ts
@@ -26,6 +26,50 @@ async function withRepo(
   }
 }
 
+test("Forgejo PR body adapter reads the configured PR body", async () => {
+  await withRepo(async (repoRoot) => {
+    const calls: Array<{
+      command: string;
+      args: string[];
+      options: unknown;
+    }> = [];
+    const runner: CommandRunner = {
+      async run(command, args, options) {
+        calls.push({ command, args, options });
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            body: "Summary\n",
+            html_url: "https://git.example/acme/repo/pulls/42",
+          }),
+          stderr: "",
+        };
+      },
+    };
+
+    const body = await readForgejoPullRequestBody(
+      { runner, repoRoot, login: "robot" },
+      "https://git.example/acme/repo/pulls/42",
+    );
+
+    assert.equal(body, "Summary\n");
+    assert.deepEqual(calls, [
+      {
+        command: "tea",
+        args: [
+          "api",
+          "/repos/{owner}/{repo}/pulls/42",
+          "--repo",
+          "acme/repo",
+          "--login",
+          "robot",
+        ],
+        options: { cwd: repoRoot },
+      },
+    ]);
+  });
+});
+
 test("Forgejo PR body adapter validates returned repository URLs", async () => {
   await withRepo(async (repoRoot) => {
     const runner: CommandRunner = {

--- a/src/host/forgejo-pr-body.test.ts
+++ b/src/host/forgejo-pr-body.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp, rm } from "node:fs/promises";
+import test from "node:test";
+import {
+  readForgejoPullRequestBody,
+  updateForgejoPullRequestBody,
+} from "./forgejo-pr-body.ts";
+import type { CommandRunner } from "../cli/commands/triage/types.ts";
+
+async function withRepo(
+  fn: (repoRoot: string) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "patchmill-forgejo-pr-body-"));
+  try {
+    await mkdir(join(root, ".git"));
+    await writeFile(
+      join(root, ".git", "config"),
+      '[remote "origin"]\n\turl = git@git.example:acme/repo.git\n',
+    );
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("Forgejo PR body adapter validates returned repository URLs", async () => {
+  await withRepo(async (repoRoot) => {
+    const runner: CommandRunner = {
+      async run() {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            body: "Summary",
+            html_url: "https://git.example/other/repo/pulls/42",
+          }),
+          stderr: "",
+        };
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        readForgejoPullRequestBody(
+          { runner, repoRoot, login: "robot" },
+          "https://git.example/acme/repo/pulls/42",
+        ),
+      /mismatched PR body/u,
+    );
+  });
+});
+
+test("Forgejo PR body adapter passes the description as one multiline argument", async () => {
+  await withRepo(async (repoRoot) => {
+    const calls: string[][] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        assert.equal(command, "tea");
+        calls.push(args);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    };
+
+    await updateForgejoPullRequestBody(
+      { runner, repoRoot, login: "robot" },
+      "https://git.example/acme/repo/pulls/42",
+      "Summary\n\nDetails\n",
+    );
+
+    assert.deepEqual(calls, [
+      [
+        "pulls",
+        "edit",
+        "42",
+        "--description",
+        "Summary\n\nDetails\n",
+        "--repo",
+        "acme/repo",
+        "--login",
+        "robot",
+      ],
+    ]);
+  });
+});

--- a/src/host/forgejo-pr-body.ts
+++ b/src/host/forgejo-pr-body.ts
@@ -1,0 +1,65 @@
+import type { CommandRunner } from "../cli/commands/triage/types.ts";
+import { withTeaContext } from "./forgejo-tea-context.ts";
+import {
+  pullRequestNumber,
+  sameCanonicalUrl,
+} from "./pull-request-reference.ts";
+export type ForgejoPrBodyOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  login?: string;
+};
+function output(result: { stdout: string; stderr: string }): string {
+  return (
+    [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n") ||
+    "no output"
+  );
+}
+export async function readForgejoPullRequestBody(
+  options: ForgejoPrBodyOptions,
+  prUrl: string,
+): Promise<string> {
+  const number = pullRequestNumber(prUrl, "pulls");
+  const args = withTeaContext(
+    ["api", `/repos/{owner}/{repo}/pulls/${number}`],
+    options.repoRoot,
+    options.login,
+  );
+  const result = await options.runner.run("tea", args, {
+    cwd: options.repoRoot,
+  });
+  if (result.code !== 0) throw new Error(`tea api failed: ${output(result)}`);
+  let value: unknown;
+  try {
+    value = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new Error("tea api returned invalid JSON", { cause });
+  }
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof (value as Record<string, unknown>).body !== "string" ||
+    typeof (value as Record<string, unknown>).html_url !== "string" ||
+    !sameCanonicalUrl(prUrl, (value as Record<string, string>).html_url)
+  )
+    throw new Error("tea api returned an invalid or mismatched PR body");
+  return (value as Record<string, string>).body;
+}
+export async function updateForgejoPullRequestBody(
+  options: ForgejoPrBodyOptions,
+  prUrl: string,
+  body: string,
+): Promise<void> {
+  const number = pullRequestNumber(prUrl, "pulls");
+  const result = await options.runner.run(
+    "tea",
+    withTeaContext(
+      ["pulls", "edit", String(number), "--description", body],
+      options.repoRoot,
+      options.login,
+    ),
+    { cwd: options.repoRoot },
+  );
+  if (result.code !== 0)
+    throw new Error(`tea pulls edit failed: ${output(result)}`);
+}

--- a/src/host/forgejo-tea.ts
+++ b/src/host/forgejo-tea.ts
@@ -1,4 +1,8 @@
 import {
+  readForgejoPullRequestBody,
+  updateForgejoPullRequestBody,
+} from "./forgejo-pr-body.ts";
+import {
   applyIssueLabels,
   commentIssue,
   createLabel as createLabelWithTea,
@@ -18,6 +22,7 @@ import type {
   RepositoryInfo,
   RepositorySetupHostProvider,
   RepositoryTarget,
+  PullRequestBodyHostProvider,
 } from "./types.ts";
 
 export type ForgejoTeaHostOptions = {
@@ -141,7 +146,10 @@ function isDefaultTeaLogin(entry: TeaLoginEntry): boolean {
 }
 
 export class ForgejoTeaHostProvider
-  implements IssueHostProvider, RepositorySetupHostProvider
+  implements
+    IssueHostProvider,
+    RepositorySetupHostProvider,
+    PullRequestBodyHostProvider
 {
   readonly id = "forgejo-tea" as const;
   readonly displayName = "Forgejo via tea";
@@ -150,6 +158,14 @@ export class ForgejoTeaHostProvider
 
   constructor(options: ForgejoTeaHostOptions) {
     this.options = options;
+  }
+
+  readPullRequestBody(prUrl: string): Promise<string> {
+    return readForgejoPullRequestBody(this.options, prUrl);
+  }
+
+  updatePullRequestBody(prUrl: string, body: string): Promise<void> {
+    return updateForgejoPullRequestBody(this.options, prUrl, body);
   }
 
   async checkCli(): Promise<HostCliCheck> {

--- a/src/host/github-gh.ts
+++ b/src/host/github-gh.ts
@@ -1,3 +1,7 @@
+import {
+  readGitHubPullRequestBody,
+  updateGitHubPullRequestBody,
+} from "./github-pr-body.ts";
 import type {
   CommandResult,
   CommandRunner,
@@ -13,6 +17,7 @@ import type {
   RepositoryInfo,
   RepositorySetupHostProvider,
   RepositoryTarget,
+  PullRequestBodyHostProvider,
 } from "./types.ts";
 
 const ISSUE_LIST_JSON_FIELDS =
@@ -213,7 +218,10 @@ function isRepositoryNotFound(result: CommandResult): boolean {
 }
 
 export class GitHubGhHostProvider
-  implements IssueHostProvider, RepositorySetupHostProvider
+  implements
+    IssueHostProvider,
+    RepositorySetupHostProvider,
+    PullRequestBodyHostProvider
 {
   readonly id = "github-gh" as const;
   readonly displayName = "GitHub via gh";
@@ -222,6 +230,14 @@ export class GitHubGhHostProvider
 
   constructor(options: GitHubGhHostOptions) {
     this.options = options;
+  }
+
+  readPullRequestBody(prUrl: string): Promise<string> {
+    return readGitHubPullRequestBody(this.options, prUrl);
+  }
+
+  updatePullRequestBody(prUrl: string, body: string): Promise<void> {
+    return updateGitHubPullRequestBody(this.options, prUrl, body);
   }
 
   async checkCli(): Promise<HostCliCheck> {

--- a/src/host/github-pr-body.test.ts
+++ b/src/host/github-pr-body.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  readGitHubPullRequestBody,
+  updateGitHubPullRequestBody,
+} from "./github-pr-body.ts";
+import type { CommandRunner } from "../cli/commands/triage/types.ts";
+
+test("GitHub PR body adapter rejects a body returned for another repository", async () => {
+  const runner: CommandRunner = {
+    async run() {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          body: "Summary",
+          url: "https://github.com/other/repo/pull/42",
+        }),
+        stderr: "",
+      };
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      readGitHubPullRequestBody(
+        { runner, repoRoot: "/repo" },
+        "https://github.com/acme/repo/pull/42",
+      ),
+    /mismatched PR body/u,
+  );
+});
+
+test("GitHub PR body adapter removes its temporary body file after an edit failure", async () => {
+  let bodyPath = "";
+  const runner: CommandRunner = {
+    async run(_, args) {
+      bodyPath = args[4]!;
+      return { code: 1, stdout: "", stderr: "permission denied" };
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      updateGitHubPullRequestBody(
+        { runner, repoRoot: "/repo" },
+        "https://github.com/acme/repo/pull/42",
+        "Summary\n",
+      ),
+    /gh pr edit failed: permission denied/u,
+  );
+  await assert.rejects(() => access(bodyPath));
+});
+
+test("GitHub PR body adapter writes multiline bodies through a cleaned temporary file", async () => {
+  let bodyPath = "";
+  const runner: CommandRunner = {
+    async run(command, args) {
+      assert.equal(command, "gh");
+      assert.deepEqual(args.slice(0, 4), ["pr", "edit", "42", "--body-file"]);
+      bodyPath = args[4]!;
+      assert.equal(await readFile(bodyPath, "utf8"), "Summary\n\nDetails\n");
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  };
+
+  await updateGitHubPullRequestBody(
+    { runner, repoRoot: "/repo" },
+    "https://github.com/acme/repo/pull/42",
+    "Summary\n\nDetails\n",
+  );
+
+  await assert.rejects(() => access(bodyPath));
+});

--- a/src/host/github-pr-body.test.ts
+++ b/src/host/github-pr-body.test.ts
@@ -7,6 +7,41 @@ import {
 } from "./github-pr-body.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
 
+test("GitHub PR body adapter reads the configured PR body", async () => {
+  const calls: Array<{
+    command: string;
+    args: string[];
+    options: unknown;
+  }> = [];
+  const runner: CommandRunner = {
+    async run(command, args, options) {
+      calls.push({ command, args, options });
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          body: "Summary\n",
+          url: "https://github.com/acme/repo/pull/42",
+        }),
+        stderr: "",
+      };
+    },
+  };
+
+  const body = await readGitHubPullRequestBody(
+    { runner, repoRoot: "/repo" },
+    "https://github.com/acme/repo/pull/42",
+  );
+
+  assert.equal(body, "Summary\n");
+  assert.deepEqual(calls, [
+    {
+      command: "gh",
+      args: ["pr", "view", "42", "--json", "body,url"],
+      options: { cwd: "/repo", env: { GH_REPO: undefined } },
+    },
+  ]);
+});
+
 test("GitHub PR body adapter rejects a body returned for another repository", async () => {
   const runner: CommandRunner = {
     async run() {

--- a/src/host/github-pr-body.ts
+++ b/src/host/github-pr-body.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CommandRunner } from "../cli/commands/triage/types.ts";
+import {
+  pullRequestNumber,
+  sameCanonicalUrl,
+} from "./pull-request-reference.ts";
+export type GitHubPrBodyOptions = { runner: CommandRunner; repoRoot: string };
+function output(result: { stdout: string; stderr: string }): string {
+  return (
+    [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n") ||
+    "no output"
+  );
+}
+function bodyPayload(stdout: string, url: string): string {
+  let data: unknown;
+  try {
+    data = JSON.parse(stdout);
+  } catch (cause) {
+    throw new Error("gh pr view returned invalid JSON", { cause });
+  }
+  if (
+    !data ||
+    typeof data !== "object" ||
+    typeof (data as Record<string, unknown>).body !== "string" ||
+    typeof (data as Record<string, unknown>).url !== "string" ||
+    !sameCanonicalUrl(url, (data as Record<string, string>).url)
+  )
+    throw new Error("gh pr view returned an invalid or mismatched PR body");
+  return (data as Record<string, string>).body;
+}
+export async function readGitHubPullRequestBody(
+  options: GitHubPrBodyOptions,
+  prUrl: string,
+): Promise<string> {
+  const number = pullRequestNumber(prUrl, "pull");
+  const result = await options.runner.run(
+    "gh",
+    ["pr", "view", String(number), "--json", "body,url"],
+    { cwd: options.repoRoot, env: { GH_REPO: undefined } },
+  );
+  if (result.code !== 0)
+    throw new Error(`gh pr view failed: ${output(result)}`);
+  return bodyPayload(result.stdout, prUrl);
+}
+export async function updateGitHubPullRequestBody(
+  options: GitHubPrBodyOptions,
+  prUrl: string,
+  body: string,
+): Promise<void> {
+  const number = pullRequestNumber(prUrl, "pull");
+  const directory = await mkdtemp(join(tmpdir(), "patchmill-pr-body-"));
+  try {
+    const path = join(directory, "body.md");
+    await writeFile(path, body, "utf8");
+    const result = await options.runner.run(
+      "gh",
+      ["pr", "edit", String(number), "--body-file", path],
+      { cwd: options.repoRoot, env: { GH_REPO: undefined } },
+    );
+    if (result.code !== 0)
+      throw new Error(`gh pr edit failed: ${output(result)}`);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/src/host/pull-request-reference.test.ts
+++ b/src/host/pull-request-reference.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  pullRequestNumber,
+  sameCanonicalUrl,
+} from "./pull-request-reference.ts";
+
+test("pullRequestNumber accepts only the requested provider pull path", () => {
+  assert.equal(
+    pullRequestNumber("https://github.com/acme/repo/pull/42", "pull"),
+    42,
+  );
+  assert.equal(
+    pullRequestNumber("https://forge.example/acme/repo/pulls/43", "pulls"),
+    43,
+  );
+  assert.throws(
+    () => pullRequestNumber("https://github.com/acme/repo/pulls/42", "pull"),
+    /Invalid pull request URL/u,
+  );
+});
+
+test("sameCanonicalUrl rejects a different repository but permits one trailing slash", () => {
+  assert.equal(
+    sameCanonicalUrl(
+      "https://github.com/acme/repo/pull/42",
+      "https://github.com/acme/repo/pull/42/",
+    ),
+    true,
+  );
+  assert.equal(
+    sameCanonicalUrl(
+      "https://github.com/acme/repo/pull/42",
+      "https://github.com/other/repo/pull/42",
+    ),
+    false,
+  );
+});

--- a/src/host/pull-request-reference.ts
+++ b/src/host/pull-request-reference.ts
@@ -1,0 +1,34 @@
+function parse(value: string): URL | undefined {
+  try {
+    const url = new URL(value);
+    return url.username || url.password || url.search || url.hash
+      ? undefined
+      : url;
+  } catch {
+    return undefined;
+  }
+}
+export function pullRequestNumber(prUrl: string, pathSegment: string): number {
+  const url = parse(prUrl);
+  const parts = url?.pathname.split("/").filter(Boolean);
+  if (
+    !url ||
+    !parts ||
+    parts.length !== 4 ||
+    parts[2] !== pathSegment ||
+    !/^[1-9]\d*$/u.test(parts[3])
+  )
+    throw new Error(`Invalid pull request URL: ${prUrl}`);
+  return Number(parts[3]);
+}
+export function sameCanonicalUrl(left: string, right: string): boolean {
+  const a = parse(left),
+    b = parse(right);
+  if (!a || !b) return false;
+  const path = (url: URL) => url.pathname.replace(/\/$/u, "");
+  return (
+    a.protocol === b.protocol &&
+    a.host.toLowerCase() === b.host.toLowerCase() &&
+    path(a) === path(b)
+  );
+}

--- a/src/host/types.ts
+++ b/src/host/types.ts
@@ -70,6 +70,11 @@ export type HostCliCheck =
   | { ok: true; message: string }
   | { ok: false; message: string; remediation: string[] };
 
+export type PullRequestBodyHostProvider = {
+  readPullRequestBody(prUrl: string): Promise<string>;
+  updatePullRequestBody(prUrl: string, body: string): Promise<void>;
+};
+
 export type IssueHostProvider = {
   readonly id: PatchmillHostProviderId;
   readonly displayName: string;
@@ -84,3 +89,6 @@ export type IssueHostProvider = {
   applyLabels(change: LabelChangePlan): Promise<void>;
   commentIssue(issueNumber: number, body: string): Promise<void>;
 };
+
+export type RunOnceHostProvider = IssueHostProvider &
+  PullRequestBodyHostProvider;

--- a/test-support/run-once/mock-runner.ts
+++ b/test-support/run-once/mock-runner.ts
@@ -228,6 +228,34 @@ export async function writePiSessionMessage(
   );
 }
 
+export async function writePiPricedSessionMessage(
+  call: Call,
+  input: {
+    id: string;
+    model: string;
+    input: number;
+    cacheRead: number;
+    cacheWrite: number;
+    output: number;
+    estimatedCostUsd: number;
+  },
+): Promise<void> {
+  const sessionDirIndex = call.args.indexOf("--session-dir");
+  assert.ok(
+    sessionDirIndex >= 0,
+    `expected --session-dir in ${call.args.join(" ")}`,
+  );
+  const sessionDir = call.args[sessionDirIndex + 1];
+  assert.ok(sessionDir);
+  const sessionSubdir = join(sessionDir, "--repo--");
+  await mkdir(sessionSubdir, { recursive: true });
+  await writeFile(
+    join(sessionSubdir, "priced-session.jsonl"),
+    `${JSON.stringify({ type: "session", id: "session-priced", timestamp: "2026-07-19T12:00:00.000Z" })}\n${JSON.stringify({ type: "message", id: input.id, message: { role: "assistant", model: input.model, usage: { input: input.input, cacheRead: input.cacheRead, cacheWrite: input.cacheWrite, output: input.output, cost: { total: input.estimatedCostUsd } } } })}\n`,
+    "utf8",
+  );
+}
+
 export async function piSessionPath(call: Call): Promise<string> {
   const sessionDirIndex = call.args.indexOf("--session-dir");
   assert.ok(


### PR DESCRIPTION
Summary

- Added run-once Pi session cost aggregation with stable entry-ID deduplication, stage/model grouping, persisted report validation, and stable durable-session snapshots.
- Added idempotent PR cost-section rendering/publication plus GitHub and Forgejo/Gitea PR-body adapters.
- Wired run-once finish/recovery state so cost reports are persisted, publication is checkpointed, and reporting failures remain nonfatal to successful PR handoff.

## Validation

- npm test — 1,090 passed, 0 failed
- npm run lint — passed
- npm run format:check — passed
- npm run build — passed
- git diff --check — passed

## Reviews

- Final Codex full-worktree review passed after accepted fixes.
- Final thermo-nuclear full-worktree review passed after accepted fixes.
- Final validation-readiness review passed all required commands.

Closes #107
