### PR TITLE
docs: document cleanup hook lifecycle and configuration

### DIFF
--- a/docs/plans/2026-07-24-cleanup-hook-documentation.md
+++ b/docs/plans/2026-07-24-cleanup-hook-documentation.md
@@ -1,0 +1,275 @@
+# Cleanup Hook Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document Patchmill's existing `cleanupHook` configuration and
+terminal-success lifecycle without changing runtime behavior.
+
+**Architecture:** Extend the operational `run-once` guide and lifecycle
+reference first so they define the canonical cleanup contract. Then add concise
+getting-started configuration guidance that links to that contract. Keep the
+full configuration example and all production code unchanged.
+
+**Tech Stack:** Markdown, Astro/Starlight documentation, Prettier,
+markdownlint-cli2
+
+## Global Constraints
+
+- Follow `docs/specs/2026-07-24-cleanup-hook-documentation-design.md`.
+- This is documentation-only: do not change configuration parsing, hook
+  execution, progress events, result statuses, skills, or workspace cleanup.
+- Describe `cleanupHook` as a top-level script path executed as
+  `bash <cleanupHook>` from the issue worktree.
+- State that the hook runs only after terminal `pr-created` or `merged` success,
+  after handoff recording and before built-in PR workspace removal.
+- State that a hook failure is reported but does not reverse an already
+  successful handoff.
+- State that approval-required, blocked, failed, and other retryable outcomes
+  retain their environments and do not run the hook.
+- Keep project-specific environment cleanup separate from Patchmill-owned
+  worktree and branch cleanup.
+- Recommend idempotent, issue- or worktree-scoped scripts that tolerate
+  already-absent resources and return non-zero when cleanup remains incomplete.
+- Do not add automated tests that assert documentation prose; use formatting,
+  lint, build, and direct content verification instead.
+
+---
+
+### Task 1: Document the cleanup lifecycle
+
+**Files:**
+
+- Modify: `site/src/content/docs/using-patchmill/run-once.md:40-106`
+- Modify: `site/src/content/docs/reference/agent-workflow-lifecycle.md:82-107`
+
+**Interfaces:**
+
+- Consumes: Existing `run-once` terminal-success behavior in
+  `src/cli/commands/run-once/pipeline-finish.ts` and hook execution in
+  `src/pi/hooks.ts`.
+- Produces: The canonical `#cleanup-after-successful-handoff` documentation
+  anchor referenced by Task 2.
+
+- [ ] **Step 1: Add cleanup to the run-once sequence and operational guide**
+
+In `site/src/content/docs/using-patchmill/run-once.md`, extend the execute-mode
+list after current step 12:
+
+```markdown
+12. Record run state and handoff information.
+13. After a successful PR or merge handoff, run the configured cleanup hook and
+    then perform built-in local PR workspace cleanup.
+```
+
+Add this section between “Development environment and implementation” and “Run
+state and retries”:
+
+````markdown
+## Cleanup after successful handoff
+
+Set the top-level `cleanupHook` when the repository needs a deterministic script
+to stop local services or remove issue-specific development resources. After
+implementation finishes as `pr-created` or `merged`, Patchmill records and
+reports the successful handoff, then runs:
+
+```sh
+bash <cleanupHook>
+```
+
+The command runs from the issue worktree. Relative hook paths therefore resolve
+from that worktree, and the script does not need its executable bit set because
+Patchmill invokes it through `bash`.
+
+For `pr-created`, Patchmill removes its local issue worktree and branch after
+the hook finishes. Keep environment cleanup inside the hook, but leave worktree,
+local branch, remote branch, pull request, and run-state cleanup to Patchmill.
+
+Make the script idempotent and scope its resources to the current issue or
+worktree. It should tolerate resources that are already absent and return a
+non-zero exit code when cleanup remains incomplete. Patchmill reports a hook
+failure as cleanup progress but does not change an already successful PR or
+merge result into an implementation failure.
+
+The hook does not run for approval gates, blockers, implementation failures, or
+other retryable outcomes. Those runs retain their environment for a later
+`run-once` retry, and Patchmill does not retry a failed cleanup hook
+automatically.
+````
+
+- [ ] **Step 2: Add terminal cleanup to the lifecycle reference**
+
+In `site/src/content/docs/reference/agent-workflow-lifecycle.md`, retain step 15
+and add step 16:
+
+```markdown
+15. Record run state, labels, comments, commits, and final handoff data.
+16. After a successful `pr-created` or `merged` handoff, run the configured
+    cleanup hook from the issue worktree and, for a PR handoff, remove the local
+    issue worktree and branch.
+```
+
+Add this paragraph immediately after the numbered list:
+
+```markdown
+See
+[Cleanup after successful handoff](/using-patchmill/run-once/#cleanup-after-successful-handoff)
+for hook execution, failure, retry, and workspace-ownership details.
+```
+
+- [ ] **Step 3: Verify the two edited Markdown files**
+
+Run:
+
+```sh
+npx prettier --check \
+  site/src/content/docs/using-patchmill/run-once.md \
+  site/src/content/docs/reference/agent-workflow-lifecycle.md
+npx markdownlint-cli2 \
+  site/src/content/docs/using-patchmill/run-once.md \
+  site/src/content/docs/reference/agent-workflow-lifecycle.md
+```
+
+Expected: Prettier reports both files use its code style; markdownlint reports
+`0 error(s)`.
+
+- [ ] **Step 4: Build the site**
+
+Run:
+
+```sh
+npm run site:build
+```
+
+Expected: Astro completes the production build with exit code 0.
+
+- [ ] **Step 5: Commit the lifecycle documentation**
+
+```sh
+git add \
+  site/src/content/docs/using-patchmill/run-once.md \
+  site/src/content/docs/reference/agent-workflow-lifecycle.md
+git commit -m "docs(site): explain cleanup hook lifecycle"
+```
+
+### Task 2: Document cleanup-hook configuration
+
+**Files:**
+
+- Modify: `site/src/content/docs/getting-started/configuration.md:95-160`
+- Verify unchanged:
+  `site/src/content/docs/reference/configuration-example.md:80`
+
+**Interfaces:**
+
+- Consumes: Task 1's
+  `/using-patchmill/run-once/#cleanup-after-successful-handoff` anchor.
+- Produces: Discoverable setup guidance for the existing top-level `cleanupHook`
+  configuration.
+
+- [ ] **Step 1: Add getting-started cleanup configuration guidance**
+
+In `site/src/content/docs/getting-started/configuration.md`, add this section
+after the link to “Skills configuration” and before “Configure visual evidence
+paths”:
+
+````markdown
+## Clean up successful development environments
+
+Use the top-level `cleanupHook` when a successful implementation leaves local
+services or issue-specific development resources that a deterministic script can
+remove:
+
+```json
+{
+  "cleanupHook": "./scripts/cleanup.sh"
+}
+```
+
+Patchmill invokes the configured path through `bash` from the issue worktree.
+For example, a repository using a worktree-scoped Docker Compose project could
+provide:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down --remove-orphans
+```
+
+Use the repository's own teardown command when it uses another environment tool.
+Make cleanup idempotent, namespace resources to the current issue or worktree,
+tolerate resources that are already absent, and leave Patchmill's Git worktree
+and branch intact.
+
+The hook runs only after a successful PR or merge handoff. See
+[Cleanup after successful handoff](/using-patchmill/run-once/#cleanup-after-successful-handoff)
+for ordering, retry, failure-reporting, and workspace-ownership details.
+````
+
+- [ ] **Step 2: Confirm the full configuration example still exposes the key**
+
+Run:
+
+```sh
+rg -n '"cleanupHook": "\./scripts/cleanup\.sh"' \
+  site/src/content/docs/reference/configuration-example.md
+```
+
+Expected: one match for the existing top-level `cleanupHook` example. Do not
+modify that file.
+
+- [ ] **Step 3: Verify cross-document terminology and link targets**
+
+Run:
+
+```sh
+rg -n \
+  'cleanupHook|Cleanup after successful handoff|cleanup-after-successful-handoff' \
+  site/src/content/docs/getting-started/configuration.md \
+  site/src/content/docs/using-patchmill/run-once.md \
+  site/src/content/docs/reference/agent-workflow-lifecycle.md \
+  site/src/content/docs/reference/configuration-example.md
+```
+
+Expected: the configuration guide and example name `cleanupHook`; the run-once
+guide defines the cleanup heading; and both links use its generated anchor.
+
+- [ ] **Step 4: Run full documentation verification**
+
+Run:
+
+```sh
+npm run format:check
+npm run lint:md
+npm run site:build
+```
+
+Expected: Prettier reports no formatting differences, markdownlint reports
+`0 error(s)`, and Astro completes the production build with exit code 0.
+
+No new automated test is added because this change only documents existing
+behavior; static prose assertions would not provide regression value under the
+Testing Value Gate.
+
+- [ ] **Step 5: Commit the configuration documentation**
+
+```sh
+git add site/src/content/docs/getting-started/configuration.md
+git commit -m "docs(site): document cleanup hook configuration"
+```
+
+- [ ] **Step 6: Verify the completed branch**
+
+Run:
+
+```sh
+git status --short
+git log -2 --oneline
+```
+
+Expected: `git status --short` prints nothing. The two latest commits are the
+cleanup lifecycle and cleanup configuration documentation commits from this
+plan.

--- a/docs/specs/2026-07-24-cleanup-hook-documentation-design.md
+++ b/docs/specs/2026-07-24-cleanup-hook-documentation-design.md
@@ -1,0 +1,156 @@
+# Cleanup Hook Documentation Design
+
+## Goal
+
+Make Patchmill's existing `cleanupHook` configuration discoverable and explain
+its lifecycle contract well enough that projects can use it to tear down local
+development environments after successful `run-once` handoff.
+
+## Decision
+
+Use the existing top-level `cleanupHook` configuration for deterministic
+development-environment cleanup. Do not add another workflow stage, skill slot,
+Pi invocation, or cleanup implementation to Patchmill.
+
+The documentation must distinguish environment cleanup from Patchmill-owned Git
+cleanup:
+
+- the configured hook cleans project-specific resources such as Tilt sessions,
+  Kubernetes namespaces, Docker Compose projects, local services, ports, or
+  seeded data;
+- Patchmill retains responsibility for its issue worktree and local branch;
+- planning, failed, blocked, approval-required, and other retryable outcomes do
+  not run the hook.
+
+## Existing behavior to document
+
+`cleanupHook` is an optional path in `patchmill.config.json`. When it is
+configured, successful `run-once` finalization executes:
+
+```sh
+bash <cleanupHook>
+```
+
+The command runs with the issue worktree as its current working directory, so a
+relative path is resolved from that worktree. The script does not need its
+executable bit set because Patchmill invokes it through `bash`.
+
+The lifecycle order is:
+
+1. implementation returns terminal success as `pr-created` or `merged`;
+2. Patchmill records and reports the successful handoff;
+3. Patchmill runs `cleanupHook` from the issue worktree;
+4. for `pr-created`, Patchmill performs its built-in local worktree and branch
+   cleanup.
+
+A missing hook configuration is a no-op. A hook failure is emitted as cleanup
+progress but does not change an already successful PR or merge result into an
+implementation failure. The run log and final run state remain available as
+audit evidence.
+
+The docs should recommend that cleanup scripts:
+
+- are idempotent;
+- target only resources namespaced to the current issue or worktree;
+- tolerate resources that are already absent;
+- return a non-zero exit code when cleanup is incomplete;
+- avoid deleting Patchmill's worktree, local branch, remote branch, PR, or run
+  state;
+- avoid depending on a future retry, because the hook runs only after terminal
+  success.
+
+## Site documentation changes
+
+### Getting-started configuration
+
+Add a short cleanup-hook section to
+`site/src/content/docs/getting-started/configuration.md` near the workflow skill
+and project-environment configuration.
+
+Include:
+
+- a minimal `patchmill.config.json` example;
+- a minimal Bash script example;
+- the issue-worktree working-directory rule;
+- the idempotence and resource-scoping guidance;
+- a link to the detailed `run-once` lifecycle explanation.
+
+Example configuration:
+
+```json
+{
+  "cleanupHook": "./scripts/cleanup.sh"
+}
+```
+
+The example script should demonstrate safe shell defaults and an idempotent,
+project-specific teardown command without prescribing Tilt, Kubernetes, or
+Docker as a required tool.
+
+### Run-once guide
+
+Add a “Cleanup after successful handoff” section to
+`site/src/content/docs/using-patchmill/run-once.md` after the development
+environment and implementation discussion.
+
+Explain:
+
+- the terminal-success-only trigger;
+- execution through `bash` from the issue worktree;
+- the ordering after handoff recording and before built-in PR workspace removal;
+- non-fatal cleanup failure reporting;
+- why retryable outcomes retain their environments;
+- the boundary between environment cleanup and Patchmill-owned Git cleanup.
+
+### Lifecycle reference
+
+Update the numbered terminal portion of
+`site/src/content/docs/reference/agent-workflow-lifecycle.md` to include the
+configured cleanup hook and subsequent built-in PR worktree cleanup. Keep this
+entry concise and link to the `run-once` guide for the detailed contract.
+
+### Configuration example
+
+Retain the existing `cleanupHook` entry in
+`site/src/content/docs/reference/configuration-example.md`. No schema or example
+value change is required.
+
+## Compatibility and error handling
+
+This is a documentation-only change. It describes current behavior and does not
+change configuration parsing, hook execution, progress events, result statuses,
+or workspace cleanup.
+
+The documentation must not imply that:
+
+- cleanup runs after failures, blockers, or approval gates;
+- Patchmill retries a failed cleanup hook automatically;
+- a failed hook changes a successful implementation result;
+- the hook receives structured arguments or environment metadata;
+- the hook should remove Patchmill's Git resources.
+
+## Validation
+
+Do not add automated tests for documentation text. This falls outside the
+Testing Value Gate because it would assert static prose rather than production
+behavior.
+
+Verify the change with:
+
+```sh
+npm run lint:md
+npm run format:check
+npm run site:build
+```
+
+Also review the rendered navigation and links to confirm readers can move from
+configuration to the detailed `run-once` cleanup contract.
+
+## Non-goals
+
+- Adding `skills.cleanup` or `skills.developmentEnvironmentCleanup`.
+- Re-invoking `skills.developmentEnvironment` after implementation.
+- Changing `cleanupHook` execution or failure semantics.
+- Adding automatic cleanup for abandoned or retryable runs.
+- Supplying a project-specific production cleanup script.
+- Changing built-in worktree or branch cleanup.

--- a/site/src/content/docs/getting-started/configuration.md
+++ b/site/src/content/docs/getting-started/configuration.md
@@ -157,6 +157,38 @@ installs opt-in implementation skills such as:
 See [Skills configuration](/guides/skills-configuration/) for the full skill
 surface.
 
+## Clean up successful development environments
+
+Use the top-level `cleanupHook` when a successful implementation leaves local
+services or issue-specific development resources that a deterministic script can
+remove:
+
+```json
+{
+  "cleanupHook": "./scripts/cleanup.sh"
+}
+```
+
+Patchmill invokes the configured path through `bash` from the issue worktree.
+For example, a repository using a worktree-scoped Docker Compose project could
+provide:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down --remove-orphans
+```
+
+Use the repository's own teardown command when it uses another environment tool.
+Make cleanup idempotent, namespace resources to the current issue or worktree,
+tolerate resources that are already absent, and leave Patchmill's Git worktree
+and branch intact.
+
+The hook runs only after a successful PR or merge handoff. See
+[Cleanup after successful handoff](/using-patchmill/run-once/#cleanup-after-successful-handoff)
+for ordering, retry, failure-reporting, and workspace-ownership details.
+
 ## Configure visual evidence paths
 
 Visual evidence has two parts:

--- a/site/src/content/docs/reference/agent-workflow-lifecycle.md
+++ b/site/src/content/docs/reference/agent-workflow-lifecycle.md
@@ -101,6 +101,13 @@ Execute mode follows this high-level sequence:
 14. Run configured review, visual-evidence, and landing procedures when the
     workflow asks for them.
 15. Record run state, labels, comments, commits, and final handoff data.
+16. After a successful `pr-created` or `merged` handoff, run the configured
+    cleanup hook from the issue worktree and, for a PR handoff, remove the local
+    issue worktree and branch.
+
+See
+[Cleanup after successful handoff](/using-patchmill/run-once/#cleanup-after-successful-handoff)
+for hook execution, failure, retry, and workspace-ownership details.
 
 Dry-run mode keeps the preview cheap. It previews the selected issue and planned
 workflow transition, but it does not read workflow artifacts or write resumable

--- a/site/src/content/docs/using-patchmill/run-once.md
+++ b/site/src/content/docs/using-patchmill/run-once.md
@@ -60,6 +60,8 @@ When `run-once` executes work, the high-level sequence is:
 11. Run configured review, visual-evidence, and landing procedures when the
     workflow asks for them.
 12. Record run state and handoff information.
+13. After a successful PR or merge handoff, run the configured cleanup hook and,
+    for a PR handoff, perform built-in local workspace cleanup.
 
 Use [workflow artifacts](/using-patchmill/workflow-artifacts/) when humans have
 already written the spec or plan that Patchmill should reuse.
@@ -94,6 +96,36 @@ Implementation then runs with the configured implementation skill. Optional
 `toolchain`, `review`, `visualEvidence`, and `landing` skills add repository
 rules for validation commands, review passes, screenshot evidence, and the
 choice between direct landing and opening a pull request.
+
+## Cleanup after successful handoff
+
+Set the top-level `cleanupHook` when the repository needs a deterministic script
+to stop local services or remove issue-specific development resources. After
+implementation finishes as `pr-created` or `merged`, Patchmill records and
+reports the successful handoff, then runs:
+
+```sh
+bash <cleanupHook>
+```
+
+The command runs from the issue worktree. Relative hook paths therefore resolve
+from that worktree, and the script does not need its executable bit set because
+Patchmill invokes it through `bash`.
+
+For `pr-created`, Patchmill removes its local issue worktree and branch after
+the hook finishes. Keep environment cleanup inside the hook, but leave worktree,
+local branch, remote branch, pull request, and run-state cleanup to Patchmill.
+
+Make the script idempotent and scope its resources to the current issue or
+worktree. It should tolerate resources that are already absent and return a
+non-zero exit code when cleanup remains incomplete. Patchmill reports a hook
+failure as cleanup progress but does not change an already successful PR or
+merge result into an implementation failure.
+
+The hook does not run for approval gates, blockers, implementation failures, or
+other retryable outcomes. Those runs retain their environment for a later
+`run-once` retry, and Patchmill does not retry a failed cleanup hook
+automatically.
 
 ## Run state and retries
 


### PR DESCRIPTION
## Summary

- document the existing top-level `cleanupHook` configuration and an idempotent teardown example
- explain terminal-success timing, failure reporting, and retry behavior
- clarify the boundary between project environment cleanup and Patchmill-owned worktree and branch cleanup
- include the approved design and implementation plan

## Validation

- `npm test` — 1,118 passed
- `npm run format:check`
- `npm run lint:md` — 0 errors
- `npm run site:build` — 17 pages built
