### PR TITLE
fix(cli): sanitize inherited Pi package directory

### DIFF
--- a/bin/patchmill.test.ts
+++ b/bin/patchmill.test.ts
@@ -7,6 +7,42 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { HELP_TEXT } from "../src/cli/main.ts";
 
+test("patchmill sanitizes inherited Pi state before loading the actual executable CLI", () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const registerPath = join(
+    repoRoot,
+    "test-support",
+    "patchmill-bootstrap-register.mjs",
+  );
+  const executablePath = join(repoRoot, "bin", "patchmill.ts");
+
+  const result = spawnSync(
+    process.execPath,
+    ["--import", registerPath, executablePath],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PI_PACKAGE_DIR: "/nix/store/outer-pi/libexec/pi",
+        ANTHROPIC_API_KEY: "test-provider-token",
+        PI_SUBAGENT_PARENT_SESSION: "test-parent-session",
+        PATCHMILL_TEST_SENTINEL: "preserved",
+      },
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 23, result.stderr);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(JSON.parse(result.stdout), {
+    piPackageDir: null,
+    providerCredential: "test-provider-token",
+    parentSession: "test-parent-session",
+    sentinel: "preserved",
+  });
+});
+
 test("patchmill executes when invoked through a symlink", () => {
   const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
   const fixtureDir = mkdtempSync(join(tmpdir(), "patchmill-"));

--- a/bin/patchmill.ts
+++ b/bin/patchmill.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { main } from "../src/cli/main.ts";
 
 function isMainModule(metaUrl: string, argv1 = process.argv[1]): boolean {
   if (!argv1) return false;
@@ -14,5 +13,7 @@ function isMainModule(metaUrl: string, argv1 = process.argv[1]): boolean {
 }
 
 if (isMainModule(import.meta.url)) {
+  delete process.env.PI_PACKAGE_DIR;
+  const { main } = await import("../src/cli/main.ts");
   process.exitCode = await main();
 }

--- a/docs/plans/2026-07-28-sanitize-inherited-pi-package-dir.md
+++ b/docs/plans/2026-07-28-sanitize-inherited-pi-package-dir.md
@@ -1,0 +1,379 @@
+# Sanitize Inherited Pi Package Directory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure executable Patchmill invocations remove an inherited
+`PI_PACKAGE_DIR` before loading or launching bundled Pi code while preserving
+every unrelated environment value.
+
+**Architecture:** Make the executable-only branch in `bin/patchmill.ts` the
+single process-ownership boundary. It will delete the inherited package
+override, dynamically import the existing CLI dispatcher, invoke it, and
+propagate its exit code; a registered ESM loader and deterministic CLI probe
+will test the actual executable in a fresh process without exporting a
+production test seam.
+
+**Tech Stack:** Node.js 24, TypeScript ES modules, Node's built-in test runner
+and ESM loader hooks, ESLint, Prettier, markdownlint, TypeScript compiler, Nix
+
+**Specification:**
+`docs/specs/2026-07-27-sanitize-inherited-pi-package-dir-design.md`
+
+## Global Constraints
+
+- Apply sanitization only to Patchmill launched through `bin/patchmill.ts`;
+  direct imports of `src/cli/main.ts` retain current behavior.
+- Delete only `process.env.PI_PACKAGE_DIR`, before importing `src/cli/main.ts`
+  or any bundled Pi command graph.
+- Do not restore `PI_PACKAGE_DIR` during the executable process lifetime.
+- Preserve provider credentials, Pi session metadata, Patchmill configuration
+  variables, and every other environment entry unchanged.
+- Do not export a bootstrap helper or dependency-injection seam; `bin` and
+  `dist` are published and deep-importable because the package has no `exports`
+  map.
+- Do not add cleanup to doctor, triage, run-once, init, Pi call sites, or the
+  shared command runner.
+- Do not change provider authentication, skill loading, resource discovery,
+  subprocess APIs, configuration, dependencies, lock files, or package exports.
+- Preserve symlink-based executable detection, fail-fast dynamic-import and
+  `main()` behavior, and exit-code propagation; do not add a local catch or
+  fallback.
+- Parse the child-process probe JSON directly with `JSON.parse`; malformed
+  output must fail the test rather than fall back.
+- The implementation worker must use `test-driven-development` and
+  `verification-before-completion` because this is a production regression at a
+  reusable process boundary.
+
+---
+
+### Task 1: Sanitize the actual executable before loading the CLI
+
+**Files:**
+
+- Create: `test-support/patchmill-bootstrap-register.mjs`
+- Create: `test-support/patchmill-bootstrap-loader.mjs`
+- Create: `test-support/patchmill-bootstrap-main.mjs`
+- Modify: `bin/patchmill.test.ts:1-31`
+- Modify: `bin/patchmill.ts:1-18`
+
+**Interfaces:**
+
+- Consumes: the real `bin/patchmill.ts` executable; inherited `process.env`;
+  Node's `--import` preload option; `node:module` `register()`; an ESM
+  `resolve(specifier, context, nextResolve)` hook; existing `isMainModule()`
+  behavior.
+- Produces: no new production export. The executable removes `PI_PACKAGE_DIR`,
+  dynamically imports `src/cli/main.ts`, awaits `main()`, and assigns its
+  numeric result to `process.exitCode`.
+- Test contract: the loader redirects only `../src/cli/main.ts` to a probe
+  module in the spawned test process. The probe rejects a package override
+  during module evaluation, launches a child with inherited environment, emits
+  one JSON object, and returns exit code `23`.
+
+- [ ] **Step 1: Create the ESM loader registration fixture**
+
+Create `test-support/patchmill-bootstrap-register.mjs`:
+
+```js
+import { register } from "node:module";
+
+register("./patchmill-bootstrap-loader.mjs", import.meta.url);
+```
+
+This module is preloaded with Node's `--import` option before the actual
+executable is evaluated. It registers the resolver hook without modifying
+production code or using deprecated loader flags.
+
+- [ ] **Step 2: Create the CLI-module resolver fixture**
+
+Create `test-support/patchmill-bootstrap-loader.mjs`:
+
+```js
+const cliFixtureUrl = new URL("./patchmill-bootstrap-main.mjs", import.meta.url)
+  .href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "../src/cli/main.ts") {
+    return { url: cliFixtureUrl, shortCircuit: true };
+  }
+
+  return nextResolve(specifier, context);
+}
+```
+
+The hook must redirect only the CLI import used by `bin/patchmill.ts`. Every
+other module resolution delegates to Node and fails normally if Node cannot
+resolve it.
+
+- [ ] **Step 3: Create the fail-fast CLI and child-inheritance probe**
+
+Create `test-support/patchmill-bootstrap-main.mjs`:
+
+```js
+import { spawnSync } from "node:child_process";
+
+if (process.env.PI_PACKAGE_DIR !== undefined) {
+  throw new Error("PI_PACKAGE_DIR reached the CLI module");
+}
+
+export function main() {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `process.stdout.write(JSON.stringify({
+        piPackageDir: process.env.PI_PACKAGE_DIR ?? null,
+        providerCredential: process.env.ANTHROPIC_API_KEY,
+        parentSession: process.env.PI_SUBAGENT_PARENT_SESSION,
+        sentinel: process.env.PATCHMILL_TEST_SENTINEL,
+      }));`,
+    ],
+    { encoding: "utf8" },
+  );
+
+  if (child.error) throw child.error;
+  if (child.status !== 0) {
+    throw new Error(
+      `child environment probe failed (${child.status}): ${child.stderr}`,
+    );
+  }
+
+  process.stdout.write(child.stdout);
+  return 23;
+}
+```
+
+The top-level check proves sanitization precedes CLI-module evaluation. Omitting
+`env` from `spawnSync` proves a later child inherits the sanitized process
+environment. Errors are rethrown or raised with command context; no fallback
+output is permitted.
+
+- [ ] **Step 4: Add the failing fresh-process executable regression test**
+
+Add this test before the existing symlink test in `bin/patchmill.test.ts`:
+
+```ts
+test("patchmill sanitizes inherited Pi state before loading the actual executable CLI", () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const registerPath = join(
+    repoRoot,
+    "test-support",
+    "patchmill-bootstrap-register.mjs",
+  );
+  const executablePath = join(repoRoot, "bin", "patchmill.ts");
+
+  const result = spawnSync(
+    process.execPath,
+    ["--import", registerPath, executablePath],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PI_PACKAGE_DIR: "/nix/store/outer-pi/libexec/pi",
+        ANTHROPIC_API_KEY: "test-provider-token",
+        PI_SUBAGENT_PARENT_SESSION: "test-parent-session",
+        PATCHMILL_TEST_SENTINEL: "preserved",
+      },
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 23, result.stderr);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(JSON.parse(result.stdout), {
+    piPackageDir: null,
+    providerCredential: "test-provider-token",
+    parentSession: "test-parent-session",
+    sentinel: "preserved",
+  });
+});
+```
+
+Do not import a bootstrap helper. The test must set the foreign value in the
+spawned process before `bin/patchmill.ts` or its static dependency graph can
+evaluate.
+
+- [ ] **Step 5: Run the targeted test and verify the real regression fails**
+
+Run:
+
+```sh
+node --test bin/patchmill.test.ts
+```
+
+Expected: exit non-zero. The new test reports that the spawned executable exited
+with status `1`, and its assertion message includes:
+
+```text
+PI_PACKAGE_DIR reached the CLI module
+```
+
+This failure proves the registered probe replaced the real CLI import while the
+current static import still evaluates before any sanitization. Do not continue
+if the failure comes from loader registration, fixture resolution, JSON parsing,
+or another setup problem.
+
+- [ ] **Step 6: Implement the private executable bootstrap sequence**
+
+Replace `bin/patchmill.ts` with:
+
+```ts
+#!/usr/bin/env node
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+function isMainModule(metaUrl: string, argv1 = process.argv[1]): boolean {
+  if (!argv1) return false;
+
+  try {
+    return metaUrl === pathToFileURL(realpathSync(argv1)).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  delete process.env.PI_PACKAGE_DIR;
+  const { main } = await import("../src/cli/main.ts");
+  process.exitCode = await main();
+}
+```
+
+The deletion must remain before the dynamic import. Do not retain a static
+import of `src/cli/main.ts`, export the bootstrap sequence, copy or restore the
+environment, catch import or command failures, or modify command-specific Pi
+integrations.
+
+- [ ] **Step 7: Run the targeted test and verify executable coverage passes**
+
+Run:
+
+```sh
+node --test bin/patchmill.test.ts
+```
+
+Expected: exit 0 with two passing tests and zero failures:
+
+```text
+patchmill sanitizes inherited Pi state before loading the actual executable CLI
+patchmill executes when invoked through a symlink
+```
+
+The first test's child JSON proves that `PI_PACKAGE_DIR` was absent before the
+probe module loaded and remained absent in a later child while the credential,
+parent-session metadata, and sentinel survived unchanged. Exit status `23`
+proves `main()` result propagation through the actual executable branch.
+
+- [ ] **Step 8: Run the complete automated test suite**
+
+Run:
+
+```sh
+npm test
+```
+
+Expected: exit 0 with all tests passing and zero failures.
+
+- [ ] **Step 9: Run the repository linters and format checks**
+
+Run:
+
+```sh
+npm run lint
+```
+
+Expected: exit 0 with no Prettier, ESLint, or markdownlint errors.
+
+- [ ] **Step 10: Emit the distributable JavaScript**
+
+Run:
+
+```sh
+npm run build
+```
+
+Expected: exit 0 and a generated `dist/bin/patchmill.js` whose dynamic CLI
+import path was rewritten successfully.
+
+This is an emission/build check, not a semantic TypeScript check:
+`tsconfig.build.json` sets `noCheck: true`. Do not report it as proof that the
+repository is free of TypeScript type errors.
+
+- [ ] **Step 11: Smoke-test the npm-built executable path**
+
+Run:
+
+```sh
+node dist/bin/patchmill.js --help
+```
+
+Expected: exit 0, no stderr, and stdout beginning with:
+
+```text
+Usage:
+  patchmill <command> [options]
+```
+
+- [ ] **Step 12: Build and smoke-test the Nix-packaged TypeScript entrypoint**
+
+Run:
+
+```sh
+package_path="$(nix build .#patchmill --no-link --print-out-paths)"
+PI_PACKAGE_DIR=/nix/store/outer-pi/libexec/pi \
+  "$package_path/bin/patchmill" --help
+```
+
+Expected: the Nix build and its package checks exit 0 without creating a
+`result` link. The packaged wrapper, which executes
+`$out/share/patchmill/bin/patchmill.ts`, exits 0 with normal Patchmill help
+despite the foreign `PI_PACKAGE_DIR`.
+
+No dependency file changes are planned, so this Nix build verifies the directly
+affected packaged entrypoint rather than satisfying the dependency-change
+policy.
+
+- [ ] **Step 13: Check the final implementation diff**
+
+Run:
+
+```sh
+git diff --check
+git status --short
+```
+
+Expected: `git diff --check` prints nothing and exits 0. Status lists only:
+
+```text
+ M bin/patchmill.test.ts
+ M bin/patchmill.ts
+?? test-support/patchmill-bootstrap-loader.mjs
+?? test-support/patchmill-bootstrap-main.mjs
+?? test-support/patchmill-bootstrap-register.mjs
+```
+
+If any dependency, lock, configuration, doctor, Pi integration, command-runner,
+or other production file appears, remove the unrelated change or stop for
+review.
+
+- [ ] **Step 14: Commit the verified implementation**
+
+Run:
+
+```sh
+git add \
+  bin/patchmill.test.ts \
+  bin/patchmill.ts \
+  test-support/patchmill-bootstrap-loader.mjs \
+  test-support/patchmill-bootstrap-main.mjs \
+  test-support/patchmill-bootstrap-register.mjs
+git commit -m "fix(cli): sanitize inherited Pi package directory"
+```
+
+Expected: one commit containing only the fresh-process regression fixtures and
+private executable bootstrap change.

--- a/docs/specs/2026-07-27-sanitize-inherited-pi-package-dir-design.md
+++ b/docs/specs/2026-07-27-sanitize-inherited-pi-package-dir-design.md
@@ -1,0 +1,201 @@
+# Sanitize Inherited Pi Package Directory Design
+
+**Issue:** [#117](https://github.com/rochecompaan/patchmill/issues/117)
+
+## Problem
+
+Patchmill can be launched by a command process created inside another Pi
+session. That process inherits the outer Pi installation's `PI_PACKAGE_DIR`.
+Patchmill bundles its own `@earendil-works/pi-coding-agent`, but the bundled
+dependency treats `PI_PACKAGE_DIR` as an explicit package-root override. It can
+therefore resolve themes and other runtime resources beneath the outer Pi
+package instead of beneath Patchmill's dependency tree.
+
+This produces misleading readiness failures even when Patchmill's repository
+configuration, installed skills, and provider authentication are valid.
+
+## Root Cause
+
+`bin/patchmill.ts` statically imports `src/cli/main.ts`. That import loads the
+complete command graph, including modules that use the bundled Pi API, before
+the executable performs any environment ownership step.
+
+The bundled Pi dependency reads `process.env.PI_PACKAGE_DIR` when resolving
+package assets. Patchmill's command runner also either inherits `process.env`
+directly or merges per-command overrides into it. A foreign package override can
+therefore affect both in-process Pi API calls and bundled Pi subprocesses.
+
+A dependency-level reproduction confirms the data flow: setting `PI_PACKAGE_DIR`
+to a foreign directory makes Pi's `getPackageDir()` return that directory and
+makes its theme path resolve beneath the same foreign root.
+
+## Goals
+
+- Make executable Patchmill invocations own the package-directory context used
+  by their bundled Pi dependency.
+- Remove an inherited `PI_PACKAGE_DIR` before any Patchmill command module or
+  bundled Pi module loads.
+- Ensure Pi subprocesses launched later inherit the same sanitized environment.
+- Preserve provider credentials, Pi session metadata, Patchmill configuration
+  variables, and all other unrelated environment entries.
+- Add regression coverage that fails if command loading occurs before
+  sanitization.
+
+## Non-Goals
+
+- Do not change the behavior of callers that import `src/cli/main.ts` directly.
+  Embedding callers retain ownership of their process environment.
+- Do not add command-specific cleanup to doctor, triage, run-once, init, or the
+  shared command runner.
+- Do not infer whether a `PI_PACKAGE_DIR` value is foreign; executable Patchmill
+  invocations do not honor this Pi package override.
+- Do not change provider authentication, skill loading, resource discovery, or
+  subprocess option APIs.
+- Do not add configuration or documentation for selecting a Pi package
+  directory.
+
+## Design
+
+### Executable bootstrap boundary
+
+`bin/patchmill.ts` becomes the single ownership boundary for executable
+invocations. It will no longer statically import `src/cli/main.ts`.
+
+The executable-only branch will:
+
+1. Delete only `process.env.PI_PACKAGE_DIR`.
+2. Dynamically import `src/cli/main.ts` after deletion.
+3. Invoke the imported `main()` function.
+4. Assign its exit code to `process.exitCode`.
+
+The sequence remains private to the executable module. Patchmill will not export
+a bootstrap helper or dependency-injection seam because the published package
+includes `bin` and `dist`, allowing consumers to deep-import exported symbols
+even without a package `exports` map.
+
+The existing symlink-aware main-module detection remains unchanged.
+
+### Environment lifetime
+
+The deleted override will not be restored. Every operation in an executable
+Patchmill process must use Patchmill's bundled Pi ownership context for the
+entire process lifetime.
+
+Deleting an absent `PI_PACKAGE_DIR` is a no-op. No other environment key is
+copied, filtered, renamed, or removed.
+
+### Data flow
+
+The resulting startup flow is:
+
+1. An outer process launches Patchmill with its inherited environment.
+2. Patchmill's executable bootstrap removes `PI_PACKAGE_DIR`.
+3. The bootstrap loads the CLI command graph.
+4. In-process bundled Pi APIs resolve resources from their own installed
+   package.
+5. Command handlers launch subprocesses through the existing runner.
+6. Those subprocesses inherit the already-sanitized `process.env`, plus their
+   existing per-command overrides.
+
+This one boundary covers current and future commands without duplicating
+environment policy across Pi call sites.
+
+### Module responsibilities
+
+- `bin/patchmill.ts`: detect executable invocation, sanitize executable-owned
+  environment, lazily load the CLI, and propagate its exit code.
+- `src/cli/main.ts`: resolve and dispatch Patchmill commands exactly as it does
+  today.
+- Existing doctor, Pi command, and command-runner modules: remain unchanged and
+  consume the sanitized process environment naturally.
+
+The bootstrap remains a small, cohesive module; no new general-purpose
+environment utility or command-runner abstraction is needed.
+
+## Failure Behavior
+
+Dynamic import failures continue to surface as startup failures, matching the
+current behavior of static import failures. Existing command error handling and
+exit-code behavior remain unchanged.
+
+Patchmill will not restore or fall back to the removed override if bundled Pi
+resource discovery fails for another reason. Remediation for genuine dependency,
+provider, skill, or repository failures remains unchanged.
+
+## Testing
+
+The Testing Value Gate is satisfied because this is a production regression at a
+reusable process boundary and a future static import or reordered bootstrap
+could reintroduce it.
+
+Extend `bin/patchmill.test.ts` with a fresh-process regression test that
+launches the actual `bin/patchmill.ts` executable with:
+
+- a foreign `PI_PACKAGE_DIR` present before bootstrap evaluation;
+- representative unrelated values, including a provider credential and Pi
+  session metadata; and
+- a registered ESM loader that substitutes a deterministic CLI probe for
+  `src/cli/main.ts` in the spawned process only.
+
+The probe module must fail at module evaluation if `PI_PACKAGE_DIR` is still
+present. Its `main()` function must launch a child process without an explicit
+environment, emit that child's relevant environment as JSON, and return a known
+non-zero exit code. The parent test must parse the JSON without fallback and
+verify that the child lacks `PI_PACKAGE_DIR`, preserves every unrelated value,
+and receives the known exit code through the real executable wiring.
+
+This test fails if the CLI returns to a static import, sanitization moves after
+the dynamic import, the executable bypasses the private bootstrap sequence,
+unrelated variables are removed, child inheritance changes, or exit-code
+propagation breaks. The probe and loader live under `test-support` and are not
+published package APIs.
+
+Keep the existing symlink execution test as integration coverage that the
+executable still starts and dynamically reaches the real CLI.
+
+Implementation verification will run:
+
+```sh
+node --test bin/patchmill.test.ts
+npm test
+npm run lint
+npm run build
+node dist/bin/patchmill.js --help
+package_path="$(nix build .#patchmill --no-link --print-out-paths)"
+PI_PACKAGE_DIR=/nix/store/outer-pi/libexec/pi \
+  "$package_path/bin/patchmill" --help
+```
+
+`npm run build` is an emission check, not a semantic TypeScript check, because
+`tsconfig.build.json` sets `noCheck: true`. No dependency files change, so the
+dependency-triggered Nix requirement does not apply; the explicit Nix build is
+still required here to verify the affected wrapper that executes
+`$out/share/patchmill/bin/patchmill.ts`.
+
+## Alternatives Considered
+
+### Static side-effect prelude
+
+A side-effect-only module could delete the variable before a static CLI import.
+This would make ordering implicit in module evaluation and hide a process-wide
+mutation inside an import. The explicit dynamic-import sequence is easier to
+reason about and test.
+
+### Per-integration sanitization
+
+Doctor resource discovery and each bundled Pi subprocess could receive separate
+cleanup. This duplicates policy, risks missing future call sites, and still
+requires special handling for in-process APIs that read `process.env` directly.
+
+### Command-runner-only sanitization
+
+Filtering the variable in the shared child-process runner would cover
+subprocesses but not in-process bundled Pi APIs. It would also apply Pi-specific
+policy to unrelated child commands.
+
+## Compatibility and Scope
+
+The change affects only Patchmill launched through its executable entrypoint.
+Command names, arguments, configuration, host operations, credentials, session
+metadata, and direct programmatic CLI imports retain their existing behavior. No
+dependencies, generated locks, or public package exports change.

--- a/test-support/patchmill-bootstrap-loader.mjs
+++ b/test-support/patchmill-bootstrap-loader.mjs
@@ -1,0 +1,10 @@
+const cliFixtureUrl = new URL("./patchmill-bootstrap-main.mjs", import.meta.url)
+  .href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "../src/cli/main.ts") {
+    return { url: cliFixtureUrl, shortCircuit: true };
+  }
+
+  return nextResolve(specifier, context);
+}

--- a/test-support/patchmill-bootstrap-main.mjs
+++ b/test-support/patchmill-bootstrap-main.mjs
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+
+if (process.env.PI_PACKAGE_DIR !== undefined) {
+  throw new Error("PI_PACKAGE_DIR reached the CLI module");
+}
+
+export function main() {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `process.stdout.write(JSON.stringify({
+        piPackageDir: process.env.PI_PACKAGE_DIR ?? null,
+        providerCredential: process.env.ANTHROPIC_API_KEY,
+        parentSession: process.env.PI_SUBAGENT_PARENT_SESSION,
+        sentinel: process.env.PATCHMILL_TEST_SENTINEL,
+      }));`,
+    ],
+    { encoding: "utf8" },
+  );
+
+  if (child.error) throw child.error;
+  if (child.status !== 0) {
+    throw new Error(
+      `child environment probe failed (${child.status}): ${child.stderr}`,
+    );
+  }
+
+  process.stdout.write(child.stdout);
+  return 23;
+}

--- a/test-support/patchmill-bootstrap-register.mjs
+++ b/test-support/patchmill-bootstrap-register.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./patchmill-bootstrap-loader.mjs", import.meta.url);


### PR DESCRIPTION
Summary

- Sanitized executable Patchmill invocations by deleting inherited `PI_PACKAGE_DIR` before loading the bundled CLI graph.
- Added a fresh-process regression fixture that proves sanitization precedes CLI module evaluation, child processes inherit the sanitized environment, unrelated credentials/session metadata remain available, and exit-code propagation still works.

## Validation

- `node --test bin/patchmill.test.ts` passed (2/2)
- `npm test` passed (1122 tests, 0 failures)
- `npm run lint` passed
- `npm run build` passed (emission check; TypeScript build has `noCheck` enabled)
- `node dist/bin/patchmill.js --help` passed
- `PI_PACKAGE_DIR=/nix/store/outer-pi/libexec/pi "$package_path/bin/patchmill" --help` passed after `nix build .#patchmill --no-link --print-out-paths`
- `git diff --check` passed; worktree clean

## Reviews

- Final Codex full-worktree review: pass, no findings.
- Final thermo-nuclear full-worktree review: pass, no findings.
- Final validation-readiness review: pass, all required commands rerun.

Closes #117

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Development environment | gpt-5.5 | 321,202 | 1,700 | $0.5857 |
| Implementation | gpt-5.5 | 1,640,610 | 12,277 | $1.6133 |
| Implementation | gpt-5.6-sol | 1,198,844 | 17,221 | $1.9858 |
| Implementation | gpt-5.6-terra | 1,244,518 | 4,376 | $0.5688 |
| **Implementation subtotal** |  | **4,083,972** | **33,874** | **$4.1679** |
| **Total** |  | **4,405,174** | **35,574** | **$4.7535** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->