### PR TITLE
Add deterministic abortable run-once Pi session streaming

### DIFF
--- a/docs/plans/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming.md
+++ b/docs/plans/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming.md
@@ -1,35 +1,73 @@
 # Deterministic Abortable Run-Once Pi Session Streaming Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make `run-once` observe exactly one owned parent Pi session with serial callback backpressure, prompt cancellation on observation failure, and complete terminal error reporting.
+**Goal:** Make `run-once` observe exactly one owned parent Pi session with
+serial callback backpressure, prompt cancellation on observation failure, and
+complete terminal error reporting.
 
-**Architecture:** Observed `runPiPrompt()` calls allocate a unique pre-created parent JSONL file in the durable invocation leaf, pass that file to Pi with `--session`, and start an exact-file observer that never scans for the newest recursive JSONL. The command runner accepts an `AbortSignal`, and `runPiPrompt()` coordinates the runner, streamer, heartbeat, parsing, and cleanup through ordered cause collection so independent failures are preserved.
+**Architecture:** Observed `runPiPrompt()` calls allocate a unique pre-created
+parent JSONL file in the durable invocation leaf, pass that file to Pi with
+`--session`, and start an exact-file observer that never scans for the newest
+recursive JSONL. The command runner accepts an `AbortSignal`, and
+`runPiPrompt()` coordinates the runner, streamer, heartbeat, parsing, and
+cleanup through ordered cause collection so independent failures are preserved.
 
-**Tech Stack:** Node.js 22.19+, TypeScript ESM, `node:test`, Node `child_process.spawn`, Node `fs/promises`, existing Patchmill progress reporters and Pi JSONL session parsing.
+**Tech Stack:** Node.js 22.19+, TypeScript ESM, `node:test`, Node
+`child_process.spawn`, Node `fs/promises`, existing Patchmill progress reporters
+and Pi JSONL session parsing.
 
 ## Global Constraints
 
-- Scope is limited to exact-session ownership, streaming backpressure, cancellation, and terminal-error preservation for issue #123.
+- Scope is limited to exact-session ownership, streaming backpressure,
+  cancellation, and terminal-error preservation for issue #123.
 - Do not change `pi-subagents` or parse/render subagent-specific metadata.
-- Do not migrate triage to exact-session observation; triage keeps the legacy directory-based observer and receives regression coverage only.
-- Successful `run-once` stdout remains the final JSON object only; progress, verbose Pi output, and error detail stay on stderr and in the JSONL run log.
-- Tests for new production behavior must use deterministic synchronization primitives, not timing races.
-- Apply Patchmill's Testing Value Gate: automated tests are required here because this changes reusable streaming, cancellation, API contracts, error handling, and regressions.
-- Do not change `package.json`, `npm-shrinkwrap.json`, or `package-lock.json`; if an implementation accidentally changes npm dependency files, revert them or run the Nix build required by `AGENTS.md`.
+- Do not migrate triage to exact-session observation; triage keeps the legacy
+  directory-based observer and receives regression coverage only.
+- Successful `run-once` stdout remains the final JSON object only; progress,
+  verbose Pi output, and error detail stay on stderr and in the JSONL run log.
+- Tests for new production behavior must use deterministic synchronization
+  primitives, not timing races.
+- Apply Patchmill's Testing Value Gate: automated tests are required here
+  because this changes reusable streaming, cancellation, API contracts, error
+  handling, and regressions.
+- Do not change `package.json`, `npm-shrinkwrap.json`, or `package-lock.json`;
+  if an implementation accidentally changes npm dependency files, revert them or
+  run the Nix build required by `AGENTS.md`.
 
 ---
 
 ## File Structure
 
-- `src/cli/commands/triage/types.ts` owns the shared command-runner type. Add only `signal?: AbortSignal` to `CommandRunOptions` so all current callers remain compatible.
-- `src/cli/commands/triage/command.ts` owns the real spawned-process adapter. Add abort handling here without changing its `CommandResult` return contract.
-- `src/cli/commands/run-once/pi-session-allocation.ts` is a new focused module for durable invocation directory creation and exact parent session file pre-creation. This keeps filesystem allocation separate from `pi.ts`, which is already a broad Pi orchestration module.
-- `src/cli/commands/run-once/pi-errors.ts` is a new focused module for converting independent terminal causes into a single thrown error and formatting aggregate causes for CLI/log output.
-- `src/cli/commands/run-once/pi-session-stream.ts` keeps session JSONL parsing and streaming. Add exact-file observation beside the legacy directory observer; do not remove `findNewestSessionFile()` because triage still depends on it.
-- `src/cli/commands/run-once/pi.ts` remains the `runPiPrompt()` orchestration facade. Replace observed-session directory discovery with exact session allocation, wire the abort controller, and delegate aggregation to `pi-errors.ts`.
-- `src/cli/commands/run-once/main.ts` owns run-once CLI terminal JSON/log formatting. Teach its error path to include aggregate causes without changing success-result JSON.
-- Tests stay near owners: `src/cli/commands/triage/command.test.ts`, `src/cli/commands/triage/tool-call-observer.test.ts`, and `src/cli/commands/run-once/pi.test.ts`.
+- `src/cli/commands/triage/types.ts` owns the shared command-runner type. Add
+  only `signal?: AbortSignal` to `CommandRunOptions` so all current callers
+  remain compatible.
+- `src/cli/commands/triage/command.ts` owns the real spawned-process adapter.
+  Add abort handling here without changing its `CommandResult` return contract.
+- `src/cli/commands/run-once/pi-session-allocation.ts` is a new focused module
+  for durable invocation directory creation and exact parent session file
+  pre-creation. This keeps filesystem allocation separate from `pi.ts`, which is
+  already a broad Pi orchestration module.
+- `src/cli/commands/run-once/pi-errors.ts` is a new focused module for
+  converting independent terminal causes into a single thrown error and
+  formatting aggregate causes for CLI/log output.
+- `src/cli/commands/run-once/pi-session-stream.ts` keeps session JSONL parsing
+  and streaming. Add exact-file observation beside the legacy directory
+  observer; do not remove `findNewestSessionFile()` because triage still depends
+  on it.
+- `src/cli/commands/run-once/pi.ts` remains the `runPiPrompt()` orchestration
+  facade. Replace observed-session directory discovery with exact session
+  allocation, wire the abort controller, and delegate aggregation to
+  `pi-errors.ts`.
+- `src/cli/commands/run-once/main.ts` owns run-once CLI terminal JSON/log
+  formatting. Teach its error path to include aggregate causes without changing
+  success-result JSON.
+- Tests stay near owners: `src/cli/commands/triage/command.test.ts`,
+  `src/cli/commands/triage/tool-call-observer.test.ts`, and
+  `src/cli/commands/run-once/pi.test.ts`.
 
 ---
 
@@ -45,7 +83,10 @@
 **Interfaces:**
 
 - Consumes: existing `CommandRunner.run(command, args, options)` contract.
-- Produces: `CommandRunOptions.signal?: AbortSignal`; real runner terminates an in-flight child on abort, keeps collecting stdout/stderr until `close`, and returns a nonzero `CommandResult` without spawning when the signal is already aborted.
+- Produces: `CommandRunOptions.signal?: AbortSignal`; real runner terminates an
+  in-flight child on abort, keeps collecting stdout/stderr until `close`, and
+  returns a nonzero `CommandResult` without spawning when the signal is already
+  aborted.
 
 - [ ] **Step 1: Write the failing command-runner abort tests**
 
@@ -105,7 +146,8 @@
   node --test src/cli/commands/triage/command.test.ts
   ```
 
-  Expected: TypeScript or runtime failure because `CommandRunOptions` has no `signal` property and `createCommandRunner()` ignores aborts.
+  Expected: TypeScript or runtime failure because `CommandRunOptions` has no
+  `signal` property and `createCommandRunner()` ignores aborts.
 
 - [ ] **Step 3: Extend the shared command-runner type and test support**
 
@@ -121,7 +163,8 @@
   };
   ```
 
-  In `test-support/command-runner.ts`, keep static-runner compatibility and record no new state unless a future test needs it:
+  In `test-support/command-runner.ts`, keep static-runner compatibility and
+  record no new state unless a future test needs it:
 
   ```ts
   async run(command, args, options = {}) {
@@ -134,7 +177,10 @@
 
 - [ ] **Step 4: Implement minimal abort handling in `createCommandRunner()`**
 
-  Update `src/cli/commands/triage/command.ts` so it checks `options.signal?.aborted` before `spawn`, attaches one abort listener after spawn, calls `child.kill("SIGTERM")`, and settles only from `close` or `error`:
+  Update `src/cli/commands/triage/command.ts` so it checks
+  `options.signal?.aborted` before `spawn`, attaches one abort listener after
+  spawn, calls `child.kill("SIGTERM")`, and settles only from `close` or
+  `error`:
 
   ```ts
   if (options.signal?.aborted) {
@@ -146,7 +192,8 @@
   }
   ```
 
-  Ensure the abort path appends an abort marker to `stderr` without discarding existing stderr:
+  Ensure the abort path appends an abort marker to `stderr` without discarding
+  existing stderr:
 
   ```ts
   const onAbort = () => {
@@ -175,7 +222,8 @@
   node --test src/cli/commands/triage/command.test.ts
   ```
 
-  Expected: PASS, including existing stdout/stderr/cwd tests and the two abort tests.
+  Expected: PASS, including existing stdout/stderr/cwd tests and the two abort
+  tests.
 
 - [ ] **Step 6: Commit this task**
 
@@ -196,12 +244,17 @@
 
 **Interfaces:**
 
-- Consumes: `RunPiPromptOptions.stage`, `observeSession`, `streamOutput`, `sessionRoot`, `sessionDir`, and the prompt temp dir.
-- Produces: `PiSessionAllocation { sessionDir: string; sessionPath?: string }`; observed calls receive a pre-created `sessionPath` passed via `--session <path>`, while non-observed message streaming keeps `--session-dir <dir>`.
+- Consumes: `RunPiPromptOptions.stage`, `observeSession`, `streamOutput`,
+  `sessionRoot`, `sessionDir`, and the prompt temp dir.
+- Produces: `PiSessionAllocation { sessionDir: string; sessionPath?: string }`;
+  observed calls receive a pre-created `sessionPath` passed via
+  `--session <path>`, while non-observed message streaming keeps
+  `--session-dir <dir>`.
 
 - [ ] **Step 1: Write failing exact-session allocation tests**
 
-  In `src/cli/commands/run-once/pi.test.ts`, add tests that assert observed calls pass `--session` and not `--session-dir`:
+  In `src/cli/commands/run-once/pi.test.ts`, add tests that assert observed
+  calls pass `--session` and not `--session-dir`:
 
   ```ts
   test("runPiPrompt pre-creates and passes an exact observed parent session", async (t) => {
@@ -209,7 +262,13 @@
     t.after(async () => {
       await rm(repoRoot, { recursive: true, force: true });
     });
-    const sessionRoot = join(repoRoot, ".patchmill", "runs", "issue-123", "run-pi-sessions");
+    const sessionRoot = join(
+      repoRoot,
+      ".patchmill",
+      "runs",
+      "issue-123",
+      "run-pi-sessions",
+    );
     const events: AgentIssueProgressEvent[] = [];
     let observedSessionPath = "";
 
@@ -229,7 +288,11 @@
         JSON.stringify({ type: "session", id: "parent", cwd: "/repo" }) + "\n",
         "utf8",
       );
-      return { code: 0, stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}', stderr: "" };
+      return {
+        code: 0,
+        stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+        stderr: "",
+      };
     });
 
     await runPiPrompt(runner, "/repo", "prompt", {
@@ -240,11 +303,20 @@
     });
 
     assert.ok(observedSessionPath.endsWith(".jsonl"));
-    assert.ok(events.some((event) => event.message === "pi session path" && event.data === observedSessionPath));
+    assert.ok(
+      events.some(
+        (event) =>
+          event.message === "pi session path" &&
+          event.data === observedSessionPath,
+      ),
+    );
   });
   ```
 
-  Also replace the current observed `sessionDir` override assertion so it expects `--session <exactSessionDir>/parent-*.jsonl` and a `pi session path` debug event. Keep the existing non-observed `streamOutput` tests expecting `--session-dir`.
+  Also replace the current observed `sessionDir` override assertion so it
+  expects `--session <exactSessionDir>/parent-*.jsonl` and a `pi session path`
+  debug event. Keep the existing non-observed `streamOutput` tests expecting
+  `--session-dir`.
 
 - [ ] **Step 2: Run the exact-session allocation tests and confirm failure**
 
@@ -254,11 +326,13 @@
   node --test src/cli/commands/run-once/pi.test.ts
   ```
 
-  Expected: FAIL because observed `runPiPrompt()` still passes `--session-dir` and does not pre-create a parent file.
+  Expected: FAIL because observed `runPiPrompt()` still passes `--session-dir`
+  and does not pre-create a parent file.
 
 - [ ] **Step 3: Add the allocation module**
 
-  Create `src/cli/commands/run-once/pi-session-allocation.ts` with this public surface:
+  Create `src/cli/commands/run-once/pi-session-allocation.ts` with this public
+  surface:
 
   ```ts
   import { mkdir, mkdtemp, open } from "node:fs/promises";
@@ -297,11 +371,16 @@
   }
   ```
 
-  Implement private `createInvocationDir()` with the current `sessionRoot/<stage>/invocation-*`, explicit `sessionDir`, and prompt temp `sessions` behavior. Implement private `createExactParentSessionFile()` with `await open(path, "wx")`, `await handle.close()`, and a bounded retry loop such as 10 attempts using names `parent-${idFactory()}.jsonl`.
+  Implement private `createInvocationDir()` with the current
+  `sessionRoot/<stage>/invocation-*`, explicit `sessionDir`, and prompt temp
+  `sessions` behavior. Implement private `createExactParentSessionFile()` with
+  `await open(path, "wx")`, `await handle.close()`, and a bounded retry loop
+  such as 10 attempts using names `parent-${idFactory()}.jsonl`.
 
 - [ ] **Step 4: Switch Pi argument construction to support exact session paths**
 
-  In `src/cli/commands/run-once/pi.ts`, replace `createSessionDirForPi()` with the new allocation module and change `piPromptArgs()` to accept an allocation:
+  In `src/cli/commands/run-once/pi.ts`, replace `createSessionDirForPi()` with
+  the new allocation module and change `piPromptArgs()` to accept an allocation:
 
   ```ts
   function piPromptArgs(
@@ -312,15 +391,23 @@
   ): string[] {
     const skillArgs = skillPaths.flatMap((path) => ["--skill", path]);
     const baseArgs = [...extensionArgs, ...skillArgs, "-p"];
-    if (session?.sessionPath) return [...baseArgs, "--session", session.sessionPath, `@${promptPath}`];
-    if (session?.sessionDir) return [...baseArgs, "--session-dir", session.sessionDir, `@${promptPath}`];
+    if (session?.sessionPath)
+      return [...baseArgs, "--session", session.sessionPath, `@${promptPath}`];
+    if (session?.sessionDir)
+      return [
+        ...baseArgs,
+        "--session-dir",
+        session.sessionDir,
+        `@${promptPath}`,
+      ];
     return [...baseArgs, `@${promptPath}`];
   }
   ```
 
 - [ ] **Step 5: Log exact session metadata**
 
-  In `runPiPrompt()`, emit both the invocation directory and exact path when present:
+  In `runPiPrompt()`, emit both the invocation directory and exact path when
+  present:
 
   ```ts
   if (sessionAllocation?.sessionDir) {
@@ -351,7 +438,9 @@
   node --test src/cli/commands/run-once/pi.test.ts
   ```
 
-  Expected: PASS for exact observed `--session`, pre-created zero-byte parent files, debug metadata, and unchanged non-observed `--session-dir` message streaming.
+  Expected: PASS for exact observed `--session`, pre-created zero-byte parent
+  files, debug metadata, and unchanged non-observed `--session-dir` message
+  streaming.
 
 - [ ] **Step 7: Commit this task**
 
@@ -371,12 +460,19 @@
 
 **Interfaces:**
 
-- Consumes: exact `sessionPath`, existing `sessionEntryToObservations()`, and optional verbose output callback.
-- Produces: `createExactPiSessionObservationStreamer(sessionPath, onObservation, options)` whose callback can return `void | Promise<void>`, whose polls are serialized, and whose `stop()` rejects with parse, stat, read, or callback failures. The legacy `createPiSessionObservationStreamer(sessionDir, ...)` remains directory-based for triage.
+- Consumes: exact `sessionPath`, existing `sessionEntryToObservations()`, and
+  optional verbose output callback.
+- Produces:
+  `createExactPiSessionObservationStreamer(sessionPath, onObservation, options)`
+  whose callback can return `void | Promise<void>`, whose polls are serialized,
+  and whose `stop()` rejects with parse, stat, read, or callback failures. The
+  legacy `createPiSessionObservationStreamer(sessionDir, ...)` remains
+  directory-based for triage.
 
 - [ ] **Step 1: Write failing deterministic streaming tests**
 
-  Add tests to `src/cli/commands/run-once/pi.test.ts` using explicit promises instead of timers:
+  Add tests to `src/cli/commands/run-once/pi.test.ts` using explicit promises
+  instead of timers:
 
   ```ts
   test("exact session observation awaits callbacks in file order", async (t) => {
@@ -388,8 +484,20 @@
     await writeFile(
       sessionPath,
       [
-        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "first" }] } }),
-        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "second" }] } }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "first" }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "second" }],
+          },
+        }),
       ].join("\n") + "\n",
       "utf8",
     );
@@ -425,7 +533,8 @@
   });
   ```
 
-  Add companion tests that `stop()` rejects on malformed non-empty JSON and on injected `stat`/`readRange` failures with the original error message.
+  Add companion tests that `stop()` rejects on malformed non-empty JSON and on
+  injected `stat`/`readRange` failures with the original error message.
 
 - [ ] **Step 2: Run the streaming tests and confirm failure**
 
@@ -435,27 +544,33 @@
   node --test src/cli/commands/run-once/pi.test.ts
   ```
 
-  Expected: FAIL because there is no exact streamer, malformed JSON is skipped, and observation callbacks are not awaited inline.
+  Expected: FAIL because there is no exact streamer, malformed JSON is skipped,
+  and observation callbacks are not awaited inline.
 
 - [ ] **Step 3: Export exact-streamer types and parse failure behavior**
 
-  In `src/cli/commands/run-once/pi-session-stream.ts`, add a strict parser used only by exact observation:
+  In `src/cli/commands/run-once/pi-session-stream.ts`, add a strict parser used
+  only by exact observation:
 
   ```ts
   function parseStrictSessionLine(line: string): JsonObject | undefined {
     const trimmed = line.trim();
     if (!trimmed) return undefined;
     const parsed = JSON.parse(trimmed) as unknown;
-    if (!isObject(parsed)) throw new Error("Pi session line must be a JSON object");
+    if (!isObject(parsed))
+      throw new Error("Pi session line must be a JSON object");
     return parsed;
   }
   ```
 
-  Keep `parseSessionLine()` lenient for message streaming and legacy triage behavior.
+  Keep `parseSessionLine()` lenient for message streaming and legacy triage
+  behavior.
 
 - [ ] **Step 4: Implement `createExactPiSessionObservationStreamer()`**
 
-  Add an exact streamer that stores only `sessionPath`, never calls `findNewestSessionFile()`, awaits `onObservation()` inline, and records the first asynchronous failure so `stop()` rejects:
+  Add an exact streamer that stores only `sessionPath`, never calls
+  `findNewestSessionFile()`, awaits `onObservation()` inline, and records the
+  first asynchronous failure so `stop()` rejects:
 
   ```ts
   export function createExactPiSessionObservationStreamer(
@@ -481,7 +596,10 @@
 
 - [ ] **Step 5: Keep legacy triage behavior unchanged**
 
-  Leave `createPiSessionObservationStreamer(sessionDir, ...)` as the directory-discovery observer. If its callback type changes, make it accept `void | Promise<void>` but do not make it strict and do not remove `findNewestSessionFile()`.
+  Leave `createPiSessionObservationStreamer(sessionDir, ...)` as the
+  directory-discovery observer. If its callback type changes, make it accept
+  `void | Promise<void>` but do not make it strict and do not remove
+  `findNewestSessionFile()`.
 
 - [ ] **Step 6: Verify exact and legacy streaming tests**
 
@@ -492,7 +610,8 @@
   node --test src/cli/commands/triage/*.test.ts
   ```
 
-  Expected: PASS. Exact streaming rejects meaningful failures and preserves callback order; triage tests remain compatible with directory discovery.
+  Expected: PASS. Exact streaming rejects meaningful failures and preserves
+  callback order; triage tests remain compatible with directory discovery.
 
 - [ ] **Step 7: Commit this task**
 
@@ -513,8 +632,13 @@
 
 **Interfaces:**
 
-- Consumes: `CommandRunner` with `signal`, `createExactPiSessionObservationStreamer()`, `ProgressReporter`, and prompt temp cleanup.
-- Produces: observed `runPiPrompt()` starts the exact streamer before Pi, aborts the command when observation fails, awaits runner close and streamer cleanup, then throws either the single original error or an `AggregateError` preserving observation, runner, parse, heartbeat/progress, and cleanup causes.
+- Consumes: `CommandRunner` with `signal`,
+  `createExactPiSessionObservationStreamer()`, `ProgressReporter`, and prompt
+  temp cleanup.
+- Produces: observed `runPiPrompt()` starts the exact streamer before Pi, aborts
+  the command when observation fails, awaits runner close and streamer cleanup,
+  then throws either the single original error or an `AggregateError` preserving
+  observation, runner, parse, heartbeat/progress, and cleanup causes.
 
 - [ ] **Step 1: Write failing cancellation and aggregation tests**
 
@@ -541,38 +665,54 @@
         allowClose();
       });
       await closeAllowed;
-      return { code: 1, stdout: "partial stdout", stderr: "runner closed after abort" };
+      return {
+        code: 1,
+        stdout: "partial stdout",
+        stderr: "runner closed after abort",
+      };
     });
 
     await assert.rejects(
-      () => runPiPrompt(runner, "/repo", "prompt", { stage: "pi-plan", observeSession: true, sessionRoot: repoRoot }),
+      () =>
+        runPiPrompt(runner, "/repo", "prompt", {
+          stage: "pi-plan",
+          observeSession: true,
+          sessionRoot: repoRoot,
+        }),
       (error) => error instanceof AggregateError && error.errors.length >= 2,
     );
     assert.equal(abortObserved, true);
   });
   ```
 
-  Extend the local test `Call` type and `createMockRunner()` in `pi.test.ts` to carry `signal?: AbortSignal` so mocks can assert abort behavior.
+  Extend the local test `Call` type and `createMockRunner()` in `pi.test.ts` to
+  carry `signal?: AbortSignal` so mocks can assert abort behavior.
 
 - [ ] **Step 2: Add terminal aggregation tests for runner plus cleanup**
 
-  Add a test that injects three independent failures: callback rejection, runner nonzero result, and prompt temp cleanup rejection. Use a test-only `cleanupPromptTempDir` option on `RunPiPromptOptions` so cleanup failure is deterministic:
+  Add a test that injects three independent failures: callback rejection, runner
+  nonzero result, and prompt temp cleanup rejection. Use a test-only
+  `cleanupPromptTempDir` option on `RunPiPromptOptions` so cleanup failure is
+  deterministic:
 
   ```ts
   await assert.rejects(
-    () => runPiPrompt(runner, "/repo", "prompt", {
-      stage: "pi-plan",
-      observeSession: true,
-      onObservation: () => Promise.reject(new Error("callback exploded")),
-      cleanupPromptTempDir: async () => {
-        throw new Error("cleanup exploded");
-      },
-    }),
+    () =>
+      runPiPrompt(runner, "/repo", "prompt", {
+        stage: "pi-plan",
+        observeSession: true,
+        onObservation: () => Promise.reject(new Error("callback exploded")),
+        cleanupPromptTempDir: async () => {
+          throw new Error("cleanup exploded");
+        },
+      }),
     (error) => {
       assert.equal(error instanceof AggregateError, true);
       assert.match(String(error), /pi prompt failed/);
       assert.deepEqual(
-        (error as AggregateError).errors.map((cause) => (cause as Error).message),
+        (error as AggregateError).errors.map(
+          (cause) => (cause as Error).message,
+        ),
         ["callback exploded", "pi failed: runner failed", "cleanup exploded"],
       );
       return true;
@@ -588,7 +728,8 @@
   node --test src/cli/commands/run-once/pi.test.ts
   ```
 
-  Expected: FAIL because `runPiPrompt()` does not pass a signal, does not abort on observation failure, and masks failures through nested `finally` blocks.
+  Expected: FAIL because `runPiPrompt()` does not pass a signal, does not abort
+  on observation failure, and masks failures through nested `finally` blocks.
 
 - [ ] **Step 4: Add `pi-errors.ts`**
 
@@ -604,33 +745,49 @@
     return error instanceof Error ? error : new Error(String(error));
   }
 
-  export function aggregatePiErrors(message: string, causes: PiErrorCause[]): Error | undefined {
+  export function aggregatePiErrors(
+    message: string,
+    causes: PiErrorCause[],
+  ): Error | undefined {
     const normalized = causes.map((cause) => {
       const error = errorFromUnknown(cause.error);
       return new Error(`${cause.label}: ${error.message}`, { cause: error });
     });
     if (normalized.length === 0) return undefined;
-    if (normalized.length === 1) return normalized[0].cause instanceof Error ? normalized[0].cause : normalized[0];
+    if (normalized.length === 1)
+      return normalized[0].cause instanceof Error
+        ? normalized[0].cause
+        : normalized[0];
     return new AggregateError(normalized, message);
   }
 
-  export function formatErrorWithCauses(error: unknown): { message: string; causes?: string[] } {
+  export function formatErrorWithCauses(error: unknown): {
+    message: string;
+    causes?: string[];
+  } {
     const normalized = errorFromUnknown(error);
     if (normalized instanceof AggregateError) {
       return {
         message: normalized.message,
-        causes: normalized.errors.map((cause) => errorFromUnknown(cause).message),
+        causes: normalized.errors.map(
+          (cause) => errorFromUnknown(cause).message,
+        ),
       };
     }
     return { message: normalized.message };
   }
   ```
 
-  The single-cause path must return the original `Error` object so existing `assert.rejects()` checks that match the original message continue to work without wrapping.
+  The single-cause path must return the original `Error` object so existing
+  `assert.rejects()` checks that match the original message continue to work
+  without wrapping.
 
-- [ ] **Step 5: Rework `runPiPrompt()` orchestration around one `AbortController`**
+- [ ] **Step 5: Rework `runPiPrompt()` orchestration around one
+      `AbortController`**
 
-  In `src/cli/commands/run-once/pi.ts`, create an `AbortController` for observed exact sessions, pass `signal: controller.signal` to `runner.run()`, and attach `sessionStreamer.failure.catch(...)` before awaiting the runner:
+  In `src/cli/commands/run-once/pi.ts`, create an `AbortController` for observed
+  exact sessions, pass `signal: controller.signal` to `runner.run()`, and attach
+  `sessionStreamer.failure.catch(...)` before awaiting the runner:
 
   ```ts
   const controller = new AbortController();
@@ -639,7 +796,11 @@
     terminalCauses.push({ label: "observation", error });
     controller.abort(error);
   });
-  const runnerPromise = runner.run(command, args, { cwd, env, signal: controller.signal });
+  const runnerPromise = runner.run(command, args, {
+    cwd,
+    env,
+    signal: controller.signal,
+  });
   const result = await runnerPromise.catch((error) => {
     terminalCauses.push({ label: "runner", error });
     return undefined;
@@ -647,9 +808,11 @@
   await observationFailure;
   ```
 
-  Preserve existing behavior for non-observed message streaming: it may pass no signal unless the refactor makes a signal harmless there.
+  Preserve existing behavior for non-observed message streaming: it may pass no
+  signal unless the refactor makes a signal harmless there.
 
-- [ ] **Step 6: Record all shutdown, parse, heartbeat, progress, and cleanup errors**
+- [ ] **Step 6: Record all shutdown, parse, heartbeat, progress, and cleanup
+      errors**
 
   Replace nested `finally` masking with ordered cause collection:
 
@@ -665,7 +828,10 @@
     terminalCauses.push({ label: "progress", error });
   }
   if (result && result.code !== 0) {
-    terminalCauses.push({ label: "runner", error: new Error(`pi failed: ${result.stderr || result.stdout}`) });
+    terminalCauses.push({
+      label: "runner",
+      error: new Error(`pi failed: ${result.stderr || result.stdout}`),
+    });
   }
   if (result && terminalCauses.length === 0) {
     try {
@@ -678,9 +844,12 @@
   if (combined) throw combined;
   ```
 
-  In the outer cleanup path, catch `await (options?.cleanupPromptTempDir ?? defaultRm)(dir)` errors and aggregate them with any earlier error instead of replacing the earlier failure.
+  In the outer cleanup path, catch
+  `await (options?.cleanupPromptTempDir ?? defaultRm)(dir)` errors and aggregate
+  them with any earlier error instead of replacing the earlier failure.
 
-- [ ] **Step 7: Verify cancellation, aggregation, and existing run-once behavior**
+- [ ] **Step 7: Verify cancellation, aggregation, and existing run-once
+      behavior**
 
   Run:
 
@@ -689,7 +858,9 @@
   npm run test:run-once
   ```
 
-  Expected: PASS. Observation failures abort the mock runner before normal completion, all independent causes appear in thrown aggregate errors, and successful result parsing remains unchanged.
+  Expected: PASS. Observation failures abort the mock runner before normal
+  completion, all independent causes appear in thrown aggregate errors, and
+  successful result parsing remains unchanged.
 
 - [ ] **Step 8: Commit this task**
 
@@ -705,23 +876,32 @@
 **Files:**
 
 - Modify: `src/cli/commands/run-once/main.ts`
-- Modify: `src/cli/commands/run-once/pipeline-failures.test.ts` or `src/cli/commands/run-once/main.test.ts`
+- Modify: `src/cli/commands/run-once/pipeline-failures.test.ts` or
+  `src/cli/commands/run-once/main.test.ts`
 - Create: `src/cli/commands/triage/tool-call-observer.test.ts`
-- Modify: `src/cli/commands/triage/tool-call-observer.ts` only if type compatibility requires it
+- Modify: `src/cli/commands/triage/tool-call-observer.ts` only if type
+  compatibility requires it
 
 **Interfaces:**
 
-- Consumes: `formatErrorWithCauses(error)` from `pi-errors.ts` and legacy `runWithToolCallObservation(onToolCall, run)`.
-- Produces: CLI error JSON may include `causes: string[]` for error results, JSONL error events include cause data, terminal success JSON remains unchanged, and triage still observes tool calls from a session directory.
+- Consumes: `formatErrorWithCauses(error)` from `pi-errors.ts` and legacy
+  `runWithToolCallObservation(onToolCall, run)`.
+- Produces: CLI error JSON may include `causes: string[]` for error results,
+  JSONL error events include cause data, terminal success JSON remains
+  unchanged, and triage still observes tool calls from a session directory.
 
 - [ ] **Step 1: Write failing CLI aggregate-format test**
 
-  In the most focused existing run-once CLI error test file, add coverage that an `AggregateError` is logged and printed with all causes:
+  In the most focused existing run-once CLI error test file, add coverage that
+  an `AggregateError` is logged and printed with all causes:
 
   ```ts
   test("run-once CLI includes aggregate causes in error output", async () => {
     const error = new AggregateError(
-      [new Error("observation: malformed json"), new Error("runner: pi failed")],
+      [
+        new Error("observation: malformed json"),
+        new Error("runner: pi failed"),
+      ],
       "pi prompt failed",
     );
     const formatted = formatErrorWithCauses(error);
@@ -733,10 +913,16 @@
   });
   ```
 
-  If the repository already has a stronger `main()` stdout capture test, assert the final JSON shape instead:
+  If the repository already has a stronger `main()` stdout capture test, assert
+  the final JSON shape instead:
 
   ```json
-  {"status":"error","error":"pi prompt failed","causes":["observation: malformed json","runner: pi failed"],"logPath":"..."}
+  {
+    "status": "error",
+    "error": "pi prompt failed",
+    "causes": ["observation: malformed json", "runner: pi failed"],
+    "logPath": "..."
+  }
   ```
 
 - [ ] **Step 2: Write triage legacy observer regression coverage**
@@ -749,7 +935,11 @@
     let suppliedSessionDir = "";
 
     const result = await runWithToolCallObservation(
-      (event) => observed.push({ toolName: event.toolName, toolCallId: event.toolCallId }),
+      (event) =>
+        observed.push({
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+        }),
       async (sessionDir) => {
         assert.ok(sessionDir);
         suppliedSessionDir = sessionDir;
@@ -758,7 +948,11 @@
           join(sessionDir, "child", "session.jsonl"),
           JSON.stringify({
             type: "message",
-            message: { role: "toolResult", toolName: "bash", toolCallId: "call-1" },
+            message: {
+              role: "toolResult",
+              toolName: "bash",
+              toolCallId: "call-1",
+            },
           }) + "\n",
           "utf8",
         );
@@ -780,11 +974,14 @@
   node --test src/cli/commands/run-once/main.test.ts src/cli/commands/triage/tool-call-observer.test.ts
   ```
 
-  Expected: CLI formatting test fails until `main.ts` uses aggregate formatting. The triage regression should pass unless an earlier task changed legacy observation behavior; if it fails, restore directory-based behavior.
+  Expected: CLI formatting test fails until `main.ts` uses aggregate formatting.
+  The triage regression should pass unless an earlier task changed legacy
+  observation behavior; if it fails, restore directory-based behavior.
 
 - [ ] **Step 4: Use aggregate formatting in `main.ts`**
 
-  Import `formatErrorWithCauses()` and replace both current `const message = ...` error blocks with:
+  Import `formatErrorWithCauses()` and replace both current
+  `const message = ...` error blocks with:
 
   ```ts
   const formatted = formatErrorWithCauses(error);
@@ -795,19 +992,27 @@
     message: `blocked: ${formatted.message}`,
     data: { error: formatted.message, causes: formatted.causes },
   });
-  console.log(JSON.stringify({
-    status: "error",
-    error: formatted.message,
-    ...(formatted.causes ? { causes: formatted.causes } : {}),
-    logPath,
-  }));
+  console.log(
+    JSON.stringify({
+      status: "error",
+      error: formatted.message,
+      ...(formatted.causes ? { causes: formatted.causes } : {}),
+      logPath,
+    }),
+  );
   ```
 
-  In the outer `catch`, use the same formatter but omit `logPath` because it may not exist yet.
+  In the outer `catch`, use the same formatter but omit `logPath` because it may
+  not exist yet.
 
 - [ ] **Step 5: Keep successful stdout contracts unchanged**
 
-  Run or add an assertion using `summarizeResult()` that successful `plan-created`, `pr-created`, `merged`, `blocked`, and approval JSON do not gain a `causes` property. Do not add new tests that only restate static JSON shape if existing tests already cover these success variants; the Testing Value Gate permits direct verification through the focused formatting test plus existing run-once tests.
+  Run or add an assertion using `summarizeResult()` that successful
+  `plan-created`, `pr-created`, `merged`, `blocked`, and approval JSON do not
+  gain a `causes` property. Do not add new tests that only restate static JSON
+  shape if existing tests already cover these success variants; the Testing
+  Value Gate permits direct verification through the focused formatting test
+  plus existing run-once tests.
 
 - [ ] **Step 6: Verify CLI and triage behavior**
 
@@ -818,7 +1023,8 @@
   node --test src/cli/commands/triage/*.test.ts
   ```
 
-  Expected: PASS. Error JSON and JSONL logs preserve cause arrays, and triage still supplies a session directory rather than `--session` metadata.
+  Expected: PASS. Error JSON and JSONL logs preserve cause arrays, and triage
+  still supplies a session directory rather than `--session` metadata.
 
 - [ ] **Step 7: Commit this task**
 
@@ -834,17 +1040,23 @@
 **Files:**
 
 - Modify: `src/cli/commands/run-once/pi.test.ts`
-- Modify: `src/cli/commands/triage/*.test.ts` only if a previous task required compatibility updates
-- No production code changes unless this task exposes a regression from Tasks 1-5
+- Modify: `src/cli/commands/triage/*.test.ts` only if a previous task required
+  compatibility updates
+- No production code changes unless this task exposes a regression from Tasks
+  1-5
 
 **Interfaces:**
 
-- Consumes: exact allocation, exact streamer, abortable runner, aggregate errors, and legacy triage behavior from earlier tasks.
-- Produces: deterministic regression coverage for sibling/nested JSONL isolation and concurrent observed invocation isolation, plus final validation evidence for the PR.
+- Consumes: exact allocation, exact streamer, abortable runner, aggregate
+  errors, and legacy triage behavior from earlier tasks.
+- Produces: deterministic regression coverage for sibling/nested JSONL isolation
+  and concurrent observed invocation isolation, plus final validation evidence
+  for the PR.
 
 - [ ] **Step 1: Add deterministic exact-session ownership tests**
 
-  In `src/cli/commands/run-once/pi.test.ts`, add a test that writes a newer sibling/nested JSONL file and verifies only the exact parent file is observed:
+  In `src/cli/commands/run-once/pi.test.ts`, add a test that writes a newer
+  sibling/nested JSONL file and verifies only the exact parent file is observed:
 
   ```ts
   test("runPiPrompt ignores newer sibling and nested JSONL when observing exact parent", async (t) => {
@@ -861,20 +1073,42 @@
       await mkdir(join(invocationDir, "nested"), { recursive: true });
       await writeFile(
         join(invocationDir, "nested", "session.jsonl"),
-        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "nested" }] } }) + "\n",
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "nested" }],
+          },
+        }) + "\n",
         "utf8",
       );
       await writeFile(
         join(invocationDir, "sibling.jsonl"),
-        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "sibling" }] } }) + "\n",
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "sibling" }],
+          },
+        }) + "\n",
         "utf8",
       );
       await writeFile(
         sessionPath,
-        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "parent" }] } }) + "\n",
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "parent" }],
+          },
+        }) + "\n",
         "utf8",
       );
-      return { code: 0, stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}', stderr: "" };
+      return {
+        code: 0,
+        stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+        stderr: "",
+      };
     });
 
     await runPiPrompt(runner, "/repo", "prompt", {
@@ -892,7 +1126,9 @@
 
 - [ ] **Step 2: Add concurrent observed invocation isolation test**
 
-  Add a test that starts two `runPiPrompt()` calls with the same `sessionRoot`, captures both `--session` paths, writes distinct parent observations, and asserts both paths and observations are distinct:
+  Add a test that starts two `runPiPrompt()` calls with the same `sessionRoot`,
+  captures both `--session` paths, writes distinct parent observations, and
+  asserts both paths and observations are distinct:
 
   ```ts
   assert.notEqual(firstSessionPath, secondSessionPath);
@@ -900,7 +1136,8 @@
   assert.deepEqual(secondObservations, ["second parent"]);
   ```
 
-  Use explicit deferred promises to control when each mock runner writes and closes; do not use `setTimeout()` to order the two invocations.
+  Use explicit deferred promises to control when each mock runner writes and
+  closes; do not use `setTimeout()` to order the two invocations.
 
 - [ ] **Step 3: Run the focused issue tests**
 
@@ -910,7 +1147,8 @@
   node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/triage/*.test.ts
   ```
 
-  Expected: PASS. Concurrent or nested sessions cannot redirect observed parent progress, and triage still uses directory observation.
+  Expected: PASS. Concurrent or nested sessions cannot redirect observed parent
+  progress, and triage still uses directory observation.
 
 - [ ] **Step 4: Run the required run-once suite**
 
@@ -950,16 +1188,20 @@
   git diff -- package.json npm-shrinkwrap.json package-lock.json
   ```
 
-  Expected: no output. Because no npm dependency files changed, no Nix build is required by `AGENTS.md`.
+  Expected: no output. Because no npm dependency files changed, no Nix build is
+  required by `AGENTS.md`.
 
-- [ ] **Step 8: Commit final validation-only test adjustments if any were needed**
+- [ ] **Step 8: Commit final validation-only test adjustments if any were
+      needed**
 
   ```sh
   git add src/cli/commands/run-once/pi.test.ts src/cli/commands/triage
   git commit -m "test: cover exact pi session isolation"
   ```
 
-  If Step 1 and Step 2 were already committed in earlier tasks and this task only ran validation, skip this commit and record the validation output in the PR summary.
+  If Step 1 and Step 2 were already committed in earlier tasks and this task
+  only ran validation, skip this commit and record the validation output in the
+  PR summary.
 
 ---
 
@@ -978,12 +1220,23 @@ git diff -- package.json npm-shrinkwrap.json package-lock.json
 Expected final results:
 
 - All listed tests and lints pass.
-- The dependency-file diff command prints no output; therefore no Nix build is required.
+- The dependency-file diff command prints no output; therefore no Nix build is
+  required.
 - Successful `run-once` still prints only the final JSON object to stdout.
-- Error `run-once` JSON may include `causes`, and the same cause details appear in JSONL progress data.
+- Error `run-once` JSON may include `causes`, and the same cause details appear
+  in JSONL progress data.
 
 ## Self-Review Notes
 
-- Spec coverage: Tasks 2 and 6 cover exact parent session ownership and nested/concurrent isolation; Task 3 covers exact-file reading, strict malformed JSON failure, I/O failure, serialized polling, and callback backpressure; Task 4 covers prompt abort, awaiting runner close and cleanup, and preserving independent terminal causes; Task 5 covers CLI aggregate formatting and triage non-migration; Task 1 covers reusable command-runner cancellation.
-- Placeholder scan: The plan contains concrete file paths, interfaces, tests, commands, expected outcomes, and commit messages for each task.
-- Type consistency: `CommandRunOptions.signal`, `PiSessionAllocation`, `createExactPiSessionObservationStreamer()`, `aggregatePiErrors()`, and `formatErrorWithCauses()` names are used consistently across tasks.
+- Spec coverage: Tasks 2 and 6 cover exact parent session ownership and
+  nested/concurrent isolation; Task 3 covers exact-file reading, strict
+  malformed JSON failure, I/O failure, serialized polling, and callback
+  backpressure; Task 4 covers prompt abort, awaiting runner close and cleanup,
+  and preserving independent terminal causes; Task 5 covers CLI aggregate
+  formatting and triage non-migration; Task 1 covers reusable command-runner
+  cancellation.
+- Placeholder scan: The plan contains concrete file paths, interfaces, tests,
+  commands, expected outcomes, and commit messages for each task.
+- Type consistency: `CommandRunOptions.signal`, `PiSessionAllocation`,
+  `createExactPiSessionObservationStreamer()`, `aggregatePiErrors()`, and
+  `formatErrorWithCauses()` names are used consistently across tasks.

--- a/docs/plans/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming.md
+++ b/docs/plans/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming.md
@@ -1,0 +1,989 @@
+# Deterministic Abortable Run-Once Pi Session Streaming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `run-once` observe exactly one owned parent Pi session with serial callback backpressure, prompt cancellation on observation failure, and complete terminal error reporting.
+
+**Architecture:** Observed `runPiPrompt()` calls allocate a unique pre-created parent JSONL file in the durable invocation leaf, pass that file to Pi with `--session`, and start an exact-file observer that never scans for the newest recursive JSONL. The command runner accepts an `AbortSignal`, and `runPiPrompt()` coordinates the runner, streamer, heartbeat, parsing, and cleanup through ordered cause collection so independent failures are preserved.
+
+**Tech Stack:** Node.js 22.19+, TypeScript ESM, `node:test`, Node `child_process.spawn`, Node `fs/promises`, existing Patchmill progress reporters and Pi JSONL session parsing.
+
+## Global Constraints
+
+- Scope is limited to exact-session ownership, streaming backpressure, cancellation, and terminal-error preservation for issue #123.
+- Do not change `pi-subagents` or parse/render subagent-specific metadata.
+- Do not migrate triage to exact-session observation; triage keeps the legacy directory-based observer and receives regression coverage only.
+- Successful `run-once` stdout remains the final JSON object only; progress, verbose Pi output, and error detail stay on stderr and in the JSONL run log.
+- Tests for new production behavior must use deterministic synchronization primitives, not timing races.
+- Apply Patchmill's Testing Value Gate: automated tests are required here because this changes reusable streaming, cancellation, API contracts, error handling, and regressions.
+- Do not change `package.json`, `npm-shrinkwrap.json`, or `package-lock.json`; if an implementation accidentally changes npm dependency files, revert them or run the Nix build required by `AGENTS.md`.
+
+---
+
+## File Structure
+
+- `src/cli/commands/triage/types.ts` owns the shared command-runner type. Add only `signal?: AbortSignal` to `CommandRunOptions` so all current callers remain compatible.
+- `src/cli/commands/triage/command.ts` owns the real spawned-process adapter. Add abort handling here without changing its `CommandResult` return contract.
+- `src/cli/commands/run-once/pi-session-allocation.ts` is a new focused module for durable invocation directory creation and exact parent session file pre-creation. This keeps filesystem allocation separate from `pi.ts`, which is already a broad Pi orchestration module.
+- `src/cli/commands/run-once/pi-errors.ts` is a new focused module for converting independent terminal causes into a single thrown error and formatting aggregate causes for CLI/log output.
+- `src/cli/commands/run-once/pi-session-stream.ts` keeps session JSONL parsing and streaming. Add exact-file observation beside the legacy directory observer; do not remove `findNewestSessionFile()` because triage still depends on it.
+- `src/cli/commands/run-once/pi.ts` remains the `runPiPrompt()` orchestration facade. Replace observed-session directory discovery with exact session allocation, wire the abort controller, and delegate aggregation to `pi-errors.ts`.
+- `src/cli/commands/run-once/main.ts` owns run-once CLI terminal JSON/log formatting. Teach its error path to include aggregate causes without changing success-result JSON.
+- Tests stay near owners: `src/cli/commands/triage/command.test.ts`, `src/cli/commands/triage/tool-call-observer.test.ts`, and `src/cli/commands/run-once/pi.test.ts`.
+
+---
+
+### Task 1: Add AbortSignal Support to the Reusable Command Runner
+
+**Files:**
+
+- Modify: `src/cli/commands/triage/types.ts`
+- Modify: `src/cli/commands/triage/command.ts`
+- Modify: `src/cli/commands/triage/command.test.ts`
+- Modify: `test-support/command-runner.ts`
+
+**Interfaces:**
+
+- Consumes: existing `CommandRunner.run(command, args, options)` contract.
+- Produces: `CommandRunOptions.signal?: AbortSignal`; real runner terminates an in-flight child on abort, keeps collecting stdout/stderr until `close`, and returns a nonzero `CommandResult` without spawning when the signal is already aborted.
+
+- [ ] **Step 1: Write the failing command-runner abort tests**
+
+  Add these tests to `src/cli/commands/triage/command.test.ts`:
+
+  ```ts
+  test("command runner aborts an in-flight process and waits for close", async () => {
+    const runner = createCommandRunner();
+    const controller = new AbortController();
+    const resultPromise = runner.run(
+      process.execPath,
+      [
+        "-e",
+        [
+          "process.stdout.write('started\\n');",
+          "process.stderr.write('stderr-before-abort\\n');",
+          "process.on('SIGTERM', () => {",
+          "  process.stdout.write('closed-after-abort\\n');",
+          "  process.exit(0);",
+          "});",
+          "setInterval(() => {}, 1000);",
+        ].join(""),
+      ],
+      { signal: controller.signal },
+    );
+
+    controller.abort();
+    const result = await resultPromise;
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stdout, /started|closed-after-abort/);
+    assert.match(result.stderr, /stderr-before-abort|aborted/i);
+  });
+
+  test("command runner does not spawn when signal is already aborted", async () => {
+    const runner = createCommandRunner();
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await runner.run(
+      process.execPath,
+      ["-e", "process.stdout.write('should-not-run')"],
+      { signal: controller.signal },
+    );
+
+    assert.notEqual(result.code, 0);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, /aborted/i);
+  });
+  ```
+
+- [ ] **Step 2: Run the failing command-runner tests**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/triage/command.test.ts
+  ```
+
+  Expected: TypeScript or runtime failure because `CommandRunOptions` has no `signal` property and `createCommandRunner()` ignores aborts.
+
+- [ ] **Step 3: Extend the shared command-runner type and test support**
+
+  In `src/cli/commands/triage/types.ts`, change `CommandRunOptions` to:
+
+  ```ts
+  export type CommandRunOptions = {
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+    onStdout?: (chunk: string) => void;
+    onStderr?: (chunk: string) => void;
+    signal?: AbortSignal;
+  };
+  ```
+
+  In `test-support/command-runner.ts`, keep static-runner compatibility and record no new state unless a future test needs it:
+
+  ```ts
+  async run(command, args, options = {}) {
+    calls.push(normalizeRecordedPiCall(command, args, options.cwd));
+    const result = results[index];
+    index += 1;
+    return result ?? { code: 0, stdout: "", stderr: "" };
+  }
+  ```
+
+- [ ] **Step 4: Implement minimal abort handling in `createCommandRunner()`**
+
+  Update `src/cli/commands/triage/command.ts` so it checks `options.signal?.aborted` before `spawn`, attaches one abort listener after spawn, calls `child.kill("SIGTERM")`, and settles only from `close` or `error`:
+
+  ```ts
+  if (options.signal?.aborted) {
+    return Promise.resolve({
+      code: 1,
+      stdout: "",
+      stderr: "command aborted before spawn",
+    });
+  }
+  ```
+
+  Ensure the abort path appends an abort marker to `stderr` without discarding existing stderr:
+
+  ```ts
+  const onAbort = () => {
+    stderr += stderr.endsWith("\n") || stderr.length === 0 ? "" : "\n";
+    stderr += "command aborted\n";
+    child.kill("SIGTERM");
+  };
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+  child.on("close", (code, signal) => {
+    options.signal?.removeEventListener("abort", onAbort);
+    const aborted = options.signal?.aborted === true;
+    settle({
+      code: aborted ? 1 : (code ?? 1),
+      stdout,
+      stderr:
+        signal && !stderr.includes(signal) ? `${stderr}${signal}\n` : stderr,
+    });
+  });
+  ```
+
+- [ ] **Step 5: Verify command-runner behavior**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/triage/command.test.ts
+  ```
+
+  Expected: PASS, including existing stdout/stderr/cwd tests and the two abort tests.
+
+- [ ] **Step 6: Commit this task**
+
+  ```sh
+  git add src/cli/commands/triage/types.ts src/cli/commands/triage/command.ts src/cli/commands/triage/command.test.ts test-support/command-runner.ts
+  git commit -m "feat: make command runner abortable"
+  ```
+
+---
+
+### Task 2: Allocate and Pass Exact Parent Pi Session Files for Observed Run-Once Calls
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/pi-session-allocation.ts`
+- Modify: `src/cli/commands/run-once/pi.ts`
+- Modify: `src/cli/commands/run-once/pi.test.ts`
+
+**Interfaces:**
+
+- Consumes: `RunPiPromptOptions.stage`, `observeSession`, `streamOutput`, `sessionRoot`, `sessionDir`, and the prompt temp dir.
+- Produces: `PiSessionAllocation { sessionDir: string; sessionPath?: string }`; observed calls receive a pre-created `sessionPath` passed via `--session <path>`, while non-observed message streaming keeps `--session-dir <dir>`.
+
+- [ ] **Step 1: Write failing exact-session allocation tests**
+
+  In `src/cli/commands/run-once/pi.test.ts`, add tests that assert observed calls pass `--session` and not `--session-dir`:
+
+  ```ts
+  test("runPiPrompt pre-creates and passes an exact observed parent session", async (t) => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-exact-session-"));
+    t.after(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+    });
+    const sessionRoot = join(repoRoot, ".patchmill", "runs", "issue-123", "run-pi-sessions");
+    const events: AgentIssueProgressEvent[] = [];
+    let observedSessionPath = "";
+
+    const runner = createMockRunner(async (call) => {
+      const args = assertBundledPiCall(call);
+      const sessionIndex = args.indexOf("--session");
+      assert.ok(sessionIndex >= 0, `expected --session in ${args.join(" ")}`);
+      assert.equal(args.includes("--session-dir"), false);
+      observedSessionPath = args[sessionIndex + 1] ?? "";
+      const invocationDir = dirname(observedSessionPath);
+      assert.equal(dirname(invocationDir), join(sessionRoot, "pi-plan"));
+      assert.match(basename(invocationDir), /^invocation-/);
+      assert.match(basename(observedSessionPath), /^parent-[0-9a-f-]+\.jsonl$/);
+      assert.equal(await readFile(observedSessionPath, "utf8"), "");
+      await writeFile(
+        observedSessionPath,
+        JSON.stringify({ type: "session", id: "parent", cwd: "/repo" }) + "\n",
+        "utf8",
+      );
+      return { code: 0, stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}', stderr: "" };
+    });
+
+    await runPiPrompt(runner, "/repo", "prompt", {
+      progress: { event: (event) => events.push(event) },
+      stage: "pi-plan",
+      observeSession: true,
+      sessionRoot,
+    });
+
+    assert.ok(observedSessionPath.endsWith(".jsonl"));
+    assert.ok(events.some((event) => event.message === "pi session path" && event.data === observedSessionPath));
+  });
+  ```
+
+  Also replace the current observed `sessionDir` override assertion so it expects `--session <exactSessionDir>/parent-*.jsonl` and a `pi session path` debug event. Keep the existing non-observed `streamOutput` tests expecting `--session-dir`.
+
+- [ ] **Step 2: Run the exact-session allocation tests and confirm failure**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts
+  ```
+
+  Expected: FAIL because observed `runPiPrompt()` still passes `--session-dir` and does not pre-create a parent file.
+
+- [ ] **Step 3: Add the allocation module**
+
+  Create `src/cli/commands/run-once/pi-session-allocation.ts` with this public surface:
+
+  ```ts
+  import { mkdir, mkdtemp, open } from "node:fs/promises";
+  import { randomUUID } from "node:crypto";
+  import { join } from "node:path";
+
+  export type PiSessionAllocation = {
+    sessionDir: string;
+    sessionPath?: string;
+  };
+
+  export type PiSessionAllocationOptions = {
+    stage: string;
+    promptTempDir: string;
+    observeSession?: boolean;
+    streamOutput?: boolean;
+    sessionRoot?: string;
+    sessionDir?: string;
+    idFactory?: () => string;
+  };
+
+  export async function createPiSessionAllocation(
+    options: PiSessionAllocationOptions,
+  ): Promise<PiSessionAllocation | undefined> {
+    const shouldCreateSession = options.observeSession || options.streamOutput;
+    if (!shouldCreateSession) return undefined;
+
+    const sessionDir = await createInvocationDir(options);
+    if (!options.observeSession) return { sessionDir };
+
+    const sessionPath = await createExactParentSessionFile(
+      sessionDir,
+      options.idFactory ?? randomUUID,
+    );
+    return { sessionDir, sessionPath };
+  }
+  ```
+
+  Implement private `createInvocationDir()` with the current `sessionRoot/<stage>/invocation-*`, explicit `sessionDir`, and prompt temp `sessions` behavior. Implement private `createExactParentSessionFile()` with `await open(path, "wx")`, `await handle.close()`, and a bounded retry loop such as 10 attempts using names `parent-${idFactory()}.jsonl`.
+
+- [ ] **Step 4: Switch Pi argument construction to support exact session paths**
+
+  In `src/cli/commands/run-once/pi.ts`, replace `createSessionDirForPi()` with the new allocation module and change `piPromptArgs()` to accept an allocation:
+
+  ```ts
+  function piPromptArgs(
+    promptPath: string,
+    session: PiSessionAllocation | undefined,
+    skillPaths: string[] = [],
+    extensionArgs: string[] = [],
+  ): string[] {
+    const skillArgs = skillPaths.flatMap((path) => ["--skill", path]);
+    const baseArgs = [...extensionArgs, ...skillArgs, "-p"];
+    if (session?.sessionPath) return [...baseArgs, "--session", session.sessionPath, `@${promptPath}`];
+    if (session?.sessionDir) return [...baseArgs, "--session-dir", session.sessionDir, `@${promptPath}`];
+    return [...baseArgs, `@${promptPath}`];
+  }
+  ```
+
+- [ ] **Step 5: Log exact session metadata**
+
+  In `runPiPrompt()`, emit both the invocation directory and exact path when present:
+
+  ```ts
+  if (sessionAllocation?.sessionDir) {
+    await options?.progress?.event({
+      time: new Date().toISOString(),
+      level: "debug",
+      stage: options.stage,
+      message: "pi session dir",
+      data: sessionAllocation.sessionDir,
+    });
+  }
+  if (sessionAllocation?.sessionPath) {
+    await options?.progress?.event({
+      time: new Date().toISOString(),
+      level: "debug",
+      stage: options.stage,
+      message: "pi session path",
+      data: sessionAllocation.sessionPath,
+    });
+  }
+  ```
+
+- [ ] **Step 6: Verify allocation behavior**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts
+  ```
+
+  Expected: PASS for exact observed `--session`, pre-created zero-byte parent files, debug metadata, and unchanged non-observed `--session-dir` message streaming.
+
+- [ ] **Step 7: Commit this task**
+
+  ```sh
+  git add src/cli/commands/run-once/pi-session-allocation.ts src/cli/commands/run-once/pi.ts src/cli/commands/run-once/pi.test.ts
+  git commit -m "feat: allocate exact run-once pi sessions"
+  ```
+
+---
+
+### Task 3: Add Exact-File Observation with Serial Backpressure and Hard Failures
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pi-session-stream.ts`
+- Modify: `src/cli/commands/run-once/pi.test.ts`
+
+**Interfaces:**
+
+- Consumes: exact `sessionPath`, existing `sessionEntryToObservations()`, and optional verbose output callback.
+- Produces: `createExactPiSessionObservationStreamer(sessionPath, onObservation, options)` whose callback can return `void | Promise<void>`, whose polls are serialized, and whose `stop()` rejects with parse, stat, read, or callback failures. The legacy `createPiSessionObservationStreamer(sessionDir, ...)` remains directory-based for triage.
+
+- [ ] **Step 1: Write failing deterministic streaming tests**
+
+  Add tests to `src/cli/commands/run-once/pi.test.ts` using explicit promises instead of timers:
+
+  ```ts
+  test("exact session observation awaits callbacks in file order", async (t) => {
+    const dir = await mkdtemp(join(tmpdir(), "patchmill-exact-stream-"));
+    t.after(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+    const sessionPath = join(dir, "parent.jsonl");
+    await writeFile(
+      sessionPath,
+      [
+        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "first" }] } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "second" }] } }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const delivered: string[] = [];
+    let releaseFirst!: () => void;
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted!: () => void;
+    const firstWasDelivered = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const streamer = createExactPiSessionObservationStreamer(
+      sessionPath,
+      async (observation) => {
+        if (observation.type !== "text") return;
+        delivered.push(observation.text);
+        if (observation.text === "first") {
+          firstStarted();
+          await firstCanFinish;
+        }
+      },
+      { pollMs: 60_000 },
+    );
+
+    streamer.start();
+    await firstWasDelivered;
+    assert.deepEqual(delivered, ["first"]);
+    releaseFirst();
+    await streamer.stop();
+    assert.deepEqual(delivered, ["first", "second"]);
+  });
+  ```
+
+  Add companion tests that `stop()` rejects on malformed non-empty JSON and on injected `stat`/`readRange` failures with the original error message.
+
+- [ ] **Step 2: Run the streaming tests and confirm failure**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts
+  ```
+
+  Expected: FAIL because there is no exact streamer, malformed JSON is skipped, and observation callbacks are not awaited inline.
+
+- [ ] **Step 3: Export exact-streamer types and parse failure behavior**
+
+  In `src/cli/commands/run-once/pi-session-stream.ts`, add a strict parser used only by exact observation:
+
+  ```ts
+  function parseStrictSessionLine(line: string): JsonObject | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) return undefined;
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!isObject(parsed)) throw new Error("Pi session line must be a JSON object");
+    return parsed;
+  }
+  ```
+
+  Keep `parseSessionLine()` lenient for message streaming and legacy triage behavior.
+
+- [ ] **Step 4: Implement `createExactPiSessionObservationStreamer()`**
+
+  Add an exact streamer that stores only `sessionPath`, never calls `findNewestSessionFile()`, awaits `onObservation()` inline, and records the first asynchronous failure so `stop()` rejects:
+
+  ```ts
+  export function createExactPiSessionObservationStreamer(
+    sessionPath: string,
+    onObservation: (observation: PiSessionObservation) => void | Promise<void>,
+    options: ExactPiSessionObservationStreamerOptions = {},
+  ): { start(): void; stop(): Promise<void>; failure: Promise<never> } {
+    // exact implementation reads only sessionPath, serializes runPoll(),
+    // and rejects failure when stat, read, JSON.parse, or onObservation fails.
+  }
+  ```
+
+  Use options with deterministic test seams:
+
+  ```ts
+  type ExactPiSessionObservationStreamerOptions = {
+    pollMs?: number;
+    verboseOutput?: (chunk: string) => void;
+    statFile?: typeof stat;
+    readRange?: typeof readRange;
+  };
+  ```
+
+- [ ] **Step 5: Keep legacy triage behavior unchanged**
+
+  Leave `createPiSessionObservationStreamer(sessionDir, ...)` as the directory-discovery observer. If its callback type changes, make it accept `void | Promise<void>` but do not make it strict and do not remove `findNewestSessionFile()`.
+
+- [ ] **Step 6: Verify exact and legacy streaming tests**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts
+  node --test src/cli/commands/triage/*.test.ts
+  ```
+
+  Expected: PASS. Exact streaming rejects meaningful failures and preserves callback order; triage tests remain compatible with directory discovery.
+
+- [ ] **Step 7: Commit this task**
+
+  ```sh
+  git add src/cli/commands/run-once/pi-session-stream.ts src/cli/commands/run-once/pi.test.ts src/cli/commands/triage
+  git commit -m "feat: stream exact pi sessions serially"
+  ```
+
+---
+
+### Task 4: Abort Pi Prompt Runs on Observation Failure and Preserve All Terminal Causes
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/pi-errors.ts`
+- Modify: `src/cli/commands/run-once/pi.ts`
+- Modify: `src/cli/commands/run-once/pi.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CommandRunner` with `signal`, `createExactPiSessionObservationStreamer()`, `ProgressReporter`, and prompt temp cleanup.
+- Produces: observed `runPiPrompt()` starts the exact streamer before Pi, aborts the command when observation fails, awaits runner close and streamer cleanup, then throws either the single original error or an `AggregateError` preserving observation, runner, parse, heartbeat/progress, and cleanup causes.
+
+- [ ] **Step 1: Write failing cancellation and aggregation tests**
+
+  Add deterministic mock-runner tests to `src/cli/commands/run-once/pi.test.ts`:
+
+  ```ts
+  test("runPiPrompt aborts the runner when exact observation fails", async (t) => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-observe-abort-"));
+    t.after(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+    });
+    let abortObserved = false;
+    let allowClose!: () => void;
+    const closeAllowed = new Promise<void>((resolve) => {
+      allowClose = resolve;
+    });
+
+    const runner = createMockRunner(async (call) => {
+      const args = assertBundledPiCall(call);
+      const sessionPath = args[args.indexOf("--session") + 1] ?? "";
+      await writeFile(sessionPath, "{bad json\n", "utf8");
+      call.signal?.addEventListener("abort", () => {
+        abortObserved = true;
+        allowClose();
+      });
+      await closeAllowed;
+      return { code: 1, stdout: "partial stdout", stderr: "runner closed after abort" };
+    });
+
+    await assert.rejects(
+      () => runPiPrompt(runner, "/repo", "prompt", { stage: "pi-plan", observeSession: true, sessionRoot: repoRoot }),
+      (error) => error instanceof AggregateError && error.errors.length >= 2,
+    );
+    assert.equal(abortObserved, true);
+  });
+  ```
+
+  Extend the local test `Call` type and `createMockRunner()` in `pi.test.ts` to carry `signal?: AbortSignal` so mocks can assert abort behavior.
+
+- [ ] **Step 2: Add terminal aggregation tests for runner plus cleanup**
+
+  Add a test that injects three independent failures: callback rejection, runner nonzero result, and prompt temp cleanup rejection. Use a test-only `cleanupPromptTempDir` option on `RunPiPromptOptions` so cleanup failure is deterministic:
+
+  ```ts
+  await assert.rejects(
+    () => runPiPrompt(runner, "/repo", "prompt", {
+      stage: "pi-plan",
+      observeSession: true,
+      onObservation: () => Promise.reject(new Error("callback exploded")),
+      cleanupPromptTempDir: async () => {
+        throw new Error("cleanup exploded");
+      },
+    }),
+    (error) => {
+      assert.equal(error instanceof AggregateError, true);
+      assert.match(String(error), /pi prompt failed/);
+      assert.deepEqual(
+        (error as AggregateError).errors.map((cause) => (cause as Error).message),
+        ["callback exploded", "pi failed: runner failed", "cleanup exploded"],
+      );
+      return true;
+    },
+  );
+  ```
+
+- [ ] **Step 3: Run the new run-once tests and confirm failure**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts
+  ```
+
+  Expected: FAIL because `runPiPrompt()` does not pass a signal, does not abort on observation failure, and masks failures through nested `finally` blocks.
+
+- [ ] **Step 4: Add `pi-errors.ts`**
+
+  Create `src/cli/commands/run-once/pi-errors.ts` with narrow helpers:
+
+  ```ts
+  export type PiErrorCause = {
+    label: string;
+    error: unknown;
+  };
+
+  export function errorFromUnknown(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+
+  export function aggregatePiErrors(message: string, causes: PiErrorCause[]): Error | undefined {
+    const normalized = causes.map((cause) => {
+      const error = errorFromUnknown(cause.error);
+      return new Error(`${cause.label}: ${error.message}`, { cause: error });
+    });
+    if (normalized.length === 0) return undefined;
+    if (normalized.length === 1) return normalized[0].cause instanceof Error ? normalized[0].cause : normalized[0];
+    return new AggregateError(normalized, message);
+  }
+
+  export function formatErrorWithCauses(error: unknown): { message: string; causes?: string[] } {
+    const normalized = errorFromUnknown(error);
+    if (normalized instanceof AggregateError) {
+      return {
+        message: normalized.message,
+        causes: normalized.errors.map((cause) => errorFromUnknown(cause).message),
+      };
+    }
+    return { message: normalized.message };
+  }
+  ```
+
+  The single-cause path must return the original `Error` object so existing `assert.rejects()` checks that match the original message continue to work without wrapping.
+
+- [ ] **Step 5: Rework `runPiPrompt()` orchestration around one `AbortController`**
+
+  In `src/cli/commands/run-once/pi.ts`, create an `AbortController` for observed exact sessions, pass `signal: controller.signal` to `runner.run()`, and attach `sessionStreamer.failure.catch(...)` before awaiting the runner:
+
+  ```ts
+  const controller = new AbortController();
+  const terminalCauses: PiErrorCause[] = [];
+  const observationFailure = sessionStreamer?.failure.catch((error) => {
+    terminalCauses.push({ label: "observation", error });
+    controller.abort(error);
+  });
+  const runnerPromise = runner.run(command, args, { cwd, env, signal: controller.signal });
+  const result = await runnerPromise.catch((error) => {
+    terminalCauses.push({ label: "runner", error });
+    return undefined;
+  });
+  await observationFailure;
+  ```
+
+  Preserve existing behavior for non-observed message streaming: it may pass no signal unless the refactor makes a signal harmless there.
+
+- [ ] **Step 6: Record all shutdown, parse, heartbeat, progress, and cleanup errors**
+
+  Replace nested `finally` masking with ordered cause collection:
+
+  ```ts
+  try {
+    await sessionStreamer?.stop();
+  } catch (error) {
+    terminalCauses.push({ label: "streamer shutdown", error });
+  }
+  try {
+    await emitPiOutput(result, options);
+  } catch (error) {
+    terminalCauses.push({ label: "progress", error });
+  }
+  if (result && result.code !== 0) {
+    terminalCauses.push({ label: "runner", error: new Error(`pi failed: ${result.stderr || result.stdout}`) });
+  }
+  if (result && terminalCauses.length === 0) {
+    try {
+      return parseResult(result.stdout) as Result;
+    } catch (error) {
+      terminalCauses.push({ label: "result parsing", error });
+    }
+  }
+  const combined = aggregatePiErrors("pi prompt failed", terminalCauses);
+  if (combined) throw combined;
+  ```
+
+  In the outer cleanup path, catch `await (options?.cleanupPromptTempDir ?? defaultRm)(dir)` errors and aggregate them with any earlier error instead of replacing the earlier failure.
+
+- [ ] **Step 7: Verify cancellation, aggregation, and existing run-once behavior**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Observation failures abort the mock runner before normal completion, all independent causes appear in thrown aggregate errors, and successful result parsing remains unchanged.
+
+- [ ] **Step 8: Commit this task**
+
+  ```sh
+  git add src/cli/commands/run-once/pi-errors.ts src/cli/commands/run-once/pi.ts src/cli/commands/run-once/pi.test.ts
+  git commit -m "feat: abort pi runs on observation failure"
+  ```
+
+---
+
+### Task 5: Format Aggregate Errors in Run-Once CLI Output and Preserve Triage Regression Behavior
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/main.ts`
+- Modify: `src/cli/commands/run-once/pipeline-failures.test.ts` or `src/cli/commands/run-once/main.test.ts`
+- Create: `src/cli/commands/triage/tool-call-observer.test.ts`
+- Modify: `src/cli/commands/triage/tool-call-observer.ts` only if type compatibility requires it
+
+**Interfaces:**
+
+- Consumes: `formatErrorWithCauses(error)` from `pi-errors.ts` and legacy `runWithToolCallObservation(onToolCall, run)`.
+- Produces: CLI error JSON may include `causes: string[]` for error results, JSONL error events include cause data, terminal success JSON remains unchanged, and triage still observes tool calls from a session directory.
+
+- [ ] **Step 1: Write failing CLI aggregate-format test**
+
+  In the most focused existing run-once CLI error test file, add coverage that an `AggregateError` is logged and printed with all causes:
+
+  ```ts
+  test("run-once CLI includes aggregate causes in error output", async () => {
+    const error = new AggregateError(
+      [new Error("observation: malformed json"), new Error("runner: pi failed")],
+      "pi prompt failed",
+    );
+    const formatted = formatErrorWithCauses(error);
+
+    assert.deepEqual(formatted, {
+      message: "pi prompt failed",
+      causes: ["observation: malformed json", "runner: pi failed"],
+    });
+  });
+  ```
+
+  If the repository already has a stronger `main()` stdout capture test, assert the final JSON shape instead:
+
+  ```json
+  {"status":"error","error":"pi prompt failed","causes":["observation: malformed json","runner: pi failed"],"logPath":"..."}
+  ```
+
+- [ ] **Step 2: Write triage legacy observer regression coverage**
+
+  Create `src/cli/commands/triage/tool-call-observer.test.ts`:
+
+  ```ts
+  test("runWithToolCallObservation supplies a session directory and observes legacy tool calls", async () => {
+    const observed: Array<{ toolName?: string; toolCallId?: string }> = [];
+    let suppliedSessionDir = "";
+
+    const result = await runWithToolCallObservation(
+      (event) => observed.push({ toolName: event.toolName, toolCallId: event.toolCallId }),
+      async (sessionDir) => {
+        assert.ok(sessionDir);
+        suppliedSessionDir = sessionDir;
+        await mkdir(join(sessionDir, "child"), { recursive: true });
+        await writeFile(
+          join(sessionDir, "child", "session.jsonl"),
+          JSON.stringify({
+            type: "message",
+            message: { role: "toolResult", toolName: "bash", toolCallId: "call-1" },
+          }) + "\n",
+          "utf8",
+        );
+        return "ok";
+      },
+    );
+
+    assert.equal(result, "ok");
+    assert.deepEqual(observed, [{ toolName: "bash", toolCallId: "call-1" }]);
+    await assert.rejects(stat(suppliedSessionDir), { code: "ENOENT" });
+  });
+  ```
+
+- [ ] **Step 3: Run the new formatting and triage tests and confirm failure**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/main.test.ts src/cli/commands/triage/tool-call-observer.test.ts
+  ```
+
+  Expected: CLI formatting test fails until `main.ts` uses aggregate formatting. The triage regression should pass unless an earlier task changed legacy observation behavior; if it fails, restore directory-based behavior.
+
+- [ ] **Step 4: Use aggregate formatting in `main.ts`**
+
+  Import `formatErrorWithCauses()` and replace both current `const message = ...` error blocks with:
+
+  ```ts
+  const formatted = formatErrorWithCauses(error);
+  await progress.event({
+    time: new Date().toISOString(),
+    level: "error",
+    stage: "error",
+    message: `blocked: ${formatted.message}`,
+    data: { error: formatted.message, causes: formatted.causes },
+  });
+  console.log(JSON.stringify({
+    status: "error",
+    error: formatted.message,
+    ...(formatted.causes ? { causes: formatted.causes } : {}),
+    logPath,
+  }));
+  ```
+
+  In the outer `catch`, use the same formatter but omit `logPath` because it may not exist yet.
+
+- [ ] **Step 5: Keep successful stdout contracts unchanged**
+
+  Run or add an assertion using `summarizeResult()` that successful `plan-created`, `pr-created`, `merged`, `blocked`, and approval JSON do not gain a `causes` property. Do not add new tests that only restate static JSON shape if existing tests already cover these success variants; the Testing Value Gate permits direct verification through the focused formatting test plus existing run-once tests.
+
+- [ ] **Step 6: Verify CLI and triage behavior**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/main.test.ts src/cli/commands/triage/tool-call-observer.test.ts
+  node --test src/cli/commands/triage/*.test.ts
+  ```
+
+  Expected: PASS. Error JSON and JSONL logs preserve cause arrays, and triage still supplies a session directory rather than `--session` metadata.
+
+- [ ] **Step 7: Commit this task**
+
+  ```sh
+  git add src/cli/commands/run-once/main.ts src/cli/commands/run-once/main.test.ts src/cli/commands/run-once/pipeline-failures.test.ts src/cli/commands/triage/tool-call-observer.ts src/cli/commands/triage/tool-call-observer.test.ts
+  git commit -m "feat: report aggregate run-once errors"
+  ```
+
+---
+
+### Task 6: Verify Exact Ownership Under Concurrency and Complete the Issue Validation
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pi.test.ts`
+- Modify: `src/cli/commands/triage/*.test.ts` only if a previous task required compatibility updates
+- No production code changes unless this task exposes a regression from Tasks 1-5
+
+**Interfaces:**
+
+- Consumes: exact allocation, exact streamer, abortable runner, aggregate errors, and legacy triage behavior from earlier tasks.
+- Produces: deterministic regression coverage for sibling/nested JSONL isolation and concurrent observed invocation isolation, plus final validation evidence for the PR.
+
+- [ ] **Step 1: Add deterministic exact-session ownership tests**
+
+  In `src/cli/commands/run-once/pi.test.ts`, add a test that writes a newer sibling/nested JSONL file and verifies only the exact parent file is observed:
+
+  ```ts
+  test("runPiPrompt ignores newer sibling and nested JSONL when observing exact parent", async (t) => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-exact-ignore-"));
+    t.after(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+    });
+    const observations: string[] = [];
+
+    const runner = createMockRunner(async (call) => {
+      const args = assertBundledPiCall(call);
+      const sessionPath = args[args.indexOf("--session") + 1] ?? "";
+      const invocationDir = dirname(sessionPath);
+      await mkdir(join(invocationDir, "nested"), { recursive: true });
+      await writeFile(
+        join(invocationDir, "nested", "session.jsonl"),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "nested" }] } }) + "\n",
+        "utf8",
+      );
+      await writeFile(
+        join(invocationDir, "sibling.jsonl"),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "sibling" }] } }) + "\n",
+        "utf8",
+      );
+      await writeFile(
+        sessionPath,
+        JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "parent" }] } }) + "\n",
+        "utf8",
+      );
+      return { code: 0, stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}', stderr: "" };
+    });
+
+    await runPiPrompt(runner, "/repo", "prompt", {
+      stage: "pi-plan",
+      observeSession: true,
+      sessionRoot: repoRoot,
+      onObservation: (observation) => {
+        if (observation.type === "text") observations.push(observation.text);
+      },
+    });
+
+    assert.deepEqual(observations, ["parent"]);
+  });
+  ```
+
+- [ ] **Step 2: Add concurrent observed invocation isolation test**
+
+  Add a test that starts two `runPiPrompt()` calls with the same `sessionRoot`, captures both `--session` paths, writes distinct parent observations, and asserts both paths and observations are distinct:
+
+  ```ts
+  assert.notEqual(firstSessionPath, secondSessionPath);
+  assert.deepEqual(firstObservations, ["first parent"]);
+  assert.deepEqual(secondObservations, ["second parent"]);
+  ```
+
+  Use explicit deferred promises to control when each mock runner writes and closes; do not use `setTimeout()` to order the two invocations.
+
+- [ ] **Step 3: Run the focused issue tests**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/triage/*.test.ts
+  ```
+
+  Expected: PASS. Concurrent or nested sessions cannot redirect observed parent progress, and triage still uses directory observation.
+
+- [ ] **Step 4: Run the required run-once suite**
+
+  Run:
+
+  ```sh
+  npm run test:run-once
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Run TypeScript lint**
+
+  Run:
+
+  ```sh
+  npm run lint:ts
+  ```
+
+  Expected: PASS with zero warnings.
+
+- [ ] **Step 6: Run Markdown lint**
+
+  Run:
+
+  ```sh
+  npm run lint:md
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 7: Confirm dependency files did not change**
+
+  Run:
+
+  ```sh
+  git diff -- package.json npm-shrinkwrap.json package-lock.json
+  ```
+
+  Expected: no output. Because no npm dependency files changed, no Nix build is required by `AGENTS.md`.
+
+- [ ] **Step 8: Commit final validation-only test adjustments if any were needed**
+
+  ```sh
+  git add src/cli/commands/run-once/pi.test.ts src/cli/commands/triage
+  git commit -m "test: cover exact pi session isolation"
+  ```
+
+  If Step 1 and Step 2 were already committed in earlier tasks and this task only ran validation, skip this commit and record the validation output in the PR summary.
+
+---
+
+## Final Verification Commands
+
+Run these commands before opening the implementation PR:
+
+```sh
+node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/triage/*.test.ts
+npm run test:run-once
+npm run lint:ts
+npm run lint:md
+git diff -- package.json npm-shrinkwrap.json package-lock.json
+```
+
+Expected final results:
+
+- All listed tests and lints pass.
+- The dependency-file diff command prints no output; therefore no Nix build is required.
+- Successful `run-once` still prints only the final JSON object to stdout.
+- Error `run-once` JSON may include `causes`, and the same cause details appear in JSONL progress data.
+
+## Self-Review Notes
+
+- Spec coverage: Tasks 2 and 6 cover exact parent session ownership and nested/concurrent isolation; Task 3 covers exact-file reading, strict malformed JSON failure, I/O failure, serialized polling, and callback backpressure; Task 4 covers prompt abort, awaiting runner close and cleanup, and preserving independent terminal causes; Task 5 covers CLI aggregate formatting and triage non-migration; Task 1 covers reusable command-runner cancellation.
+- Placeholder scan: The plan contains concrete file paths, interfaces, tests, commands, expected outcomes, and commit messages for each task.
+- Type consistency: `CommandRunOptions.signal`, `PiSessionAllocation`, `createExactPiSessionObservationStreamer()`, `aggregatePiErrors()`, and `formatErrorWithCauses()` names are used consistently across tasks.

--- a/docs/specs/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming-design.md
+++ b/docs/specs/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming-design.md
@@ -1,0 +1,280 @@
+# Issue 123 deterministic abortable run-once Pi session streaming design
+
+## Context
+
+`run-once` currently asks Pi to store session logs in a Patchmill-owned
+`--session-dir` and the observation streamer recursively follows the newest
+JSONL file it can find there. That was safe only while each observed directory
+contained exactly one relevant parent session. Durable session retention and
+nested Pi/subagent sessions make that assumption unsafe: a concurrent, stale, or
+child JSONL can become the newest file and redirect progress observation away
+from the parent Pi process that `run-once` owns.
+
+The current observation path also delivers callback work by accumulating promises
+and awaiting them at shutdown. Slow callbacks can therefore overlap and reorder
+observable side effects. Poll/read failures and malformed JSON can be skipped or
+surface late, and callback failures do not cancel the running Pi command. When
+multiple shutdown failures happen together, later cleanup or runner errors can
+mask earlier observation failures.
+
+Issue #123 is limited to the exact-session, streaming, cancellation, and
+terminal-error portions of parent issue #116. It does not change pi-subagents and
+it does not migrate triage to the exact-session API.
+
+## Goals
+
+- `run-once` observes one explicitly owned parent Pi session file per Pi
+  invocation.
+- The observed parent file is pre-created atomically and passed to Pi with
+  `--session <path>`.
+- Observation follows only that exact file, never recursive newest-file
+  discovery.
+- Observations are delivered serially; each consumer callback is awaited before
+  the next observation is delivered.
+- Malformed JSON, session I/O errors, callback failures, runner failures, and
+  cleanup failures are all reported without masking independent causes.
+- Observation failure aborts the running Pi command promptly, then awaits process
+  close and cleanup before reporting the complete terminal error.
+- Successful `run-once` still writes only the final JSON object to stdout.
+  Progress, verbose Pi output, and error detail remain on stderr and in the JSONL
+  run log.
+- Tests use explicit synchronization primitives instead of timing races.
+
+## Non-goals
+
+- Do not parse or render subagent-specific metadata.
+- Do not change `pi-subagents`.
+- Do not change run-once issue selection, artifact extraction, stage ordering, or
+  final result parsing except for preserving richer terminal errors.
+- Do not migrate triage to exact-session observation. Triage keeps its current
+  directory-based tool-call observer and receives regression coverage only.
+- Do not make exact-session streaming a broad public API for every Patchmill
+  command in this issue.
+
+## Approaches considered
+
+### Keep `--session-dir` and baseline existing files
+
+The streamer could snapshot all JSONL files before Pi starts and ignore any file
+that existed before the invocation. This is compatible with the current CLI
+arguments, but it still has to decide which new file is the parent when parent
+and child sessions appear close together. It also keeps recursive discovery in
+the trusted observation path.
+
+### Use Pi `--session-id` and discover by ID
+
+Patchmill could choose a session id and let Pi create the session file under its
+normal directory layout. This avoids partial UUID collisions, but the observer
+would still have to discover a path by scanning the session tree. Concurrent or
+nested sessions could still race discovery unless the streamer learns more about
+Pi internals.
+
+### Pre-create one exact session file and pass `--session` (chosen)
+
+Patchmill creates a unique empty JSONL file with exclusive-create semantics in
+the durable invocation leaf, passes that path to Pi as `--session <path>`, and
+hands the same path to the observer. Pi initializes empty explicit session files
+with a valid session header before appending assistant output. The observer no
+longer performs path discovery, so stale, sibling, and nested JSONL files cannot
+redirect parent observation.
+
+This is the smallest design that satisfies deterministic ownership and keeps
+child/subagent logs available under the same durable invocation directory.
+
+## Proposed behavior
+
+### Exact parent session allocation
+
+When `runPiPrompt()` is called by `run-once` with `observeSession: true`, it
+should allocate an exact parent session file instead of only a session directory:
+
+1. Resolve the durable invocation directory using the existing
+   `sessionRoot/<stage>/invocation-*` policy from issue #92.
+2. Create the invocation directory recursively.
+3. Choose a unique parent filename under that directory, for example
+   `parent-<session-id>.jsonl` or `parent-<timestamp>_<session-id>.jsonl`.
+4. Atomically pre-create the file with exclusive create (`wx`/`open(..., "wx")`)
+   and close it immediately, leaving a zero-byte file for Pi to initialize.
+5. Pass the exact file path to Pi with `--session <path>`.
+6. Do not pass the exact parent path through `--session-dir` discovery. If Pi
+   needs a session directory, it can derive it from the explicit file path.
+
+Existing non-observed `streamOutput` behavior may keep the current
+`--session-dir` message streamer until a later issue needs exact file semantics
+there. The `run-once` stages that require progress/tool observation already use
+`observeSession: true`, so this issue can stay focused.
+
+### Exact observation streamer
+
+Add an exact-file observation mode, either by extending
+`createPiSessionObservationStreamer()` with `{ sessionPath }` or by adding a new
+small wrapper such as `createExactPiSessionObservationStreamer()`.
+
+In exact mode the streamer:
+
+- stores the exact `sessionPath` at construction and never calls
+  `findNewestSessionFile()`;
+- stats and reads byte ranges only from that file;
+- buffers incomplete trailing data until a newline or `stop()`;
+- treats malformed non-empty JSON as an observation failure instead of silently
+  ignoring it;
+- converts each parsed entry with the existing `sessionEntryToObservations()`;
+- awaits `onObservation(observation)` before delivering the next observation;
+- serializes polling so a new poll cannot start while a previous poll or
+  callback is still running; and
+- returns/rejects from `stop()` with any pending poll, parse, I/O, or callback
+  failure.
+
+The legacy directory-discovery streamer remains available for triage so triage
+behavior does not change in this PR.
+
+### Backpressure and ordering
+
+`runPiPrompt()` should not collect observation callback promises in an unordered
+array. The exact streamer owns delivery order and awaits each callback inline.
+If callback 1 is slow, callback 2 is not delivered until callback 1 resolves,
+even if both JSONL entries are already present on disk. This gives consumers a
+simple invariant: observation side effects happen in file order.
+
+### Abortable command runner
+
+Extend the reusable command runner only as much as this contract requires:
+
+```ts
+type CommandRunOptions = {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+  signal?: AbortSignal;
+};
+```
+
+`createCommandRunner()` should listen for `signal.abort`, send a termination
+signal to the child process, continue collecting stdout/stderr until `close`, and
+then settle exactly once. If the signal is already aborted before spawn, the
+runner should fail without spawning. A hard-kill timeout is optional only if the
+implementation can test it deterministically; the acceptance contract requires
+prompt cancellation and awaiting close, not a new process supervisor.
+
+Mock runners used by tests can observe the signal directly without spawning real
+processes.
+
+### Failure and cleanup flow
+
+`runPiPrompt()` should run Pi and exact observation under a single
+`AbortController`:
+
+1. Start the exact observation streamer before invoking Pi.
+2. Start the Pi command with `signal: controller.signal`.
+3. If observation fails first, record that failure and abort the controller.
+4. Always await the Pi command result/close after aborting.
+5. Stop the streamer and drain any final buffered line.
+6. Emit Pi stdout/stderr debug events and parse the final stdout only if no
+   terminal failure has already made the run invalid.
+7. Run prompt-temp cleanup.
+8. Throw a combined error if any independent failure occurred.
+
+Failure combination should preserve every independent cause. A small helper can
+normalize errors into an ordered list and throw:
+
+- the single original error when there is only one cause; or
+- an `AggregateError` with contextual messages when there are multiple causes.
+
+The combined error should include, when present:
+
+- observation parse/I/O/callback errors;
+- command runner spawn, abort, close, or nonzero-exit errors;
+- result parsing errors;
+- streamer shutdown errors;
+- heartbeat/progress emission errors; and
+- prompt-temp cleanup errors.
+
+The CLI error path should format aggregate causes for both the JSONL log and the
+terminal. The final stdout object can add a `causes` array for error results, but
+successful and structured blocked/spec/plan/PR JSON contracts should remain
+unchanged.
+
+### stdout and stderr contract
+
+The run-once CLI should continue to reserve stdout for its final JSON object.
+Observation progress and verbose Pi output remain stderr-only via existing
+progress reporters and `streamPiOutput`. Exact-session debug metadata should be
+written to the JSONL run log, including the exact parent session file path and
+actual invocation directory.
+
+## Affected components
+
+- `src/cli/commands/run-once/pi.ts`
+  - allocate exact parent session files for observed run-once Pi invocations;
+  - pass `--session <path>` to Pi;
+  - coordinate observer failure, command abort, process close, parsing, and
+    cleanup with error aggregation.
+- `src/cli/commands/run-once/pi-session-stream.ts`
+  - add exact-file observation;
+  - make exact observation async/backpressured;
+  - surface malformed JSON and I/O failures.
+- `src/cli/commands/triage/command.ts` and shared types
+  - add optional `AbortSignal` support to the command runner.
+- `src/cli/commands/run-once/main.ts` and error reporting helpers
+  - format aggregate terminal errors without breaking successful final JSON.
+- `src/cli/commands/triage/tool-call-observer.ts`
+  - keep behavior unchanged; update only if type signatures require a trivial
+    compatibility adjustment.
+- Tests under `src/cli/commands/run-once/`, `src/cli/commands/triage/`, and the
+  command runner tests.
+
+## Verification strategy
+
+Automated tests are valuable here because this is reusable orchestration,
+streaming, cancellation, and error-preservation behavior.
+
+Add focused tests for exact session ownership:
+
+- `runPiPrompt()` pre-creates the exact parent JSONL, passes it as
+  `--session <path>`, and records the exact path in debug progress.
+- A newer sibling or nested JSONL file under the same durable session root is
+  ignored while observations are read from the exact parent file.
+- Concurrent observed invocations receive distinct exact parent files and cannot
+  observe each other's output.
+
+Add deterministic streaming tests:
+
+- Two observations written before the first callback resolves are delivered in
+  file order, and the second callback is not invoked until the first promise is
+  resolved.
+- Malformed JSON rejects observation immediately instead of being skipped.
+- Injected read/stat failures reject observation with the original I/O error.
+
+Add cancellation and terminal-error tests:
+
+- Malformed JSON or callback rejection aborts the Pi command via the runner
+  signal before the mock runner is allowed to complete normally.
+- After abort, `runPiPrompt()` still awaits runner close and cleanup.
+- Observation failure plus runner failure plus cleanup failure are all present in
+  the thrown aggregate error and in CLI error formatting.
+- A Pi nonzero exit without observation failure still reports stdout/stderr as
+  before.
+
+Add command-runner tests:
+
+- Aborting an in-flight spawned process terminates it and resolves after `close`
+  with collected stdout/stderr.
+- An already-aborted signal does not spawn a child.
+
+Add triage regression coverage:
+
+- `runWithToolCallObservation()` still supplies a session directory to its
+  callback and observes tool calls using the legacy directory-based behavior.
+- No triage test should require `--session` or exact parent session metadata.
+
+Run at least:
+
+```sh
+node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/triage/*.test.ts
+npm run test:run-once
+npm run lint:ts
+npm run lint:md
+```
+
+No Nix build is required unless implementation changes npm dependency files.

--- a/docs/specs/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming-design.md
+++ b/docs/specs/2026-08-01-issue-123-add-deterministic-abortable-run-once-pi-session-streaming-design.md
@@ -10,16 +10,16 @@ nested Pi/subagent sessions make that assumption unsafe: a concurrent, stale, or
 child JSONL can become the newest file and redirect progress observation away
 from the parent Pi process that `run-once` owns.
 
-The current observation path also delivers callback work by accumulating promises
-and awaiting them at shutdown. Slow callbacks can therefore overlap and reorder
-observable side effects. Poll/read failures and malformed JSON can be skipped or
-surface late, and callback failures do not cancel the running Pi command. When
-multiple shutdown failures happen together, later cleanup or runner errors can
-mask earlier observation failures.
+The current observation path also delivers callback work by accumulating
+promises and awaiting them at shutdown. Slow callbacks can therefore overlap and
+reorder observable side effects. Poll/read failures and malformed JSON can be
+skipped or surface late, and callback failures do not cancel the running Pi
+command. When multiple shutdown failures happen together, later cleanup or
+runner errors can mask earlier observation failures.
 
 Issue #123 is limited to the exact-session, streaming, cancellation, and
-terminal-error portions of parent issue #116. It does not change pi-subagents and
-it does not migrate triage to the exact-session API.
+terminal-error portions of parent issue #116. It does not change pi-subagents
+and it does not migrate triage to the exact-session API.
 
 ## Goals
 
@@ -33,19 +33,19 @@ it does not migrate triage to the exact-session API.
   the next observation is delivered.
 - Malformed JSON, session I/O errors, callback failures, runner failures, and
   cleanup failures are all reported without masking independent causes.
-- Observation failure aborts the running Pi command promptly, then awaits process
-  close and cleanup before reporting the complete terminal error.
+- Observation failure aborts the running Pi command promptly, then awaits
+  process close and cleanup before reporting the complete terminal error.
 - Successful `run-once` still writes only the final JSON object to stdout.
-  Progress, verbose Pi output, and error detail remain on stderr and in the JSONL
-  run log.
+  Progress, verbose Pi output, and error detail remain on stderr and in the
+  JSONL run log.
 - Tests use explicit synchronization primitives instead of timing races.
 
 ## Non-goals
 
 - Do not parse or render subagent-specific metadata.
 - Do not change `pi-subagents`.
-- Do not change run-once issue selection, artifact extraction, stage ordering, or
-  final result parsing except for preserving richer terminal errors.
+- Do not change run-once issue selection, artifact extraction, stage ordering,
+  or final result parsing except for preserving richer terminal errors.
 - Do not migrate triage to exact-session observation. Triage keeps its current
   directory-based tool-call observer and receives regression coverage only.
 - Do not make exact-session streaming a broad public API for every Patchmill
@@ -86,7 +86,8 @@ child/subagent logs available under the same durable invocation directory.
 ### Exact parent session allocation
 
 When `runPiPrompt()` is called by `run-once` with `observeSession: true`, it
-should allocate an exact parent session file instead of only a session directory:
+should allocate an exact parent session file instead of only a session
+directory:
 
 1. Resolve the durable invocation directory using the existing
    `sessionRoot/<stage>/invocation-*` policy from issue #92.
@@ -151,8 +152,8 @@ type CommandRunOptions = {
 ```
 
 `createCommandRunner()` should listen for `signal.abort`, send a termination
-signal to the child process, continue collecting stdout/stderr until `close`, and
-then settle exactly once. If the signal is already aborted before spawn, the
+signal to the child process, continue collecting stdout/stderr until `close`,
+and then settle exactly once. If the signal is already aborted before spawn, the
 runner should fail without spawning. A hard-kill timeout is optional only if the
 implementation can test it deterministically; the acceptance contract requires
 prompt cancellation and awaiting close, not a new process supervisor.
@@ -191,8 +192,8 @@ The combined error should include, when present:
 - prompt-temp cleanup errors.
 
 The CLI error path should format aggregate causes for both the JSONL log and the
-terminal. The final stdout object can add a `causes` array for error results, but
-successful and structured blocked/spec/plan/PR JSON contracts should remain
+terminal. The final stdout object can add a `causes` array for error results,
+but successful and structured blocked/spec/plan/PR JSON contracts should remain
 unchanged.
 
 ### stdout and stderr contract
@@ -251,8 +252,8 @@ Add cancellation and terminal-error tests:
 - Malformed JSON or callback rejection aborts the Pi command via the runner
   signal before the mock runner is allowed to complete normally.
 - After abort, `runPiPrompt()` still awaits runner close and cleanup.
-- Observation failure plus runner failure plus cleanup failure are all present in
-  the thrown aggregate error and in CLI error formatting.
+- Observation failure plus runner failure plus cleanup failure are all present
+  in the thrown aggregate error and in CLI error formatting.
 - A Pi nonzero exit without observation failure still reports stdout/stderr as
   before.
 

--- a/src/cli/commands/run-once/main.ts
+++ b/src/cli/commands/run-once/main.ts
@@ -14,6 +14,7 @@ import {
 } from "./progress.ts";
 import { createCommandRunner } from "../triage/command.ts";
 import { detectDefaultBaseBranch } from "./git.ts";
+import { formatErrorWithCauses } from "./pi-errors.ts";
 import type {
   AgentIssuePipelineResult,
   AgentIssueVisualEvidence,
@@ -333,15 +334,22 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
             : undefined,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const formatted = formatErrorWithCauses(error);
       await progress.event({
         time: new Date().toISOString(),
         level: "error",
         stage: "error",
-        message: `blocked: ${message}`,
-        data: { error: message },
+        message: `blocked: ${formatted.message}`,
+        data: { error: formatted.message, causes: formatted.causes },
       });
-      console.log(JSON.stringify({ status: "error", error: message, logPath }));
+      console.log(
+        JSON.stringify({
+          status: "error",
+          error: formatted.message,
+          ...(formatted.causes ? { causes: formatted.causes } : {}),
+          logPath,
+        }),
+      );
       return 1;
     }
 
@@ -360,8 +368,14 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
       ? 1
       : 0;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.log(JSON.stringify({ status: "error", error: message }));
+    const formatted = formatErrorWithCauses(error);
+    console.log(
+      JSON.stringify({
+        status: "error",
+        error: formatted.message,
+        ...(formatted.causes ? { causes: formatted.causes } : {}),
+      }),
+    );
     return 1;
   }
 }

--- a/src/cli/commands/run-once/main.ts
+++ b/src/cli/commands/run-once/main.ts
@@ -14,7 +14,7 @@ import {
 } from "./progress.ts";
 import { createCommandRunner } from "../triage/command.ts";
 import { detectDefaultBaseBranch } from "./git.ts";
-import { formatErrorWithCauses } from "./pi-errors.ts";
+import { appendPiErrorCause, formatErrorWithCauses } from "./pi-errors.ts";
 import type {
   AgentIssuePipelineResult,
   AgentIssueVisualEvidence,
@@ -335,18 +335,30 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
       });
     } catch (error) {
       const formatted = formatErrorWithCauses(error);
-      await progress.event({
-        time: new Date().toISOString(),
-        level: "error",
-        stage: "error",
-        message: `blocked: ${formatted.message}`,
-        data: { error: formatted.message, causes: formatted.causes },
-      });
+      let terminalError = error;
+      try {
+        await progress.event({
+          time: new Date().toISOString(),
+          level: "error",
+          stage: "error",
+          message: `blocked: ${formatted.message}`,
+          data: { error: formatted.message, causes: formatted.causes },
+        });
+      } catch (reportingError) {
+        terminalError = appendPiErrorCause(
+          error,
+          "error reporting",
+          reportingError,
+        );
+      }
+      const terminalFormatted = formatErrorWithCauses(terminalError);
       console.log(
         JSON.stringify({
           status: "error",
-          error: formatted.message,
-          ...(formatted.causes ? { causes: formatted.causes } : {}),
+          error: terminalFormatted.message,
+          ...(terminalFormatted.causes
+            ? { causes: terminalFormatted.causes }
+            : {}),
           logPath,
         }),
       );

--- a/src/cli/commands/run-once/pi-errors.test.ts
+++ b/src/cli/commands/run-once/pi-errors.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatErrorWithCauses } from "./pi-errors.ts";
+
+test("formatErrorWithCauses preserves every aggregate terminal cause", () => {
+  const formatted = formatErrorWithCauses(
+    new AggregateError(
+      [
+        new Error("observation: malformed json"),
+        new Error("runner: pi failed"),
+      ],
+      "pi prompt failed",
+    ),
+  );
+
+  assert.deepEqual(formatted, {
+    message: "pi prompt failed",
+    causes: ["observation: malformed json", "runner: pi failed"],
+  });
+});

--- a/src/cli/commands/run-once/pi-errors.test.ts
+++ b/src/cli/commands/run-once/pi-errors.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { formatErrorWithCauses } from "./pi-errors.ts";
+import { appendPiErrorCause, formatErrorWithCauses } from "./pi-errors.ts";
 
 test("formatErrorWithCauses preserves every aggregate terminal cause", () => {
   const formatted = formatErrorWithCauses(
@@ -17,4 +17,29 @@ test("formatErrorWithCauses preserves every aggregate terminal cause", () => {
     message: "pi prompt failed",
     causes: ["observation: malformed json", "runner: pi failed"],
   });
+});
+
+test("appendPiErrorCause preserves aggregate causes with reporting failure", () => {
+  const original = new AggregateError(
+    [new Error("observation: malformed json"), new Error("runner: pi failed")],
+    "pi prompt failed",
+  );
+
+  assert.deepEqual(
+    formatErrorWithCauses(
+      appendPiErrorCause(
+        original,
+        "error reporting",
+        new Error("log write failed"),
+      ),
+    ),
+    {
+      message: "pi prompt failed",
+      causes: [
+        "observation: malformed json",
+        "runner: pi failed",
+        "error reporting: log write failed",
+      ],
+    },
+  );
 });

--- a/src/cli/commands/run-once/pi-errors.ts
+++ b/src/cli/commands/run-once/pi-errors.ts
@@ -22,6 +22,23 @@ export function aggregatePiErrors(
   );
 }
 
+export function appendPiErrorCause(
+  error: unknown,
+  label: string,
+  additionalError: unknown,
+): AggregateError {
+  const original = errorFromUnknown(error);
+  const additional = errorFromUnknown(additionalError);
+  const cause = new Error(`${label}: ${additional.message}`, {
+    cause: additional,
+  });
+  const causes =
+    original instanceof AggregateError
+      ? [...original.errors, cause]
+      : [original, cause];
+  return new AggregateError(causes, original.message);
+}
+
 export function formatErrorWithCauses(error: unknown): {
   message: string;
   causes?: string[];

--- a/src/cli/commands/run-once/pi-errors.ts
+++ b/src/cli/commands/run-once/pi-errors.ts
@@ -1,0 +1,37 @@
+export type PiErrorCause = {
+  label: string;
+  error: unknown;
+};
+
+export function errorFromUnknown(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export function aggregatePiErrors(
+  message: string,
+  causes: PiErrorCause[],
+): Error | undefined {
+  if (causes.length === 0) return undefined;
+  if (causes.length === 1) return errorFromUnknown(causes[0].error);
+  return new AggregateError(
+    causes.map(({ label, error }) => {
+      const cause = errorFromUnknown(error);
+      return new Error(`${label}: ${cause.message}`, { cause });
+    }),
+    message,
+  );
+}
+
+export function formatErrorWithCauses(error: unknown): {
+  message: string;
+  causes?: string[];
+} {
+  const normalized = errorFromUnknown(error);
+  if (normalized instanceof AggregateError) {
+    return {
+      message: normalized.message,
+      causes: normalized.errors.map((cause) => errorFromUnknown(cause).message),
+    };
+  }
+  return { message: normalized.message };
+}

--- a/src/cli/commands/run-once/pi-session-allocation.ts
+++ b/src/cli/commands/run-once/pi-session-allocation.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, open } from "node:fs/promises";
+import { join } from "node:path";
+
+export type PiSessionAllocation = {
+  sessionDir: string;
+  sessionPath?: string;
+};
+
+export type PiSessionAllocationOptions = {
+  stage: string;
+  promptTempDir: string;
+  observeSession?: boolean;
+  streamOutput?: boolean;
+  sessionRoot?: string;
+  sessionDir?: string;
+  idFactory?: () => string;
+};
+
+async function createInvocationDir(
+  options: PiSessionAllocationOptions,
+): Promise<string> {
+  if (options.sessionDir) {
+    await mkdir(options.sessionDir, { recursive: true });
+    return options.sessionDir;
+  }
+  if (options.sessionRoot) {
+    const stageRoot = join(options.sessionRoot, options.stage);
+    await mkdir(stageRoot, { recursive: true });
+    return mkdtemp(join(stageRoot, "invocation-"));
+  }
+  const sessionDir = join(options.promptTempDir, "sessions");
+  await mkdir(sessionDir, { recursive: true });
+  return sessionDir;
+}
+
+async function createExactParentSessionFile(
+  sessionDir: string,
+  idFactory: () => string,
+): Promise<string> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const sessionPath = join(sessionDir, `parent-${idFactory()}.jsonl`);
+    try {
+      const handle = await open(sessionPath, "wx");
+      await handle.close();
+      return sessionPath;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  }
+  throw new Error("could not allocate a unique Pi parent session file");
+}
+
+export async function createPiSessionAllocation(
+  options: PiSessionAllocationOptions,
+): Promise<PiSessionAllocation | undefined> {
+  if (!options.observeSession && !options.streamOutput) return undefined;
+
+  const sessionDir = await createInvocationDir(options);
+  if (!options.observeSession) return { sessionDir };
+  return {
+    sessionDir,
+    sessionPath: await createExactParentSessionFile(
+      sessionDir,
+      options.idFactory ?? randomUUID,
+    ),
+  };
+}

--- a/src/cli/commands/run-once/pi-session-stream.ts
+++ b/src/cli/commands/run-once/pi-session-stream.ts
@@ -26,6 +26,13 @@ type SessionStreamerOptions = {
   totalTokensSoFar?: number;
 };
 
+export type ExactPiSessionObservationStreamerOptions = {
+  pollMs?: number;
+  verboseOutput?: (chunk: string) => void;
+  statFile?: typeof stat;
+  readRange?: typeof readRange;
+};
+
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -40,6 +47,15 @@ function parseSessionLine(line: string): JsonObject | undefined {
   } catch {
     return undefined;
   }
+}
+
+function parseStrictSessionLine(line: string): JsonObject | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  const parsed = JSON.parse(trimmed) as unknown;
+  if (!isObject(parsed))
+    throw new Error("Pi session line must be a JSON object");
+  return parsed;
 }
 
 function textContent(content: unknown): string | undefined {
@@ -249,10 +265,7 @@ async function findNewestSessionFile(dir: string): Promise<string | undefined> {
     await Promise.all(
       entries.map(async (entry) => {
         const path = join(current, entry.name);
-        if (entry.isDirectory()) {
-          await walk(path);
-          return;
-        }
+        if (entry.isDirectory()) return walk(path);
         if (!entry.isFile() || !entry.name.endsWith(".jsonl")) return;
 
         const info = await stat(path);
@@ -283,6 +296,102 @@ function readRange(path: string, start: number, end: number): Promise<string> {
     stream.on("error", reject);
     stream.on("end", () => resolve(text));
   });
+}
+
+export function createExactPiSessionObservationStreamer(
+  sessionPath: string,
+  onObservation: (observation: PiSessionObservation) => void | Promise<void>,
+  options: ExactPiSessionObservationStreamerOptions = {},
+): { start(): void; stop(): Promise<void>; failure: Promise<never> } {
+  const pollMs = options.pollMs ?? 100;
+  const statFile = options.statFile ?? stat;
+  const readFileRange = options.readRange ?? readRange;
+  let timer: NodeJS.Timeout | undefined;
+  let polling: Promise<void> | undefined;
+  let offset = 0;
+  let buffered = "";
+  let failureError: unknown;
+  let rejectFailure!: (error: unknown) => void;
+  const failure = new Promise<never>((_resolve, reject) => {
+    rejectFailure = reject;
+  });
+  void failure.catch(() => undefined);
+
+  const recordFailure = (error: unknown) => {
+    if (failureError !== undefined) return;
+    failureError = error;
+    if (timer) clearInterval(timer);
+    timer = undefined;
+    rejectFailure(error);
+  };
+
+  const processLine = async (line: string) => {
+    const entry = parseStrictSessionLine(line);
+    if (!entry) return;
+    for (const observation of sessionEntryToObservations(entry)) {
+      await onObservation(observation);
+    }
+    const text = sessionEntryToRawText(entry);
+    if (text !== undefined) options.verboseOutput?.(text);
+  };
+
+  const poll = async () => {
+    const info = await statFile(sessionPath);
+    if (info.size < offset) {
+      offset = 0;
+      buffered = "";
+    }
+    if (info.size === offset) return;
+
+    const chunk = await readFileRange(sessionPath, offset, info.size);
+    offset = info.size;
+    buffered += chunk;
+    let newlineIndex = buffered.indexOf("\n");
+    while (newlineIndex >= 0) {
+      await processLine(buffered.slice(0, newlineIndex));
+      buffered = buffered.slice(newlineIndex + 1);
+      newlineIndex = buffered.indexOf("\n");
+    }
+  };
+
+  const runPoll = async (): Promise<void> => {
+    if (polling) return polling;
+    if (failureError !== undefined) throw failureError;
+    polling = poll()
+      .catch((error: unknown) => {
+        recordFailure(error);
+        throw error;
+      })
+      .finally(() => {
+        polling = undefined;
+      });
+    return polling;
+  };
+
+  return {
+    start() {
+      if (timer || failureError !== undefined) return;
+      void runPoll().catch(() => undefined);
+      timer = setInterval(() => {
+        void runPoll().catch(() => undefined);
+      }, pollMs);
+    },
+    async stop() {
+      if (timer) clearInterval(timer);
+      timer = undefined;
+      try {
+        await runPoll();
+        if (buffered.trim()) {
+          await processLine(buffered);
+          buffered = "";
+        }
+      } catch (error) {
+        recordFailure(error);
+      }
+      if (failureError !== undefined) throw failureError;
+    },
+    failure,
+  };
 }
 
 export function createPiSessionMessageStreamer(
@@ -317,18 +426,15 @@ export function createPiSessionMessageStreamer(
       sessionPath = await findNewestSessionFile(sessionDir);
       if (!sessionPath) return;
     }
-
     const info = await stat(sessionPath);
     if (info.size < offset) {
       offset = 0;
       buffered = "";
     }
     if (info.size === offset) return;
-
     const chunk = await readRange(sessionPath, offset, info.size);
     offset = info.size;
     buffered += chunk;
-
     let newlineIndex = buffered.indexOf("\n");
     while (newlineIndex >= 0) {
       processLine(buffered.slice(0, newlineIndex));
@@ -349,15 +455,11 @@ export function createPiSessionMessageStreamer(
     start() {
       if (timer) return;
       void runPoll();
-      timer = setInterval(() => {
-        void runPoll();
-      }, pollMs);
+      timer = setInterval(() => void runPoll(), pollMs);
     },
     async stop() {
-      if (timer) {
-        clearInterval(timer);
-        timer = undefined;
-      }
+      if (timer) clearInterval(timer);
+      timer = undefined;
       await runPoll();
       if (buffered.trim()) {
         processLine(buffered);
@@ -369,7 +471,7 @@ export function createPiSessionMessageStreamer(
 
 export function createPiSessionObservationStreamer(
   sessionDir: string,
-  onObservation: (observation: PiSessionObservation) => void,
+  onObservation: (observation: PiSessionObservation) => void | Promise<void>,
   options: { pollMs?: number; verboseOutput?: (chunk: string) => void } = {},
 ): { start(): void; stop(): Promise<void> } {
   const pollMs = options.pollMs ?? 100;
@@ -388,12 +490,10 @@ export function createPiSessionObservationStreamer(
         if (observedToolCallIds.has(observation.toolCallId)) continue;
         observedToolCallIds.add(observation.toolCallId);
       }
-      onObservation(observation);
+      void onObservation(observation);
     }
-    if (options.verboseOutput) {
-      const text = sessionEntryToRawText(entry);
-      if (text !== undefined) options.verboseOutput(text);
-    }
+    const text = sessionEntryToRawText(entry);
+    if (text !== undefined) options.verboseOutput?.(text);
   };
 
   const poll = async () => {
@@ -401,18 +501,15 @@ export function createPiSessionObservationStreamer(
       sessionPath = await findNewestSessionFile(sessionDir);
       if (!sessionPath) return;
     }
-
     const info = await stat(sessionPath);
     if (info.size < offset) {
       offset = 0;
       buffered = "";
     }
     if (info.size === offset) return;
-
     const chunk = await readRange(sessionPath, offset, info.size);
     offset = info.size;
     buffered += chunk;
-
     let newlineIndex = buffered.indexOf("\n");
     while (newlineIndex >= 0) {
       processLine(buffered.slice(0, newlineIndex));
@@ -433,15 +530,11 @@ export function createPiSessionObservationStreamer(
     start() {
       if (timer) return;
       void runPoll();
-      timer = setInterval(() => {
-        void runPoll();
-      }, pollMs);
+      timer = setInterval(() => void runPoll(), pollMs);
     },
     async stop() {
-      if (timer) {
-        clearInterval(timer);
-        timer = undefined;
-      }
+      if (timer) clearInterval(timer);
+      timer = undefined;
       await runPoll();
       if (buffered.trim()) {
         processLine(buffered);

--- a/src/cli/commands/run-once/pi-session-stream.ts
+++ b/src/cli/commands/run-once/pi-session-stream.ts
@@ -380,6 +380,8 @@ export function createExactPiSessionObservationStreamer(
       if (timer) clearInterval(timer);
       timer = undefined;
       try {
+        const activePoll = polling;
+        if (activePoll) await activePoll;
         await runPoll();
         if (buffered.trim()) {
           await processLine(buffered);

--- a/src/cli/commands/run-once/pi-session-stream.ts
+++ b/src/cli/commands/run-once/pi-session-stream.ts
@@ -26,11 +26,17 @@ type SessionStreamerOptions = {
   totalTokensSoFar?: number;
 };
 
+type ExactSessionReadRange = (
+  path: string,
+  start: number,
+  end: number,
+) => Promise<Uint8Array>;
+
 export type ExactPiSessionObservationStreamerOptions = {
   pollMs?: number;
   verboseOutput?: (chunk: string) => void;
   statFile?: typeof stat;
-  readRange?: typeof readRange;
+  readRange?: ExactSessionReadRange;
 };
 
 function isObject(value: unknown): value is JsonObject {
@@ -298,6 +304,24 @@ function readRange(path: string, start: number, end: number): Promise<string> {
   });
 }
 
+function readExactRange(
+  path: string,
+  start: number,
+  end: number,
+): Promise<Uint8Array> {
+  if (end <= start) return Promise.resolve(new Uint8Array());
+
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    const stream = createReadStream(path, { start, end: end - 1 });
+    stream.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    stream.on("error", reject);
+    stream.on("end", () => resolve(Buffer.concat(chunks)));
+  });
+}
+
 export function createExactPiSessionObservationStreamer(
   sessionPath: string,
   onObservation: (observation: PiSessionObservation) => void | Promise<void>,
@@ -305,11 +329,13 @@ export function createExactPiSessionObservationStreamer(
 ): { start(): void; stop(): Promise<void>; failure: Promise<never> } {
   const pollMs = options.pollMs ?? 100;
   const statFile = options.statFile ?? stat;
-  const readFileRange = options.readRange ?? readRange;
+  const readFileRange = options.readRange ?? readExactRange;
   let timer: NodeJS.Timeout | undefined;
   let polling: Promise<void> | undefined;
   let offset = 0;
   let buffered = "";
+  let decoder = new TextDecoder();
+  let failed = false;
   let failureError: unknown;
   let rejectFailure!: (error: unknown) => void;
   const failure = new Promise<never>((_resolve, reject) => {
@@ -318,17 +344,23 @@ export function createExactPiSessionObservationStreamer(
   void failure.catch(() => undefined);
 
   const recordFailure = (error: unknown) => {
-    if (failureError !== undefined) return;
+    if (failed) return;
+    failed = true;
     failureError = error;
     if (timer) clearInterval(timer);
     timer = undefined;
     rejectFailure(error);
   };
 
+  const observedToolCallIds = new Set<string>();
   const processLine = async (line: string) => {
     const entry = parseStrictSessionLine(line);
     if (!entry) return;
     for (const observation of sessionEntryToObservations(entry)) {
+      if (observation.type === "tool-call" && observation.toolCallId) {
+        if (observedToolCallIds.has(observation.toolCallId)) continue;
+        observedToolCallIds.add(observation.toolCallId);
+      }
       await onObservation(observation);
     }
     const text = sessionEntryToRawText(entry);
@@ -340,12 +372,13 @@ export function createExactPiSessionObservationStreamer(
     if (info.size < offset) {
       offset = 0;
       buffered = "";
+      decoder = new TextDecoder();
     }
     if (info.size === offset) return;
 
     const chunk = await readFileRange(sessionPath, offset, info.size);
     offset = info.size;
-    buffered += chunk;
+    buffered += decoder.decode(chunk, { stream: true });
     let newlineIndex = buffered.indexOf("\n");
     while (newlineIndex >= 0) {
       await processLine(buffered.slice(0, newlineIndex));
@@ -356,7 +389,7 @@ export function createExactPiSessionObservationStreamer(
 
   const runPoll = async (): Promise<void> => {
     if (polling) return polling;
-    if (failureError !== undefined) throw failureError;
+    if (failed) throw failureError;
     polling = poll()
       .catch((error: unknown) => {
         recordFailure(error);
@@ -370,7 +403,7 @@ export function createExactPiSessionObservationStreamer(
 
   return {
     start() {
-      if (timer || failureError !== undefined) return;
+      if (timer || failed) return;
       void runPoll().catch(() => undefined);
       timer = setInterval(() => {
         void runPoll().catch(() => undefined);
@@ -383,6 +416,7 @@ export function createExactPiSessionObservationStreamer(
         const activePoll = polling;
         if (activePoll) await activePoll;
         await runPoll();
+        buffered += decoder.decode();
         if (buffered.trim()) {
           await processLine(buffered);
           buffered = "";
@@ -390,7 +424,7 @@ export function createExactPiSessionObservationStreamer(
       } catch (error) {
         recordFailure(error);
       }
-      if (failureError !== undefined) throw failureError;
+      if (failed) throw failureError;
     },
     failure,
   };

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { Stats } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { DEFAULT_PI_TASK_CONTRACT } from "../../../policy/task-contract.ts";
@@ -792,12 +800,20 @@ test("runPiPrompt ignores newer sibling and nested JSONL when observing an exact
         type: "message",
         message: { role: "assistant", content: [{ type: "text", text }] },
       }) + "\n";
-    await writeFile(
-      join(invocationDir, "nested", "session.jsonl"),
-      entry("nested"),
-    );
-    await writeFile(join(invocationDir, "sibling.jsonl"), entry("sibling"));
     await writeFile(sessionPath, entry("parent"));
+    const nestedPath = join(invocationDir, "nested", "session.jsonl");
+    const siblingPath = join(invocationDir, "sibling.jsonl");
+    await writeFile(nestedPath, entry("nested"));
+    await writeFile(siblingPath, entry("sibling"));
+    await utimes(sessionPath, new Date(1_000), new Date(1_000));
+    await utimes(nestedPath, new Date(2_000), new Date(2_000));
+    await utimes(siblingPath, new Date(3_000), new Date(3_000));
+    assert.ok(
+      (await stat(nestedPath)).mtimeMs > (await stat(sessionPath)).mtimeMs,
+    );
+    assert.ok(
+      (await stat(siblingPath)).mtimeMs > (await stat(sessionPath)).mtimeMs,
+    );
     return {
       code: 0,
       stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
@@ -1014,6 +1030,113 @@ test("exact session observation awaits callbacks in file order", async (t) => {
   assert.deepEqual(delivered, ["first", "second"]);
 });
 
+test("exact session observation de-duplicates matching tool call IDs", async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-exact-tool-call-"));
+  t.after(async () => rm(dir, { recursive: true, force: true }));
+  const sessionPath = join(dir, "parent.jsonl");
+  await writeFile(
+    sessionPath,
+    [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-1", name: "bash" }],
+        },
+      },
+      {
+        type: "message",
+        message: { role: "toolResult", toolCallId: "call-1", toolName: "bash" },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n") + "\n",
+    "utf8",
+  );
+  const observed: Array<{ toolName?: string; toolCallId?: string }> = [];
+  const streamer = createExactPiSessionObservationStreamer(
+    sessionPath,
+    (observation) => {
+      if (observation.type === "tool-call") observed.push(observation);
+    },
+  );
+
+  streamer.start();
+  await streamer.stop();
+
+  assert.deepEqual(observed, [
+    { type: "tool-call", toolName: "bash", toolCallId: "call-1" },
+  ]);
+});
+
+test("exact session observation preserves UTF-8 split across byte-range polls", async () => {
+  const line = `${JSON.stringify({
+    type: "message",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "café" }],
+    },
+  })}\n`;
+  const bytes = new TextEncoder().encode(line);
+  const accentedCharacter = new TextEncoder().encode("é");
+  const accentedStart = bytes.findIndex(
+    (_byte, index) =>
+      bytes[index] === accentedCharacter[0] &&
+      bytes[index + 1] === accentedCharacter[1],
+  );
+  assert.ok(accentedStart >= 0);
+  const split = accentedStart + 1;
+  let statCalls = 0;
+  let firstReadComplete!: () => void;
+  const firstReadCompleted = new Promise<void>((resolve) => {
+    firstReadComplete = resolve;
+  });
+  const delivered: string[] = [];
+  const streamer = createExactPiSessionObservationStreamer(
+    "parent.jsonl",
+    (observation) => {
+      if (observation.type === "text") delivered.push(observation.text);
+    },
+    {
+      statFile: async () => {
+        statCalls += 1;
+        return { size: statCalls === 1 ? split : bytes.length } as Stats;
+      },
+      readRange: async (_path, start, end) => {
+        const chunk = bytes.slice(start, end);
+        if (start === 0) firstReadComplete();
+        return chunk;
+      },
+    },
+  );
+
+  streamer.start();
+  await firstReadCompleted;
+  await streamer.stop();
+
+  assert.deepEqual(delivered, ["café"]);
+});
+
+test("exact session observation retains an undefined callback rejection", async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-exact-undefined-"));
+  t.after(async () => rm(dir, { recursive: true, force: true }));
+  const sessionPath = join(dir, "parent.jsonl");
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({
+      type: "message",
+      message: { role: "assistant", content: [{ type: "text", text: "boom" }] },
+    })}\n`,
+    "utf8",
+  );
+  const streamer = createExactPiSessionObservationStreamer(sessionPath, () =>
+    Promise.reject(),
+  );
+
+  streamer.start();
+  await assert.rejects(streamer.stop(), (error) => error === undefined);
+});
+
 test("exact session observation performs a final read after an active poll", async () => {
   const first = `${JSON.stringify({
     type: "message",
@@ -1049,9 +1172,9 @@ test("exact session observation performs a final read after an active poll", asy
         if (start === 0) {
           firstReadStarted();
           await firstReadCanFinish;
-          return first;
+          return new TextEncoder().encode(first);
         }
-        return second;
+        return new TextEncoder().encode(second);
       },
     },
   );
@@ -1130,6 +1253,46 @@ test("runPiPrompt emits heartbeat events while pi is pending", async () => {
           event.message,
         ),
     ),
+  );
+});
+
+test("runPiPrompt aggregates heartbeat failures while Pi is pending", async () => {
+  const heartbeatError = new Error("heartbeat exploded");
+  let finishRun!: () => void;
+  let runnerStarted!: () => void;
+  const runnerHasStarted = new Promise<void>((resolve) => {
+    runnerStarted = resolve;
+  });
+  const runner = createMockRunner(
+    () =>
+      new Promise<CommandResult>((resolve) => {
+        finishRun = () =>
+          resolve({
+            code: 0,
+            stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+            stderr: "",
+          });
+        runnerStarted();
+      }),
+  );
+
+  const run = runPiPrompt(runner, "/repo", "prompt", {
+    progress: {
+      event: (event) => {
+        if (event.level !== "heartbeat") return;
+        return runnerHasStarted.then(() => {
+          finishRun();
+          throw heartbeatError;
+        });
+      },
+    },
+    stage: "pi-plan",
+    heartbeatMs: 1,
+  });
+
+  await assert.rejects(
+    run,
+    (error) => error instanceof Error && error.message === "heartbeat exploded",
   );
 });
 

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -759,6 +759,25 @@ test("runPiPrompt verbose mode does not append synthetic token lines", async () 
   assert.deepEqual(streamed, ["verbose narration\n"]);
 });
 
+test("runPiPrompt reports cleanup failure after a successful Pi result", async () => {
+  const runner = createMockRunner(() => ({
+    code: 0,
+    stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+    stderr: "",
+  }));
+
+  await assert.rejects(
+    () =>
+      runPiPrompt(runner, "/repo", "prompt", {
+        stage: "pi-plan",
+        cleanupPromptTempDir: async () => {
+          throw new Error("cleanup exploded");
+        },
+      }),
+    /cleanup exploded/,
+  );
+});
+
 test("runPiPrompt ignores newer sibling and nested JSONL when observing an exact parent", async (t) => {
   const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-exact-ignore-"));
   t.after(async () => rm(repoRoot, { recursive: true, force: true }));

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -847,14 +847,18 @@ test("concurrent observed Pi prompts receive isolated exact parent sessions", as
   });
   const runner = createMockRunner(async (call) => {
     const sessionPath = call.args[call.args.indexOf("--session") + 1] ?? "";
+    const prompt = await readFile(promptPath(call.args), "utf8");
+    const text =
+      prompt === "first"
+        ? "first parent"
+        : prompt === "second"
+          ? "second parent"
+          : undefined;
+    assert.ok(text, `unexpected concurrent prompt: ${prompt}`);
     sessionPaths.push(sessionPath);
     arrivals += 1;
     if (arrivals === 2) bothStarted();
     await released;
-    const text =
-      sessionPaths.indexOf(sessionPath) === 0
-        ? "first parent"
-        : "second parent";
     await writeFile(
       sessionPath,
       JSON.stringify({

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -1262,6 +1262,7 @@ test("runPiPrompt emits heartbeat events while pi is pending", async () => {
 
 test("runPiPrompt aggregates heartbeat failures while Pi is pending", async () => {
   const heartbeatError = new Error("heartbeat exploded");
+  let heartbeatFailed = false;
   let finishRun!: () => void;
   let runnerStarted!: () => void;
   const runnerHasStarted = new Promise<void>((resolve) => {
@@ -1283,7 +1284,8 @@ test("runPiPrompt aggregates heartbeat failures while Pi is pending", async () =
   const run = runPiPrompt(runner, "/repo", "prompt", {
     progress: {
       event: (event) => {
-        if (event.level !== "heartbeat") return;
+        if (event.level !== "heartbeat" || heartbeatFailed) return;
+        heartbeatFailed = true;
         return runnerHasStarted.then(() => {
           finishRun();
           throw heartbeatError;

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -6,6 +6,7 @@ import { basename, dirname, join } from "node:path";
 import { DEFAULT_PI_TASK_CONTRACT } from "../../../policy/task-contract.ts";
 import { parseDevelopmentEnvironmentResult, runPiPrompt } from "./pi.ts";
 import {
+  createExactPiSessionObservationStreamer,
   sessionEntryToObservations,
   sessionEntryToStreamText,
 } from "./pi-session-stream.ts";
@@ -22,6 +23,7 @@ type Call = {
   env?: Record<string, string | undefined>;
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
+  signal?: AbortSignal;
 };
 
 function createMockRunner(
@@ -36,6 +38,7 @@ function createMockRunner(
         env: (options as { env?: Record<string, string | undefined> }).env,
         onStdout: options.onStdout,
         onStderr: options.onStderr,
+        signal: options.signal,
       });
     },
   };
@@ -506,6 +509,53 @@ test("runPiPrompt creates a fresh durable invocation leaf and ignores stale JSON
   );
 });
 
+test("runPiPrompt pre-creates and passes an exact observed parent session", async (t) => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-exact-session-"));
+  t.after(async () => rm(repoRoot, { recursive: true, force: true }));
+  const sessionRoot = join(
+    repoRoot,
+    ".patchmill",
+    "runs",
+    "issue-123",
+    "sessions",
+  );
+  const events: AgentIssueProgressEvent[] = [];
+  let sessionPath = "";
+  const runner = createMockRunner(async (call) => {
+    const args = assertBundledPiCall(call);
+    const sessionIndex = args.indexOf("--session");
+    assert.ok(sessionIndex >= 0, `expected --session in ${args.join(" ")}`);
+    assert.equal(args.includes("--session-dir"), false);
+    sessionPath = args[sessionIndex + 1] ?? "";
+    assert.equal(await readFile(sessionPath, "utf8"), "");
+    assert.equal(dirname(dirname(sessionPath)), join(sessionRoot, "pi-plan"));
+    assert.match(basename(sessionPath), /^parent-[0-9a-f-]+\.jsonl$/);
+    await writeFile(
+      sessionPath,
+      JSON.stringify({ type: "session", id: "parent" }) + "\n",
+    );
+    return {
+      code: 0,
+      stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+      stderr: "",
+    };
+  });
+
+  await runPiPrompt(runner, "/repo", "prompt", {
+    progress: { event: (event) => events.push(event) },
+    stage: "pi-plan",
+    observeSession: true,
+    sessionRoot,
+  });
+
+  assert.ok(
+    events.some(
+      (event) =>
+        event.message === "pi session path" && event.data === sessionPath,
+    ),
+  );
+});
+
 test("runPiPrompt preserves an exact sessionDir override and logs the actual session dir", async (t) => {
   const repoRoot = await mkdtemp(
     join(tmpdir(), "patchmill-pi-session-override-"),
@@ -517,20 +567,21 @@ test("runPiPrompt preserves an exact sessionDir override and logs the actual ses
   const events: AgentIssueProgressEvent[] = [];
   const exactSessionDir = join(repoRoot, "exact-session-dir");
   let capturedPromptPath = "";
+  let capturedSessionPath = "";
 
   const runner = createMockRunner(async (call) => {
     const args = assertBundledPiCall(call);
     capturedPromptPath = promptPath(args);
-    const sessionDirIndex = args.indexOf("--session-dir");
-    assert.ok(
-      sessionDirIndex >= 0,
-      `expected --session-dir in ${args.join(" ")}`,
-    );
-    assert.equal(args[sessionDirIndex + 1], exactSessionDir);
+    const sessionIndex = args.indexOf("--session");
+    assert.ok(sessionIndex >= 0, `expected --session in ${args.join(" ")}`);
+    const sessionPath = args[sessionIndex + 1] ?? "";
+    capturedSessionPath = sessionPath;
+    assert.equal(dirname(sessionPath), exactSessionDir);
+    assert.match(basename(sessionPath), /^parent-[0-9a-f-]+\.jsonl$/);
+    assert.equal(await readFile(sessionPath, "utf8"), "");
 
-    await mkdir(join(exactSessionDir, "--repo--"), { recursive: true });
     await writeFile(
-      join(exactSessionDir, "--repo--", "session.jsonl"),
+      sessionPath,
       JSON.stringify({ type: "session", id: "session-1", cwd: "/repo" }) + "\n",
       "utf8",
     );
@@ -553,7 +604,7 @@ test("runPiPrompt preserves an exact sessionDir override and logs the actual ses
     code: "ENOENT",
   });
   assert.equal(
-    await readFile(join(exactSessionDir, "--repo--", "session.jsonl"), "utf8"),
+    await readFile(capturedSessionPath, "utf8"),
     JSON.stringify({ type: "session", id: "session-1", cwd: "/repo" }) + "\n",
   );
   assert.ok(
@@ -576,15 +627,13 @@ test("runPiPrompt emits structured observations and suppresses raw text unless s
   }> = [];
   const streamed: string[] = [];
   const runner = createMockRunner(async (call) => {
-    const sessionDirIndex = call.args.indexOf("--session-dir");
+    const sessionIndex = call.args.indexOf("--session");
     assert.ok(
-      sessionDirIndex >= 0,
-      `expected --session-dir in ${call.args.join(" ")}`,
+      sessionIndex >= 0,
+      `expected --session in ${call.args.join(" ")}`,
     );
-    const sessionDir = call.args[sessionDirIndex + 1];
-    assert.ok(sessionDir);
-    const sessionPath = join(sessionDir, "--repo--", "session.jsonl");
-    await mkdir(join(sessionDir, "--repo--"), { recursive: true });
+    const sessionPath = call.args[sessionIndex + 1] ?? "";
+    assert.equal(await readFile(sessionPath, "utf8"), "");
     await writeFile(
       sessionPath,
       [
@@ -644,13 +693,11 @@ test("runPiPrompt emits structured observations and suppresses raw text unless s
 test("runPiPrompt streams raw text in verbose mode", async () => {
   const streamed: string[] = [];
   const runner = createMockRunner(async (call) => {
-    const sessionDirIndex = call.args.indexOf("--session-dir");
-    assert.ok(sessionDirIndex >= 0);
-    const sessionDir = call.args[sessionDirIndex + 1];
-    assert.ok(sessionDir);
-    await mkdir(join(sessionDir, "--repo--"), { recursive: true });
+    const sessionIndex = call.args.indexOf("--session");
+    assert.ok(sessionIndex >= 0);
+    const sessionPath = call.args[sessionIndex + 1] ?? "";
     await writeFile(
-      join(sessionDir, "--repo--", "session.jsonl"),
+      sessionPath,
       JSON.stringify({
         type: "message",
         message: {
@@ -680,13 +727,11 @@ test("runPiPrompt streams raw text in verbose mode", async () => {
 test("runPiPrompt verbose mode does not append synthetic token lines", async () => {
   const streamed: string[] = [];
   const runner = createMockRunner(async (call) => {
-    const sessionDirIndex = call.args.indexOf("--session-dir");
-    assert.ok(sessionDirIndex >= 0);
-    const sessionDir = call.args[sessionDirIndex + 1];
-    assert.ok(sessionDir);
-    await mkdir(join(sessionDir, "--repo--"), { recursive: true });
+    const sessionIndex = call.args.indexOf("--session");
+    assert.ok(sessionIndex >= 0);
+    const sessionPath = call.args[sessionIndex + 1] ?? "";
     await writeFile(
-      join(sessionDir, "--repo--", "session.jsonl"),
+      sessionPath,
       JSON.stringify({
         type: "message",
         message: {
@@ -712,6 +757,267 @@ test("runPiPrompt verbose mode does not append synthetic token lines", async () 
   });
 
   assert.deepEqual(streamed, ["verbose narration\n"]);
+});
+
+test("runPiPrompt ignores newer sibling and nested JSONL when observing an exact parent", async (t) => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-exact-ignore-"));
+  t.after(async () => rm(repoRoot, { recursive: true, force: true }));
+  const observations: string[] = [];
+  const runner = createMockRunner(async (call) => {
+    const sessionPath = call.args[call.args.indexOf("--session") + 1] ?? "";
+    const invocationDir = dirname(sessionPath);
+    await mkdir(join(invocationDir, "nested"), { recursive: true });
+    const entry = (text: string) =>
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text }] },
+      }) + "\n";
+    await writeFile(
+      join(invocationDir, "nested", "session.jsonl"),
+      entry("nested"),
+    );
+    await writeFile(join(invocationDir, "sibling.jsonl"), entry("sibling"));
+    await writeFile(sessionPath, entry("parent"));
+    return {
+      code: 0,
+      stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+      stderr: "",
+    };
+  });
+
+  await runPiPrompt(runner, "/repo", "prompt", {
+    stage: "pi-plan",
+    observeSession: true,
+    sessionRoot: repoRoot,
+    onObservation: (observation) => {
+      if (observation.type === "text") observations.push(observation.text);
+    },
+  });
+  assert.deepEqual(observations, ["parent"]);
+});
+
+test("concurrent observed Pi prompts receive isolated exact parent sessions", async (t) => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-exact-concurrent-"));
+  t.after(async () => rm(repoRoot, { recursive: true, force: true }));
+  const sessionPaths: string[] = [];
+  let bothStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    bothStarted = resolve;
+  });
+  let arrivals = 0;
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const runner = createMockRunner(async (call) => {
+    const sessionPath = call.args[call.args.indexOf("--session") + 1] ?? "";
+    sessionPaths.push(sessionPath);
+    arrivals += 1;
+    if (arrivals === 2) bothStarted();
+    await released;
+    const text =
+      sessionPaths.indexOf(sessionPath) === 0
+        ? "first parent"
+        : "second parent";
+    await writeFile(
+      sessionPath,
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text }] },
+      }) + "\n",
+      "utf8",
+    );
+    return {
+      code: 0,
+      stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
+      stderr: "",
+    };
+  });
+  const first: string[] = [];
+  const second: string[] = [];
+  const firstRun = runPiPrompt(runner, "/repo", "first", {
+    stage: "pi-plan",
+    observeSession: true,
+    sessionRoot: repoRoot,
+    onObservation: (observation) => {
+      if (observation.type === "text") first.push(observation.text);
+    },
+  });
+  const secondRun = runPiPrompt(runner, "/repo", "second", {
+    stage: "pi-plan",
+    observeSession: true,
+    sessionRoot: repoRoot,
+    onObservation: (observation) => {
+      if (observation.type === "text") second.push(observation.text);
+    },
+  });
+  await started;
+  release();
+  await Promise.all([firstRun, secondRun]);
+  assert.notEqual(sessionPaths[0], sessionPaths[1]);
+  assert.deepEqual(first, ["first parent"]);
+  assert.deepEqual(second, ["second parent"]);
+});
+
+test("runPiPrompt aborts the runner when exact observation fails", async (t) => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-observe-abort-"));
+  t.after(async () => rm(repoRoot, { recursive: true, force: true }));
+  let abortObserved = false;
+  let allowClose!: () => void;
+  const closeAllowed = new Promise<void>((resolve) => {
+    allowClose = resolve;
+  });
+  const runner = createMockRunner(async (call) => {
+    const args = assertBundledPiCall(call);
+    const sessionPath = args[args.indexOf("--session") + 1] ?? "";
+    await writeFile(sessionPath, "{bad json\n", "utf8");
+    call.signal?.addEventListener("abort", () => {
+      abortObserved = true;
+      allowClose();
+    });
+    await closeAllowed;
+    return {
+      code: 1,
+      stdout: "partial stdout",
+      stderr: "runner closed after abort",
+    };
+  });
+
+  await assert.rejects(
+    () =>
+      runPiPrompt(runner, "/repo", "prompt", {
+        stage: "pi-plan",
+        observeSession: true,
+        sessionRoot: repoRoot,
+      }),
+    (error) => error instanceof AggregateError && error.errors.length >= 2,
+  );
+  assert.equal(abortObserved, true);
+});
+
+test("runPiPrompt preserves observation, runner, and cleanup failures", async (t) => {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-observe-causes-"));
+  t.after(async () => rm(repoRoot, { recursive: true, force: true }));
+  let allowClose!: () => void;
+  const closeAllowed = new Promise<void>((resolve) => {
+    allowClose = resolve;
+  });
+  const runner = createMockRunner(async (call) => {
+    const sessionPath = call.args[call.args.indexOf("--session") + 1] ?? "";
+    await writeFile(
+      sessionPath,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "progress" }],
+        },
+      }) + "\n",
+      "utf8",
+    );
+    call.signal?.addEventListener("abort", allowClose);
+    await closeAllowed;
+    return { code: 1, stdout: "", stderr: "runner failed" };
+  });
+
+  await assert.rejects(
+    () =>
+      runPiPrompt(runner, "/repo", "prompt", {
+        stage: "pi-plan",
+        observeSession: true,
+        sessionRoot: repoRoot,
+        onObservation: () => Promise.reject(new Error("callback exploded")),
+        cleanupPromptTempDir: async () => {
+          throw new Error("cleanup exploded");
+        },
+      }),
+    (error) => {
+      assert.equal(error instanceof AggregateError, true);
+      assert.deepEqual(
+        (error as AggregateError).errors.map(
+          (cause) => (cause as Error).message,
+        ),
+        [
+          "observation: callback exploded",
+          "runner: pi failed: runner failed",
+          "cleanup: cleanup exploded",
+        ],
+      );
+      return true;
+    },
+  );
+});
+
+test("exact session observation awaits callbacks in file order", async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-exact-stream-"));
+  t.after(async () => rm(dir, { recursive: true, force: true }));
+  const sessionPath = join(dir, "parent.jsonl");
+  await writeFile(
+    sessionPath,
+    ["first", "second"]
+      .map((text) =>
+        JSON.stringify({
+          type: "message",
+          message: { role: "assistant", content: [{ type: "text", text }] },
+        }),
+      )
+      .join("\n") + "\n",
+    "utf8",
+  );
+  const delivered: string[] = [];
+  let releaseFirst!: () => void;
+  const firstCanFinish = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let firstStarted!: () => void;
+  const firstWasDelivered = new Promise<void>((resolve) => {
+    firstStarted = resolve;
+  });
+  const streamer = createExactPiSessionObservationStreamer(
+    sessionPath,
+    async (observation) => {
+      if (observation.type !== "text") return;
+      delivered.push(observation.text);
+      if (observation.text === "first") {
+        firstStarted();
+        await firstCanFinish;
+      }
+    },
+    { pollMs: 60_000 },
+  );
+
+  streamer.start();
+  await firstWasDelivered;
+  assert.deepEqual(delivered, ["first"]);
+  releaseFirst();
+  await streamer.stop();
+  assert.deepEqual(delivered, ["first", "second"]);
+});
+
+test("exact session observation rejects malformed JSON and I/O errors", async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-exact-error-"));
+  t.after(async () => rm(dir, { recursive: true, force: true }));
+  const sessionPath = join(dir, "parent.jsonl");
+  await writeFile(sessionPath, "{bad json\n", "utf8");
+  const malformed = createExactPiSessionObservationStreamer(
+    sessionPath,
+    () => undefined,
+  );
+  malformed.start();
+  await assert.rejects(malformed.stop(), SyntaxError);
+
+  const ioError = new Error("injected stat failure");
+  const io = createExactPiSessionObservationStreamer(
+    sessionPath,
+    () => undefined,
+    {
+      statFile: async () => {
+        throw ioError;
+      },
+    },
+  );
+  io.start();
+  await assert.rejects(io.stop(), (error) => error === ioError);
 });
 
 test("runPiPrompt emits heartbeat events while pi is pending", async () => {

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import type { Stats } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
@@ -1010,6 +1011,57 @@ test("exact session observation awaits callbacks in file order", async (t) => {
   assert.deepEqual(delivered, ["first"]);
   releaseFirst();
   await streamer.stop();
+  assert.deepEqual(delivered, ["first", "second"]);
+});
+
+test("exact session observation performs a final read after an active poll", async () => {
+  const first = `${JSON.stringify({
+    type: "message",
+    message: { role: "assistant", content: [{ type: "text", text: "first" }] },
+  })}\n`;
+  const second = `${JSON.stringify({
+    type: "message",
+    message: { role: "assistant", content: [{ type: "text", text: "second" }] },
+  })}\n`;
+  let releaseFirstRead!: () => void;
+  const firstReadCanFinish = new Promise<void>((resolve) => {
+    releaseFirstRead = resolve;
+  });
+  let firstReadStarted!: () => void;
+  const firstReadHasStarted = new Promise<void>((resolve) => {
+    firstReadStarted = resolve;
+  });
+  let statCalls = 0;
+  const delivered: string[] = [];
+  const streamer = createExactPiSessionObservationStreamer(
+    "parent.jsonl",
+    (observation) => {
+      if (observation.type === "text") delivered.push(observation.text);
+    },
+    {
+      statFile: async () => {
+        statCalls += 1;
+        return {
+          size: statCalls === 1 ? first.length : first.length + second.length,
+        } as Stats;
+      },
+      readRange: async (_path, start) => {
+        if (start === 0) {
+          firstReadStarted();
+          await firstReadCanFinish;
+          return first;
+        }
+        return second;
+      },
+    },
+  );
+
+  streamer.start();
+  await firstReadHasStarted;
+  const stopped = streamer.stop();
+  releaseFirstRead();
+  await stopped;
+
   assert.deepEqual(delivered, ["first", "second"]);
 });
 

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -398,6 +398,8 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
     causes.push({ label, error });
   };
   let result: CommandResult | undefined;
+  let parsedResult: Result | undefined;
+  let hasParsedResult = false;
   let latestTokenUsage: string | undefined;
   const pendingHeartbeats: Promise<void>[] = [];
   const heartbeatMs = options?.heartbeatMs ?? 60_000;
@@ -547,7 +549,8 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
       if (causes.length === 0) {
         try {
           const parseResult = options?.parseResult ?? parsePiResult;
-          return parseResult(result.stdout) as Result;
+          parsedResult = parseResult(result.stdout) as Result;
+          hasParsedResult = true;
         } catch (error) {
           record("result parsing", error);
         }
@@ -574,5 +577,6 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
 
   const combined = aggregatePiErrors("pi prompt failed", causes);
   if (combined) throw combined;
+  if (hasParsedResult) return parsedResult as Result;
   throw new Error("pi prompt finished without a result");
 }

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -407,19 +407,25 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
   const timer = options?.progress
     ? setInterval(() => {
         const elapsedSeconds = Math.round((Date.now() - started) / 1000);
-        pendingHeartbeats.push(
-          heartbeatStatusLine(options, elapsedSeconds, latestTokenUsage)
-            .then((message) =>
-              options.progress?.event({
-                time: new Date().toISOString(),
-                level: "heartbeat",
-                stage: options.stage,
-                message,
-                elapsedSeconds,
-              }),
-            )
-            .then(() => undefined),
-        );
+        const heartbeat = heartbeatStatusLine(
+          options,
+          elapsedSeconds,
+          latestTokenUsage,
+        )
+          .then((message) =>
+            options.progress?.event({
+              time: new Date().toISOString(),
+              level: "heartbeat",
+              stage: options.stage,
+              message,
+              elapsedSeconds,
+            }),
+          )
+          .then(() => undefined)
+          .catch((error: unknown) => {
+            record("heartbeat", error);
+          });
+        pendingHeartbeats.push(heartbeat);
       }, heartbeatMs)
     : undefined;
 

--- a/src/cli/commands/run-once/pi.ts
+++ b/src/cli/commands/run-once/pi.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -19,10 +19,15 @@ import {
 import { finalJsonCandidates } from "./final-json.ts";
 import { issueTodoProgress } from "./issue-todos.ts";
 import {
+  createExactPiSessionObservationStreamer,
   createPiSessionMessageStreamer,
-  createPiSessionObservationStreamer,
   type PiSessionObservation,
 } from "./pi-session-stream.ts";
+import {
+  createPiSessionAllocation,
+  type PiSessionAllocation,
+} from "./pi-session-allocation.ts";
+import { aggregatePiErrors, type PiErrorCause } from "./pi-errors.ts";
 import type {
   AgentIssueBlockerQuestion,
   AgentIssueDevelopmentEnvironmentResult,
@@ -35,15 +40,19 @@ import type {
 
 function piPromptArgs(
   promptPath: string,
-  sessionDir?: string,
+  session: PiSessionAllocation | undefined,
   skillPaths: string[] = [],
   extensionArgs: string[] = [],
 ): string[] {
   const skillArgs = skillPaths.flatMap((path) => ["--skill", path]);
   const baseArgs = [...extensionArgs, ...skillArgs, "-p"];
-  return sessionDir
-    ? [...baseArgs, "--session-dir", sessionDir, `@${promptPath}`]
-    : [...baseArgs, `@${promptPath}`];
+  if (session?.sessionPath) {
+    return [...baseArgs, "--session", session.sessionPath, `@${promptPath}`];
+  }
+  if (session?.sessionDir) {
+    return [...baseArgs, "--session-dir", session.sessionDir, `@${promptPath}`];
+  }
+  return [...baseArgs, `@${promptPath}`];
 }
 
 function stringArray(value: unknown): string[] {
@@ -299,6 +308,7 @@ export type RunPiPromptOptions<Result = AgentIssuePiResult> = {
   taskContract?: PatchmillPiTaskContract;
   piAgentDir?: string;
   piCommand?: PiCommandSpec;
+  cleanupPromptTempDir?: (dir: string) => Promise<void>;
 };
 
 function stageStatus(stage: RunPiPromptStage): string {
@@ -375,29 +385,6 @@ async function emitPiOutput(
   });
 }
 
-async function createSessionDirForPi(
-  options: RunPiPromptOptions,
-  promptTempDir: string,
-): Promise<string | undefined> {
-  const shouldCreateSession = options.observeSession || options.streamOutput;
-  if (!shouldCreateSession) return undefined;
-
-  if (options.sessionDir) {
-    await mkdir(options.sessionDir, { recursive: true });
-    return options.sessionDir;
-  }
-
-  if (options.sessionRoot) {
-    const stageRoot = join(options.sessionRoot, options.stage);
-    await mkdir(stageRoot, { recursive: true });
-    return await mkdtemp(join(stageRoot, "invocation-"));
-  }
-
-  const sessionDir = join(promptTempDir, "sessions");
-  await mkdir(sessionDir, { recursive: true });
-  return sessionDir;
-}
-
 export async function runPiPrompt<Result = AgentIssuePiResult>(
   runner: CommandRunner,
   cwd: string,
@@ -406,11 +393,15 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
 ): Promise<Result> {
   const dir = await mkdtemp(join(tmpdir(), "agent-issue-prompt-"));
   const promptPath = join(dir, "prompt.md");
-  await writeFile(promptPath, prompt, "utf8");
-  const heartbeatMs = options?.heartbeatMs ?? 60_000;
-  const started = Date.now();
+  const causes: PiErrorCause[] = [];
+  const record = (label: string, error: unknown) => {
+    causes.push({ label, error });
+  };
+  let result: CommandResult | undefined;
   let latestTokenUsage: string | undefined;
   const pendingHeartbeats: Promise<void>[] = [];
+  const heartbeatMs = options?.heartbeatMs ?? 60_000;
+  const started = Date.now();
   const timer = options?.progress
     ? setInterval(() => {
         const elapsedSeconds = Math.round((Date.now() - started) / 1000);
@@ -431,52 +422,58 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
     : undefined;
 
   try {
+    await writeFile(promptPath, prompt, "utf8");
     await options?.progress?.event({
       time: new Date().toISOString(),
       level: "debug",
       stage: options.stage,
       message: "started pi",
     });
-    const streamOutput = options?.streamOutput;
-    const sessionDir = options
-      ? await createSessionDirForPi(options, dir)
+    const session = options
+      ? await createPiSessionAllocation({ ...options, promptTempDir: dir })
       : undefined;
-    if (sessionDir) {
+    if (session?.sessionDir) {
       await options?.progress?.event({
         time: new Date().toISOString(),
         level: "debug",
         stage: options.stage,
         message: "pi session dir",
-        data: sessionDir,
+        data: session.sessionDir,
       });
     }
-    const pendingObservations: Promise<void>[] = [];
-    const sessionStreamer = sessionDir
-      ? options?.observeSession
-        ? createPiSessionObservationStreamer(
-            sessionDir,
-            (observation) => {
-              if (observation.type === "assistant-usage") {
-                latestTokenUsage = `tok: task=${observation.outputTokens} total=?`;
-                if (options?.tokenUsageState) {
-                  options.tokenUsageState.total += observation.outputTokens;
-                }
+    if (session?.sessionPath) {
+      await options?.progress?.event({
+        time: new Date().toISOString(),
+        level: "debug",
+        stage: options.stage,
+        message: "pi session path",
+        data: session.sessionPath,
+      });
+    }
+
+    const controller = session?.sessionPath ? new AbortController() : undefined;
+    const sessionStreamer = session?.sessionPath
+      ? createExactPiSessionObservationStreamer(
+          session.sessionPath,
+          async (observation) => {
+            if (observation.type === "assistant-usage") {
+              latestTokenUsage = `tok: task=${observation.outputTokens} total=?`;
+              if (options?.tokenUsageState) {
+                options.tokenUsageState.total += observation.outputTokens;
               }
-              if (options?.onObservation) {
-                pendingObservations.push(
-                  Promise.resolve(options.onObservation(observation)).then(
-                    () => undefined,
-                  ),
-                );
-              }
-            },
-            {
-              verboseOutput: options.verbosePiOutput ? streamOutput : undefined,
-            },
-          )
-        : createPiSessionMessageStreamer(
-            sessionDir,
-            streamOutput ?? (() => undefined),
+            }
+            await options?.onObservation?.(observation);
+          },
+          {
+            verboseOutput: options?.verbosePiOutput
+              ? options.streamOutput
+              : undefined,
+          },
+        )
+      : session?.sessionDir
+        ? createPiSessionMessageStreamer(
+            session.sessionDir,
+            options?.streamOutput ?? (() => undefined),
             {
               totalTokensSoFar: options?.tokenUsageState?.total ?? 0,
               onTokenUsage: (usage) => {
@@ -486,9 +483,16 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
               },
             },
           )
-      : undefined;
+        : undefined;
+    let observationFailure: Promise<void> | undefined;
+    if (sessionStreamer && "failure" in sessionStreamer) {
+      observationFailure = sessionStreamer.failure.catch((error) => {
+        record("observation", error);
+        controller?.abort(error);
+      });
+    }
     sessionStreamer?.start();
-    let result: CommandResult;
+
     try {
       const piCommand = options?.piCommand ?? resolveBundledPiCommand();
       result = await runner.run(
@@ -497,7 +501,7 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
           piCommand,
           piPromptArgs(
             promptPath,
-            sessionDir,
+            session,
             options?.skillPaths,
             options?.extensionArgs,
           ),
@@ -513,23 +517,62 @@ export async function runPiPrompt<Result = AgentIssuePiResult>(
                 DEFAULT_PI_TASK_CONTRACT.doneStatuses,
             ),
           }),
+          signal: controller?.signal,
         },
       );
-    } finally {
-      await sessionStreamer?.stop();
-      await Promise.all(pendingObservations);
-    }
-    await emitPiOutput(result, options);
-    const stdout = result.stdout;
-    if (result.code !== 0) {
-      throw new Error(`pi failed: ${result.stderr || stdout || result.stdout}`);
+    } catch (error) {
+      record("runner", error);
     }
 
-    const parseResult = options?.parseResult ?? parsePiResult;
-    return parseResult(stdout) as Result;
+    void observationFailure;
+    try {
+      await sessionStreamer?.stop();
+    } catch (error) {
+      if (!causes.some((cause) => cause.error === error)) {
+        record("streamer shutdown", error);
+      }
+    }
+    if (result) {
+      try {
+        await emitPiOutput(result, options);
+      } catch (error) {
+        record("progress", error);
+      }
+      if (result.code !== 0) {
+        record(
+          "runner",
+          new Error(`pi failed: ${result.stderr || result.stdout}`),
+        );
+      }
+      if (causes.length === 0) {
+        try {
+          const parseResult = options?.parseResult ?? parsePiResult;
+          return parseResult(result.stdout) as Result;
+        } catch (error) {
+          record("result parsing", error);
+        }
+      }
+    }
+  } catch (error) {
+    record("pi prompt", error);
   } finally {
     if (timer) clearInterval(timer);
-    await Promise.all(pendingHeartbeats);
-    await rm(dir, { recursive: true, force: true });
+    try {
+      await Promise.all(pendingHeartbeats);
+    } catch (error) {
+      record("heartbeat", error);
+    }
+    try {
+      await (
+        options?.cleanupPromptTempDir ??
+        ((path: string) => rm(path, { recursive: true, force: true }))
+      )(dir);
+    } catch (error) {
+      record("cleanup", error);
+    }
   }
+
+  const combined = aggregatePiErrors("pi prompt failed", causes);
+  if (combined) throw combined;
+  throw new Error("pi prompt finished without a result");
 }

--- a/src/cli/commands/run-once/pipeline-development-environment.test.ts
+++ b/src/cli/commands/run-once/pipeline-development-environment.test.ts
@@ -34,12 +34,12 @@ function assertInvocationLeaf(actual: string, expectedStageRoot: string): void {
 
 function sessionDirs(calls: ReturnType<typeof workflowPiCalls>): string[] {
   return calls.map((call) => {
-    const sessionDirIndex = call.args.indexOf("--session-dir");
+    const sessionIndex = call.args.indexOf("--session");
     assert.ok(
-      sessionDirIndex >= 0,
-      `expected --session-dir in ${call.args.join(" ")}`,
+      sessionIndex >= 0,
+      `expected --session in ${call.args.join(" ")}`,
     );
-    return call.args[sessionDirIndex + 1] ?? "";
+    return dirname(call.args[sessionIndex + 1] ?? "");
   });
 }
 

--- a/src/cli/commands/run-once/pipeline-implementation-scenarios.test.ts
+++ b/src/cli/commands/run-once/pipeline-implementation-scenarios.test.ts
@@ -38,12 +38,12 @@ function assertInvocationLeaf(actual: string, expectedStageRoot: string): void {
 
 function sessionDirs(calls: ReturnType<typeof workflowPiCalls>): string[] {
   return calls.map((call) => {
-    const sessionDirIndex = call.args.indexOf("--session-dir");
+    const sessionIndex = call.args.indexOf("--session");
     assert.ok(
-      sessionDirIndex >= 0,
-      `expected --session-dir in ${call.args.join(" ")}`,
+      sessionIndex >= 0,
+      `expected --session in ${call.args.join(" ")}`,
     );
-    return call.args[sessionDirIndex + 1] ?? "";
+    return dirname(call.args[sessionIndex + 1] ?? "");
   });
 }
 

--- a/src/cli/commands/triage/command.test.ts
+++ b/src/cli/commands/triage/command.test.ts
@@ -89,13 +89,14 @@ test("command runner aborts an in-flight process and waits for close", async () 
         "  process.stdout.write('closed-after-abort\\n');",
         "  process.exit(0);",
         "});",
+        "process.stdout.write('ready-to-abort\\n');",
         "setInterval(() => {}, 1000);",
       ].join(""),
     ],
     {
       signal: controller.signal,
       onStdout: (chunk) => {
-        if (chunk.includes("started")) started();
+        if (chunk.includes("ready-to-abort")) started();
       },
     },
   );
@@ -105,7 +106,7 @@ test("command runner aborts an in-flight process and waits for close", async () 
   const result = await resultPromise;
 
   assert.notEqual(result.code, 0);
-  assert.match(result.stdout, /started|closed-after-abort/);
+  assert.match(result.stdout, /closed-after-abort/);
   assert.match(result.stderr, /stderr-before-abort|aborted/i);
 });
 

--- a/src/cli/commands/triage/command.test.ts
+++ b/src/cli/commands/triage/command.test.ts
@@ -71,6 +71,60 @@ test("command runner uses the provided cwd", async () => {
   assert.equal(result.stdout, `${cwd}\n`);
 });
 
+test("command runner aborts an in-flight process and waits for close", async () => {
+  const runner = createCommandRunner();
+  const controller = new AbortController();
+  let started!: () => void;
+  const didStart = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const resultPromise = runner.run(
+    process.execPath,
+    [
+      "-e",
+      [
+        "process.stdout.write('started\\n');",
+        "process.stderr.write('stderr-before-abort\\n');",
+        "process.on('SIGTERM', () => {",
+        "  process.stdout.write('closed-after-abort\\n');",
+        "  process.exit(0);",
+        "});",
+        "setInterval(() => {}, 1000);",
+      ].join(""),
+    ],
+    {
+      signal: controller.signal,
+      onStdout: (chunk) => {
+        if (chunk.includes("started")) started();
+      },
+    },
+  );
+
+  await didStart;
+  controller.abort();
+  const result = await resultPromise;
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /started|closed-after-abort/);
+  assert.match(result.stderr, /stderr-before-abort|aborted/i);
+});
+
+test("command runner does not spawn when signal is already aborted", async () => {
+  const runner = createCommandRunner();
+  const controller = new AbortController();
+  controller.abort();
+
+  const result = await runner.run(
+    process.execPath,
+    ["-e", "process.stdout.write('should-not-run')"],
+    { signal: controller.signal },
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /aborted/i);
+});
+
 test("static runner returns queued results and records calls", async () => {
   const runner = createStaticCommandRunner([
     { code: 0, stdout: "one", stderr: "" },

--- a/src/cli/commands/triage/command.ts
+++ b/src/cli/commands/triage/command.ts
@@ -1,14 +1,29 @@
 import { spawn } from "node:child_process";
 import type { CommandResult, CommandRunner } from "./types.ts";
 
+function appendAbortMarker(stderr: string): string {
+  return `${stderr}${stderr.length > 0 && !stderr.endsWith("\n") ? "\n" : ""}command aborted\n`;
+}
+
 export function createCommandRunner(): CommandRunner {
   return {
     run(command, args, options = {}) {
+      if (options.signal?.aborted) {
+        return Promise.resolve({
+          code: 1,
+          stdout: "",
+          stderr: "command aborted before spawn",
+        });
+      }
+
       return new Promise<CommandResult>((resolve) => {
         let settled = false;
+        let stdout = "";
+        let stderr = "";
         const settle = (result: CommandResult) => {
           if (settled) return;
           settled = true;
+          options.signal?.removeEventListener("abort", onAbort);
           resolve(result);
         };
         const child = spawn(command, args, {
@@ -16,8 +31,11 @@ export function createCommandRunner(): CommandRunner {
           env: options.env ? { ...process.env, ...options.env } : undefined,
           stdio: ["ignore", "pipe", "pipe"],
         });
-        let stdout = "";
-        let stderr = "";
+        const onAbort = () => {
+          stderr = appendAbortMarker(stderr);
+          child.kill("SIGTERM");
+        };
+        options.signal?.addEventListener("abort", onAbort, { once: true });
         child.stdout.on("data", (chunk) => {
           const text = String(chunk);
           stdout += text;
@@ -31,8 +49,13 @@ export function createCommandRunner(): CommandRunner {
         child.on("error", (error) => {
           settle({ code: 1, stdout, stderr: stderr + error.message });
         });
-        child.on("close", (code) => {
-          settle({ code: code ?? 1, stdout, stderr });
+        child.on("close", (code, signal) => {
+          if (signal && !stderr.includes(signal)) stderr += `${signal}\n`;
+          settle({
+            code: options.signal?.aborted ? 1 : (code ?? 1),
+            stdout,
+            stderr,
+          });
         });
       });
     },

--- a/src/cli/commands/triage/tool-call-observer.test.ts
+++ b/src/cli/commands/triage/tool-call-observer.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { runWithToolCallObservation } from "./tool-call-observer.ts";
+
+test("runWithToolCallObservation supplies a session directory and observes legacy tool calls", async () => {
+  const observed: Array<{ toolName?: string; toolCallId?: string }> = [];
+  let suppliedSessionDir = "";
+
+  const result = await runWithToolCallObservation(
+    (event) =>
+      observed.push({ toolName: event.toolName, toolCallId: event.toolCallId }),
+    async (sessionDir) => {
+      assert.ok(sessionDir);
+      suppliedSessionDir = sessionDir;
+      await mkdir(join(sessionDir, "child"), { recursive: true });
+      await writeFile(
+        join(sessionDir, "child", "session.jsonl"),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "toolResult",
+            toolName: "bash",
+            toolCallId: "call-1",
+          },
+        }) + "\n",
+        "utf8",
+      );
+      return "ok";
+    },
+  );
+
+  assert.equal(result, "ok");
+  assert.deepEqual(observed, [{ toolName: "bash", toolCallId: "call-1" }]);
+  await assert.rejects(stat(suppliedSessionDir), { code: "ENOENT" });
+});

--- a/src/cli/commands/triage/types.ts
+++ b/src/cli/commands/triage/types.ts
@@ -53,6 +53,7 @@ export type CommandRunOptions = {
   env?: Record<string, string | undefined>;
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
+  signal?: AbortSignal;
 };
 
 export type CommandRunner = {

--- a/src/pi/runner.test.ts
+++ b/src/pi/runner.test.ts
@@ -121,7 +121,13 @@ test("PiRunner plan forwards runOptions into runPiPrompt", async () => {
     assertBundledPiCall(call);
     assert.equal(call.cwd, repoRoot);
     assert.ok(call.args.includes("-p"));
-    assert.ok(call.args.includes("--session-dir"));
+    const sessionIndex = call.args.indexOf("--session");
+    assert.ok(sessionIndex >= 0);
+    assert.equal(call.args.includes("--session-dir"), false);
+    assert.match(
+      call.args[sessionIndex + 1] ?? "",
+      /parent-[0-9a-f-]+\.jsonl$/,
+    );
     assert.match(call.prompt, /Create an implementation plan/);
     assert.match(
       call.prompt,
@@ -274,7 +280,13 @@ test("PiRunner implementation uses the worktree root, derives the default landin
   const runner = createFakeRunner(async (call) => {
     assertBundledPiCall(call);
     assert.equal(call.cwd, worktreeRoot);
-    assert.ok(call.args.includes("--session-dir"));
+    const sessionIndex = call.args.indexOf("--session");
+    assert.ok(sessionIndex >= 0);
+    assert.equal(call.args.includes("--session-dir"), false);
+    assert.match(
+      call.args[sessionIndex + 1] ?? "",
+      /parent-[0-9a-f-]+\.jsonl$/,
+    );
     assert.match(call.prompt, /Resume context:/);
     assert.match(call.prompt, /Subagent support:/);
     assert.doesNotMatch(

--- a/test-support/run-once/mock-runner.ts
+++ b/test-support/run-once/mock-runner.ts
@@ -200,17 +200,8 @@ export async function writePiSessionMessage(
   text: string,
   usage?: { input: number; output: number; totalTokens: number },
 ): Promise<void> {
-  const sessionDirIndex = call.args.indexOf("--session-dir");
-  assert.ok(
-    sessionDirIndex >= 0,
-    `expected --session-dir in ${call.args.join(" ")}`,
-  );
-  const sessionDir = call.args[sessionDirIndex + 1];
-  assert.ok(sessionDir);
-  const sessionSubdir = join(sessionDir, "--repo--");
-  await mkdir(sessionSubdir, { recursive: true });
   await writeFile(
-    join(sessionSubdir, "session.jsonl"),
+    await piSessionPath(call),
     [
       JSON.stringify({
         type: "session",
@@ -246,27 +237,24 @@ export async function writePiPricedSessionMessage(
     estimatedCostUsd: number;
   },
 ): Promise<void> {
-  const sessionDirIndex = call.args.indexOf("--session-dir");
-  assert.ok(
-    sessionDirIndex >= 0,
-    `expected --session-dir in ${call.args.join(" ")}`,
-  );
-  const sessionDir = call.args[sessionDirIndex + 1];
-  assert.ok(sessionDir);
-  const sessionSubdir = join(sessionDir, "--repo--");
-  await mkdir(sessionSubdir, { recursive: true });
   await writeFile(
-    join(sessionSubdir, "priced-session.jsonl"),
+    await piSessionPath(call),
     `${JSON.stringify({ type: "session", id: "session-priced", timestamp: "2026-07-19T12:00:00.000Z" })}\n${JSON.stringify({ type: "message", id: input.id, message: { role: "assistant", model: input.model, usage: { input: input.input, cacheRead: input.cacheRead, cacheWrite: input.cacheWrite, output: input.output, cost: { total: input.estimatedCostUsd } } } })}\n`,
     "utf8",
   );
 }
 
 export async function piSessionPath(call: Call): Promise<string> {
+  const sessionIndex = call.args.indexOf("--session");
+  if (sessionIndex >= 0) {
+    const sessionPath = call.args[sessionIndex + 1];
+    assert.ok(sessionPath);
+    return sessionPath;
+  }
   const sessionDirIndex = call.args.indexOf("--session-dir");
   assert.ok(
     sessionDirIndex >= 0,
-    `expected --session-dir in ${call.args.join(" ")}`,
+    `expected a Pi session argument in ${call.args.join(" ")}`,
   );
   const sessionDir = call.args[sessionDirIndex + 1];
   assert.ok(sessionDir);


### PR DESCRIPTION
Summary

- Allocate exact parent Pi session files for observed run-once prompts and pass them with `--session`.
- Stream exact session JSONL serially with callback backpressure, strict errors, UTF-8-safe reads, cancellation, and aggregate terminal causes.
- Keep triage on legacy session-dir observation while adding regression coverage.

## Validation

- `node --test src/cli/commands/run-once/pi.test.ts src/cli/commands/triage/*.test.ts` — 187 tests passed.
- `npm run test:run-once` — 431 tests passed.
- `npm run lint:ts` — passed with zero warnings.
- `npm run lint:md` — 177 files, zero errors.
- `git diff -- package.json npm-shrinkwrap.json package-lock.json` — no output.
- Final validation-readiness reviewer also ran `npm test` — 1,154 tests passed.

## Reviews

- Final Codex full-worktree review passed after accepted fixes.
- Final thermo-nuclear review passed with one deferred minor test-organization suggestion.
- Final validation-readiness review passed all required commands.

Closes #123

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Planning | gpt-5.5 | 1,549,932 | 18,856 | $1.7443 |
| Development environment | gpt-5.5 | 670,781 | 2,262 | $0.7353 |
| Implementation | gpt-5.5 | 6,136,856 | 18,466 | $4.5119 |
| Implementation | gpt-5.6-sol | 14,146,920 | 82,481 | $14.2658 |
| Implementation | gpt-5.6-terra | 13,632,353 | 47,926 | $6.3315 |
| **Implementation subtotal** |  | **33,916,129** | **148,873** | **$25.1092** |
| **Total** |  | **36,136,842** | **169,991** | **$27.5888** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->