### PR TITLE
docs: publish Patchmill product roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Start here:
 - [Triage](https://patchmill.dev/using-patchmill/triage/)
 - [Run-once](https://patchmill.dev/using-patchmill/run-once/)
 
+## Roadmap
+
+Patchmill's roadmap moves from safe, unattended local operation to broader work
+sources, a unified control plane, and cloud-operated agents running in isolated
+sandboxes. The phases describe product direction rather than date or version
+commitments.
+
+Read the [Patchmill roadmap](docs/roadmap.md).
+
 ## Install
 
 ```sh

--- a/docs/plans/2026-07-30-patchmill-roadmap.md
+++ b/docs/plans/2026-07-30-patchmill-roadmap.md
@@ -1,0 +1,406 @@
+# Patchmill Public Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish Patchmill's four-phase product roadmap and announce it from
+the README without presenting planned capabilities as already available.
+
+**Architecture:** Keep the complete public roadmap in `docs/roadmap.md`, which
+is already covered by the npm package's `docs` file inclusion. Add only a short
+announcement and relative link to `README.md` so the README stays introductory
+and the roadmap has one canonical source.
+
+**Tech Stack:** Markdown, Prettier 3.8.3, markdownlint-cli2 0.22.1
+
+## Global Constraints
+
+- Implement the approved design in
+  `docs/specs/2026-07-30-patchmill-roadmap-design.md`.
+- Organize the roadmap as four ordered, outcome-based phases with no release
+  dates or version assignments.
+- Describe listed features as candidate capabilities and current direction, not
+  guaranteed commitments.
+- Preserve local-first operation as a first-class option after dashboard and
+  cloud deployment capabilities exist.
+- State that Kubernetes is an execution backend, not a requirement or
+  Patchmill's core architecture.
+- Do not present `patchmill run`, Linear, local trackers, the dashboard, or
+  cloud workers as currently available.
+- Keep the README announcement concise and link it to the canonical roadmap.
+- Do not add automated tests for static documentation text. Use formatting,
+  Markdown linting, link/path checks, and direct review instead, as required by
+  the Testing Value Gate.
+
+## File Structure
+
+- Create `docs/roadmap.md` as the canonical public roadmap, including
+  principles, four phases, scope boundaries, and a feedback invitation.
+- Modify `README.md` to announce the roadmap and link to `docs/roadmap.md` after
+  the existing Documentation section.
+
+---
+
+### Task 1: Publish the canonical roadmap
+
+**Files:**
+
+- Create: `docs/roadmap.md`
+- Reference: `docs/specs/2026-07-30-patchmill-roadmap-design.md`
+
+**Interfaces:**
+
+- Consumes: The approved product narrative, phase outcomes, candidate
+  capabilities, and scope boundaries from the design specification.
+- Produces: The canonical `docs/roadmap.md` target that the README links to in
+  Task 2.
+
+- [ ] **Step 1: Create the canonical roadmap with the approved public copy**
+
+Create `docs/roadmap.md` with exactly this content:
+
+```markdown
+# Patchmill Roadmap
+
+Patchmill is growing from a supervised local workflow into a safe, extensible,
+cloud-operated software factory. The roadmap follows four stages: operate
+unattended safely, bring work from more sources, see and direct the factory from
+a unified control plane, and run isolated workers in managed infrastructure.
+
+> This roadmap describes Patchmill's current direction, not a release or version
+> commitment. Ordering and details may change as the architecture is validated
+> and maintainers learn from real-world use.
+
+## Principles
+
+- Organize work around user outcomes rather than internal projects.
+- Establish safety, observability, and human control before increasing autonomy
+  or scale.
+- Keep local-first operation available as shared and remote deployment options
+  grow.
+- Build durable boundaries that support later phases without requiring earlier
+  workflows to be replaced.
+- Treat every capability below as a candidate until its dedicated design is
+  approved.
+
+## Phase I: Operate unattended, safely
+
+**Outcome:** A maintainer can leave Patchmill running under a process supervisor
+without risking duplicate work or uncontrolled spending.
+
+Candidate capabilities include:
+
+- A continuous `patchmill run` command built around the existing atomic
+  `run-once` workflow.
+- One issue at a time by default, with safe configurable concurrency later.
+- Idle polling with configurable intervals, backoff, and jitter.
+- Graceful shutdown, pause, resume, and drain controls.
+- Single-instance locking and durable resumable run state.
+- Daily and weekly token and estimated US dollar budgets.
+- An initial budget policy that finishes the current issue, then stops before
+  selecting another.
+- Configurable budget stopping boundaries in later iterations.
+- Repeated-failure circuit breakers and issue quarantine.
+- Notification hooks for blockers, approvals, failures, and budget limits.
+- A structured event, usage, and audit ledger.
+
+Cost limits will use Patchmill's recorded model usage and estimated cost. They
+will not claim exact equivalence with provider billing or guarantee that every
+provider request can be interrupted at an exact billing boundary.
+
+## Phase II: Bring work from anywhere
+
+**Outcome:** Teams can keep product work in one system and source code in
+another.
+
+Candidate capabilities include:
+
+- Independent work-source and code-host configuration.
+- Provider-qualified issue identities rather than numeric-only issue numbers.
+- A built-in Linear work source.
+- A generic local-command adapter with a documented JSON protocol.
+- Beads as the reference local tracker integration.
+- Capability discovery and adapter conformance tests.
+- Priority, dependency, and readiness signals across work sources.
+
+A public plugin SDK will wait until built-in and local adapters have proven the
+underlying contract. Kata and other local trackers can be evaluated after the
+generic adapter works; they are not initial commitments.
+
+## Phase III: See and direct the factory
+
+**Outcome:** A maintainer can understand and direct Patchmill from one local
+interface.
+
+Candidate capabilities include:
+
+- A local control-plane API and event stream.
+- A unified kanban, list, and factory-status dashboard.
+- Issue details, artifacts, run history, and agent timelines.
+- Issue-centered conversations with an agent.
+- Agent-drafted issues, specifications, and plans.
+- Explicit approval for proposed workflow actions initially, with selected
+  actions becoming optionally autonomous through policy later.
+- An approval inbox and intervention controls.
+- Pause, resume, drain, retry, and quarantine actions.
+- Logs, token and cost breakdowns, budget status, and forecasting.
+
+The first dashboard will be read-mostly: inspection, conversation, approval, and
+essential operational controls come before a general workflow builder. Work will
+remain central through board and list views, while active runs, queue health,
+approvals, and budget state remain visible.
+
+## Phase IV: Run the factory anywhere
+
+**Outcome:** Teams primarily use a shared dashboard while Patchmill schedules
+isolated workers into managed infrastructure.
+
+Candidate capabilities include:
+
+- A remote controller and shared dashboard.
+- A durable database, event stream, queue, and worker leases.
+- Containerized disposable agent workers.
+- Kubernetes Jobs as an execution backend.
+- Cancellation, recovery, autoscaling, and resource quotas.
+- Scoped repository credentials and secrets.
+- Filesystem, network, model, and tool policies for each sandbox.
+- Central logs, artifacts, costs, and audit history.
+- Authentication, role-based access control, projects, and multi-tenancy.
+- Docker Compose and Helm deployment paths.
+
+Kubernetes will be one execution backend, not Patchmill's core architecture.
+Local operation will remain supported without requiring a cluster or hosted
+service.
+
+## How the phases build on each other
+
+Phase I establishes the coordinator and event ledger around `run-once`. Phase II
+normalizes work from independently configured work sources and code hosts. Phase
+III exposes those capabilities through a stable local API and control plane.
+Phase IV distributes the control plane and execution backend while preserving
+the same domain boundaries.
+
+Substantial roadmap capabilities will receive their own design and
+implementation plan before development.
+
+## Feedback and contributions
+
+Feedback from maintainers and teams using Patchmill will shape the details
+within each phase. To propose a use case, integration, or change in priority,
+[open a GitHub issue](https://github.com/rochecompaan/patchmill/issues).
+```
+
+- [ ] **Step 2: Format the roadmap**
+
+Run:
+
+```bash
+npx prettier --write docs/roadmap.md
+```
+
+Expected: Prettier reports `docs/roadmap.md` and exits successfully.
+
+- [ ] **Step 3: Lint the roadmap**
+
+Run:
+
+```bash
+npx markdownlint-cli2 docs/roadmap.md
+```
+
+Expected: exit 0 with `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Verify the public structure and commitment language directly**
+
+Run:
+
+```bash
+node - <<'NODE'
+const { readFileSync } = require("node:fs");
+const roadmap = readFileSync("docs/roadmap.md", "utf8");
+const required = [
+  "## Phase I: Operate unattended, safely",
+  "## Phase II: Bring work from anywhere",
+  "## Phase III: See and direct the factory",
+  "## Phase IV: Run the factory anywhere",
+  "current direction, not a release or version",
+  "Local operation will remain supported",
+];
+const missing = required.filter((text) => !roadmap.includes(text));
+if (missing.length > 0) {
+  console.error(`Missing roadmap language: ${missing.join(", ")}`);
+  process.exit(1);
+}
+console.log("Roadmap structure and scope language verified");
+NODE
+```
+
+Expected: `Roadmap structure and scope language verified`.
+
+This is a one-off documentation check, not a new automated test.
+
+- [ ] **Step 5: Inspect the roadmap diff and whitespace**
+
+Run:
+
+```bash
+git diff --check
+git diff -- docs/roadmap.md
+```
+
+Expected: `git diff --check` exits 0. The roadmap diff contains four phases,
+uses candidate-capability language, makes local operation optional, and contains
+no dates or version promises.
+
+- [ ] **Step 6: Commit the canonical roadmap**
+
+```bash
+git add docs/roadmap.md
+git commit -m "docs(roadmap): publish product direction"
+```
+
+Expected: one commit containing only `docs/roadmap.md`.
+
+---
+
+### Task 2: Announce the roadmap in the README
+
+**Files:**
+
+- Modify: `README.md:17-29`
+- Verify: `docs/roadmap.md`
+
+**Interfaces:**
+
+- Consumes: The canonical relative link target `docs/roadmap.md` created in
+  Task 1.
+- Produces: A concise README announcement that directs GitHub and npm readers to
+  the roadmap without duplicating it.
+
+- [ ] **Step 1: Insert the Roadmap section after Documentation**
+
+In `README.md`, replace this exact boundary:
+
+```markdown
+- [Run-once](https://patchmill.dev/using-patchmill/run-once/)
+
+## Install
+```
+
+with:
+
+```markdown
+- [Run-once](https://patchmill.dev/using-patchmill/run-once/)
+
+## Roadmap
+
+Patchmill's roadmap moves from safe, unattended local operation to broader work
+sources, a unified control plane, and cloud-operated agents running in isolated
+sandboxes. The phases describe product direction rather than date or version
+commitments.
+
+Read the [Patchmill roadmap](docs/roadmap.md).
+
+## Install
+```
+
+- [ ] **Step 2: Format the README and roadmap**
+
+Run:
+
+```bash
+npx prettier --write README.md docs/roadmap.md
+```
+
+Expected: Prettier reports both Markdown files and exits successfully.
+
+- [ ] **Step 3: Lint the changed Markdown files**
+
+Run:
+
+```bash
+npx markdownlint-cli2 README.md docs/roadmap.md
+```
+
+Expected: exit 0 with `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Verify the README link and announcement boundary**
+
+Run:
+
+```bash
+node - <<'NODE'
+const { existsSync, readFileSync } = require("node:fs");
+const readme = readFileSync("README.md", "utf8");
+if (!readme.includes("## Roadmap\n")) {
+  throw new Error("README Roadmap heading is missing");
+}
+if (!readme.includes("[Patchmill roadmap](docs/roadmap.md)")) {
+  throw new Error("README roadmap link is missing");
+}
+if (!existsSync("docs/roadmap.md")) {
+  throw new Error("README roadmap link target does not exist");
+}
+if (readme.indexOf("## Documentation") > readme.indexOf("## Roadmap")) {
+  throw new Error("Roadmap must follow Documentation");
+}
+if (readme.indexOf("## Roadmap") > readme.indexOf("## Install")) {
+  throw new Error("Roadmap must precede Install");
+}
+console.log("README roadmap announcement and link verified");
+NODE
+```
+
+Expected: `README roadmap announcement and link verified`.
+
+This is a one-off link and placement check, not a new automated test.
+
+- [ ] **Step 5: Review the complete documentation diff**
+
+Run:
+
+```bash
+git diff --check
+git diff -- README.md docs/roadmap.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- The README adds only the concise Roadmap section.
+- The existing Basic workflow and Main commands continue to list only current
+  commands; `patchmill run` appears only in the roadmap as planned work.
+- Linear, Beads, the dashboard, and cloud workers appear only as roadmap
+  direction, not supported current features.
+
+- [ ] **Step 6: Run final changed-file validation**
+
+Run:
+
+```bash
+npx prettier --check README.md docs/roadmap.md
+npx markdownlint-cli2 README.md docs/roadmap.md
+git status --short
+```
+
+Expected:
+
+- Prettier reports `All matched files use Prettier code style!`.
+- Markdownlint reports `Summary: 0 error(s)`.
+- `git status --short` lists only `M README.md` before the commit.
+
+No new automated tests are added because the Testing Value Gate excludes static
+documentation text. The clean 1,136-test baseline established in the worktree is
+sufficient production-code evidence for this documentation-only change.
+
+- [ ] **Step 7: Commit the README announcement**
+
+```bash
+git add README.md
+git commit -m "docs(readme): announce product roadmap"
+```
+
+Expected: one commit containing only `README.md`, with the worktree clean after
+the commit.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,128 @@
+# Patchmill Roadmap
+
+Patchmill is growing from a supervised local workflow into a safe, extensible,
+cloud-operated software factory. The roadmap follows four stages: operate
+unattended safely, bring work from more sources, see and direct the factory from
+a unified control plane, and run isolated workers in managed infrastructure.
+
+> This roadmap describes Patchmill's current direction, not a release or version
+> commitment. Ordering and details may change as the architecture is validated
+> and maintainers learn from real-world use.
+
+## Principles
+
+- Organize work around user outcomes rather than internal projects.
+- Establish safety, observability, and human control before increasing autonomy
+  or scale.
+- Keep local-first operation available as shared and remote deployment options
+  grow.
+- Build durable boundaries that support later phases without requiring earlier
+  workflows to be replaced.
+- Treat every capability below as a candidate until its dedicated design is
+  approved.
+
+## Phase I: Operate unattended, safely
+
+**Outcome:** A maintainer can leave Patchmill running under a process supervisor
+without risking duplicate work or uncontrolled spending.
+
+Candidate capabilities include:
+
+- A continuous `patchmill run` command built around the existing atomic
+  `run-once` workflow.
+- One issue at a time by default, with safe configurable concurrency later.
+- Idle polling with configurable intervals, backoff, and jitter.
+- Graceful shutdown, pause, resume, and drain controls.
+- Single-instance locking and durable resumable run state.
+- Daily and weekly token and estimated US dollar budgets.
+- An initial budget policy that finishes the current issue, then stops before
+  selecting another.
+- Configurable budget stopping boundaries in later iterations.
+- Repeated-failure circuit breakers and issue quarantine.
+- Notification hooks for blockers, approvals, failures, and budget limits.
+- A structured event, usage, and audit ledger.
+
+Cost limits will use Patchmill's recorded model usage and estimated cost. They
+will not claim exact equivalence with provider billing or guarantee that every
+provider request can be interrupted at an exact billing boundary.
+
+## Phase II: Bring work from anywhere
+
+**Outcome:** Teams can keep product work in one system and source code in
+another.
+
+Candidate capabilities include:
+
+- Independent work-source and code-host configuration.
+- Provider-qualified issue identities rather than numeric-only issue numbers.
+- A built-in Linear work source.
+- A generic local-command adapter with a documented JSON protocol.
+- Beads as the reference local tracker integration.
+- Capability discovery and adapter conformance tests.
+- Priority, dependency, and readiness signals across work sources.
+
+A public plugin SDK will wait until built-in and local adapters have proven the
+underlying contract. Kata and other local trackers can be evaluated after the
+generic adapter works; they are not initial commitments.
+
+## Phase III: See and direct the factory
+
+**Outcome:** A maintainer can understand and direct Patchmill from one local
+interface.
+
+Candidate capabilities include:
+
+- A local control-plane API and event stream.
+- A unified kanban, list, and factory-status dashboard.
+- Issue details, artifacts, run history, and agent timelines.
+- Issue-centered conversations with an agent.
+- Agent-drafted issues, specifications, and plans.
+- Explicit approval for proposed workflow actions initially, with selected
+  actions becoming optionally autonomous through policy later.
+- An approval inbox and intervention controls.
+- Pause, resume, drain, retry, and quarantine actions.
+- Logs, token and cost breakdowns, budget status, and forecasting.
+
+The first dashboard will be read-mostly: inspection, conversation, approval, and
+essential operational controls come before a general workflow builder. Work will
+remain central through board and list views, while active runs, queue health,
+approvals, and budget state remain visible.
+
+## Phase IV: Run the factory anywhere
+
+**Outcome:** Teams primarily use a shared dashboard while Patchmill schedules
+isolated workers into managed infrastructure.
+
+Candidate capabilities include:
+
+- A remote controller and shared dashboard.
+- A durable database, event stream, queue, and worker leases.
+- Containerized disposable agent workers.
+- Kubernetes Jobs as an execution backend.
+- Cancellation, recovery, autoscaling, and resource quotas.
+- Scoped repository credentials and secrets.
+- Filesystem, network, model, and tool policies for each sandbox.
+- Central logs, artifacts, costs, and audit history.
+- Authentication, role-based access control, projects, and multi-tenancy.
+- Docker Compose and Helm deployment paths.
+
+Kubernetes will be one execution backend, not Patchmill's core architecture.
+Local operation will remain supported without requiring a cluster or hosted
+service.
+
+## How the phases build on each other
+
+Phase I establishes the coordinator and event ledger around `run-once`. Phase II
+normalizes work from independently configured work sources and code hosts. Phase
+III exposes those capabilities through a stable local API and control plane.
+Phase IV distributes the control plane and execution backend while preserving
+the same domain boundaries.
+
+Substantial roadmap capabilities will receive their own design and
+implementation plan before development.
+
+## Feedback and contributions
+
+Feedback from maintainers and teams using Patchmill will shape the details
+within each phase. To propose a use case, integration, or change in priority,
+[open a GitHub issue](https://github.com/rochecompaan/patchmill/issues).

--- a/docs/specs/2026-07-30-patchmill-roadmap-design.md
+++ b/docs/specs/2026-07-30-patchmill-roadmap-design.md
@@ -1,0 +1,313 @@
+# Patchmill Roadmap Design
+
+**Status:** Approved
+
+## Purpose
+
+Patchmill needs a public roadmap that connects its next features into a coherent
+product direction. The roadmap should explain how Patchmill can grow from a
+supervised local workflow into a safe, extensible, cloud-operated software
+factory without implying dates or fixed release commitments.
+
+The immediate documentation change consists of:
+
+- a canonical roadmap at `docs/roadmap.md`; and
+- a concise roadmap announcement in `README.md`.
+
+This design describes that public roadmap. It does not serve as the
+implementation specification for every capability named in it. Each substantial
+runtime, integration, dashboard, or cloud feature will receive its own design
+and implementation plan before development.
+
+## Audience
+
+The first phases optimize for solo developers and maintainers who want Patchmill
+to operate locally with minimal infrastructure. Interfaces and state boundaries
+must preserve a path toward small-team and platform deployments rather than
+requiring a later rewrite.
+
+## Product narrative
+
+The roadmap tells a four-stage maturity story:
+
+1. **Operate unattended, safely.** Turn `run-once` into a dependable continuous
+   factory with budgets, scheduling, recovery, and operator controls.
+2. **Bring work from anywhere.** Separate work sources from code hosts, then
+   support Linear and local trackers through a reusable adapter boundary.
+3. **See and direct the factory.** Add a local-first unified control plane for
+   kanban work management, agent collaboration, approvals, costs, and
+   observability.
+4. **Run the factory anywhere.** Evolve into a remotely operated
+   controller/worker system with sandboxed agents, Kubernetes execution, shared
+   dashboards, and team governance.
+
+The concise product arc is:
+
+> From a supervised local workflow to a safe, extensible, cloud-operated
+> software factory.
+
+## Roadmap principles
+
+The public roadmap will follow these rules:
+
+- Organize work by user outcomes rather than internal projects.
+- Use ordered phases without release dates or version assignments.
+- Describe capabilities as current direction, not guaranteed commitments.
+- Preserve local-first operation as shared and remote deployment options grow.
+- Establish safety, observability, and human control before increasing autonomy
+  or scale.
+- Keep individual deliverables visible beneath each phase so the roadmap remains
+  actionable rather than purely thematic.
+- Invite feedback and contribution without implying that public demand alone
+  overrides safety or architectural sequencing.
+
+## Architectural through-line
+
+The phases build on five durable boundaries rather than forming disconnected
+feature lists.
+
+### Coordinator
+
+`patchmill run` will coordinate repeated calls to the existing atomic `run-once`
+workflow. Scheduling, backoff, locking, pausing, and budget checks belong
+outside `run-once`; the continuous command must not duplicate workflow logic.
+
+### Event and usage ledger
+
+Patchmill will persist structured lifecycle, cost, token, approval, and failure
+events. Initially local, this ledger becomes the source for budget enforcement,
+audit history, observability, and dashboard state.
+
+### Work source and code host
+
+A work source supplies issues and workflow metadata. A code host supplies Git
+repositories and pull requests. These responsibilities must be independently
+configurable so combinations such as Linear with GitHub or Beads with Forgejo
+are ordinary configurations.
+
+### Control-plane API
+
+The dashboard will consume a stable API and event stream instead of reading
+Patchmill's internal files directly. The API can begin in-process and
+local-only, then become remotely accessible without replacing the UI or its
+domain model.
+
+### Execution backend
+
+Local worktrees remain the first execution backend. A later execution contract
+will allow the controller to dispatch isolated container workers or Kubernetes
+Jobs with scoped credentials and explicit policy.
+
+## Phase I: Operate unattended, safely
+
+**Outcome:** A maintainer can leave Patchmill running under a process supervisor
+without risking duplicate work or uncontrolled spending.
+
+Candidate capabilities:
+
+- A continuous `patchmill run` command.
+- One issue at a time by default.
+- Idle polling with configurable intervals, backoff, and jitter.
+- Graceful shutdown, pause, resume, and drain controls.
+- Single-instance locking, followed by configurable concurrency when the state
+  and lease model can support it safely.
+- Daily and weekly token and US dollar budgets.
+- An initial budget policy that finishes the current issue, then stops before
+  selecting another.
+- Configurable budget stopping boundaries in later iterations.
+- Repeated-failure circuit breakers and issue quarantine.
+- Notification hooks for blockers, approvals, failures, and budget limits.
+- A structured event, usage, and audit ledger.
+
+Cost limits are based on Patchmill's recorded model usage and estimated cost.
+The roadmap will not imply that these estimates are identical to provider
+billing or that Patchmill can interrupt every provider request at an exact
+billing boundary.
+
+## Phase II: Bring work from anywhere
+
+**Outcome:** Teams can keep product work in one system and source code in
+another.
+
+Candidate capabilities:
+
+- Separate work-source and code-host contracts.
+- Provider-qualified issue identities rather than numeric-only issue numbers.
+- A built-in Linear work source.
+- A generic local-command adapter with a documented JSON protocol.
+- Beads as the reference local tracker integration.
+- Capability discovery and adapter conformance tests.
+- Priority, dependency, and readiness signals across work sources.
+
+A public plugin SDK is deferred until built-in and local adapters have proven
+the underlying contract. Kata and other local trackers can be evaluated after
+the generic adapter works; they are not initial roadmap commitments.
+
+## Phase III: See and direct the factory
+
+**Outcome:** A maintainer can understand and direct Patchmill from one local
+interface.
+
+Candidate capabilities:
+
+- A local control-plane API and event stream.
+- A unified kanban, list, and factory-status dashboard.
+- Issue details, artifacts, run history, and agent timelines.
+- Issue-centered conversations with an agent.
+- Agent-drafted issues, specifications, and plans.
+- Explicit approval for proposed workflow actions initially, with selected
+  actions becoming optionally autonomous through policy later.
+- An approval inbox and intervention controls.
+- Pause, resume, drain, retry, and quarantine actions.
+- Logs, token and cost breakdowns, budget status, and forecasting.
+
+The first dashboard is read-mostly: it supports inspection, conversation,
+approval, and essential operational controls. A general workflow builder is out
+of scope.
+
+The primary dashboard layout is a unified control plane. Work remains central
+through board and list views, while active runs, queue health, approvals, and
+budget state remain persistently visible. Detailed issue and operations views
+are one level deeper.
+
+## Phase IV: Run the factory anywhere
+
+**Outcome:** Teams primarily use a shared dashboard while Patchmill schedules
+isolated workers into managed infrastructure.
+
+Candidate capabilities:
+
+- A remote controller and shared dashboard.
+- A durable database, event stream, queue, and worker leases.
+- Containerized disposable agent workers.
+- Kubernetes Jobs as an execution backend.
+- Cancellation, recovery, autoscaling, and resource quotas.
+- Scoped repository credentials and secrets.
+- Filesystem, network, model, and tool policies for each sandbox.
+- Central logs, artifacts, costs, and audit history.
+- Authentication, role-based access control, projects, and multi-tenancy.
+- Docker Compose and Helm deployment paths.
+
+Kubernetes is one execution backend, not Patchmill's core architecture. Local
+operation remains supported and does not require a cluster or hosted service.
+
+## Sequencing and data flow
+
+The ordering is intentional:
+
+1. Phase I creates the coordinator and event ledger while retaining `run-once`
+   as the atomic unit of work.
+2. Phase II introduces independent work-source and code-host adapters that feed
+   normalized work into the existing workflow.
+3. Phase III exposes coordinator state, normalized work, events, artifacts, and
+   policies through the local control-plane API.
+4. Phase IV distributes the control plane and execution backend while preserving
+   the same domain contracts.
+
+At maturity, the principal data flow is:
+
+1. A work-source adapter discovers eligible work.
+2. The coordinator evaluates policy, capacity, and budgets.
+3. An execution backend runs the existing issue workflow in an isolated
+   workspace.
+4. Workers emit structured state, usage, artifact, approval, and failure events.
+5. The control plane persists and publishes those events.
+6. The dashboard presents state and submits policy-authorized commands.
+7. The code-host adapter publishes or lands the resulting repository changes.
+
+## Safety and failure handling
+
+The roadmap will establish these expectations without prematurely specifying
+each feature's implementation:
+
+- A lost loop or worker must not silently create duplicate work.
+- Pauses and budget exhaustion must preserve resumable issue state.
+- Repeated failures must back off and eventually quarantine affected work rather
+  than spin indefinitely.
+- Dashboard actions must pass through the same policy and audit boundaries as
+  CLI actions.
+- Remote workers receive only the credentials, filesystem access, network
+  access, models, and tools required for their task.
+- Controller and worker communication must support durable leases, cancellation,
+  and recovery before horizontal scale is offered.
+- Human approvals remain explicit by default as interaction moves from the CLI
+  to the dashboard.
+
+## Public scope boundaries
+
+The roadmap will avoid these promises:
+
+- release dates or version assignments;
+- guarantees that every candidate capability ships unchanged;
+- a requirement to use Kubernetes or a hosted service for local operation;
+- an immediate public plugin SDK;
+- an initial multi-user dashboard, workflow builder, or marketplace;
+- initial support for Kata before the local adapter contract is proven; or
+- exact equivalence between estimated model cost and provider billing.
+
+The following dependencies will be stated or reflected in phase ordering:
+
+- The dashboard depends on the event ledger and stable control-plane API.
+- Cloud workers depend on proven local execution and sandbox contracts.
+- Team autonomy remains policy-controlled.
+- Local-first operation remains supported after remote deployment exists.
+
+## Canonical roadmap document
+
+The public roadmap will live at `docs/roadmap.md`. This location keeps it
+available in the repository and in Patchmill's published npm package, whose
+package file list already includes `docs`.
+
+The document structure will be:
+
+1. Product direction.
+2. Roadmap principles and commitment disclaimer.
+3. The four phases, each with an outcome and candidate capabilities.
+4. Scope boundaries where they prevent likely misunderstandings.
+5. A feedback and contribution invitation.
+
+The roadmap should be concise enough to scan. It will describe product outcomes
+and representative capabilities without reproducing this design's complete
+architectural rationale.
+
+## README announcement
+
+`README.md` will gain a short `Roadmap` section after `Documentation` and before
+`Install`. The announcement will:
+
+- summarize the four-stage direction in two or three sentences;
+- highlight safe autonomy, integrations, the control plane, and cloud sandboxes;
+- link to `docs/roadmap.md`; and
+- avoid presenting planned commands or integrations as currently available.
+
+The README remains an introduction and does not duplicate the canonical roadmap.
+
+## Verification
+
+This change affects documentation only. Under the Testing Value Gate, new
+automated tests would assert static text rather than meaningful production
+behavior, so no new tests will be added.
+
+Verification will use:
+
+- Prettier against the changed Markdown files.
+- Markdownlint against the changed Markdown files.
+- Direct inspection of the README-to-roadmap link and file path.
+- Review of the rendered heading hierarchy and wording for accidental feature
+  promises.
+- The repository's relevant existing validation if the implementation changes
+  any non-documentation file unexpectedly.
+
+## Success criteria
+
+The roadmap documentation succeeds when:
+
+- readers can explain Patchmill's progression from safe local autonomy to
+  cloud-operated sandbox workers;
+- each phase has a clear user outcome and credible enabling capabilities;
+- Linear, local trackers, the dashboard, and Kubernetes appear as parts of one
+  architectural progression rather than unrelated promises;
+- current and planned capabilities cannot reasonably be confused;
+- local-first users understand that remote infrastructure is optional; and
+- maintainers can revise candidate scope without violating date or version
+  promises.


### PR DESCRIPTION
Summary

- Published the canonical Patchmill product roadmap in `docs/roadmap.md`.
- Announced the roadmap from the README with a concise link to the canonical document.
- Preserved roadmap language as candidate product direction without dates, versions, or current-feature promises.

## Validation

- `npx prettier --check README.md docs/roadmap.md`
- `npx markdownlint-cli2 README.md docs/roadmap.md`
- Roadmap one-off structure and commitment-language check
- README one-off roadmap link and placement check
- `git diff --check`
- `git status --short`

## Reviews

- Final Codex full-worktree review: pass, no findings.
- Final thermo-nuclear full-worktree review: pass, no findings.
- Final validation-readiness review: pass, all required validation commands passed.

Closes #130

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Development environment | gpt-5.5 | 201,667 | 1,584 | $0.4176 |
| Implementation | gpt-5.5 | 1,649,526 | 11,845 | $1.5366 |
| Implementation | gpt-5.6-sol | 684,709 | 14,558 | $1.3374 |
| Implementation | gpt-5.6-terra | 473,042 | 3,582 | $0.3021 |
| **Implementation subtotal** |  | **2,807,277** | **29,985** | **$3.1761** |
| **Total** |  | **3,008,944** | **31,569** | **$3.5937** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->