### PR TITLE
Pin pi-subagents child metadata contract release

### DIFF
--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -395,8 +395,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 
   Expected: PASS. If it fails because installed `0.39.0` omits a Pi extension
   manifest, cannot be resolved through normal Node resolution, or cannot be
-  loaded by `pi --mode json --offline -e <package-root> /subagents-doctor`, stop
-  and open a focused upstream blocker instead of adding a Patchmill fallback.
+  loaded by deterministic RPC `get_commands` with explicit `-e <package-root>`,
+  stop and open a focused upstream blocker instead of adding a Patchmill
+  fallback.
 
 - [ ] **Step 6: Commit Task 1**
 
@@ -591,13 +592,13 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     details: {
       results: [
         {
-          id: "child-a",
+          index: 0,
           model: "provider/model-a",
           thinking: "low",
           content: "ok",
         },
         {
-          id: "child-b",
+          index: 1,
           model: "provider/model-a",
           thinking: "low",
           content: "ok",
@@ -653,7 +654,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
               type: "tool_execution_end",
               toolName: "subagent",
               result: {
-                details: { results: [{ id: "child-a", thinking: "low" }] },
+                details: { results: [{ index: 0, thinking: "low" }] },
               },
               isError: false,
             },
@@ -665,7 +666,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     assert.throws(
       () =>
         validateShapeContract({
-          label: "missing-id",
+          label: "missing-index",
           expectedModel: "provider/model-a",
           expectedThinking: "low",
           expectedFinalChildren: 1,
@@ -690,7 +691,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     assert.throws(
       () =>
         validateShapeContract({
-          label: "duplicate-id",
+          label: "duplicate-index",
           expectedModel: "provider/model-a",
           expectedThinking: "low",
           expectedFinalChildren: 2,
@@ -703,8 +704,8 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
               result: {
                 details: {
                   results: [
-                    { id: "same", model: "provider/model-a", thinking: "low" },
-                    { id: "same", model: "provider/model-a", thinking: "low" },
+                    { index: 0, model: "provider/model-a", thinking: "low" },
+                    { index: 0, model: "provider/model-a", thinking: "low" },
                   ],
                 },
               },
@@ -722,7 +723,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
         toolName: "subagent",
         result: {
           details: {
-            results: [{ id: "child-a", model: "provider/no-thinking" }],
+            results: [{ index: 0, model: "provider/no-thinking" }],
           },
         },
         isError: false,
@@ -812,7 +813,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     }
     const finalIds = finalChildren.map(childIdentity);
     finalChildren.forEach((child, index) => {
-      if (!finalIds[index])
+      if (finalIds[index] === undefined)
         throw new Error(
           `${options.label}: child ${index} missing upstream identity`,
         );
@@ -853,7 +854,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
         continue;
       }
       partialChildren.forEach((child, index) => {
-        if (!partialIds[index])
+        if (partialIds[index] === undefined)
           throw new Error(
             `${options.label}: partial child ${index} missing upstream identity`,
           );

--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -958,9 +958,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 
   ```sh
   node --test scripts/verify-pi-subagents-child-metadata.test.mjs
-  PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="anthropic/claude-sonnet-4-5" \
+  PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="openai-codex/gpt-5.5" \
     PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING="low" \
-    PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai/gpt-4o" \
+    PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai-codex/gpt-5.5" \
     node scripts/verify-pi-subagents-child-metadata.mjs
   ```
 
@@ -1146,9 +1146,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   ```sh
   node --test src/pi/resource-profiles.test.ts
   node --test src/pi/pi-subagents-dependency-contract.test.ts
-  PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="anthropic/claude-sonnet-4-5" \
+  PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="openai-codex/gpt-5.5" \
     PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING="low" \
-    PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai/gpt-4o" \
+    PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai-codex/gpt-5.5" \
     node scripts/verify-pi-subagents-child-metadata.mjs
   ```
 
@@ -1205,8 +1205,10 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     const json = JSON.parse(fs.readFileSync(file, 'utf8'));
     console.log(file, json.dependencies?.['pi-subagents'] ?? json.packages?.['']?.dependencies?.['pi-subagents'], json.packages?.['node_modules/pi-subagents']?.version ?? 'root');
   }
+  const { dirname, join } = require('node:path');
   const piSubagentsEntry = require.resolve('pi-subagents');
-  const piSubagentsManifest = require('node:path').join(require('node:path').dirname(piSubagentsEntry), 'package.json');
+  const piSubagentsRoot = dirname(piSubagentsEntry);
+  const piSubagentsManifest = join(piSubagentsRoot, 'package.json');
   console.log('installed', JSON.parse(fs.readFileSync(piSubagentsManifest, 'utf8')).version);
   NODE
   ```

--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -1,0 +1,991 @@
+# Upgrade pi-subagents Child Metadata Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin a `pi-subagents` release that exposes authoritative child
+`model`, `thinking`, identity, and ordering metadata, then prove Patchmill can
+load and validate that release in source, packed npm, and Nix-installed layouts.
+
+**Architecture:** Keep `pi-subagents` as the only authority for child runtime
+metadata. Add a small Patchmill-side package-manifest validation helper, extend
+resource-profile, packed-artifact, and Nix install checks to prove the resolved
+extension files exist in the order Patchmill loads them, and add a live JSON-mode
+Pi contract script that validates raw foreground `subagent` partial/final
+results for direct, counted, parallel, and chain shapes without recomputing
+upstream model or thinking resolution.
+
+**Tech Stack:** TypeScript ESM, Node.js 22.19+/24 `node:test`, npm exact pins
+and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
+`buildNpmPackage`.
+
+## Global Constraints
+
+- Pin one exact `pi-subagents` release; validate `0.37.2` first and pin the
+  first release that passes the contract.
+- Do not infer child `model`, `thinking`, identity, or ordering from Patchmill
+  configuration, parent Pi settings, agent frontmatter, defaults, array indexes,
+  or local copies of upstream resolution logic.
+- Missing required metadata or identity for a supported shape blocks the PR; do
+  not merge a local fallback or downgraded contract.
+- Validate direct single child, counted children, `tasks`-based parallel
+  children including a repeated-count task, and chain children including a
+  sequential chain and chain parallel fanout when supported by the pinned
+  release.
+- Preserve absence semantics for legitimate upstream `thinking` absence; absence
+  must remain absent rather than backfilled.
+- Preserve run-once extension order: dependency-owned `pi-subagents` package
+  root first, then Patchmill `extensions/todos.ts`.
+- Do not implement Patchmill lifecycle observers, session streaming, progress
+  correlation, console rendering, or local upstream resolution logic in this
+  issue.
+- Do not add `pi-subagents` to helper lists that assume
+  `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` upgrade in
+  version lockstep.
+- Because `package.json`, `package-lock.json`, and `npm-shrinkwrap.json` change,
+  rerun the Nix build as part of verification.
+- Apply Patchmill's Testing Value Gate: automated tests are warranted for
+  package manifest parsing, exact-pin/version agreement, installed-file
+  resolution, resource-profile extension existence/order, packed/Nix installed
+  layout checks, and live child metadata contract parsing; do not add tests that
+  merely assert static dependency strings or Nix expression text.
+
+---
+
+## File Structure
+
+- Modify `package.json`: replace `"pi-subagents": "^0.25.0"` with the passing
+  exact version, expected `"0.37.2"`.
+- Modify `package-lock.json` and `npm-shrinkwrap.json`: regenerate from npm so
+  root dependency entries and `node_modules/pi-subagents.version` agree with the
+  exact pin.
+- Create `src/pi/pi-subagents-package.ts`: shared helpers that resolve
+  `pi-subagents/package.json` via Node resolution, read the installed manifest,
+  assert the installed version equals the exact root pin, and return declared Pi
+  extension file paths that exist as regular files.
+- Create `src/pi/pi-subagents-dependency-contract.test.ts`: automated tests for
+  exact root pin parsing, installed package version agreement, lockfile and
+  shrinkwrap agreement, manifest extension declarations, and normal Pi
+  extension-load path resolution.
+- Modify `src/pi/resource-profiles.ts`: keep dependency-owned package-root
+  resolution separate from Patchmill package-root resolution, but use the helper
+  for the resolved `pi-subagents` package root and manifest validation.
+- Modify `src/pi/resource-profiles.test.ts`: assert run-once profiles return
+  existing extensions in stable order and that the first path is the installed
+  `pi-subagents` package root with declared extension files.
+- Modify `src/pi/resource-profiles.compiled.test.ts`: assert the compiled layout
+  still resolves `pi-subagents` from `node_modules` and validates declared
+  extension files.
+- Create `scripts/verify-pi-subagents-child-metadata.mjs`: live Pi JSON-mode
+  verification that loads `pi-subagents` with `-e <resolved-package-root>`, runs
+  direct/counted/parallel/chain/no-thinking fixtures, captures
+  `tool_execution_update` and `tool_execution_end`, and validates raw child
+  metadata.
+- Create `scripts/verify-pi-subagents-child-metadata.test.mjs`: deterministic
+  unit tests for the script's JSON event parsing and metadata validation using
+  fixture event rows.
+- Modify `scripts/smoke-packed-artifact.mjs`: add `pi-subagents` version,
+  manifest extension-file, and run-once extension-order checks for the packed npm
+  install without adding it to the Pi runtime lockstep package list.
+- Modify `nix/package.nix`: refresh `npmDepsHash` and extend
+  `installCheckPhase` to verify installed `pi-subagents` version, manifest
+  extension files, and run-once extension order.
+
+---
+
+### Task 1: Pin `pi-subagents` exactly and add installed package helpers
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `npm-shrinkwrap.json`
+- Create: `src/pi/pi-subagents-package.ts`
+- Create: `src/pi/pi-subagents-dependency-contract.test.ts`
+
+**Interfaces:**
+
+- Produces from `src/pi/pi-subagents-package.ts`:
+  - `PI_SUBAGENTS_PACKAGE_NAME = "pi-subagents"`
+  - `isExactNpmVersion(spec: string | undefined): spec is string`
+  - `readRootPiSubagentsPin(rootPackageJsonPath?: string): string`
+  - `resolvePiSubagentsPackageRoot(): string`
+  - `readInstalledPiSubagentsManifest(): PiSubagentsPackageManifest`
+  - `piSubagentsExtensionFiles(): string[]`
+  - `assertInstalledPiSubagentsMatchesRootPin(rootPackageJsonPath?: string): void`
+- Consumes: root `package.json`, installed `pi-subagents/package.json`,
+  `package-lock.json`, and `npm-shrinkwrap.json`.
+- Provides to later tasks: one shared manifest/version contract so resource
+  profiles, smoke checks, and Nix checks do not duplicate path rules.
+
+- [ ] **Step 1: Update the dependency pin and npm lock data**
+
+  Run from the repository root:
+
+  ```sh
+  npm pkg set dependencies.pi-subagents=0.37.2
+  npm install --package-lock-only --ignore-scripts
+  tmp_shrinkwrap="$(mktemp)"
+  cp npm-shrinkwrap.json "$tmp_shrinkwrap"
+  rm npm-shrinkwrap.json
+  npm install --package-lock-only --ignore-scripts
+  cp "$tmp_shrinkwrap" npm-shrinkwrap.json
+  rm "$tmp_shrinkwrap"
+  npm install --ignore-scripts
+  ```
+
+  Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`
+  change; `package.json.dependencies["pi-subagents"]` is exactly `"0.37.2"`;
+  both lockfiles contain `packages[""].dependencies["pi-subagents"] ===
+  "0.37.2"` and `packages["node_modules/pi-subagents"].version ===
+  "0.37.2"`.
+
+- [ ] **Step 2: Write the failing dependency contract tests**
+
+  Create `src/pi/pi-subagents-dependency-contract.test.ts` with tests that:
+
+  ```ts
+  import assert from "node:assert/strict";
+  import { existsSync, readFileSync, statSync } from "node:fs";
+  import { spawnSync } from "node:child_process";
+  import { dirname, join } from "node:path";
+  import { test } from "node:test";
+  import { fileURLToPath } from "node:url";
+  import {
+    assertInstalledPiSubagentsMatchesRootPin,
+    isExactNpmVersion,
+    piSubagentsExtensionFiles,
+    readInstalledPiSubagentsManifest,
+    readRootPiSubagentsPin,
+    resolvePiSubagentsPackageRoot,
+  } from "./pi-subagents-package.ts";
+
+  const rootDir = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+  function readJson(path: string): unknown {
+    return JSON.parse(readFileSync(path, "utf8"));
+  }
+
+  test("root pi-subagents dependency is an exact installed pin", () => {
+    const pin = readRootPiSubagentsPin(join(rootDir, "package.json"));
+    assert.equal(isExactNpmVersion(pin), true);
+    assertInstalledPiSubagentsMatchesRootPin(join(rootDir, "package.json"));
+  });
+
+  test("lockfiles agree with the root pi-subagents pin", () => {
+    const pin = readRootPiSubagentsPin(join(rootDir, "package.json"));
+    for (const filename of ["package-lock.json", "npm-shrinkwrap.json"]) {
+      const lockfile = readJson(join(rootDir, filename)) as {
+        packages?: Record<string, { version?: string; dependencies?: Record<string, string> }>;
+      };
+      assert.equal(lockfile.packages?.[""]?.dependencies?.["pi-subagents"], pin);
+      assert.equal(lockfile.packages?.["node_modules/pi-subagents"]?.version, pin);
+    }
+  });
+
+  test("installed pi-subagents manifest declares existing extension files", () => {
+    const packageRoot = resolvePiSubagentsPackageRoot();
+    assert.equal(packageRoot.endsWith("pi-subagents"), true);
+    const manifest = readInstalledPiSubagentsManifest();
+    assert.equal(manifest.version, readRootPiSubagentsPin(join(rootDir, "package.json")));
+    assert.ok(Array.isArray(manifest.pi?.extensions));
+    assert.ok((manifest.pi?.extensions ?? []).length > 0);
+    for (const extensionFile of piSubagentsExtensionFiles()) {
+      assert.equal(extensionFile.startsWith(packageRoot), true);
+      assert.equal(existsSync(extensionFile), true, `missing extension ${extensionFile}`);
+      assert.equal(statSync(extensionFile).isFile(), true, `not a file ${extensionFile}`);
+    }
+  });
+
+  test("pi can load the resolved pi-subagents extension package without model execution", () => {
+    const result = spawnSync("./node_modules/.bin/pi", [
+      "--mode",
+      "json",
+      "--no-session",
+      "--offline",
+      "-e",
+      resolvePiSubagentsPackageRoot(),
+      "/subagents-doctor",
+    ], {
+      cwd: rootDir,
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(`${result.stdout}\n${result.stderr}`, /subagents|doctor|runtime paths/ui);
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /Unknown command|No such command|extension load failed/ui);
+  });
+  ```
+
+- [ ] **Step 3: Run the new test to verify it fails before the helper exists**
+
+  Run:
+
+  ```sh
+  node --test src/pi/pi-subagents-dependency-contract.test.ts
+  ```
+
+  Expected: FAIL with `ERR_MODULE_NOT_FOUND` for
+  `src/pi/pi-subagents-package.ts`.
+
+- [ ] **Step 4: Implement the helper without metadata inference**
+
+  Create `src/pi/pi-subagents-package.ts`:
+
+  ```ts
+  import { readFileSync, statSync } from "node:fs";
+  import { createRequire } from "node:module";
+  import { dirname, resolve } from "node:path";
+
+  const require = createRequire(import.meta.url);
+  export const PI_SUBAGENTS_PACKAGE_NAME = "pi-subagents";
+
+  export type PiSubagentsPackageManifest = {
+    name?: string;
+    version: string;
+    pi?: {
+      extensions?: string[];
+      skills?: string[];
+      prompts?: string[];
+    };
+  };
+
+  export function isExactNpmVersion(spec: string | undefined): spec is string {
+    return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      spec ?? "",
+    );
+  }
+
+  function readJson<T>(path: string): T {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  }
+
+  export function readRootPiSubagentsPin(
+    rootPackageJsonPath = resolve("package.json"),
+  ): string {
+    const packageJson = readJson<{ dependencies?: Record<string, string> }>(
+      rootPackageJsonPath,
+    );
+    const spec = packageJson.dependencies?.[PI_SUBAGENTS_PACKAGE_NAME];
+    if (!isExactNpmVersion(spec)) {
+      throw new Error(
+        `${PI_SUBAGENTS_PACKAGE_NAME} must be pinned to an exact version; found ${spec ?? "missing"}`,
+      );
+    }
+    return spec;
+  }
+
+  export function resolvePiSubagentsPackageJson(): string {
+    return require.resolve(`${PI_SUBAGENTS_PACKAGE_NAME}/package.json`);
+  }
+
+  export function resolvePiSubagentsPackageRoot(): string {
+    return dirname(resolvePiSubagentsPackageJson());
+  }
+
+  export function readInstalledPiSubagentsManifest(): PiSubagentsPackageManifest {
+    return readJson<PiSubagentsPackageManifest>(resolvePiSubagentsPackageJson());
+  }
+
+  export function piSubagentsExtensionFiles(): string[] {
+    const packageRoot = resolvePiSubagentsPackageRoot();
+    const manifest = readInstalledPiSubagentsManifest();
+    const extensions = manifest.pi?.extensions ?? [];
+    if (extensions.length === 0) {
+      throw new Error(`${PI_SUBAGENTS_PACKAGE_NAME} manifest declares no Pi extensions`);
+    }
+    return extensions.map((entry) => {
+      const extensionPath = resolve(packageRoot, entry);
+      if (!extensionPath.startsWith(`${packageRoot}/`) && extensionPath !== packageRoot) {
+        throw new Error(`${PI_SUBAGENTS_PACKAGE_NAME} extension escapes package root: ${entry}`);
+      }
+      const stats = statSync(extensionPath);
+      if (!stats.isFile()) {
+        throw new Error(`${PI_SUBAGENTS_PACKAGE_NAME} extension is not a regular file: ${extensionPath}`);
+      }
+      return extensionPath;
+    });
+  }
+
+  export function assertInstalledPiSubagentsMatchesRootPin(
+    rootPackageJsonPath = resolve("package.json"),
+  ): void {
+    const expected = readRootPiSubagentsPin(rootPackageJsonPath);
+    const manifest = readInstalledPiSubagentsManifest();
+    if (manifest.version !== expected) {
+      throw new Error(
+        `${PI_SUBAGENTS_PACKAGE_NAME} resolved ${manifest.version} but package.json pins ${expected}`,
+      );
+    }
+  }
+  ```
+
+- [ ] **Step 5: Run the dependency contract test**
+
+  Run:
+
+  ```sh
+  node --test src/pi/pi-subagents-dependency-contract.test.ts
+  ```
+
+  Expected: PASS. If it fails because installed `0.37.2` omits a Pi extension
+  manifest, cannot be resolved through normal Node resolution, or cannot be
+  loaded by `pi --mode json --offline -e <package-root> /subagents-doctor`, stop and open a focused
+  upstream blocker instead of adding a Patchmill fallback.
+
+- [ ] **Step 6: Commit Task 1**
+
+  Run:
+
+  ```sh
+  git add package.json package-lock.json npm-shrinkwrap.json src/pi/pi-subagents-package.ts src/pi/pi-subagents-dependency-contract.test.ts
+  git commit -m "chore: pin pi-subagents metadata contract dependency"
+  ```
+
+---
+
+### Task 2: Validate run-once resource profiles against the installed package
+
+**Files:**
+
+- Modify: `src/pi/resource-profiles.ts`
+- Modify: `src/pi/resource-profiles.test.ts`
+- Modify: `src/pi/resource-profiles.compiled.test.ts`
+
+**Interfaces:**
+
+- Consumes from Task 1: `resolvePiSubagentsPackageRoot()` and
+  `piSubagentsExtensionFiles()`.
+- Preserves: `runOncePlanningPiProfile()`,
+  `runOnceDevelopmentEnvironmentPiProfile()`,
+  `runOnceImplementationPiProfile()`, `triagePiProfile()`,
+  `profileExtensionArgs()`, and public profile shapes.
+- Produces: run-once profiles whose first additional extension path is the
+  validated installed `pi-subagents` package root and whose second path is the
+  Patchmill todos extension.
+
+- [ ] **Step 1: Extend resource-profile tests before changing production code**
+
+  Update `src/pi/resource-profiles.test.ts` so the planning profile test also
+  imports `piSubagentsExtensionFiles` and `resolvePiSubagentsPackageRoot` and
+  asserts:
+
+  ```ts
+  const piSubagentsExtensions = piSubagentsExtensionFiles();
+  assert.equal(profile.additionalExtensionPaths[0], resolvePiSubagentsPackageRoot());
+  assert.ok(piSubagentsExtensions.length > 0);
+  assert.equal(profile.additionalExtensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"), true);
+  ```
+
+  Keep the existing loop that asserts every profile extension path exists. Add a
+  small helper if needed so all run-once profile tests can share the same order
+  assertion:
+
+  ```ts
+  function assertRunOnceExtensionOrder(extensionPaths: string[]): void {
+    assert.equal(extensionPaths.length, 2);
+    assert.equal(basename(extensionPaths[0] ?? ""), "pi-subagents");
+    assert.equal(extensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"), true);
+  }
+  ```
+
+- [ ] **Step 2: Run the focused resource-profile test**
+
+  Run:
+
+  ```sh
+  node --test src/pi/resource-profiles.test.ts
+  ```
+
+  Expected: FAIL if production does not yet validate declared upstream extension
+  files; PASS for unchanged order only is not enough, so keep the manifest-file
+  assertion in the test.
+
+- [ ] **Step 3: Wire resource profiles to the shared helper**
+
+  In `src/pi/resource-profiles.ts`, replace the local `createRequire`/
+  `PI_SUBAGENTS_PACKAGE_ROOT` initialization with the helper while preserving
+  Patchmill's separate package-root lookup:
+
+  ```ts
+  import { piSubagentsExtensionFiles, resolvePiSubagentsPackageRoot } from "./pi-subagents-package.ts";
+
+  const PI_SUBAGENTS_PACKAGE_ROOT = resolvePiSubagentsPackageRoot();
+  piSubagentsExtensionFiles();
+  ```
+
+  Keep `runOnceExtensionPaths()` returning:
+
+  ```ts
+  return [PI_SUBAGENTS_PACKAGE_ROOT, PATCHMILL_TODOS_EXTENSION];
+  ```
+
+  Do not change triage's empty extension list.
+
+- [ ] **Step 4: Extend the compiled-layout test**
+
+  Update `src/pi/resource-profiles.compiled.test.ts` so after importing the
+  compiled profile module it asserts the first extension path is an existing
+  `pi-subagents` directory and the installed manifest's declared extensions are
+  regular files:
+
+  ```ts
+  const profile = compiled.runOncePlanningPiProfile(skills, packageRoot);
+  const piSubagentsRoot = profile.additionalExtensionPaths[0];
+  const piSubagentsManifest = JSON.parse(
+    readFileSync(join(piSubagentsRoot, "package.json"), "utf8"),
+  ) as { pi?: { extensions?: string[] } };
+  assert.ok((piSubagentsManifest.pi?.extensions ?? []).length > 0);
+  for (const extension of piSubagentsManifest.pi?.extensions ?? []) {
+    assert.equal(existsSync(join(piSubagentsRoot, extension)), true);
+  }
+  ```
+
+- [ ] **Step 5: Run focused profile validation**
+
+  Run:
+
+  ```sh
+  node --test src/pi/resource-profiles.test.ts
+  node --test src/pi/resource-profiles.compiled.test.ts
+  ```
+
+  Expected: both PASS. If either test fails because the package manifest points
+  at missing upstream files, stop and open/link an upstream blocker; do not make
+  Patchmill load guessed paths.
+
+- [ ] **Step 6: Commit Task 2**
+
+  Run:
+
+  ```sh
+  git add src/pi/resource-profiles.ts src/pi/resource-profiles.test.ts src/pi/resource-profiles.compiled.test.ts
+  git commit -m "test: validate pi-subagents resource profile files"
+  ```
+
+---
+
+### Task 3: Add live child metadata contract verification
+
+**Files:**
+
+- Create: `scripts/verify-pi-subagents-child-metadata.mjs`
+- Create: `scripts/verify-pi-subagents-child-metadata.test.mjs`
+
+**Interfaces:**
+
+- Produces CLI command:
+  `node scripts/verify-pi-subagents-child-metadata.mjs`.
+- Environment contract:
+  - `PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL` is a configured tool-capable Pi
+    model for children that should report effective thinking.
+  - `PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING` defaults to `low` and must be one
+    Pi thinking level supported by the selected contract model.
+  - `PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL` is required and must be
+    a configured tool-capable Pi model that legitimately returns absent child
+    `thinking` in raw `pi-subagents` child rows.
+  - `PATCHMILL_PI_SUBAGENTS_PARENT_MODEL` is optional and can select the parent
+    Pi model used to drive the tool calls.
+- Consumes: Pi JSON event stream mode (`pi --mode json`), `-e` extension loading
+  with the resolved `pi-subagents` package root, and raw
+  `tool_execution_update.partialResult` / `tool_execution_end.result` events.
+- Produces validation output lines:
+  - `direct: metadata contract passed`
+  - `counted: metadata contract passed`
+  - `parallel: metadata contract passed`
+  - `chain: metadata contract passed`
+  - `no-thinking: absence contract passed`
+
+- [ ] **Step 1: Write deterministic parser and validator tests first**
+
+  Create `scripts/verify-pi-subagents-child-metadata.test.mjs` with fixture
+  JSON event rows that exercise:
+
+  ```js
+  import assert from "node:assert/strict";
+  import { test } from "node:test";
+  import {
+    collectSubagentEvents,
+    validateShapeContract,
+  } from "./verify-pi-subagents-child-metadata.mjs";
+
+  const finalResult = {
+    details: {
+      results: [
+        { id: "child-a", model: "provider/model-a", thinking: "low", content: "ok" },
+        { id: "child-b", model: "provider/model-a", thinking: "low", content: "ok" },
+      ],
+    },
+  };
+
+  test("validateShapeContract matches partial and final rows by upstream identity", () => {
+    const shape = collectSubagentEvents([
+      { type: "tool_execution_update", toolName: "subagent", partialResult: { details: { results: [finalResult.details.results[0], finalResult.details.results[1]] } } },
+      { type: "tool_execution_end", toolName: "subagent", result: finalResult, isError: false },
+    ]);
+    validateShapeContract({
+      label: "parallel",
+      expectedModel: "provider/model-a",
+      expectedThinking: "low",
+      expectedFinalChildren: 2,
+      requireUniqueSiblingIds: true,
+      requireThinking: true,
+      shape,
+    });
+  });
+
+  test("validateShapeContract fails missing model, missing id, duplicate ids, and order drift", () => {
+    assert.throws(() => validateShapeContract({
+      label: "missing-model",
+      expectedModel: "provider/model-a",
+      expectedThinking: "low",
+      expectedFinalChildren: 1,
+      requireUniqueSiblingIds: false,
+      requireThinking: true,
+      shape: collectSubagentEvents([{ type: "tool_execution_end", toolName: "subagent", result: { details: { results: [{ id: "child-a", thinking: "low" }] } }, isError: false }]),
+    }), /missing model/u);
+
+    assert.throws(() => validateShapeContract({
+      label: "missing-id",
+      expectedModel: "provider/model-a",
+      expectedThinking: "low",
+      expectedFinalChildren: 1,
+      requireUniqueSiblingIds: false,
+      requireThinking: true,
+      shape: collectSubagentEvents([{ type: "tool_execution_end", toolName: "subagent", result: { details: { results: [{ model: "provider/model-a", thinking: "low" }] } }, isError: false }]),
+    }), /missing upstream identity/u);
+
+    assert.throws(() => validateShapeContract({
+      label: "duplicate-id",
+      expectedModel: "provider/model-a",
+      expectedThinking: "low",
+      expectedFinalChildren: 2,
+      requireUniqueSiblingIds: true,
+      requireThinking: true,
+      shape: collectSubagentEvents([{ type: "tool_execution_end", toolName: "subagent", result: { details: { results: [
+        { id: "same", model: "provider/model-a", thinking: "low" },
+        { id: "same", model: "provider/model-a", thinking: "low" },
+      ] } } }]),
+    }), /duplicate upstream identity/u);
+  });
+
+  test("validateShapeContract preserves legitimate thinking absence", () => {
+    const shape = collectSubagentEvents([
+      { type: "tool_execution_end", toolName: "subagent", result: { details: { results: [{ id: "child-a", model: "provider/no-thinking" }] } }, isError: false },
+    ]);
+    validateShapeContract({
+      label: "no-thinking",
+      expectedModel: "provider/no-thinking",
+      expectedFinalChildren: 1,
+      requireUniqueSiblingIds: false,
+      requireThinking: false,
+      shape,
+    });
+  });
+  ```
+
+  The tests intentionally validate parser behavior and contract failures rather
+  than static dependency strings.
+
+- [ ] **Step 2: Run the script tests to verify they fail**
+
+  Run:
+
+  ```sh
+  node --test scripts/verify-pi-subagents-child-metadata.test.mjs
+  ```
+
+  Expected: FAIL with missing exports from the script.
+
+- [ ] **Step 3: Implement JSON event parsing and validation helpers**
+
+  In `scripts/verify-pi-subagents-child-metadata.mjs`, export pure helpers and
+  keep runtime execution behind an entrypoint guard:
+
+  ```js
+  export function collectSubagentEvents(events) {
+    return {
+      partials: events
+        .filter((event) => event.type === "tool_execution_update" && event.toolName === "subagent")
+        .map((event) => event.partialResult),
+      finals: events
+        .filter((event) => event.type === "tool_execution_end" && event.toolName === "subagent" && event.isError !== true)
+        .map((event) => event.result),
+    };
+  }
+
+  function childRows(result) {
+    if (Array.isArray(result?.details?.results)) return result.details.results;
+    throw new Error("subagent result missing details.results child rows");
+  }
+
+  function childIdentity(row) {
+    return row?.id;
+  }
+
+  export function validateShapeContract(options) {
+    assert.equal(options.shape.finals.length, 1, `${options.label}: expected exactly one final subagent tool result`);
+    const finalChildren = options.shape.finals.flatMap(childRows);
+    if (finalChildren.length !== options.expectedFinalChildren) {
+      throw new Error(`${options.label}: expected exactly ${options.expectedFinalChildren} final children, got ${finalChildren.length}`);
+    }
+    const finalIds = finalChildren.map(childIdentity);
+    finalChildren.forEach((child, index) => {
+      if (!finalIds[index]) throw new Error(`${options.label}: child ${index} missing upstream identity`);
+      if (child.model !== options.expectedModel) throw new Error(`${options.label}: child ${finalIds[index]} missing model ${options.expectedModel}`);
+      if (options.requireThinking && child.thinking !== options.expectedThinking) {
+        throw new Error(`${options.label}: child ${finalIds[index]} missing thinking ${options.expectedThinking}`);
+      }
+      if (!options.requireThinking && "thinking" in child) {
+        throw new Error(`${options.label}: expected thinking absence but found ${child.thinking}`);
+      }
+    });
+    if (options.requireUniqueSiblingIds && new Set(finalIds).size !== finalIds.length) {
+      throw new Error(`${options.label}: duplicate upstream identity in final children`);
+    }
+    if (options.shape.partials.length === 0) {
+      console.log(`${options.label}: upstream emitted no partial results`);
+    }
+    for (const partial of options.shape.partials) {
+      const partialChildren = childRows(partial);
+      const partialIds = partialChildren.map(childIdentity);
+      if (partialIds.length === 0) {
+        console.log(`${options.label}: partial result contained no child rows`);
+        continue;
+      }
+      partialChildren.forEach((child, index) => {
+        if (!partialIds[index]) throw new Error(`${options.label}: partial child ${index} missing upstream identity`);
+        if (child.model !== options.expectedModel) throw new Error(`${options.label}: partial child ${partialIds[index]} missing model ${options.expectedModel}`);
+        if (options.requireThinking && child.thinking !== options.expectedThinking) {
+          throw new Error(`${options.label}: partial child ${partialIds[index]} missing thinking ${options.expectedThinking}`);
+        }
+        if (!options.requireThinking && "thinking" in child) {
+          throw new Error(`${options.label}: partial child ${partialIds[index]} unexpectedly had thinking ${child.thinking}`);
+        }
+      });
+      assert.deepEqual(partialIds, finalIds.slice(0, partialIds.length));
+    }
+  }
+  ```
+
+  Import `assert` from `node:assert/strict`. Keep accepted identity field names
+  restricted to upstream-supplied identity fields present in raw rows; never use
+  array positions as identities.
+
+- [ ] **Step 4: Implement the live Pi runner**
+
+  Add a runtime entrypoint that:
+
+  1. Reads the exact root `pi-subagents` pin and installed package root using
+     normal Node resolution.
+  2. Creates a temporary project with local `.pi/agents/contract-thinking.md`
+     and `.pi/agents/contract-no-thinking.md` using exact frontmatter:
+
+     ```md
+     ---
+     name: contract-thinking
+     model: <PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL>
+     thinking: <PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING>
+     tools: bash
+     systemPromptMode: replace
+     inheritProjectContext: false
+     inheritSkills: false
+     ---
+
+     Return exactly the short text requested by the parent. Do not call tools.
+     ```
+
+     ```md
+     ---
+     name: contract-no-thinking
+     model: <PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL>
+     tools: bash
+     systemPromptMode: replace
+     inheritProjectContext: false
+     inheritSkills: false
+     ---
+
+     Return exactly the short text requested by the parent. Do not call tools.
+     ```
+
+  3. Spawns Pi once per shape with:
+
+     ```sh
+     pi --mode json --no-context-files --no-prompt-templates -e <pi-subagents-package-root> --model <parent-model-if-set> "<shape prompt>"
+     ```
+
+  4. Parses stdout JSON lines and validates only the raw `subagent` tool
+     partial/final events. Require exactly one successful `subagent` tool result
+     per shape and exact final child counts: direct `1`, counted `2`, parallel
+     `3`, chain `3`, and no-thinking `1`.
+
+  Use shape prompts that force the parent to call the tool once with exact JSON
+  inputs, for example:
+
+  ```text
+  Call the subagent tool exactly once with this input and then stop:
+  {"agent":"contract-thinking","task":"Return the word direct.","context":"fresh"}
+  ```
+
+  Use analogous inputs for:
+
+  ```json
+  {"tasks":[{"agent":"contract-thinking","task":"Return the word counted.","count":2}],"concurrency":2,"context":"fresh"}
+  {"tasks":[{"agent":"contract-thinking","task":"Return parallel a."},{"agent":"contract-thinking","task":"Return repeated parallel.","count":2}],"concurrency":2,"context":"fresh"}
+  {"chain":[{"agent":"contract-thinking","task":"Return chain step one."},{"parallel":[{"agent":"contract-thinking","task":"Return chain fanout a."},{"agent":"contract-thinking","task":"Return chain fanout b."}]}],"context":"fresh","clarify":false}
+  {"agent":"contract-no-thinking","task":"Return the words no thinking.","context":"fresh"}
+  ```
+
+  If the pinned release rejects chain parallel fanout as unsupported, the script
+  must fail with an explicit message that includes the raw command output so the
+  implementer can open a focused upstream blocker.
+
+- [ ] **Step 5: Run deterministic tests and live metadata validation**
+
+  Run:
+
+  ```sh
+  node --test scripts/verify-pi-subagents-child-metadata.test.mjs
+  PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="anthropic/claude-sonnet-4-5" \
+    PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING="low" \
+    PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai/gpt-4o" \
+    node scripts/verify-pi-subagents-child-metadata.mjs
+  ```
+
+  Expected: tests PASS; the live script prints the four required `metadata
+  contract passed` lines and `no-thinking: absence contract passed`. If any
+  supported shape lacks model, thinking, identity, uniqueness, or ordering, or if
+  no configured no-thinking model can prove absence semantics, stop the PR,
+  capture the failing command output, and open/link a focused upstream blocker.
+
+- [ ] **Step 6: Commit Task 3**
+
+  Run:
+
+  ```sh
+  git add scripts/verify-pi-subagents-child-metadata.mjs scripts/verify-pi-subagents-child-metadata.test.mjs
+  git commit -m "test: verify pi-subagents child metadata contract"
+  ```
+
+---
+
+### Task 4: Extend packed npm and Nix installed-layout verification
+
+**Files:**
+
+- Modify: `scripts/smoke-packed-artifact.mjs`
+- Modify: `nix/package.nix`
+
+**Interfaces:**
+
+- Consumes from Task 1: exact root pin and package manifest contract. The npm
+  smoke script may import `isExactVersion` from
+  `scripts/pi-dependency-upgrade-lib.mjs`, but must not add `pi-subagents` to
+  `PI_PACKAGES`.
+- Preserves: existing packed artifact checks for Patchmill initialization and Pi
+  runtime packages.
+- Produces: packed npm and Nix installed checks that prove `pi-subagents` version
+  agreement, manifest extension files, and run-once extension order.
+
+- [ ] **Step 1: Extend packed npm smoke checks**
+
+  In `scripts/smoke-packed-artifact.mjs`, add local helpers:
+
+  ```js
+  const PI_SUBAGENTS_PACKAGE = "pi-subagents";
+
+  function assertPiSubagentsInstalled({ projectRequire, nodeModulesDir, rootPin }) {
+    const packagePath = join(nodeModulesDir, PI_SUBAGENTS_PACKAGE, "package.json");
+    if (!existsSync(packagePath)) throw new Error(`Could not locate ${packagePath}`);
+    const manifest = JSON.parse(readFileSync(packagePath, "utf8"));
+    if (manifest.version !== rootPin) {
+      throw new Error(`${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} but package.json pins ${rootPin}`);
+    }
+    for (const extension of manifest.pi?.extensions ?? []) {
+      const extensionPath = join(dirname(packagePath), extension);
+      if (!existsSync(extensionPath)) throw new Error(`Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`);
+    }
+    projectRequire.resolve(`${PI_SUBAGENTS_PACKAGE}/package.json`);
+  }
+  ```
+
+  Use the project installation's `patchmill` package root to import
+  `dist/src/pi/resource-profiles.js`, call `runOncePlanningPiProfile()`, and
+  assert `additionalExtensionPaths[0]` is the installed `pi-subagents` package
+  root and `additionalExtensionPaths[1]` ends with `/extensions/todos.ts`.
+
+- [ ] **Step 2: Run the packed smoke script**
+
+  Run:
+
+  ```sh
+  node scripts/smoke-packed-artifact.mjs
+  ```
+
+  Expected: PASS and output includes a line equivalent to
+  `pi-subagents resolved 0.37.2 from <packed-project>/node_modules/pi-subagents/package.json`.
+
+- [ ] **Step 3: Extend Nix install checks**
+
+  In `nix/package.nix`, update the existing `installCheckPhase` Node snippet so
+  it reads `$out/share/${pname}/package.json`, resolves
+  `$out/share/${pname}/node_modules/pi-subagents/package.json`, and checks:
+
+  ```js
+  const rootPin = packageJson.dependencies['pi-subagents'];
+  if (piSubagents.version !== rootPin) throw new Error('pi-subagents version drift');
+  const extensionPaths = piSubagents.pi.extensions.map((entry) => join(piSubagentsRoot, entry));
+  const missing = extensionPaths.filter((extensionPath) => !existsSync(extensionPath));
+  if (missing.length > 0) throw new Error(`missing pi-subagents extension paths: ''${missing.join(', ')}`);
+  const profile = runOncePlanningPiProfile(skills, process.cwd());
+  assert.equal(realpathSync(profile.additionalExtensionPaths[0]), realpathSync(piSubagentsRoot));
+  assert.equal(profile.additionalExtensionPaths[1].replaceAll('\\', '/').endsWith('/extensions/todos.ts'), true);
+  ```
+
+  Import `readFileSync`, `realpathSync`, and `strict as assert` in the snippet
+  as needed so symlinked `$out/share/${pname}/node_modules` paths compare by
+  canonical filesystem identity.
+
+- [ ] **Step 4: Refresh `npmDepsHash`**
+
+  Run:
+
+  ```sh
+  scripts/update-npm-deps-hash.sh
+  git diff -- nix/package.nix
+  ```
+
+  Expected: `nix/package.nix` has a new `npmDepsHash` and the install-check
+  snippet changes from Step 3.
+
+- [ ] **Step 5: Run packed and focused source checks**
+
+  Run:
+
+  ```sh
+  node --test src/pi/pi-subagents-dependency-contract.test.ts
+  node --test src/pi/resource-profiles.test.ts
+  node --test src/pi/resource-profiles.compiled.test.ts
+  node --test scripts/verify-pi-subagents-child-metadata.test.mjs
+  node scripts/smoke-packed-artifact.mjs
+  ```
+
+  Expected: all PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+  Run:
+
+  ```sh
+  git add scripts/smoke-packed-artifact.mjs nix/package.nix
+  git commit -m "test: verify pi-subagents installed artifact contract"
+  ```
+
+---
+
+### Task 5: Run full dependency-update validation and prepare the PR
+
+**Files:**
+
+- Modify only if validation exposes a Task 1-4 defect: the affected source,
+  script, lock, or Nix file.
+
+**Interfaces:**
+
+- Consumes: all Task 1-4 deliverables.
+- Produces: final evidence that source, npm, Nix, packed artifact, extension
+  loading, and live child metadata contracts agree on the same upstream version.
+
+- [ ] **Step 1: Run the focused contract and resource-profile commands**
+
+  Run:
+
+  ```sh
+  node --test src/pi/resource-profiles.test.ts
+  node --test src/pi/pi-subagents-dependency-contract.test.ts
+  PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="anthropic/claude-sonnet-4-5" \
+    PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING="low" \
+    PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai/gpt-4o" \
+    node scripts/verify-pi-subagents-child-metadata.mjs
+  ```
+
+  Expected: PASS; live metadata output includes `direct`, `counted`, `parallel`,
+  and `chain` contract passed lines. If Pi credentials are missing, configure
+  normal Pi credentials and rerun; do not replace this command with source
+  inspection.
+
+- [ ] **Step 2: Run the full npm test suite and packed artifact smoke**
+
+  Run:
+
+  ```sh
+  npm test
+  node scripts/smoke-packed-artifact.mjs
+  npm run lint
+  ```
+
+  Expected: all PASS.
+
+- [ ] **Step 3: Confirm the Nix dependency hash is current**
+
+  Run:
+
+  ```sh
+  scripts/update-npm-deps-hash.sh
+  git diff --exit-code -- nix/package.nix
+  ```
+
+  Expected: `scripts/update-npm-deps-hash.sh` reports the hash already matches,
+  and `git diff --exit-code -- nix/package.nix` exits 0. If the script updates
+  the hash, commit the `nix/package.nix` change and rerun this step.
+
+- [ ] **Step 4: Run full Nix verification required for npm dependency changes**
+
+  Run:
+
+  ```sh
+  nix build .#patchmill --print-build-logs
+  nix flake check --print-build-logs
+  ```
+
+  Expected: both PASS, including the Nix install check that validates installed
+  `pi-subagents` manifest extension files and extension order.
+
+- [ ] **Step 5: Inspect final dependency agreement**
+
+  Run:
+
+  ```sh
+  node - <<'NODE'
+  const fs = require('node:fs');
+  for (const file of ['package.json', 'package-lock.json', 'npm-shrinkwrap.json']) {
+    const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+    console.log(file, json.dependencies?.['pi-subagents'] ?? json.packages?.['']?.dependencies?.['pi-subagents'], json.packages?.['node_modules/pi-subagents']?.version ?? 'root');
+  }
+  console.log('installed', JSON.parse(fs.readFileSync(require.resolve('pi-subagents/package.json'), 'utf8')).version);
+  NODE
+  ```
+
+  Expected: every printed `pi-subagents` value is the same exact version,
+  expected `0.37.2` unless Task 1 documented a newer first-passing release.
+
+- [ ] **Step 6: Commit validation fixes if any, then ensure the final branch is clean except intended changes**
+
+  If validation fixes changed files, run:
+
+  ```sh
+  git add <affected-source-script-lock-or-nix-files>
+  git commit -m "test: finalize pi-subagents contract validation"
+  ```
+
+  Then run:
+
+  ```sh
+  git status --short
+  ```
+
+  Expected: no unstaged changes after committing any validation fixes. Do not
+  commit `.pi/todos` files.

--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -5,21 +5,20 @@
 > superpowers:executing-plans to implement this plan task-by-task. Steps use
 > checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Pin a `pi-subagents` release that exposes authoritative child
-`model`, `thinking`, identity, and ordering metadata, then prove Patchmill can
-load and validate that release in source, packed npm, and Nix-installed layouts.
+**Goal:** Pin a `pi-subagents` release that exposes authoritative child `model`,
+`thinking`, identity, and ordering metadata, then prove Patchmill can load and
+validate that release in source, packed npm, and Nix-installed layouts.
 
 **Architecture:** Keep `pi-subagents` as the only authority for child runtime
 metadata. Add a small Patchmill-side package-manifest validation helper, extend
 resource-profile, packed-artifact, and Nix install checks to prove the resolved
-extension files exist in the order Patchmill loads them, and add a live JSON-mode
-Pi contract script that validates raw foreground `subagent` partial/final
-results for direct, counted, parallel, and chain shapes without recomputing
-upstream model or thinking resolution.
+extension files exist in the order Patchmill loads them, and add a live
+JSON-mode Pi contract script that validates raw foreground `subagent`
+partial/final results for direct, counted, parallel, and chain shapes without
+recomputing upstream model or thinking resolution.
 
 **Tech Stack:** TypeScript ESM, Node.js 22.19+/24 `node:test`, npm exact pins
-and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
-`buildNpmPackage`.
+and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 
 ## Global Constraints
 
@@ -87,11 +86,11 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   unit tests for the script's JSON event parsing and metadata validation using
   fixture event rows.
 - Modify `scripts/smoke-packed-artifact.mjs`: add `pi-subagents` version,
-  manifest extension-file, and run-once extension-order checks for the packed npm
-  install without adding it to the Pi runtime lockstep package list.
-- Modify `nix/package.nix`: refresh `npmDepsHash` and extend
-  `installCheckPhase` to verify installed `pi-subagents` version, manifest
-  extension files, and run-once extension order.
+  manifest extension-file, and run-once extension-order checks for the packed
+  npm install without adding it to the Pi runtime lockstep package list.
+- Modify `nix/package.nix`: refresh `npmDepsHash` and extend `installCheckPhase`
+  to verify installed `pi-subagents` version, manifest extension files, and
+  run-once extension order.
 
 ---
 
@@ -138,9 +137,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
 
   Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`
   change; `package.json.dependencies["pi-subagents"]` is exactly `"0.37.2"`;
-  both lockfiles contain `packages[""].dependencies["pi-subagents"] ===
-  "0.37.2"` and `packages["node_modules/pi-subagents"].version ===
-  "0.37.2"`.
+  both lockfiles contain
+  `packages[""].dependencies["pi-subagents"] === "0.37.2"` and
+  `packages["node_modules/pi-subagents"].version === "0.37.2"`.
 
 - [ ] **Step 2: Write the failing dependency contract tests**
 
@@ -178,10 +177,19 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
     const pin = readRootPiSubagentsPin(join(rootDir, "package.json"));
     for (const filename of ["package-lock.json", "npm-shrinkwrap.json"]) {
       const lockfile = readJson(join(rootDir, filename)) as {
-        packages?: Record<string, { version?: string; dependencies?: Record<string, string> }>;
+        packages?: Record<
+          string,
+          { version?: string; dependencies?: Record<string, string> }
+        >;
       };
-      assert.equal(lockfile.packages?.[""]?.dependencies?.["pi-subagents"], pin);
-      assert.equal(lockfile.packages?.["node_modules/pi-subagents"]?.version, pin);
+      assert.equal(
+        lockfile.packages?.[""]?.dependencies?.["pi-subagents"],
+        pin,
+      );
+      assert.equal(
+        lockfile.packages?.["node_modules/pi-subagents"]?.version,
+        pin,
+      );
     }
   });
 
@@ -189,34 +197,55 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
     const packageRoot = resolvePiSubagentsPackageRoot();
     assert.equal(packageRoot.endsWith("pi-subagents"), true);
     const manifest = readInstalledPiSubagentsManifest();
-    assert.equal(manifest.version, readRootPiSubagentsPin(join(rootDir, "package.json")));
+    assert.equal(
+      manifest.version,
+      readRootPiSubagentsPin(join(rootDir, "package.json")),
+    );
     assert.ok(Array.isArray(manifest.pi?.extensions));
     assert.ok((manifest.pi?.extensions ?? []).length > 0);
     for (const extensionFile of piSubagentsExtensionFiles()) {
       assert.equal(extensionFile.startsWith(packageRoot), true);
-      assert.equal(existsSync(extensionFile), true, `missing extension ${extensionFile}`);
-      assert.equal(statSync(extensionFile).isFile(), true, `not a file ${extensionFile}`);
+      assert.equal(
+        existsSync(extensionFile),
+        true,
+        `missing extension ${extensionFile}`,
+      );
+      assert.equal(
+        statSync(extensionFile).isFile(),
+        true,
+        `not a file ${extensionFile}`,
+      );
     }
   });
 
   test("pi can load the resolved pi-subagents extension package without model execution", () => {
-    const result = spawnSync("./node_modules/.bin/pi", [
-      "--mode",
-      "json",
-      "--no-session",
-      "--offline",
-      "-e",
-      resolvePiSubagentsPackageRoot(),
-      "/subagents-doctor",
-    ], {
-      cwd: rootDir,
-      encoding: "utf8",
-      timeout: 30_000,
-    });
+    const result = spawnSync(
+      "./node_modules/.bin/pi",
+      [
+        "--mode",
+        "json",
+        "--no-session",
+        "--offline",
+        "-e",
+        resolvePiSubagentsPackageRoot(),
+        "/subagents-doctor",
+      ],
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+        timeout: 30_000,
+      },
+    );
     assert.equal(result.error, undefined);
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(`${result.stdout}\n${result.stderr}`, /subagents|doctor|runtime paths/ui);
-    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /Unknown command|No such command|extension load failed/ui);
+    assert.match(
+      `${result.stdout}\n${result.stderr}`,
+      /subagents|doctor|runtime paths/iu,
+    );
+    assert.doesNotMatch(
+      `${result.stdout}\n${result.stderr}`,
+      /Unknown command|No such command|extension load failed/iu,
+    );
   });
   ```
 
@@ -287,7 +316,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   }
 
   export function readInstalledPiSubagentsManifest(): PiSubagentsPackageManifest {
-    return readJson<PiSubagentsPackageManifest>(resolvePiSubagentsPackageJson());
+    return readJson<PiSubagentsPackageManifest>(
+      resolvePiSubagentsPackageJson(),
+    );
   }
 
   export function piSubagentsExtensionFiles(): string[] {
@@ -295,16 +326,25 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
     const manifest = readInstalledPiSubagentsManifest();
     const extensions = manifest.pi?.extensions ?? [];
     if (extensions.length === 0) {
-      throw new Error(`${PI_SUBAGENTS_PACKAGE_NAME} manifest declares no Pi extensions`);
+      throw new Error(
+        `${PI_SUBAGENTS_PACKAGE_NAME} manifest declares no Pi extensions`,
+      );
     }
     return extensions.map((entry) => {
       const extensionPath = resolve(packageRoot, entry);
-      if (!extensionPath.startsWith(`${packageRoot}/`) && extensionPath !== packageRoot) {
-        throw new Error(`${PI_SUBAGENTS_PACKAGE_NAME} extension escapes package root: ${entry}`);
+      if (
+        !extensionPath.startsWith(`${packageRoot}/`) &&
+        extensionPath !== packageRoot
+      ) {
+        throw new Error(
+          `${PI_SUBAGENTS_PACKAGE_NAME} extension escapes package root: ${entry}`,
+        );
       }
       const stats = statSync(extensionPath);
       if (!stats.isFile()) {
-        throw new Error(`${PI_SUBAGENTS_PACKAGE_NAME} extension is not a regular file: ${extensionPath}`);
+        throw new Error(
+          `${PI_SUBAGENTS_PACKAGE_NAME} extension is not a regular file: ${extensionPath}`,
+        );
       }
       return extensionPath;
     });
@@ -333,8 +373,8 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
 
   Expected: PASS. If it fails because installed `0.37.2` omits a Pi extension
   manifest, cannot be resolved through normal Node resolution, or cannot be
-  loaded by `pi --mode json --offline -e <package-root> /subagents-doctor`, stop and open a focused
-  upstream blocker instead of adding a Patchmill fallback.
+  loaded by `pi --mode json --offline -e <package-root> /subagents-doctor`, stop
+  and open a focused upstream blocker instead of adding a Patchmill fallback.
 
 - [ ] **Step 6: Commit Task 1**
 
@@ -375,9 +415,17 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
 
   ```ts
   const piSubagentsExtensions = piSubagentsExtensionFiles();
-  assert.equal(profile.additionalExtensionPaths[0], resolvePiSubagentsPackageRoot());
+  assert.equal(
+    profile.additionalExtensionPaths[0],
+    resolvePiSubagentsPackageRoot(),
+  );
   assert.ok(piSubagentsExtensions.length > 0);
-  assert.equal(profile.additionalExtensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"), true);
+  assert.equal(
+    profile.additionalExtensionPaths[1]
+      ?.replaceAll("\\", "/")
+      .endsWith("/extensions/todos.ts"),
+    true,
+  );
   ```
 
   Keep the existing loop that asserts every profile extension path exists. Add a
@@ -388,7 +436,10 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   function assertRunOnceExtensionOrder(extensionPaths: string[]): void {
     assert.equal(extensionPaths.length, 2);
     assert.equal(basename(extensionPaths[0] ?? ""), "pi-subagents");
-    assert.equal(extensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"), true);
+    assert.equal(
+      extensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"),
+      true,
+    );
   }
   ```
 
@@ -411,7 +462,10 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   Patchmill's separate package-root lookup:
 
   ```ts
-  import { piSubagentsExtensionFiles, resolvePiSubagentsPackageRoot } from "./pi-subagents-package.ts";
+  import {
+    piSubagentsExtensionFiles,
+    resolvePiSubagentsPackageRoot,
+  } from "./pi-subagents-package.ts";
 
   const PI_SUBAGENTS_PACKAGE_ROOT = resolvePiSubagentsPackageRoot();
   piSubagentsExtensionFiles();
@@ -477,8 +531,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
 
 **Interfaces:**
 
-- Produces CLI command:
-  `node scripts/verify-pi-subagents-child-metadata.mjs`.
+- Produces CLI command: `node scripts/verify-pi-subagents-child-metadata.mjs`.
 - Environment contract:
   - `PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL` is a configured tool-capable Pi
     model for children that should report effective thinking.
@@ -501,8 +554,8 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
 
 - [ ] **Step 1: Write deterministic parser and validator tests first**
 
-  Create `scripts/verify-pi-subagents-child-metadata.test.mjs` with fixture
-  JSON event rows that exercise:
+  Create `scripts/verify-pi-subagents-child-metadata.test.mjs` with fixture JSON
+  event rows that exercise:
 
   ```js
   import assert from "node:assert/strict";
@@ -515,16 +568,42 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   const finalResult = {
     details: {
       results: [
-        { id: "child-a", model: "provider/model-a", thinking: "low", content: "ok" },
-        { id: "child-b", model: "provider/model-a", thinking: "low", content: "ok" },
+        {
+          id: "child-a",
+          model: "provider/model-a",
+          thinking: "low",
+          content: "ok",
+        },
+        {
+          id: "child-b",
+          model: "provider/model-a",
+          thinking: "low",
+          content: "ok",
+        },
       ],
     },
   };
 
   test("validateShapeContract matches partial and final rows by upstream identity", () => {
     const shape = collectSubagentEvents([
-      { type: "tool_execution_update", toolName: "subagent", partialResult: { details: { results: [finalResult.details.results[0], finalResult.details.results[1]] } } },
-      { type: "tool_execution_end", toolName: "subagent", result: finalResult, isError: false },
+      {
+        type: "tool_execution_update",
+        toolName: "subagent",
+        partialResult: {
+          details: {
+            results: [
+              finalResult.details.results[0],
+              finalResult.details.results[1],
+            ],
+          },
+        },
+      },
+      {
+        type: "tool_execution_end",
+        toolName: "subagent",
+        result: finalResult,
+        isError: false,
+      },
     ]);
     validateShapeContract({
       label: "parallel",
@@ -538,43 +617,94 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   });
 
   test("validateShapeContract fails missing model, missing id, duplicate ids, and order drift", () => {
-    assert.throws(() => validateShapeContract({
-      label: "missing-model",
-      expectedModel: "provider/model-a",
-      expectedThinking: "low",
-      expectedFinalChildren: 1,
-      requireUniqueSiblingIds: false,
-      requireThinking: true,
-      shape: collectSubagentEvents([{ type: "tool_execution_end", toolName: "subagent", result: { details: { results: [{ id: "child-a", thinking: "low" }] } }, isError: false }]),
-    }), /missing model/u);
+    assert.throws(
+      () =>
+        validateShapeContract({
+          label: "missing-model",
+          expectedModel: "provider/model-a",
+          expectedThinking: "low",
+          expectedFinalChildren: 1,
+          requireUniqueSiblingIds: false,
+          requireThinking: true,
+          shape: collectSubagentEvents([
+            {
+              type: "tool_execution_end",
+              toolName: "subagent",
+              result: {
+                details: { results: [{ id: "child-a", thinking: "low" }] },
+              },
+              isError: false,
+            },
+          ]),
+        }),
+      /missing model/u,
+    );
 
-    assert.throws(() => validateShapeContract({
-      label: "missing-id",
-      expectedModel: "provider/model-a",
-      expectedThinking: "low",
-      expectedFinalChildren: 1,
-      requireUniqueSiblingIds: false,
-      requireThinking: true,
-      shape: collectSubagentEvents([{ type: "tool_execution_end", toolName: "subagent", result: { details: { results: [{ model: "provider/model-a", thinking: "low" }] } }, isError: false }]),
-    }), /missing upstream identity/u);
+    assert.throws(
+      () =>
+        validateShapeContract({
+          label: "missing-id",
+          expectedModel: "provider/model-a",
+          expectedThinking: "low",
+          expectedFinalChildren: 1,
+          requireUniqueSiblingIds: false,
+          requireThinking: true,
+          shape: collectSubagentEvents([
+            {
+              type: "tool_execution_end",
+              toolName: "subagent",
+              result: {
+                details: {
+                  results: [{ model: "provider/model-a", thinking: "low" }],
+                },
+              },
+              isError: false,
+            },
+          ]),
+        }),
+      /missing upstream identity/u,
+    );
 
-    assert.throws(() => validateShapeContract({
-      label: "duplicate-id",
-      expectedModel: "provider/model-a",
-      expectedThinking: "low",
-      expectedFinalChildren: 2,
-      requireUniqueSiblingIds: true,
-      requireThinking: true,
-      shape: collectSubagentEvents([{ type: "tool_execution_end", toolName: "subagent", result: { details: { results: [
-        { id: "same", model: "provider/model-a", thinking: "low" },
-        { id: "same", model: "provider/model-a", thinking: "low" },
-      ] } } }]),
-    }), /duplicate upstream identity/u);
+    assert.throws(
+      () =>
+        validateShapeContract({
+          label: "duplicate-id",
+          expectedModel: "provider/model-a",
+          expectedThinking: "low",
+          expectedFinalChildren: 2,
+          requireUniqueSiblingIds: true,
+          requireThinking: true,
+          shape: collectSubagentEvents([
+            {
+              type: "tool_execution_end",
+              toolName: "subagent",
+              result: {
+                details: {
+                  results: [
+                    { id: "same", model: "provider/model-a", thinking: "low" },
+                    { id: "same", model: "provider/model-a", thinking: "low" },
+                  ],
+                },
+              },
+            },
+          ]),
+        }),
+      /duplicate upstream identity/u,
+    );
   });
 
   test("validateShapeContract preserves legitimate thinking absence", () => {
     const shape = collectSubagentEvents([
-      { type: "tool_execution_end", toolName: "subagent", result: { details: { results: [{ id: "child-a", model: "provider/no-thinking" }] } }, isError: false },
+      {
+        type: "tool_execution_end",
+        toolName: "subagent",
+        result: {
+          details: {
+            results: [{ id: "child-a", model: "provider/no-thinking" }],
+          },
+        },
+        isError: false,
+      },
     ]);
     validateShapeContract({
       label: "no-thinking",
@@ -609,10 +739,19 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   export function collectSubagentEvents(events) {
     return {
       partials: events
-        .filter((event) => event.type === "tool_execution_update" && event.toolName === "subagent")
+        .filter(
+          (event) =>
+            event.type === "tool_execution_update" &&
+            event.toolName === "subagent",
+        )
         .map((event) => event.partialResult),
       finals: events
-        .filter((event) => event.type === "tool_execution_end" && event.toolName === "subagent" && event.isError !== true)
+        .filter(
+          (event) =>
+            event.type === "tool_execution_end" &&
+            event.toolName === "subagent" &&
+            event.isError !== true,
+        )
         .map((event) => event.result),
     };
   }
@@ -627,24 +766,48 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   }
 
   export function validateShapeContract(options) {
-    assert.equal(options.shape.finals.length, 1, `${options.label}: expected exactly one final subagent tool result`);
+    assert.equal(
+      options.shape.finals.length,
+      1,
+      `${options.label}: expected exactly one final subagent tool result`,
+    );
     const finalChildren = options.shape.finals.flatMap(childRows);
     if (finalChildren.length !== options.expectedFinalChildren) {
-      throw new Error(`${options.label}: expected exactly ${options.expectedFinalChildren} final children, got ${finalChildren.length}`);
+      throw new Error(
+        `${options.label}: expected exactly ${options.expectedFinalChildren} final children, got ${finalChildren.length}`,
+      );
     }
     const finalIds = finalChildren.map(childIdentity);
     finalChildren.forEach((child, index) => {
-      if (!finalIds[index]) throw new Error(`${options.label}: child ${index} missing upstream identity`);
-      if (child.model !== options.expectedModel) throw new Error(`${options.label}: child ${finalIds[index]} missing model ${options.expectedModel}`);
-      if (options.requireThinking && child.thinking !== options.expectedThinking) {
-        throw new Error(`${options.label}: child ${finalIds[index]} missing thinking ${options.expectedThinking}`);
+      if (!finalIds[index])
+        throw new Error(
+          `${options.label}: child ${index} missing upstream identity`,
+        );
+      if (child.model !== options.expectedModel)
+        throw new Error(
+          `${options.label}: child ${finalIds[index]} missing model ${options.expectedModel}`,
+        );
+      if (
+        options.requireThinking &&
+        child.thinking !== options.expectedThinking
+      ) {
+        throw new Error(
+          `${options.label}: child ${finalIds[index]} missing thinking ${options.expectedThinking}`,
+        );
       }
       if (!options.requireThinking && "thinking" in child) {
-        throw new Error(`${options.label}: expected thinking absence but found ${child.thinking}`);
+        throw new Error(
+          `${options.label}: expected thinking absence but found ${child.thinking}`,
+        );
       }
     });
-    if (options.requireUniqueSiblingIds && new Set(finalIds).size !== finalIds.length) {
-      throw new Error(`${options.label}: duplicate upstream identity in final children`);
+    if (
+      options.requireUniqueSiblingIds &&
+      new Set(finalIds).size !== finalIds.length
+    ) {
+      throw new Error(
+        `${options.label}: duplicate upstream identity in final children`,
+      );
     }
     if (options.shape.partials.length === 0) {
       console.log(`${options.label}: upstream emitted no partial results`);
@@ -657,13 +820,26 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
         continue;
       }
       partialChildren.forEach((child, index) => {
-        if (!partialIds[index]) throw new Error(`${options.label}: partial child ${index} missing upstream identity`);
-        if (child.model !== options.expectedModel) throw new Error(`${options.label}: partial child ${partialIds[index]} missing model ${options.expectedModel}`);
-        if (options.requireThinking && child.thinking !== options.expectedThinking) {
-          throw new Error(`${options.label}: partial child ${partialIds[index]} missing thinking ${options.expectedThinking}`);
+        if (!partialIds[index])
+          throw new Error(
+            `${options.label}: partial child ${index} missing upstream identity`,
+          );
+        if (child.model !== options.expectedModel)
+          throw new Error(
+            `${options.label}: partial child ${partialIds[index]} missing model ${options.expectedModel}`,
+          );
+        if (
+          options.requireThinking &&
+          child.thinking !== options.expectedThinking
+        ) {
+          throw new Error(
+            `${options.label}: partial child ${partialIds[index]} missing thinking ${options.expectedThinking}`,
+          );
         }
         if (!options.requireThinking && "thinking" in child) {
-          throw new Error(`${options.label}: partial child ${partialIds[index]} unexpectedly had thinking ${child.thinking}`);
+          throw new Error(
+            `${options.label}: partial child ${partialIds[index]} unexpectedly had thinking ${child.thinking}`,
+          );
         }
       });
       assert.deepEqual(partialIds, finalIds.slice(0, partialIds.length));
@@ -678,7 +854,6 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
 - [ ] **Step 4: Implement the live Pi runner**
 
   Add a runtime entrypoint that:
-
   1. Reads the exact root `pi-subagents` pin and installed package root using
      normal Node resolution.
   2. Creates a temporary project with local `.pi/agents/contract-thinking.md`
@@ -755,11 +930,12 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
     node scripts/verify-pi-subagents-child-metadata.mjs
   ```
 
-  Expected: tests PASS; the live script prints the four required `metadata
-  contract passed` lines and `no-thinking: absence contract passed`. If any
-  supported shape lacks model, thinking, identity, uniqueness, or ordering, or if
-  no configured no-thinking model can prove absence semantics, stop the PR,
-  capture the failing command output, and open/link a focused upstream blocker.
+  Expected: tests PASS; the live script prints the four required
+  `metadata contract passed` lines and `no-thinking: absence contract passed`.
+  If any supported shape lacks model, thinking, identity, uniqueness, or
+  ordering, or if no configured no-thinking model can prove absence semantics,
+  stop the PR, capture the failing command output, and open/link a focused
+  upstream blocker.
 
 - [ ] **Step 6: Commit Task 3**
 
@@ -787,8 +963,8 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   `PI_PACKAGES`.
 - Preserves: existing packed artifact checks for Patchmill initialization and Pi
   runtime packages.
-- Produces: packed npm and Nix installed checks that prove `pi-subagents` version
-  agreement, manifest extension files, and run-once extension order.
+- Produces: packed npm and Nix installed checks that prove `pi-subagents`
+  version agreement, manifest extension files, and run-once extension order.
 
 - [ ] **Step 1: Extend packed npm smoke checks**
 
@@ -797,16 +973,30 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   ```js
   const PI_SUBAGENTS_PACKAGE = "pi-subagents";
 
-  function assertPiSubagentsInstalled({ projectRequire, nodeModulesDir, rootPin }) {
-    const packagePath = join(nodeModulesDir, PI_SUBAGENTS_PACKAGE, "package.json");
-    if (!existsSync(packagePath)) throw new Error(`Could not locate ${packagePath}`);
+  function assertPiSubagentsInstalled({
+    projectRequire,
+    nodeModulesDir,
+    rootPin,
+  }) {
+    const packagePath = join(
+      nodeModulesDir,
+      PI_SUBAGENTS_PACKAGE,
+      "package.json",
+    );
+    if (!existsSync(packagePath))
+      throw new Error(`Could not locate ${packagePath}`);
     const manifest = JSON.parse(readFileSync(packagePath, "utf8"));
     if (manifest.version !== rootPin) {
-      throw new Error(`${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} but package.json pins ${rootPin}`);
+      throw new Error(
+        `${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} but package.json pins ${rootPin}`,
+      );
     }
     for (const extension of manifest.pi?.extensions ?? []) {
       const extensionPath = join(dirname(packagePath), extension);
-      if (!existsSync(extensionPath)) throw new Error(`Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`);
+      if (!existsSync(extensionPath))
+        throw new Error(
+          `Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`,
+        );
     }
     projectRequire.resolve(`${PI_SUBAGENTS_PACKAGE}/package.json`);
   }
@@ -835,14 +1025,30 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   `$out/share/${pname}/node_modules/pi-subagents/package.json`, and checks:
 
   ```js
-  const rootPin = packageJson.dependencies['pi-subagents'];
-  if (piSubagents.version !== rootPin) throw new Error('pi-subagents version drift');
-  const extensionPaths = piSubagents.pi.extensions.map((entry) => join(piSubagentsRoot, entry));
-  const missing = extensionPaths.filter((extensionPath) => !existsSync(extensionPath));
-  if (missing.length > 0) throw new Error(`missing pi-subagents extension paths: ''${missing.join(', ')}`);
+  const rootPin = packageJson.dependencies["pi-subagents"];
+  if (piSubagents.version !== rootPin)
+    throw new Error("pi-subagents version drift");
+  const extensionPaths = piSubagents.pi.extensions.map((entry) =>
+    join(piSubagentsRoot, entry),
+  );
+  const missing = extensionPaths.filter(
+    (extensionPath) => !existsSync(extensionPath),
+  );
+  if (missing.length > 0)
+    throw new Error(
+      `missing pi-subagents extension paths: ''${missing.join(", ")}`,
+    );
   const profile = runOncePlanningPiProfile(skills, process.cwd());
-  assert.equal(realpathSync(profile.additionalExtensionPaths[0]), realpathSync(piSubagentsRoot));
-  assert.equal(profile.additionalExtensionPaths[1].replaceAll('\\', '/').endsWith('/extensions/todos.ts'), true);
+  assert.equal(
+    realpathSync(profile.additionalExtensionPaths[0]),
+    realpathSync(piSubagentsRoot),
+  );
+  assert.equal(
+    profile.additionalExtensionPaths[1]
+      .replaceAll("\\", "/")
+      .endsWith("/extensions/todos.ts"),
+    true,
+  );
   ```
 
   Import `readFileSync`, `realpathSync`, and `strict as assert` in the snippet
@@ -972,7 +1178,8 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix
   Expected: every printed `pi-subagents` value is the same exact version,
   expected `0.37.2` unless Task 1 documented a newer first-passing release.
 
-- [ ] **Step 6: Commit validation fixes if any, then ensure the final branch is clean except intended changes**
+- [ ] **Step 6: Commit validation fixes if any, then ensure the final branch is
+      clean except intended changes**
 
   If validation fixes changed files, run:
 

--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -220,33 +220,49 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   });
 
   test("pi can load the resolved pi-subagents extension package without model execution", () => {
-    const result = spawnSync(
+    const badResult = spawnSync(
       "./node_modules/.bin/pi",
       [
         "--mode",
         "json",
+        "--print",
         "--no-session",
         "--offline",
+        "-ne",
+        "-e",
+        join(rootDir, "node_modules", "not-pi-subagents"),
+        "/subagents-doctor",
+      ],
+      { cwd: rootDir, encoding: "utf8", timeout: 30_000 },
+    );
+    assert.notEqual(badResult.status, 0, badResult.stdout);
+
+    const result = spawnSync(
+      "./node_modules/.bin/pi",
+      [
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--offline",
+        "-ne",
         "-e",
         resolvePiSubagentsPackageRoot(),
-        "/subagents-doctor",
       ],
       {
         cwd: rootDir,
         encoding: "utf8",
+        input: '{"type":"get_commands"}\n',
         timeout: 30_000,
+        env: Object.fromEntries(
+          Object.entries(process.env).filter(
+            ([name]) => !name.startsWith("PI_SUBAGENT_"),
+          ),
+        ),
       },
     );
     assert.equal(result.error, undefined);
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.match(
-      `${result.stdout}\n${result.stderr}`,
-      /subagents|doctor|runtime paths/iu,
-    );
-    assert.doesNotMatch(
-      `${result.stdout}\n${result.stderr}`,
-      /Unknown command|No such command|extension load failed/iu,
-    );
+    assert.match(`${result.stdout}\n${result.stderr}`, /subagents-doctor/iu);
   });
   ```
 
@@ -743,6 +759,10 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 
   ```js
   export function collectSubagentEvents(events) {
+    const subagentFinals = events.filter(
+      (event) =>
+        event.type === "tool_execution_end" && event.toolName === "subagent",
+    );
     return {
       partials: events
         .filter(
@@ -751,14 +771,14 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
             event.toolName === "subagent",
         )
         .map((event) => event.partialResult),
-      finals: events
+      finals: subagentFinals
         .filter(
-          (event) =>
-            event.type === "tool_execution_end" &&
-            event.toolName === "subagent" &&
-            event.isError !== true,
+          (event) => event.isError !== true && event.result?.isError !== true,
         )
         .map((event) => event.result),
+      failures: subagentFinals.filter(
+        (event) => event.isError === true || event.result?.isError === true,
+      ),
     };
   }
 
@@ -768,10 +788,17 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   }
 
   function childIdentity(row) {
-    return row?.id;
+    return Number.isSafeInteger(row?.index) && row.index >= 0
+      ? row.index
+      : undefined;
   }
 
   export function validateShapeContract(options) {
+    assert.equal(
+      options.shape.failures?.length ?? 0,
+      0,
+      `${options.label}: expected no failed subagent tool results`,
+    );
     assert.equal(
       options.shape.finals.length,
       1,

--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -22,8 +22,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 
 ## Global Constraints
 
-- Pin one exact `pi-subagents` release; validate `0.37.2` first and pin the
-  first release that passes the contract.
+- Pin one exact `pi-subagents` release; `0.37.2` was validated first and blocked
+  on missing foreground row identity, and `0.39.0` is the first release that
+  passes the contract.
 - Do not infer child `model`, `thinking`, identity, or ordering from Patchmill
   configuration, parent Pi settings, agent frontmatter, defaults, array indexes,
   or local copies of upstream resolution logic.
@@ -56,7 +57,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 ## File Structure
 
 - Modify `package.json`: replace `"pi-subagents": "^0.25.0"` with the passing
-  exact version, expected `"0.37.2"`.
+  exact version, `"0.39.0"`.
 - Modify `package-lock.json` and `npm-shrinkwrap.json`: regenerate from npm so
   root dependency entries and `node_modules/pi-subagents.version` agree with the
   exact pin.
@@ -124,7 +125,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   Run from the repository root:
 
   ```sh
-  npm pkg set dependencies.pi-subagents=0.37.2
+  npm pkg set dependencies.pi-subagents=0.39.0
   npm install --package-lock-only --ignore-scripts
   tmp_shrinkwrap="$(mktemp)"
   cp npm-shrinkwrap.json "$tmp_shrinkwrap"
@@ -136,10 +137,10 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   ```
 
   Expected: `package.json`, `package-lock.json`, and `npm-shrinkwrap.json`
-  change; `package.json.dependencies["pi-subagents"]` is exactly `"0.37.2"`;
+  change; `package.json.dependencies["pi-subagents"]` is exactly `"0.39.0"`;
   both lockfiles contain
-  `packages[""].dependencies["pi-subagents"] === "0.37.2"` and
-  `packages["node_modules/pi-subagents"].version === "0.37.2"`.
+  `packages[""].dependencies["pi-subagents"] === "0.39.0"` and
+  `packages["node_modules/pi-subagents"].version === "0.39.0"`.
 
 - [ ] **Step 2: Write the failing dependency contract tests**
 
@@ -371,7 +372,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   node --test src/pi/pi-subagents-dependency-contract.test.ts
   ```
 
-  Expected: PASS. If it fails because installed `0.37.2` omits a Pi extension
+  Expected: PASS. If it fails because installed `0.39.0` omits a Pi extension
   manifest, cannot be resolved through normal Node resolution, or cannot be
   loaded by `pi --mode json --offline -e <package-root> /subagents-doctor`, stop
   and open a focused upstream blocker instead of adding a Patchmill fallback.
@@ -1016,7 +1017,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   ```
 
   Expected: PASS and output includes a line equivalent to
-  `pi-subagents resolved 0.37.2 from <packed-project>/node_modules/pi-subagents/package.json`.
+  `pi-subagents resolved 0.39.0 from <packed-project>/node_modules/pi-subagents/package.json`.
 
 - [ ] **Step 3: Extend Nix install checks**
 
@@ -1176,7 +1177,7 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
   ```
 
   Expected: every printed `pi-subagents` value is the same exact version,
-  expected `0.37.2` unless Task 1 documented a newer first-passing release.
+  expected `0.39.0`.
 
 - [ ] **Step 6: Commit validation fixes if any, then ensure the final branch is
       clean except intended changes**

--- a/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
+++ b/docs/plans/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata.md
@@ -61,10 +61,10 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
 - Modify `package-lock.json` and `npm-shrinkwrap.json`: regenerate from npm so
   root dependency entries and `node_modules/pi-subagents.version` agree with the
   exact pin.
-- Create `src/pi/pi-subagents-package.ts`: shared helpers that resolve
-  `pi-subagents/package.json` via Node resolution, read the installed manifest,
-  assert the installed version equals the exact root pin, and return declared Pi
-  extension file paths that exist as regular files.
+- Create `src/pi/pi-subagents-package.ts`: shared helpers that resolve the
+  public `pi-subagents` package entry via Node resolution, read the adjacent
+  installed manifest, assert the installed version equals the exact root pin,
+  and return declared Pi extension file paths that exist as regular files.
 - Create `src/pi/pi-subagents-dependency-contract.test.ts`: automated tests for
   exact root pin parsing, installed package version agreement, lockfile and
   shrinkwrap agreement, manifest extension declarations, and normal Pi
@@ -308,12 +308,17 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     return spec;
   }
 
-  export function resolvePiSubagentsPackageJson(): string {
-    return require.resolve(`${PI_SUBAGENTS_PACKAGE_NAME}/package.json`);
+  /**
+   * Finds the package directory through the public package entry. pi-subagents
+   * intentionally does not export package.json, so resolving that subpath would
+   * violate its export map.
+   */
+  export function resolvePiSubagentsPackageRoot(): string {
+    return dirname(require.resolve(PI_SUBAGENTS_PACKAGE_NAME));
   }
 
-  export function resolvePiSubagentsPackageRoot(): string {
-    return dirname(resolvePiSubagentsPackageJson());
+  export function resolvePiSubagentsPackageJson(): string {
+    return resolve(resolvePiSubagentsPackageRoot(), "package.json");
   }
 
   export function readInstalledPiSubagentsManifest(): PiSubagentsPackageManifest {
@@ -1172,7 +1177,9 @@ and lockfiles, Pi JSON event stream mode, `pi-subagents`, Nix `buildNpmPackage`.
     const json = JSON.parse(fs.readFileSync(file, 'utf8'));
     console.log(file, json.dependencies?.['pi-subagents'] ?? json.packages?.['']?.dependencies?.['pi-subagents'], json.packages?.['node_modules/pi-subagents']?.version ?? 'root');
   }
-  console.log('installed', JSON.parse(fs.readFileSync(require.resolve('pi-subagents/package.json'), 'utf8')).version);
+  const piSubagentsEntry = require.resolve('pi-subagents');
+  const piSubagentsManifest = require('node:path').join(require('node:path').dirname(piSubagentsEntry), 'package.json');
+  console.log('installed', JSON.parse(fs.readFileSync(piSubagentsManifest, 'utf8')).version);
   NODE
   ```
 

--- a/docs/specs/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata-design.md
+++ b/docs/specs/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata-design.md
@@ -1,0 +1,263 @@
+# Upgrade pi-subagents Child Metadata Contract Design
+
+**Issue:** #122
+
+**Parent:** #116
+
+## Context
+
+Patchmill delegates planning, development-environment, and implementation work
+to Pi with the bundled `pi-subagents` extension loaded before Patchmill's todos
+extension. The current dependency range in `package.json` is `^0.25.0`, and the
+lockfiles currently resolve `pi-subagents` to `0.25.0`. That version is too old
+for the child-result metadata contract needed by the later Patchmill lifecycle
+observer work owned outside this issue.
+
+Issue #122 is the dependency-contract slice of the #116 subagent metadata work.
+It does not implement Patchmill's observer, session streaming, progress
+correlation, or console rendering. Its job is to consume an upstream
+`pi-subagents` release that reports authoritative child runtime metadata and to
+prove that Patchmill can load and validate that release without reimplementing
+upstream configuration resolution.
+
+## Goals
+
+- Pin one `pi-subagents` release that satisfies Patchmill's child metadata
+  contract. The issue identifies `0.37.2` as the expected first candidate; the
+  implementation should validate that candidate from the installed package and
+  pin the first release that passes the contract.
+- Require effective child `model` and `thinking` metadata for every Patchmill-
+  supported `pi-subagents` execution shape: direct, counted, parallel, and
+  chain.
+- Validate stable per-child correlation identity and ordering across partial and
+  final results for every child in those execution shapes, including direct
+  single-child results.
+- Preserve absence semantics: Patchmill must fail contract validation or report
+  an upstream blocker when required metadata or identity is absent, not infer
+  the values locally from parent configuration, agent files, defaults, or array
+  positions.
+- Keep all source, npm lockfile, shrinkwrap, Nix hash, installed-file, and live
+  extension-load references aligned on the same upstream `pi-subagents` version.
+
+## Non-goals
+
+- Implement Patchmill lifecycle observation or render subagent progress.
+- Add session streaming or progress correlation logic.
+- Recreate `pi-subagents` model, thinking, settings, override, chain, or
+  discovery resolution inside Patchmill.
+- Change Patchmill's subagent prompts, default implementation workflow, todo
+  extension behavior, or extension ordering except where validation proves the
+  dependency contract.
+- Broaden the scheduled Pi runtime dependency workflow unless implementation
+  discovers an existing helper must be shared for exact dependency validation.
+  In particular, do not add `pi-subagents` to helper lists that assume
+  `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` upgrade in
+  version lockstep.
+
+## Proposed approach
+
+Use an exact dependency pin plus a focused contract-validation layer. This is
+the recommended approach because it treats `pi-subagents` as the authority for
+child runtime metadata while giving Patchmill repeatable evidence that the
+bundled extension still loads in source, packed npm, and Nix-installed layouts.
+
+Alternatives considered:
+
+1. **Keep the semver range and rely on lockfile resolution.** This leaves
+   package metadata ambiguous and can let later installs resolve a different
+   upstream contract than the one Patchmill verified.
+2. **Infer child model and thinking from Patchmill or pi-subagents config.**
+   This is explicitly out of scope and would duplicate upstream resolution rules
+   that may change independently.
+3. **Validate only the direct single-child result shape.** This misses the
+   execution modes Patchmill implementation skills use in practice and would not
+   satisfy the later observer's correlation requirements.
+
+## Runtime contract
+
+Patchmill's contract is over the raw `pi-subagents` child-result metadata, not
+over Patchmill-derived fields.
+
+For each supported execution shape, the validation fixture should capture:
+
+- every child entry emitted in partial results;
+- every child entry emitted in the final tool result;
+- the upstream-supplied child correlation identity for each entry;
+- the child entry's authoritative `model` value;
+- the child entry's effective `thinking` value, including explicit upstream
+  absence when a model or execution mode truly has no thinking level; and
+- the array ordering of children within each result.
+
+A passing execution shape must show that:
+
+- each child present in a partial result can be matched to the corresponding
+  child in the final result by upstream identity;
+- every final child, including a direct single child, has an upstream identity;
+- every multi-child shape has unique upstream identities for siblings, including
+  counted, parallel, and chain-produced siblings;
+- child ordering is stable from partial to final result;
+- `model` equals the effective known model configured for the validation child,
+  without Patchmill recomputing that value from agent resolution rules;
+- `thinking` equals the effective known thinking level configured for the
+  validation child when one is configured;
+- a dedicated no-thinking fixture proves legitimate upstream absence remains
+  absent rather than being backfilled; and
+- counted and parallel children remain distinguishable even when they use the
+  same agent definition, task text, model, or thinking level.
+
+If upstream does not expose a stable identity or required metadata for one of
+Patchmill's supported shapes, implementation should stop and document a focused
+upstream blocker. Patchmill should not downgrade the shape to an inferred local
+contract.
+
+## Execution shapes to validate
+
+The contract suite should cover these shapes with at least two children wherever
+that shape can produce multiple children:
+
+1. **Direct single child:** one foreground `subagent` call.
+2. **Counted children:** a counted invocation of the same agent that produces
+   multiple sibling child results.
+3. **Parallel children:** a `tasks`-based parallel invocation with distinct
+   child tasks and a repeated-count parallel task.
+4. **Chain children:** a sequential chain with at least two steps, plus a chain
+   step that fans out to parallel children if supported by the pinned release.
+
+The suite should observe both Pi tool-execution updates and final tool results
+when those partial updates are available. If a supported shape emits no partial
+result by design, the test should assert that absence explicitly and still
+validate final result metadata and ordering. It should not synthesize partial
+rows from final rows.
+
+## Affected components
+
+### Dependency metadata
+
+Update the root dependency from the current range to one exact `pi-subagents`
+version. Regenerate and commit:
+
+- `package.json`;
+- `package-lock.json`;
+- `npm-shrinkwrap.json`; and
+- `nix/package.nix` `npmDepsHash`.
+
+The exact root pin, both lockfile root dependency entries, both resolved
+`node_modules/pi-subagents` entries, and the installed package's own
+`package.json.version` must agree.
+
+### Pi resource profile validation
+
+`src/pi/resource-profiles.ts` should continue resolving the dependency-owned
+`pi-subagents` package root through
+`require.resolve("pi-subagents/package.json")` and loading it before
+`extensions/todos.ts`. Tests should verify not only that the package root
+exists, but also that the installed `pi-subagents` package manifest exposes its
+declared Pi extension files and that those files exist at the paths Pi will
+load.
+
+### Dependency contract tests
+
+Add a focused `pi-subagents` dependency-contract test or script that:
+
+- reads the exact root `pi-subagents` pin;
+- locates the installed package through normal Node resolution;
+- asserts the installed version equals the root pin;
+- asserts the package manifest declares Pi extension resources and those files
+  exist;
+- loads the extension through Pi with `-e` followed by the resolved
+  `pi-subagents` package-root path, matching the style used by Patchmill; and
+- validates the child-result metadata contract for direct, counted, parallel,
+  and chain shapes.
+
+Where deterministic local model execution is unavailable, keep the package and
+extension-load checks automated and make the shape contract a named live
+verification command that uses normal Pi credentials. The implementation plan
+should state the required environment and expected output. It must not replace
+live metadata validation with static source inspection or local inference.
+
+### Packed npm and Nix checks
+
+Extend packed-artifact and Nix-installed verification so both layouts prove:
+
+- Patchmill can initialize;
+- the resolved `pi-subagents` package version matches the root pin;
+- the `pi-subagents` package manifest's extension files exist in the installed
+  layout; and
+- run-once resource profiles return existing extension paths in the expected
+  order: `pi-subagents`, then Patchmill's todos extension.
+
+The Nix build remains required because the dependency graph and npm hash change.
+
+## Failure behavior
+
+- Missing `model` for any final child in a supported shape fails the dependency
+  contract.
+- Missing effective `thinking` for a child that upstream should resolve fails
+  the dependency contract.
+- Missing child identity for any child in a supported shape fails the dependency
+  contract.
+- Non-unique sibling identities in counted, parallel, or chain-produced children
+  fail the dependency contract.
+- Any supported shape that upstream cannot report with required metadata or
+  identity blocks this dependency PR until a focused upstream blocker is opened
+  and linked.
+- Identity changes between partial and final results fail the dependency
+  contract.
+- Ordering differences between partial and final results fail the dependency
+  contract.
+- Package, lockfile, shrinkwrap, installed package, or Nix-version drift fails
+  validation.
+- Patchmill never fills missing metadata from the parent model, parent thinking
+  level, agent frontmatter, settings overrides, or child array index.
+
+## Verification strategy
+
+Focused verification for the implementation PR should include:
+
+```sh
+node --test src/pi/resource-profiles.test.ts
+node --test src/pi/pi-subagents-dependency-contract.test.ts
+node scripts/verify-pi-subagents-child-metadata.mjs
+npm test
+node scripts/smoke-packed-artifact.mjs
+npm run lint
+scripts/update-npm-deps-hash.sh
+git diff --exit-code -- nix/package.nix
+nix build .#patchmill --print-build-logs
+nix flake check --print-build-logs
+```
+
+If the live metadata command cannot pass for a supported execution shape because
+upstream omits required metadata or identity, the PR should not pin a locally
+inferred workaround; it should instead block on a focused upstream issue and
+include the failing command output.
+
+## Testing value gate
+
+Automated tests are warranted for dependency contract parsing, installed-file
+resolution, package-version agreement, resource-profile extension existence, and
+any deterministic child-metadata fixture because those behaviors can regress in
+ways that break Patchmill runs.
+
+Do not add tests that merely assert dependency strings, lockfile text, Nix
+expression text, or documentation prose. Validate those with exact-pin checks,
+lockfile contract code, package smoke checks, `scripts/update-npm-deps-hash.sh`,
+and the Nix build.
+
+## Acceptance mapping
+
+- Effective child `model` and `thinking` metadata is available for every
+  supported execution shape: covered by the direct, counted, parallel, and chain
+  metadata contract suite.
+- Partial and final results preserve stable child correlation identity and
+  ordering: covered by observing tool-execution updates and final results for
+  each supported shape.
+- Missing metadata or identity remains absent rather than inferred: covered by
+  failure behavior and the prohibition on Patchmill-side resolution logic.
+- All source, npm, and Nix references agree on one upstream version: covered by
+  exact root pin, lockfile/shrinkwrap validation, installed package checks, and
+  Nix hash refresh.
+- Required extension-load and full flake verification pass: covered by the live
+  extension-load contract, packed-artifact smoke check,
+  `nix build .#patchmill --print-build-logs`, and
+  `nix flake check --print-build-logs`.

--- a/docs/specs/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata-design.md
+++ b/docs/specs/2026-08-01-issue-122-upgrade-pi-subagents-to-expose-resolved-child-model-and-thinking-metadata-design.md
@@ -25,7 +25,10 @@ upstream configuration resolution.
 - Pin one `pi-subagents` release that satisfies Patchmill's child metadata
   contract. The issue identifies `0.37.2` as the expected first candidate; the
   implementation should validate that candidate from the installed package and
-  pin the first release that passes the contract.
+  pin the first release that passes the contract. Implementation validated
+  `0.37.2` first, found the missing foreground row identity blocker, and then
+  selected `0.39.0` as the first release whose raw foreground rows satisfy the
+  required identity, model, thinking, and ordering contract.
 - Require effective child `model` and `thinking` metadata for every Patchmill-
   supported `pi-subagents` execution shape: direct, counted, parallel, and
   chain.
@@ -148,12 +151,14 @@ The exact root pin, both lockfile root dependency entries, both resolved
 ### Pi resource profile validation
 
 `src/pi/resource-profiles.ts` should continue resolving the dependency-owned
-`pi-subagents` package root through
-`require.resolve("pi-subagents/package.json")` and loading it before
-`extensions/todos.ts`. Tests should verify not only that the package root
-exists, but also that the installed `pi-subagents` package manifest exposes its
-declared Pi extension files and that those files exist at the paths Pi will
-load.
+`pi-subagents` package root through normal Node package resolution and loading
+it before `extensions/todos.ts`. Because modern `pi-subagents` packages do not
+export the `./package.json` subpath, Patchmill resolves the public package entry
+and reads the adjacent manifest instead of relying on
+`require.resolve("pi-subagents/package.json")`. Tests should verify not only
+that the package root exists, but also that the installed `pi-subagents` package
+manifest exposes its declared Pi extension files and that those files exist at
+the paths Pi will load.
 
 ### Dependency contract tests
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -25,7 +25,7 @@ buildNpmPackageNode24 rec {
         || baseName == "result");
   };
 
-  npmDepsHash = "sha256-yJ69LGTBkO1AZ5ZCUkWyCG4jK7Dj3m0MEcWXCJHYs+c=";
+  npmDepsHash = "sha256-IEqWfzil2at3+q4pbA0iErzQAB7CnjyLrmn/iqt2jQ4=";
   npmDepsFetcherVersion = 2;
 
   dontNpmBuild = true;
@@ -79,22 +79,44 @@ buildNpmPackageNode24 rec {
     (
       cd "$out/share/${pname}"
       ${nodejs_24}/bin/node --input-type=module -e "
-        import { existsSync } from 'node:fs';
+        import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+        import { join } from 'node:path';
+        import assert from 'node:assert/strict';
         import { runOncePlanningPiProfile } from './src/pi/resource-profiles.ts';
+        const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
+        const rootPin = packageJson.dependencies['pi-subagents'];
+        const piSubagentsRoot = './node_modules/pi-subagents';
+        const piSubagents = JSON.parse(readFileSync(join(piSubagentsRoot, 'package.json'), 'utf8'));
+        if (piSubagents.version !== rootPin) {
+          throw new Error('pi-subagents version drift');
+        }
+        const extensionPaths = piSubagents.pi?.extensions?.map(
+          (entry) => join(piSubagentsRoot, entry),
+        ) ?? [];
+        if (extensionPaths.length === 0) {
+          throw new Error('pi-subagents manifest declares no extensions');
+        }
+        const missing = extensionPaths.filter(
+          (extensionPath) => !existsSync(extensionPath) || !statSync(extensionPath).isFile(),
+        );
+        if (missing.length > 0) {
+          throw new Error(\`missing pi-subagents extension paths: \''${missing.join(', ')}\`);
+        }
         const skills = {
           triage: 'triage', planning: 'planning', implementation: 'implementation',
           developmentEnvironment: 'development-environment', toolchain: 'toolchain',
           review: 'review', visualEvidence: 'visual-evidence', landing: 'landing',
         };
         const profile = runOncePlanningPiProfile(skills, process.cwd());
-        const missing = profile.additionalExtensionPaths.filter(
-          (extensionPath) => !existsSync(extensionPath),
+        assert.equal(
+          realpathSync(profile.additionalExtensionPaths[0]),
+          realpathSync(piSubagentsRoot),
         );
-        if (missing.length > 0) {
-          console.error('missing installed extension paths:', missing.join(', '));
-          process.exit(1);
-        }
-        console.log('all installed extension paths exist');
+        assert.equal(
+          profile.additionalExtensionPaths[1].replaceAll('\\\\', '/').endsWith('/extensions/todos.ts'),
+          true,
+        );
+        console.log('installed pi-subagents manifest and extension order verified');
       "
     )
     runHook postInstallCheck

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -79,29 +79,17 @@ buildNpmPackageNode24 rec {
     (
       cd "$out/share/${pname}"
       ${nodejs_24}/bin/node --input-type=module -e "
-        import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
-        import { join } from 'node:path';
+        import { realpathSync } from 'node:fs';
         import assert from 'node:assert/strict';
         import { runOncePlanningPiProfile } from './src/pi/resource-profiles.ts';
-        const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
-        const rootPin = packageJson.dependencies['pi-subagents'];
-        const piSubagentsRoot = './node_modules/pi-subagents';
-        const piSubagents = JSON.parse(readFileSync(join(piSubagentsRoot, 'package.json'), 'utf8'));
-        if (piSubagents.version !== rootPin) {
-          throw new Error('pi-subagents version drift');
-        }
-        const extensionPaths = piSubagents.pi?.extensions?.map(
-          (entry) => join(piSubagentsRoot, entry),
-        ) ?? [];
-        if (extensionPaths.length === 0) {
-          throw new Error('pi-subagents manifest declares no extensions');
-        }
-        const missing = extensionPaths.filter(
-          (extensionPath) => !existsSync(extensionPath) || !statSync(extensionPath).isFile(),
-        );
-        if (missing.length > 0) {
-          throw new Error(\`missing pi-subagents extension paths: \''${missing.join(', ')}\`);
-        }
+        import {
+          assertInstalledPiSubagentsMatchesRootPin,
+          piSubagentsExtensionFiles,
+          resolvePiSubagentsPackageRoot,
+        } from './src/pi/pi-subagents-package.ts';
+        assertInstalledPiSubagentsMatchesRootPin('./package.json');
+        piSubagentsExtensionFiles();
+        const piSubagentsRoot = resolvePiSubagentsPackageRoot();
         const skills = {
           triage: 'triage', planning: 'planning', implementation: 'implementation',
           developmentEnvironment: 'development-environment', toolchain: 'toolchain',

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -25,7 +25,7 @@ buildNpmPackageNode24 rec {
         || baseName == "result");
   };
 
-  npmDepsHash = "sha256-IEqWfzil2at3+q4pbA0iErzQAB7CnjyLrmn/iqt2jQ4=";
+  npmDepsHash = "sha256-4e8QkXmodtvAOXUqCK8JMmc7XlzEjBJrGN1ITbME9b8=";
   npmDepsFetcherVersion = 2;
 
   dontNpmBuild = true;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@earendil-works/pi-tui": "0.83.0",
-        "pi-subagents": "^0.25.0",
+        "pi-subagents": "0.37.2",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
@@ -516,8 +516,7 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.83.0",
@@ -541,8 +540,7 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.83.0",
@@ -554,8 +552,7 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",
@@ -3342,17 +3339,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3615,18 +3601,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mdurl": {
@@ -4359,22 +4333,23 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.25.0.tgz",
-      "integrity": "sha512-HZK1RvT8zfQSzHRExhrnSKdhHmQeCxnpwjkf5dHQbWGcz9kk5C9Cb1rjElEM6CkOGp3eApMm3/HVi2EVYQX7OA==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.37.2.tgz",
+      "integrity": "sha512-pf7DxLBY9pFY3grOFgRfMqoS9QbElWP2ULOCOnmJNrCEvjlA81fiyp0wk1vSaJPJ/rjsP0lA1sAk7S/QD+Olpg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-tui": "^0.74.0",
-        "jiti": "^2.7.0",
-        "typebox": "^1.1.24"
+        "jiti": "2.7.0",
+        "typebox": "1.1.38",
+        "yaml": "2.8.3"
       },
       "bin": {
         "pi-subagents": "install.mjs"
       },
       "peerDependencies": {
         "@earendil-works/pi-agent-core": "*",
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*"
+        "@earendil-works/pi-ai": ">=0.80.0",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-agent-core": {
@@ -4385,23 +4360,25 @@
         },
         "@earendil-works/pi-coding-agent": {
           "optional": true
+        },
+        "@earendil-works/pi-tui": {
+          "optional": true
         }
       }
     },
-    "node_modules/pi-subagents/node_modules/@earendil-works/pi-tui": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.2.tgz",
-      "integrity": "sha512-valQPz74qbdydRqII6t9rJ46YANMOOJeDhKm25a1ZrWvWwdjAaAEu6s3ur/LWz84Wkkwcbub2ZkVjzCZi8gFGA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12"
+    "node_modules/pi-subagents/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">= 14.6"
       },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/picomatch": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@earendil-works/pi-tui": "0.83.0",
-        "pi-subagents": "0.40.0",
+        "pi-subagents": "0.39.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
@@ -4336,9 +4336,9 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.40.0.tgz",
-      "integrity": "sha512-DdFXqmRMLhCcGs32zN14hm4AztDuhG0b8yka8pzO+5GsYseifJnT/hfcqr/skPhtoDqA1qcQbucj1dciC0OQzg==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.39.0.tgz",
+      "integrity": "sha512-CoocrMQ6XP5AdldB0JJsiKDAoveyYqycFLWDhJqLWzz+9GiV9NI6/UTWdME1fIzpHHyrCVOlQaDdNM9SE6Ig/Q==",
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@earendil-works/pi-tui": "0.83.0",
-        "pi-subagents": "0.37.2",
+        "pi-subagents": "0.40.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
@@ -4333,9 +4333,9 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.37.2.tgz",
-      "integrity": "sha512-pf7DxLBY9pFY3grOFgRfMqoS9QbElWP2ULOCOnmJNrCEvjlA81fiyp0wk1vSaJPJ/rjsP0lA1sAk7S/QD+Olpg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.40.0.tgz",
+      "integrity": "sha512-DdFXqmRMLhCcGs32zN14hm4AztDuhG0b8yka8pzO+5GsYseifJnT/hfcqr/skPhtoDqA1qcQbucj1dciC0OQzg==",
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -516,7 +516,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.83.0",
@@ -540,7 +541,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.83.0",
@@ -552,7 +554,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@earendil-works/pi-tui": "0.83.0",
-        "pi-subagents": "0.37.2",
+        "pi-subagents": "0.40.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
@@ -4336,9 +4336,9 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.37.2.tgz",
-      "integrity": "sha512-pf7DxLBY9pFY3grOFgRfMqoS9QbElWP2ULOCOnmJNrCEvjlA81fiyp0wk1vSaJPJ/rjsP0lA1sAk7S/QD+Olpg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.40.0.tgz",
+      "integrity": "sha512-DdFXqmRMLhCcGs32zN14hm4AztDuhG0b8yka8pzO+5GsYseifJnT/hfcqr/skPhtoDqA1qcQbucj1dciC0OQzg==",
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@earendil-works/pi-tui": "0.83.0",
-        "pi-subagents": "0.40.0",
+        "pi-subagents": "0.39.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
@@ -4336,9 +4336,9 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.40.0.tgz",
-      "integrity": "sha512-DdFXqmRMLhCcGs32zN14hm4AztDuhG0b8yka8pzO+5GsYseifJnT/hfcqr/skPhtoDqA1qcQbucj1dciC0OQzg==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.39.0.tgz",
+      "integrity": "sha512-CoocrMQ6XP5AdldB0JJsiKDAoveyYqycFLWDhJqLWzz+9GiV9NI6/UTWdME1fIzpHHyrCVOlQaDdNM9SE6Ig/Q==",
       "license": "MIT",
       "dependencies": {
         "jiti": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@earendil-works/pi-tui": "0.83.0",
-        "pi-subagents": "^0.25.0",
+        "pi-subagents": "0.37.2",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
       },
       "bin": {
@@ -506,6 +506,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
       "version": "0.83.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
+      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "^0.83.0",
@@ -516,12 +517,12 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.83.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -541,12 +542,12 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.83.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
+      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -554,8 +555,7 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",
@@ -3342,17 +3342,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3615,18 +3604,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mdurl": {
@@ -4359,22 +4336,23 @@
       }
     },
     "node_modules/pi-subagents": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.25.0.tgz",
-      "integrity": "sha512-HZK1RvT8zfQSzHRExhrnSKdhHmQeCxnpwjkf5dHQbWGcz9kk5C9Cb1rjElEM6CkOGp3eApMm3/HVi2EVYQX7OA==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/pi-subagents/-/pi-subagents-0.37.2.tgz",
+      "integrity": "sha512-pf7DxLBY9pFY3grOFgRfMqoS9QbElWP2ULOCOnmJNrCEvjlA81fiyp0wk1vSaJPJ/rjsP0lA1sAk7S/QD+Olpg==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-tui": "^0.74.0",
-        "jiti": "^2.7.0",
-        "typebox": "^1.1.24"
+        "jiti": "2.7.0",
+        "typebox": "1.1.38",
+        "yaml": "2.8.3"
       },
       "bin": {
         "pi-subagents": "install.mjs"
       },
       "peerDependencies": {
         "@earendil-works/pi-agent-core": "*",
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*"
+        "@earendil-works/pi-ai": ">=0.80.0",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-agent-core": {
@@ -4385,23 +4363,25 @@
         },
         "@earendil-works/pi-coding-agent": {
           "optional": true
+        },
+        "@earendil-works/pi-tui": {
+          "optional": true
         }
       }
     },
-    "node_modules/pi-subagents/node_modules/@earendil-works/pi-tui": {
-      "version": "0.74.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.2.tgz",
-      "integrity": "sha512-valQPz74qbdydRqII6t9rJ46YANMOOJeDhKm25a1ZrWvWwdjAaAEu6s3ur/LWz84Wkkwcbub2ZkVjzCZi8gFGA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12"
+    "node_modules/pi-subagents/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">= 14.6"
       },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@earendil-works/pi-tui": "0.83.0",
-    "pi-subagents": "0.40.0",
+    "pi-subagents": "0.39.0",
     "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@earendil-works/pi-tui": "0.83.0",
-    "pi-subagents": "^0.25.0",
+    "pi-subagents": "0.37.2",
     "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@earendil-works/pi-tui": "0.83.0",
-    "pi-subagents": "0.37.2",
+    "pi-subagents": "0.40.0",
     "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.0.3.tar.gz"
   }
 }

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -10,47 +10,6 @@ import { getRootPins, PI_PACKAGES } from "./pi-dependency-upgrade-lib.mjs";
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const PI_SUBAGENTS_PACKAGE = "pi-subagents";
-
-function assertPiSubagentsInstalled({
-  projectRequire,
-  nodeModulesDir,
-  rootPin,
-}) {
-  const packagePath = join(
-    nodeModulesDir,
-    PI_SUBAGENTS_PACKAGE,
-    "package.json",
-  );
-  if (!existsSync(packagePath)) {
-    throw new Error(`Could not locate ${packagePath}`);
-  }
-  const manifest = JSON.parse(readFileSync(packagePath, "utf8"));
-  if (manifest.version !== rootPin) {
-    throw new Error(
-      `${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} but package.json pins ${rootPin}`,
-    );
-  }
-  const packageRoot = dirname(packagePath);
-  const extensions = manifest.pi?.extensions;
-  if (!Array.isArray(extensions) || extensions.length === 0) {
-    throw new Error(
-      `${PI_SUBAGENTS_PACKAGE} manifest declares no Pi extensions`,
-    );
-  }
-  for (const extension of extensions) {
-    const extensionPath = join(packageRoot, extension);
-    if (!existsSync(extensionPath) || !statSync(extensionPath).isFile()) {
-      throw new Error(
-        `Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`,
-      );
-    }
-  }
-  projectRequire.resolve(`${PI_SUBAGENTS_PACKAGE}`);
-  console.log(
-    `${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} from ${packagePath}`,
-  );
-  return packageRoot;
-}
 
 function run(command, args, options = {}) {
   console.log(`$ ${[command, ...args].join(" ")}`);
@@ -150,13 +109,27 @@ async function main() {
       console.log(`${name} resolved ${resolved.version} from ${packagePath}`);
     }
 
-    const piSubagentsRoot = assertPiSubagentsInstalled({
-      projectRequire,
-      nodeModulesDir,
-      rootPin: rootPackageJson.dependencies?.[PI_SUBAGENTS_PACKAGE],
-    });
     const patchmillPackageRoot = dirname(
       projectRequire.resolve("patchmill/package.json"),
+    );
+    const compiledPiPackage = await import(
+      pathToFileURL(
+        join(
+          patchmillPackageRoot,
+          "dist",
+          "src",
+          "pi",
+          "pi-subagents-package.js",
+        ),
+      ).href
+    );
+    compiledPiPackage.assertInstalledPiSubagentsMatchesRootPin(
+      join(patchmillPackageRoot, "package.json"),
+    );
+    compiledPiPackage.piSubagentsExtensionFiles();
+    const piSubagentsRoot = compiledPiPackage.resolvePiSubagentsPackageRoot();
+    console.log(
+      `${PI_SUBAGENTS_PACKAGE} resolved ${compiledPiPackage.readInstalledPiSubagentsManifest().version} from ${join(piSubagentsRoot, "package.json")}`,
     );
     const { runOncePlanningPiProfile } = await import(
       pathToFileURL(

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -1,14 +1,42 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { getRootPins, PI_PACKAGES } from "./pi-dependency-upgrade-lib.mjs";
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const PI_SUBAGENTS_PACKAGE = "pi-subagents";
+
+function assertPiSubagentsInstalled({ projectRequire, nodeModulesDir, rootPin }) {
+  const packagePath = join(nodeModulesDir, PI_SUBAGENTS_PACKAGE, "package.json");
+  if (!existsSync(packagePath)) {
+    throw new Error(`Could not locate ${packagePath}`);
+  }
+  const manifest = JSON.parse(readFileSync(packagePath, "utf8"));
+  if (manifest.version !== rootPin) {
+    throw new Error(
+      `${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} but package.json pins ${rootPin}`,
+    );
+  }
+  const packageRoot = dirname(packagePath);
+  const extensions = manifest.pi?.extensions;
+  if (!Array.isArray(extensions) || extensions.length === 0) {
+    throw new Error(`${PI_SUBAGENTS_PACKAGE} manifest declares no Pi extensions`);
+  }
+  for (const extension of extensions) {
+    const extensionPath = join(packageRoot, extension);
+    if (!existsSync(extensionPath) || !statSync(extensionPath).isFile()) {
+      throw new Error(`Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`);
+    }
+  }
+  projectRequire.resolve(`${PI_SUBAGENTS_PACKAGE}`);
+  console.log(`${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} from ${packagePath}`);
+  return packageRoot;
+}
 
 function run(command, args, options = {}) {
   console.log(`$ ${[command, ...args].join(" ")}`);
@@ -84,9 +112,10 @@ async function main() {
       throw new Error(`Installed Patchmill skill is missing: ${skillPath}`);
     }
 
-    const rootPins = getRootPins(
-      JSON.parse(await readFile(join(rootDir, "package.json"), "utf8")),
+    const rootPackageJson = JSON.parse(
+      await readFile(join(rootDir, "package.json"), "utf8"),
     );
+    const rootPins = getRootPins(rootPackageJson);
     const projectRequire = createRequire(join(projectDir, "package.json"));
     const nodeModulesDir = dirname(
       dirname(projectRequire.resolve("patchmill/package.json")),
@@ -105,6 +134,44 @@ async function main() {
         );
       }
       console.log(`${name} resolved ${resolved.version} from ${packagePath}`);
+    }
+
+    const piSubagentsRoot = assertPiSubagentsInstalled({
+      projectRequire,
+      nodeModulesDir,
+      rootPin: rootPackageJson.dependencies?.[PI_SUBAGENTS_PACKAGE],
+    });
+    const patchmillPackageRoot = dirname(
+      projectRequire.resolve("patchmill/package.json"),
+    );
+    const { runOncePlanningPiProfile } = await import(
+      pathToFileURL(
+        join(patchmillPackageRoot, "dist", "src", "pi", "resource-profiles.js"),
+      ).href,
+    );
+    const skills = {
+      triage: "triage",
+      planning: "planning",
+      implementation: "implementation",
+      developmentEnvironment: "development-environment",
+      toolchain: "toolchain",
+      review: "review",
+      visualEvidence: "visual-evidence",
+      landing: "landing",
+    };
+    const profile = runOncePlanningPiProfile(skills, patchmillPackageRoot);
+    if (
+      realpathSync(profile.additionalExtensionPaths[0]) !==
+      realpathSync(piSubagentsRoot)
+    ) {
+      throw new Error("run-once profile does not load the installed pi-subagents package first");
+    }
+    if (
+      !profile.additionalExtensionPaths[1]
+        ?.replaceAll("\\", "/")
+        .endsWith("/extensions/todos.ts")
+    ) {
+      throw new Error("run-once profile does not load the Patchmill todos extension second");
     }
   } finally {
     if (process.env.PATCHMILL_KEEP_SMOKE_ARTIFACTS !== "1") {

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -11,8 +11,16 @@ import { getRootPins, PI_PACKAGES } from "./pi-dependency-upgrade-lib.mjs";
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const PI_SUBAGENTS_PACKAGE = "pi-subagents";
 
-function assertPiSubagentsInstalled({ projectRequire, nodeModulesDir, rootPin }) {
-  const packagePath = join(nodeModulesDir, PI_SUBAGENTS_PACKAGE, "package.json");
+function assertPiSubagentsInstalled({
+  projectRequire,
+  nodeModulesDir,
+  rootPin,
+}) {
+  const packagePath = join(
+    nodeModulesDir,
+    PI_SUBAGENTS_PACKAGE,
+    "package.json",
+  );
   if (!existsSync(packagePath)) {
     throw new Error(`Could not locate ${packagePath}`);
   }
@@ -25,16 +33,22 @@ function assertPiSubagentsInstalled({ projectRequire, nodeModulesDir, rootPin })
   const packageRoot = dirname(packagePath);
   const extensions = manifest.pi?.extensions;
   if (!Array.isArray(extensions) || extensions.length === 0) {
-    throw new Error(`${PI_SUBAGENTS_PACKAGE} manifest declares no Pi extensions`);
+    throw new Error(
+      `${PI_SUBAGENTS_PACKAGE} manifest declares no Pi extensions`,
+    );
   }
   for (const extension of extensions) {
     const extensionPath = join(packageRoot, extension);
     if (!existsSync(extensionPath) || !statSync(extensionPath).isFile()) {
-      throw new Error(`Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`);
+      throw new Error(
+        `Missing ${PI_SUBAGENTS_PACKAGE} extension: ${extensionPath}`,
+      );
     }
   }
   projectRequire.resolve(`${PI_SUBAGENTS_PACKAGE}`);
-  console.log(`${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} from ${packagePath}`);
+  console.log(
+    `${PI_SUBAGENTS_PACKAGE} resolved ${manifest.version} from ${packagePath}`,
+  );
   return packageRoot;
 }
 
@@ -147,7 +161,7 @@ async function main() {
     const { runOncePlanningPiProfile } = await import(
       pathToFileURL(
         join(patchmillPackageRoot, "dist", "src", "pi", "resource-profiles.js"),
-      ).href,
+      ).href
     );
     const skills = {
       triage: "triage",
@@ -164,14 +178,18 @@ async function main() {
       realpathSync(profile.additionalExtensionPaths[0]) !==
       realpathSync(piSubagentsRoot)
     ) {
-      throw new Error("run-once profile does not load the installed pi-subagents package first");
+      throw new Error(
+        "run-once profile does not load the installed pi-subagents package first",
+      );
     }
     if (
       !profile.additionalExtensionPaths[1]
         ?.replaceAll("\\", "/")
         .endsWith("/extensions/todos.ts")
     ) {
-      throw new Error("run-once profile does not load the Patchmill todos extension second");
+      throw new Error(
+        "run-once profile does not load the Patchmill todos extension second",
+      );
     }
   } finally {
     if (process.env.PATCHMILL_KEEP_SMOKE_ARTIFACTS !== "1") {

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -16,7 +16,8 @@ export function collectSubagentEvents(events) {
     partials: events
       .filter(
         (event) =>
-          event.type === "tool_execution_update" && event.toolName === "subagent",
+          event.type === "tool_execution_update" &&
+          event.toolName === "subagent",
       )
       .map((event) => event.partialResult),
     finals: events
@@ -41,7 +42,15 @@ function childIdentity(row) {
     : undefined;
 }
 
-function validateChild({ child, id, label, expectedModel, expectedThinking, requireThinking, partial }) {
+function validateChild({
+  child,
+  id,
+  label,
+  expectedModel,
+  expectedThinking,
+  requireThinking,
+  partial,
+}) {
   const prefix = partial ? "partial child" : "child";
   if (id === undefined) {
     throw new Error(`${label}: ${prefix} missing upstream identity`);
@@ -50,10 +59,14 @@ function validateChild({ child, id, label, expectedModel, expectedThinking, requ
     throw new Error(`${label}: ${prefix} ${id} missing model ${expectedModel}`);
   }
   if (requireThinking && child?.thinking !== expectedThinking) {
-    throw new Error(`${label}: ${prefix} ${id} missing thinking ${expectedThinking}`);
+    throw new Error(
+      `${label}: ${prefix} ${id} missing thinking ${expectedThinking}`,
+    );
   }
   if (!requireThinking && "thinking" in child) {
-    throw new Error(`${label}: ${prefix} ${id} expected thinking absence but found ${child.thinking}`);
+    throw new Error(
+      `${label}: ${prefix} ${id} expected thinking absence but found ${child.thinking}`,
+    );
   }
 }
 
@@ -85,7 +98,9 @@ export function validateShapeContract(options) {
     options.requireUniqueSiblingIds &&
     new Set(finalIds).size !== finalIds.length
   ) {
-    throw new Error(`${options.label}: duplicate upstream identity in final children`);
+    throw new Error(
+      `${options.label}: duplicate upstream identity in final children`,
+    );
   }
   if (options.shape.partials.length === 0) {
     console.log(`${options.label}: upstream emitted no partial results`);
@@ -117,10 +132,16 @@ export function validateShapeContract(options) {
 }
 
 function readRootPin() {
-  const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8"));
+  const packageJson = JSON.parse(
+    readFileSync(join(rootDir, "package.json"), "utf8"),
+  );
   const pin = packageJson.dependencies?.["pi-subagents"];
-  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(pin ?? "")) {
-    throw new Error(`pi-subagents must be an exact root pin; found ${pin ?? "missing"}`);
+  if (
+    !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(pin ?? "")
+  ) {
+    throw new Error(
+      `pi-subagents must be an exact root pin; found ${pin ?? "missing"}`,
+    );
   }
   return pin;
 }
@@ -131,16 +152,20 @@ function resolvePiSubagentsRoot() {
 
 function assertInstalledPackage(pin, packageRoot) {
   const manifestPath = join(packageRoot, "package.json");
-  if (!existsSync(manifestPath)) throw new Error(`missing pi-subagents manifest: ${manifestPath}`);
+  if (!existsSync(manifestPath))
+    throw new Error(`missing pi-subagents manifest: ${manifestPath}`);
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
   if (manifest.version !== pin) {
-    throw new Error(`pi-subagents resolved ${manifest.version} but root pins ${pin}`);
+    throw new Error(
+      `pi-subagents resolved ${manifest.version} but root pins ${pin}`,
+    );
   }
 }
 
 function requiredEnvironment(name) {
   const value = process.env[name];
-  if (!value) throw new Error(`${name} is required for live child metadata validation`);
+  if (!value)
+    throw new Error(`${name} is required for live child metadata validation`);
   return value;
 }
 
@@ -168,7 +193,18 @@ function parseJsonLines(output, label) {
   return events;
 }
 
-function runShape({ label, input, expectedFinalChildren, expectedModel, expectedThinking, requireThinking, cwd, agentsDir, packageRoot, parentModel }) {
+function runShape({
+  label,
+  input,
+  expectedFinalChildren,
+  expectedModel,
+  expectedThinking,
+  requireThinking,
+  cwd,
+  agentsDir,
+  packageRoot,
+  parentModel,
+}) {
   const args = [
     "--mode",
     "json",
@@ -181,9 +217,13 @@ function runShape({ label, input, expectedFinalChildren, expectedModel, expected
     packageRoot,
   ];
   if (parentModel) args.push("--model", parentModel);
-  args.push(`Call the subagent tool exactly once with this input and then stop:\n${JSON.stringify(input)}`);
+  args.push(
+    `Call the subagent tool exactly once with this input and then stop:\n${JSON.stringify(input)}`,
+  );
   const environment = Object.fromEntries(
-    Object.entries(process.env).filter(([name]) => !name.startsWith("PI_SUBAGENT_")),
+    Object.entries(process.env).filter(
+      ([name]) => !name.startsWith("PI_SUBAGENT_"),
+    ),
   );
   environment.PI_SUBAGENT_EXTRA_AGENT_DIRS = agentsDir;
   const result = spawnSync(join(rootDir, "node_modules", ".bin", "pi"), args, {
@@ -195,7 +235,9 @@ function runShape({ label, input, expectedFinalChildren, expectedModel, expected
   });
   const rawOutput = `${result.stdout}\n${result.stderr}`;
   if (result.error || result.status !== 0) {
-    throw new Error(`${label}: Pi command failed: ${result.error?.message ?? `exit ${result.status}`}\n${rawOutput}`);
+    throw new Error(
+      `${label}: Pi command failed: ${result.error?.message ?? `exit ${result.status}`}\n${rawOutput}`,
+    );
   }
   const shape = collectSubagentEvents(parseJsonLines(result.stdout, label));
   try {
@@ -213,7 +255,9 @@ function runShape({ label, input, expectedFinalChildren, expectedModel, expected
       `${label}: ${error instanceof Error ? error.message : String(error)}\nRaw Pi output:\n${rawOutput}`,
     );
   }
-  console.log(`${label}: ${requireThinking ? "metadata contract passed" : "absence contract passed"}`);
+  console.log(
+    `${label}: ${requireThinking ? "metadata contract passed" : "absence contract passed"}`,
+  );
 }
 
 async function main() {
@@ -221,21 +265,37 @@ async function main() {
   const packageRoot = resolvePiSubagentsRoot();
   assertInstalledPackage(pin, packageRoot);
   const model = requiredEnvironment("PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL");
-  const thinking = process.env.PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING ?? "low";
-  const noThinkingModel = requiredEnvironment("PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL");
+  const thinking =
+    process.env.PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING ?? "low";
+  const noThinkingModel = requiredEnvironment(
+    "PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL",
+  );
   const parentModel = process.env.PATCHMILL_PI_SUBAGENTS_PARENT_MODEL;
   const cwd = await mkdtemp(join(tmpdir(), "patchmill-pi-subagents-contract-"));
   try {
     const agentsDir = join(cwd, ".pi", "agents");
     const legacyAgentsDir = join(cwd, ".agents");
-    await Promise.all([mkdir(agentsDir, { recursive: true }), mkdir(legacyAgentsDir)]);
-    const thinkingAgent = agentDefinition({ name: "contract-thinking", model, thinking });
-    const noThinkingAgent = agentDefinition({ name: "contract-no-thinking", model: noThinkingModel });
+    await Promise.all([
+      mkdir(agentsDir, { recursive: true }),
+      mkdir(legacyAgentsDir),
+    ]);
+    const thinkingAgent = agentDefinition({
+      name: "contract-thinking",
+      model,
+      thinking,
+    });
+    const noThinkingAgent = agentDefinition({
+      name: "contract-no-thinking",
+      model: noThinkingModel,
+    });
     await Promise.all([
       writeFile(join(agentsDir, "contract-thinking.md"), thinkingAgent),
       writeFile(join(agentsDir, "contract-no-thinking.md"), noThinkingAgent),
       writeFile(join(legacyAgentsDir, "contract-thinking.md"), thinkingAgent),
-      writeFile(join(legacyAgentsDir, "contract-no-thinking.md"), noThinkingAgent),
+      writeFile(
+        join(legacyAgentsDir, "contract-no-thinking.md"),
+        noThinkingAgent,
+      ),
     ]);
     const common = {
       cwd,
@@ -246,11 +306,82 @@ async function main() {
       requireThinking: true,
       parentModel,
     };
-    runShape({ ...common, label: "direct", expectedFinalChildren: 1, input: { agent: "contract-thinking", task: "Return the word direct.", context: "fresh" } });
-    runShape({ ...common, label: "counted", expectedFinalChildren: 2, input: { tasks: [{ agent: "contract-thinking", task: "Return the word counted.", count: 2 }], concurrency: 2, context: "fresh" } });
-    runShape({ ...common, label: "parallel", expectedFinalChildren: 3, input: { tasks: [{ agent: "contract-thinking", task: "Return parallel a." }, { agent: "contract-thinking", task: "Return repeated parallel.", count: 2 }], concurrency: 2, context: "fresh" } });
-    runShape({ ...common, label: "chain", expectedFinalChildren: 3, input: { chain: [{ agent: "contract-thinking", task: "Return chain step one." }, { parallel: [{ agent: "contract-thinking", task: "Return chain fanout a." }, { agent: "contract-thinking", task: "Return chain fanout b." }] }], context: "fresh", clarify: false } });
-    runShape({ cwd, agentsDir, packageRoot, parentModel, label: "no-thinking", expectedFinalChildren: 1, expectedModel: noThinkingModel, requireThinking: false, input: { agent: "contract-no-thinking", task: "Return the words no thinking.", context: "fresh" } });
+    runShape({
+      ...common,
+      label: "direct",
+      expectedFinalChildren: 1,
+      input: {
+        agent: "contract-thinking",
+        task: "Return the word direct.",
+        context: "fresh",
+      },
+    });
+    runShape({
+      ...common,
+      label: "counted",
+      expectedFinalChildren: 2,
+      input: {
+        tasks: [
+          {
+            agent: "contract-thinking",
+            task: "Return the word counted.",
+            count: 2,
+          },
+        ],
+        concurrency: 2,
+        context: "fresh",
+      },
+    });
+    runShape({
+      ...common,
+      label: "parallel",
+      expectedFinalChildren: 3,
+      input: {
+        tasks: [
+          { agent: "contract-thinking", task: "Return parallel a." },
+          {
+            agent: "contract-thinking",
+            task: "Return repeated parallel.",
+            count: 2,
+          },
+        ],
+        concurrency: 2,
+        context: "fresh",
+      },
+    });
+    runShape({
+      ...common,
+      label: "chain",
+      expectedFinalChildren: 3,
+      input: {
+        chain: [
+          { agent: "contract-thinking", task: "Return chain step one." },
+          {
+            parallel: [
+              { agent: "contract-thinking", task: "Return chain fanout a." },
+              { agent: "contract-thinking", task: "Return chain fanout b." },
+            ],
+          },
+        ],
+        context: "fresh",
+        clarify: false,
+      },
+    });
+    runShape({
+      cwd,
+      agentsDir,
+      packageRoot,
+      parentModel,
+      label: "no-thinking",
+      expectedFinalChildren: 1,
+      expectedModel: noThinkingModel,
+      requireThinking: false,
+      input: {
+        agent: "contract-no-thinking",
+        task: "Return the words no thinking.",
+        context: "fresh",
+      },
+    });
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  assertInstalledPiSubagentsMatchesRootPin,
+  piSubagentsExtensionFiles,
+  readRootPiSubagentsPin,
+  resolvePiSubagentsPackageRoot,
+} from "../src/pi/pi-subagents-package.ts";
 
-const require = createRequire(import.meta.url);
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
 export function collectSubagentEvents(events) {
@@ -154,37 +157,6 @@ export function validateShapeContract(options) {
   }
 }
 
-function readRootPin() {
-  const packageJson = JSON.parse(
-    readFileSync(join(rootDir, "package.json"), "utf8"),
-  );
-  const pin = packageJson.dependencies?.["pi-subagents"];
-  if (
-    !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(pin ?? "")
-  ) {
-    throw new Error(
-      `pi-subagents must be an exact root pin; found ${pin ?? "missing"}`,
-    );
-  }
-  return pin;
-}
-
-function resolvePiSubagentsRoot() {
-  return dirname(require.resolve("pi-subagents"));
-}
-
-function assertInstalledPackage(pin, packageRoot) {
-  const manifestPath = join(packageRoot, "package.json");
-  if (!existsSync(manifestPath))
-    throw new Error(`missing pi-subagents manifest: ${manifestPath}`);
-  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  if (manifest.version !== pin) {
-    throw new Error(
-      `pi-subagents resolved ${manifest.version} but root pins ${pin}`,
-    );
-  }
-}
-
 function requiredEnvironment(name) {
   const value = process.env[name];
   if (!value)
@@ -285,9 +257,10 @@ function runShape({
 }
 
 async function main() {
-  const pin = readRootPin();
-  const packageRoot = resolvePiSubagentsRoot();
-  assertInstalledPackage(pin, packageRoot);
+  readRootPiSubagentsPin(join(rootDir, "package.json"));
+  assertInstalledPiSubagentsMatchesRootPin(join(rootDir, "package.json"));
+  piSubagentsExtensionFiles();
+  const packageRoot = resolvePiSubagentsPackageRoot();
   const model = requiredEnvironment("PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL");
   const thinking =
     process.env.PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING ?? "low";

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -12,6 +12,10 @@ const require = createRequire(import.meta.url);
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
 export function collectSubagentEvents(events) {
+  const subagentFinals = events.filter(
+    (event) =>
+      event.type === "tool_execution_end" && event.toolName === "subagent",
+  );
   return {
     partials: events
       .filter(
@@ -20,15 +24,14 @@ export function collectSubagentEvents(events) {
           event.toolName === "subagent",
       )
       .map((event) => event.partialResult),
-    finals: events
+    finals: subagentFinals
       .filter(
-        (event) =>
-          event.type === "tool_execution_end" &&
-          event.toolName === "subagent" &&
-          event.isError !== true &&
-          event.result?.isError !== true,
+        (event) => event.isError !== true && event.result?.isError !== true,
       )
       .map((event) => event.result),
+    failures: subagentFinals.filter(
+      (event) => event.isError === true || event.result?.isError === true,
+    ),
   };
 }
 
@@ -90,6 +93,11 @@ function assertPartialIdsInFinalOrder(label, partialIds, finalIds) {
 }
 
 export function validateShapeContract(options) {
+  assert.equal(
+    options.shape.failures?.length ?? 0,
+    0,
+    `${options.label}: expected no failed subagent tool results`,
+  );
   assert.equal(
     options.shape.finals.length,
     1,

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -36,12 +36,16 @@ function childRows(result) {
 }
 
 function childIdentity(row) {
-  return row?.id;
+  return Number.isSafeInteger(row?.index) && row.index >= 0
+    ? row.index
+    : undefined;
 }
 
 function validateChild({ child, id, label, expectedModel, expectedThinking, requireThinking, partial }) {
   const prefix = partial ? "partial child" : "child";
-  if (!id) throw new Error(`${label}: ${prefix} missing upstream identity`);
+  if (id === undefined) {
+    throw new Error(`${label}: ${prefix} missing upstream identity`);
+  }
   if (child?.model !== expectedModel) {
     throw new Error(`${label}: ${prefix} ${id} missing model ${expectedModel}`);
   }

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -144,6 +144,12 @@ function requiredEnvironment(name) {
   return value;
 }
 
+// pi-subagents reports the exact Pi model argument it launches. This fixture
+// explicitly selects its thinking level instead of relying on parent settings.
+export function reportedThinkingModel(model, thinking) {
+  return `${model}:${thinking}`;
+}
+
 function agentDefinition({ name, model, thinking }) {
   return `---\nname: ${name}\ndescription: Contract fixture agent for pi-subagents metadata validation\nmodel: ${model}\n${thinking ? `thinking: ${thinking}\n` : ""}tools: bash\nsystemPromptMode: replace\ninheritProjectContext: false\ninheritSkills: false\n---\n\nReturn exactly the short text requested by the parent. Do not call tools.\n`;
 }
@@ -231,7 +237,15 @@ async function main() {
       writeFile(join(legacyAgentsDir, "contract-thinking.md"), thinkingAgent),
       writeFile(join(legacyAgentsDir, "contract-no-thinking.md"), noThinkingAgent),
     ]);
-    const common = { cwd, agentsDir, packageRoot, expectedModel: model, expectedThinking: thinking, requireThinking: true, parentModel };
+    const common = {
+      cwd,
+      agentsDir,
+      packageRoot,
+      expectedModel: reportedThinkingModel(model, thinking),
+      expectedThinking: thinking,
+      requireThinking: true,
+      parentModel,
+    };
     runShape({ ...common, label: "direct", expectedFinalChildren: 1, input: { agent: "contract-thinking", task: "Return the word direct.", context: "fresh" } });
     runShape({ ...common, label: "counted", expectedFinalChildren: 2, input: { tasks: [{ agent: "contract-thinking", task: "Return the word counted.", count: 2 }], concurrency: 2, context: "fresh" } });
     runShape({ ...common, label: "parallel", expectedFinalChildren: 3, input: { tasks: [{ agent: "contract-thinking", task: "Return parallel a." }, { agent: "contract-thinking", task: "Return repeated parallel.", count: 2 }], concurrency: 2, context: "fresh" } });

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -70,6 +70,19 @@ function validateChild({
   }
 }
 
+function assertPartialIdsInFinalOrder(label, partialIds, finalIds) {
+  let searchStart = 0;
+  for (const partialId of partialIds) {
+    const finalIndex = finalIds.indexOf(partialId, searchStart);
+    if (finalIndex === -1) {
+      throw new Error(
+        `${label}: partial child identity ${partialId} missing from final children or out of order`,
+      );
+    }
+    searchStart = finalIndex + 1;
+  }
+}
+
 export function validateShapeContract(options) {
   assert.equal(
     options.shape.finals.length,
@@ -123,11 +136,7 @@ export function validateShapeContract(options) {
         partial: true,
       }),
     );
-    assert.deepEqual(
-      partialIds,
-      finalIds.slice(0, partialIds.length),
-      `${options.label}: partial and final child ordering differs`,
-    );
+    assertPartialIdsInFinalOrder(options.label, partialIds, finalIds);
   }
 }
 

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -25,7 +25,8 @@ export function collectSubagentEvents(events) {
         (event) =>
           event.type === "tool_execution_end" &&
           event.toolName === "subagent" &&
-          event.isError !== true,
+          event.isError !== true &&
+          event.result?.isError !== true,
       )
       .map((event) => event.result),
   };
@@ -54,6 +55,11 @@ function validateChild({
   const prefix = partial ? "partial child" : "child";
   if (id === undefined) {
     throw new Error(`${label}: ${prefix} missing upstream identity`);
+  }
+  if (child?.exitCode !== undefined && child.exitCode !== 0) {
+    throw new Error(
+      `${label}: ${prefix} ${id} exited with code ${child.exitCode}`,
+    );
   }
   if (child?.model !== expectedModel) {
     throw new Error(`${label}: ${prefix} ${id} missing model ${expectedModel}`);

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export function collectSubagentEvents(events) {
+  return {
+    partials: events
+      .filter(
+        (event) =>
+          event.type === "tool_execution_update" && event.toolName === "subagent",
+      )
+      .map((event) => event.partialResult),
+    finals: events
+      .filter(
+        (event) =>
+          event.type === "tool_execution_end" &&
+          event.toolName === "subagent" &&
+          event.isError !== true,
+      )
+      .map((event) => event.result),
+  };
+}
+
+function childRows(result) {
+  if (Array.isArray(result?.details?.results)) return result.details.results;
+  throw new Error("subagent result missing details.results child rows");
+}
+
+function childIdentity(row) {
+  return row?.id;
+}
+
+function validateChild({ child, id, label, expectedModel, expectedThinking, requireThinking, partial }) {
+  const prefix = partial ? "partial child" : "child";
+  if (!id) throw new Error(`${label}: ${prefix} missing upstream identity`);
+  if (child?.model !== expectedModel) {
+    throw new Error(`${label}: ${prefix} ${id} missing model ${expectedModel}`);
+  }
+  if (requireThinking && child?.thinking !== expectedThinking) {
+    throw new Error(`${label}: ${prefix} ${id} missing thinking ${expectedThinking}`);
+  }
+  if (!requireThinking && "thinking" in child) {
+    throw new Error(`${label}: ${prefix} ${id} expected thinking absence but found ${child.thinking}`);
+  }
+}
+
+export function validateShapeContract(options) {
+  assert.equal(
+    options.shape.finals.length,
+    1,
+    `${options.label}: expected exactly one final subagent tool result`,
+  );
+  const finalChildren = options.shape.finals.flatMap(childRows);
+  if (finalChildren.length !== options.expectedFinalChildren) {
+    throw new Error(
+      `${options.label}: expected exactly ${options.expectedFinalChildren} final children, got ${finalChildren.length}`,
+    );
+  }
+  const finalIds = finalChildren.map(childIdentity);
+  finalChildren.forEach((child, index) =>
+    validateChild({
+      child,
+      id: finalIds[index],
+      label: options.label,
+      expectedModel: options.expectedModel,
+      expectedThinking: options.expectedThinking,
+      requireThinking: options.requireThinking,
+      partial: false,
+    }),
+  );
+  if (
+    options.requireUniqueSiblingIds &&
+    new Set(finalIds).size !== finalIds.length
+  ) {
+    throw new Error(`${options.label}: duplicate upstream identity in final children`);
+  }
+  if (options.shape.partials.length === 0) {
+    console.log(`${options.label}: upstream emitted no partial results`);
+  }
+  for (const partial of options.shape.partials) {
+    const partialChildren = childRows(partial);
+    const partialIds = partialChildren.map(childIdentity);
+    if (partialIds.length === 0) {
+      console.log(`${options.label}: partial result contained no child rows`);
+      continue;
+    }
+    partialChildren.forEach((child, index) =>
+      validateChild({
+        child,
+        id: partialIds[index],
+        label: options.label,
+        expectedModel: options.expectedModel,
+        expectedThinking: options.expectedThinking,
+        requireThinking: options.requireThinking,
+        partial: true,
+      }),
+    );
+    assert.deepEqual(
+      partialIds,
+      finalIds.slice(0, partialIds.length),
+      `${options.label}: partial and final child ordering differs`,
+    );
+  }
+}
+
+function readRootPin() {
+  const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8"));
+  const pin = packageJson.dependencies?.["pi-subagents"];
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(pin ?? "")) {
+    throw new Error(`pi-subagents must be an exact root pin; found ${pin ?? "missing"}`);
+  }
+  return pin;
+}
+
+function resolvePiSubagentsRoot() {
+  return dirname(require.resolve("pi-subagents"));
+}
+
+function assertInstalledPackage(pin, packageRoot) {
+  const manifestPath = join(packageRoot, "package.json");
+  if (!existsSync(manifestPath)) throw new Error(`missing pi-subagents manifest: ${manifestPath}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (manifest.version !== pin) {
+    throw new Error(`pi-subagents resolved ${manifest.version} but root pins ${pin}`);
+  }
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required for live child metadata validation`);
+  return value;
+}
+
+function agentDefinition({ name, model, thinking }) {
+  return `---\nname: ${name}\nmodel: ${model}\n${thinking ? `thinking: ${thinking}\n` : ""}tools: bash\nsystemPromptMode: replace\ninheritProjectContext: false\ninheritSkills: false\n---\n\nReturn exactly the short text requested by the parent. Do not call tools.\n`;
+}
+
+function parseJsonLines(output, label) {
+  const events = [];
+  for (const line of output.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // Pi may emit non-protocol diagnostics on stderr; stdout protocol rows are JSON.
+      throw new Error(`${label}: Pi emitted non-JSON stdout: ${line}`);
+    }
+  }
+  return events;
+}
+
+function runShape({ label, input, expectedFinalChildren, expectedModel, expectedThinking, requireThinking, cwd, packageRoot, parentModel }) {
+  const args = [
+    "--mode",
+    "json",
+    "--print",
+    "--no-session",
+    "--approve",
+    "--no-prompt-templates",
+    "-e",
+    packageRoot,
+  ];
+  if (parentModel) args.push("--model", parentModel);
+  args.push(`Call the subagent tool exactly once with this input and then stop:\n${JSON.stringify(input)}`);
+  const environment = Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !name.startsWith("PI_SUBAGENT_")),
+  );
+  const result = spawnSync(join(rootDir, "node_modules", ".bin", "pi"), args, {
+    cwd,
+    env: environment,
+    encoding: "utf8",
+    timeout: 180_000,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const rawOutput = `${result.stdout}\n${result.stderr}`;
+  if (result.error || result.status !== 0) {
+    throw new Error(`${label}: Pi command failed: ${result.error?.message ?? `exit ${result.status}`}\n${rawOutput}`);
+  }
+  const shape = collectSubagentEvents(parseJsonLines(result.stdout, label));
+  try {
+    validateShapeContract({
+      label,
+      expectedModel,
+      expectedThinking,
+      expectedFinalChildren,
+      requireUniqueSiblingIds: expectedFinalChildren > 1,
+      requireThinking,
+      shape,
+    });
+  } catch (error) {
+    throw new Error(
+      `${label}: ${error instanceof Error ? error.message : String(error)}\nRaw Pi output:\n${rawOutput}`,
+    );
+  }
+  console.log(`${label}: ${requireThinking ? "metadata contract passed" : "absence contract passed"}`);
+}
+
+async function main() {
+  const pin = readRootPin();
+  const packageRoot = resolvePiSubagentsRoot();
+  assertInstalledPackage(pin, packageRoot);
+  const model = requiredEnvironment("PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL");
+  const thinking = process.env.PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING ?? "low";
+  const noThinkingModel = requiredEnvironment("PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL");
+  const parentModel = process.env.PATCHMILL_PI_SUBAGENTS_PARENT_MODEL;
+  const cwd = await mkdtemp(join(tmpdir(), "patchmill-pi-subagents-contract-"));
+  try {
+    const agentsDir = join(cwd, ".pi", "agents");
+    const legacyAgentsDir = join(cwd, ".agents");
+    await Promise.all([mkdir(agentsDir, { recursive: true }), mkdir(legacyAgentsDir)]);
+    const thinkingAgent = agentDefinition({ name: "contract-thinking", model, thinking });
+    const noThinkingAgent = agentDefinition({ name: "contract-no-thinking", model: noThinkingModel });
+    await Promise.all([
+      writeFile(join(agentsDir, "contract-thinking.md"), thinkingAgent),
+      writeFile(join(agentsDir, "contract-no-thinking.md"), noThinkingAgent),
+      writeFile(join(legacyAgentsDir, "contract-thinking.md"), thinkingAgent),
+      writeFile(join(legacyAgentsDir, "contract-no-thinking.md"), noThinkingAgent),
+    ]);
+    const common = { cwd, packageRoot, expectedModel: model, expectedThinking: thinking, requireThinking: true, parentModel };
+    runShape({ ...common, label: "direct", expectedFinalChildren: 1, input: { agent: "contract-thinking", task: "Return the word direct.", context: "fresh" } });
+    runShape({ ...common, label: "counted", expectedFinalChildren: 2, input: { tasks: [{ agent: "contract-thinking", task: "Return the word counted.", count: 2 }], concurrency: 2, context: "fresh" } });
+    runShape({ ...common, label: "parallel", expectedFinalChildren: 3, input: { tasks: [{ agent: "contract-thinking", task: "Return parallel a." }, { agent: "contract-thinking", task: "Return repeated parallel.", count: 2 }], concurrency: 2, context: "fresh" } });
+    runShape({ ...common, label: "chain", expectedFinalChildren: 3, input: { chain: [{ agent: "contract-thinking", task: "Return chain step one." }, { parallel: [{ agent: "contract-thinking", task: "Return chain fanout a." }, { agent: "contract-thinking", task: "Return chain fanout b." }] }], context: "fresh", clarify: false } });
+    runShape({ cwd, packageRoot, parentModel, label: "no-thinking", expectedFinalChildren: 1, expectedModel: noThinkingModel, requireThinking: false, input: { agent: "contract-no-thinking", task: "Return the words no thinking.", context: "fresh" } });
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -141,7 +141,7 @@ function requiredEnvironment(name) {
 }
 
 function agentDefinition({ name, model, thinking }) {
-  return `---\nname: ${name}\nmodel: ${model}\n${thinking ? `thinking: ${thinking}\n` : ""}tools: bash\nsystemPromptMode: replace\ninheritProjectContext: false\ninheritSkills: false\n---\n\nReturn exactly the short text requested by the parent. Do not call tools.\n`;
+  return `---\nname: ${name}\ndescription: Contract fixture agent for pi-subagents metadata validation\nmodel: ${model}\n${thinking ? `thinking: ${thinking}\n` : ""}tools: bash\nsystemPromptMode: replace\ninheritProjectContext: false\ninheritSkills: false\n---\n\nReturn exactly the short text requested by the parent. Do not call tools.\n`;
 }
 
 function parseJsonLines(output, label) {
@@ -158,13 +158,14 @@ function parseJsonLines(output, label) {
   return events;
 }
 
-function runShape({ label, input, expectedFinalChildren, expectedModel, expectedThinking, requireThinking, cwd, packageRoot, parentModel }) {
+function runShape({ label, input, expectedFinalChildren, expectedModel, expectedThinking, requireThinking, cwd, agentsDir, packageRoot, parentModel }) {
   const args = [
     "--mode",
     "json",
     "--print",
     "--no-session",
     "--approve",
+    "-ne",
     "--no-prompt-templates",
     "-e",
     packageRoot,
@@ -174,6 +175,7 @@ function runShape({ label, input, expectedFinalChildren, expectedModel, expected
   const environment = Object.fromEntries(
     Object.entries(process.env).filter(([name]) => !name.startsWith("PI_SUBAGENT_")),
   );
+  environment.PI_SUBAGENT_EXTRA_AGENT_DIRS = agentsDir;
   const result = spawnSync(join(rootDir, "node_modules", ".bin", "pi"), args, {
     cwd,
     env: environment,
@@ -225,12 +227,12 @@ async function main() {
       writeFile(join(legacyAgentsDir, "contract-thinking.md"), thinkingAgent),
       writeFile(join(legacyAgentsDir, "contract-no-thinking.md"), noThinkingAgent),
     ]);
-    const common = { cwd, packageRoot, expectedModel: model, expectedThinking: thinking, requireThinking: true, parentModel };
+    const common = { cwd, agentsDir, packageRoot, expectedModel: model, expectedThinking: thinking, requireThinking: true, parentModel };
     runShape({ ...common, label: "direct", expectedFinalChildren: 1, input: { agent: "contract-thinking", task: "Return the word direct.", context: "fresh" } });
     runShape({ ...common, label: "counted", expectedFinalChildren: 2, input: { tasks: [{ agent: "contract-thinking", task: "Return the word counted.", count: 2 }], concurrency: 2, context: "fresh" } });
     runShape({ ...common, label: "parallel", expectedFinalChildren: 3, input: { tasks: [{ agent: "contract-thinking", task: "Return parallel a." }, { agent: "contract-thinking", task: "Return repeated parallel.", count: 2 }], concurrency: 2, context: "fresh" } });
     runShape({ ...common, label: "chain", expectedFinalChildren: 3, input: { chain: [{ agent: "contract-thinking", task: "Return chain step one." }, { parallel: [{ agent: "contract-thinking", task: "Return chain fanout a." }, { agent: "contract-thinking", task: "Return chain fanout b." }] }], context: "fresh", clarify: false } });
-    runShape({ cwd, packageRoot, parentModel, label: "no-thinking", expectedFinalChildren: 1, expectedModel: noThinkingModel, requireThinking: false, input: { agent: "contract-no-thinking", task: "Return the words no thinking.", context: "fresh" } });
+    runShape({ cwd, agentsDir, packageRoot, parentModel, label: "no-thinking", expectedFinalChildren: 1, expectedModel: noThinkingModel, requireThinking: false, input: { agent: "contract-no-thinking", task: "Return the words no thinking.", context: "fresh" } });
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -234,6 +234,7 @@ function runShape({
     "--print",
     "--no-session",
     "--approve",
+    "--no-context-files",
     "-ne",
     "--no-prompt-templates",
     "-e",

--- a/scripts/verify-pi-subagents-child-metadata.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.mjs
@@ -43,6 +43,12 @@ function childRows(result) {
   throw new Error("subagent result missing details.results child rows");
 }
 
+function resultRunId(result) {
+  const runId = result?.details?.runId;
+  if (typeof runId === "string" && runId.trim().length > 0) return runId;
+  throw new Error("subagent result missing details.runId");
+}
+
 function childIdentity(row) {
   return Number.isSafeInteger(row?.index) && row.index >= 0
     ? row.index
@@ -106,6 +112,7 @@ export function validateShapeContract(options) {
     1,
     `${options.label}: expected exactly one final subagent tool result`,
   );
+  const finalRunId = resultRunId(options.shape.finals[0]);
   const finalChildren = options.shape.finals.flatMap(childRows);
   if (finalChildren.length !== options.expectedFinalChildren) {
     throw new Error(
@@ -136,6 +143,12 @@ export function validateShapeContract(options) {
     console.log(`${options.label}: upstream emitted no partial results`);
   }
   for (const partial of options.shape.partials) {
+    const partialRunId = resultRunId(partial);
+    if (partialRunId !== finalRunId) {
+      throw new Error(
+        `${options.label}: partial runId ${partialRunId} does not match final runId ${finalRunId}`,
+      );
+    }
     const partialChildren = childRows(partial);
     const partialIds = partialChildren.map(childIdentity);
     if (partialIds.length === 0) {

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -171,6 +171,72 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
   );
 });
 
+test("validateShapeContract rejects failed tool results and child exits", () => {
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "failed-tool-result",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 1,
+        requireUniqueSiblingIds: false,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: {
+              isError: true,
+              details: {
+                results: [
+                  {
+                    index: 0,
+                    model: "provider/model-a",
+                    thinking: "low",
+                    exitCode: 1,
+                  },
+                ],
+              },
+            },
+            isError: false,
+          },
+        ]),
+      }),
+    /expected exactly one final subagent tool result/u,
+  );
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "failed-child-exit",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 1,
+        requireUniqueSiblingIds: false,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: {
+              details: {
+                results: [
+                  {
+                    index: 0,
+                    model: "provider/model-a",
+                    thinking: "low",
+                    exitCode: 1,
+                  },
+                ],
+              },
+            },
+            isError: false,
+          },
+        ]),
+      }),
+    /exited with code 1/u,
+  );
+});
+
 test("validateShapeContract preserves legitimate thinking absence", () => {
   const shape = collectSubagentEvents([
     {

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -82,7 +82,9 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
             type: "tool_execution_end",
             toolName: "subagent",
             result: {
-              details: { results: [{ model: "provider/model-a", thinking: "low" }] },
+              details: {
+                results: [{ model: "provider/model-a", thinking: "low" }],
+              },
             },
             isError: false,
           },
@@ -129,9 +131,15 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
           {
             type: "tool_execution_update",
             toolName: "subagent",
-            partialResult: { details: { results: finalResult.details.results.toReversed() } },
+            partialResult: {
+              details: { results: finalResult.details.results.toReversed() },
+            },
           },
-          { type: "tool_execution_end", toolName: "subagent", result: finalResult },
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: finalResult,
+          },
         ]),
       }),
     /ordering differs/u,

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -8,8 +8,8 @@ import {
 const finalResult = {
   details: {
     results: [
-      { id: "child-a", model: "provider/model-a", thinking: "low", content: "ok" },
-      { id: "child-b", model: "provider/model-a", thinking: "low", content: "ok" },
+      { index: 0, model: "provider/model-a", thinking: "low", content: "ok" },
+      { index: 1, model: "provider/model-a", thinking: "low", content: "ok" },
     ],
   },
 };
@@ -39,7 +39,7 @@ test("validateShapeContract matches partial and final rows by upstream identity"
   });
 });
 
-test("validateShapeContract fails missing model, missing id, duplicate ids, and order drift", () => {
+test("validateShapeContract fails missing model, missing index, duplicate indexes, and order drift", () => {
   assert.throws(
     () =>
       validateShapeContract({
@@ -53,7 +53,7 @@ test("validateShapeContract fails missing model, missing id, duplicate ids, and 
           {
             type: "tool_execution_end",
             toolName: "subagent",
-            result: { details: { results: [{ id: "child-a", thinking: "low" }] } },
+            result: { details: { results: [{ index: 0, thinking: "low" }] } },
             isError: false,
           },
         ]),
@@ -63,7 +63,7 @@ test("validateShapeContract fails missing model, missing id, duplicate ids, and 
   assert.throws(
     () =>
       validateShapeContract({
-        label: "missing-id",
+        label: "missing-index",
         expectedModel: "provider/model-a",
         expectedThinking: "low",
         expectedFinalChildren: 1,
@@ -85,7 +85,7 @@ test("validateShapeContract fails missing model, missing id, duplicate ids, and 
   assert.throws(
     () =>
       validateShapeContract({
-        label: "duplicate-id",
+        label: "duplicate-index",
         expectedModel: "provider/model-a",
         expectedThinking: "low",
         expectedFinalChildren: 2,
@@ -98,8 +98,8 @@ test("validateShapeContract fails missing model, missing id, duplicate ids, and 
             result: {
               details: {
                 results: [
-                  { id: "same", model: "provider/model-a", thinking: "low" },
-                  { id: "same", model: "provider/model-a", thinking: "low" },
+                  { index: 0, model: "provider/model-a", thinking: "low" },
+                  { index: 0, model: "provider/model-a", thinking: "low" },
                 ],
               },
             },
@@ -136,7 +136,7 @@ test("validateShapeContract preserves legitimate thinking absence", () => {
       type: "tool_execution_end",
       toolName: "subagent",
       result: {
-        details: { results: [{ id: "child-a", model: "provider/no-thinking" }] },
+        details: { results: [{ index: 0, model: "provider/no-thinking" }] },
       },
       isError: false,
     },

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -202,7 +202,44 @@ test("validateShapeContract rejects failed tool results and child exits", () => 
           },
         ]),
       }),
-    /expected exactly one final subagent tool result/u,
+    /expected no failed subagent tool results/u,
+  );
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "failed-then-successful-tool-result",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 1,
+        requireUniqueSiblingIds: false,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: { isError: true, details: { results: [] } },
+            isError: false,
+          },
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: {
+              details: {
+                results: [
+                  {
+                    index: 0,
+                    model: "provider/model-a",
+                    thinking: "low",
+                    exitCode: 0,
+                  },
+                ],
+              },
+            },
+            isError: false,
+          },
+        ]),
+      }),
+    /expected no failed subagent tool results/u,
   );
   assert.throws(
     () =>

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -47,6 +47,31 @@ test("validateShapeContract matches partial and final rows by upstream identity"
   });
 });
 
+test("validateShapeContract accepts partial rows that are an ordered subset of final rows", () => {
+  const shape = collectSubagentEvents([
+    {
+      type: "tool_execution_update",
+      toolName: "subagent",
+      partialResult: { details: { results: [finalResult.details.results[1]] } },
+    },
+    {
+      type: "tool_execution_end",
+      toolName: "subagent",
+      result: finalResult,
+      isError: false,
+    },
+  ]);
+  validateShapeContract({
+    label: "counted",
+    expectedModel: "provider/model-a",
+    expectedThinking: "low",
+    expectedFinalChildren: 2,
+    requireUniqueSiblingIds: true,
+    requireThinking: true,
+    shape,
+  });
+});
+
 test("validateShapeContract fails missing model, missing index, duplicate indexes, and order drift", () => {
   assert.throws(
     () =>
@@ -142,7 +167,7 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
           },
         ]),
       }),
-    /ordering differs/u,
+    /out of order/u,
   );
 });
 

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -8,6 +8,7 @@ import {
 
 const finalResult = {
   details: {
+    runId: "run-a",
     results: [
       { index: 0, model: "provider/model-a", thinking: "low", content: "ok" },
       { index: 1, model: "provider/model-a", thinking: "low", content: "ok" },
@@ -27,7 +28,9 @@ test("validateShapeContract matches partial and final rows by upstream identity"
     {
       type: "tool_execution_update",
       toolName: "subagent",
-      partialResult: { details: { results: finalResult.details.results } },
+      partialResult: {
+        details: { runId: "run-a", results: finalResult.details.results },
+      },
     },
     {
       type: "tool_execution_end",
@@ -52,7 +55,12 @@ test("validateShapeContract accepts partial rows that are an ordered subset of f
     {
       type: "tool_execution_update",
       toolName: "subagent",
-      partialResult: { details: { results: [finalResult.details.results[1]] } },
+      partialResult: {
+        details: {
+          runId: "run-a",
+          results: [finalResult.details.results[1]],
+        },
+      },
     },
     {
       type: "tool_execution_end",
@@ -72,6 +80,62 @@ test("validateShapeContract accepts partial rows that are an ordered subset of f
   });
 });
 
+test("validateShapeContract requires a final runId", () => {
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "missing-run-id",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 2,
+        requireUniqueSiblingIds: true,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: { details: { results: finalResult.details.results } },
+            isError: false,
+          },
+        ]),
+      }),
+    /missing details\.runId/u,
+  );
+});
+
+test("validateShapeContract rejects partial runId drift", () => {
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "run-id-drift",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 2,
+        requireUniqueSiblingIds: true,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_update",
+            toolName: "subagent",
+            partialResult: {
+              details: {
+                runId: "run-b",
+                results: finalResult.details.results,
+              },
+            },
+          },
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: finalResult,
+            isError: false,
+          },
+        ]),
+      }),
+    /partial runId run-b does not match final runId run-a/u,
+  );
+});
+
 test("validateShapeContract fails missing model, missing index, duplicate indexes, and order drift", () => {
   assert.throws(
     () =>
@@ -86,7 +150,12 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
           {
             type: "tool_execution_end",
             toolName: "subagent",
-            result: { details: { results: [{ index: 0, thinking: "low" }] } },
+            result: {
+              details: {
+                runId: "run-a",
+                results: [{ index: 0, thinking: "low" }],
+              },
+            },
             isError: false,
           },
         ]),
@@ -108,6 +177,7 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
             toolName: "subagent",
             result: {
               details: {
+                runId: "run-a",
                 results: [{ model: "provider/model-a", thinking: "low" }],
               },
             },
@@ -132,6 +202,7 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
             toolName: "subagent",
             result: {
               details: {
+                runId: "run-a",
                 results: [
                   { index: 0, model: "provider/model-a", thinking: "low" },
                   { index: 0, model: "provider/model-a", thinking: "low" },
@@ -157,7 +228,10 @@ test("validateShapeContract fails missing model, missing index, duplicate indexe
             type: "tool_execution_update",
             toolName: "subagent",
             partialResult: {
-              details: { results: finalResult.details.results.toReversed() },
+              details: {
+                runId: "run-a",
+                results: finalResult.details.results.toReversed(),
+              },
             },
           },
           {
@@ -188,6 +262,7 @@ test("validateShapeContract rejects failed tool results and child exits", () => 
             result: {
               isError: true,
               details: {
+                runId: "run-a",
                 results: [
                   {
                     index: 0,
@@ -217,7 +292,10 @@ test("validateShapeContract rejects failed tool results and child exits", () => 
           {
             type: "tool_execution_end",
             toolName: "subagent",
-            result: { isError: true, details: { results: [] } },
+            result: {
+              isError: true,
+              details: { runId: "run-a", results: [] },
+            },
             isError: false,
           },
           {
@@ -225,6 +303,7 @@ test("validateShapeContract rejects failed tool results and child exits", () => 
             toolName: "subagent",
             result: {
               details: {
+                runId: "run-a",
                 results: [
                   {
                     index: 0,
@@ -256,6 +335,7 @@ test("validateShapeContract rejects failed tool results and child exits", () => 
             toolName: "subagent",
             result: {
               details: {
+                runId: "run-a",
                 results: [
                   {
                     index: 0,
@@ -280,7 +360,10 @@ test("validateShapeContract preserves legitimate thinking absence", () => {
       type: "tool_execution_end",
       toolName: "subagent",
       result: {
-        details: { results: [{ index: 0, model: "provider/no-thinking" }] },
+        details: {
+          runId: "run-a",
+          results: [{ index: 0, model: "provider/no-thinking" }],
+        },
       },
       isError: false,
     },

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  collectSubagentEvents,
+  validateShapeContract,
+} from "./verify-pi-subagents-child-metadata.mjs";
+
+const finalResult = {
+  details: {
+    results: [
+      { id: "child-a", model: "provider/model-a", thinking: "low", content: "ok" },
+      { id: "child-b", model: "provider/model-a", thinking: "low", content: "ok" },
+    ],
+  },
+};
+
+test("validateShapeContract matches partial and final rows by upstream identity", () => {
+  const shape = collectSubagentEvents([
+    {
+      type: "tool_execution_update",
+      toolName: "subagent",
+      partialResult: { details: { results: finalResult.details.results } },
+    },
+    {
+      type: "tool_execution_end",
+      toolName: "subagent",
+      result: finalResult,
+      isError: false,
+    },
+  ]);
+  validateShapeContract({
+    label: "parallel",
+    expectedModel: "provider/model-a",
+    expectedThinking: "low",
+    expectedFinalChildren: 2,
+    requireUniqueSiblingIds: true,
+    requireThinking: true,
+    shape,
+  });
+});
+
+test("validateShapeContract fails missing model, missing id, duplicate ids, and order drift", () => {
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "missing-model",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 1,
+        requireUniqueSiblingIds: false,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: { details: { results: [{ id: "child-a", thinking: "low" }] } },
+            isError: false,
+          },
+        ]),
+      }),
+    /missing model/u,
+  );
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "missing-id",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 1,
+        requireUniqueSiblingIds: false,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: {
+              details: { results: [{ model: "provider/model-a", thinking: "low" }] },
+            },
+            isError: false,
+          },
+        ]),
+      }),
+    /missing upstream identity/u,
+  );
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "duplicate-id",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 2,
+        requireUniqueSiblingIds: true,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_end",
+            toolName: "subagent",
+            result: {
+              details: {
+                results: [
+                  { id: "same", model: "provider/model-a", thinking: "low" },
+                  { id: "same", model: "provider/model-a", thinking: "low" },
+                ],
+              },
+            },
+          },
+        ]),
+      }),
+    /duplicate upstream identity/u,
+  );
+  assert.throws(
+    () =>
+      validateShapeContract({
+        label: "order-drift",
+        expectedModel: "provider/model-a",
+        expectedThinking: "low",
+        expectedFinalChildren: 2,
+        requireUniqueSiblingIds: true,
+        requireThinking: true,
+        shape: collectSubagentEvents([
+          {
+            type: "tool_execution_update",
+            toolName: "subagent",
+            partialResult: { details: { results: finalResult.details.results.toReversed() } },
+          },
+          { type: "tool_execution_end", toolName: "subagent", result: finalResult },
+        ]),
+      }),
+    /ordering differs/u,
+  );
+});
+
+test("validateShapeContract preserves legitimate thinking absence", () => {
+  const shape = collectSubagentEvents([
+    {
+      type: "tool_execution_end",
+      toolName: "subagent",
+      result: {
+        details: { results: [{ id: "child-a", model: "provider/no-thinking" }] },
+      },
+      isError: false,
+    },
+  ]);
+  validateShapeContract({
+    label: "no-thinking",
+    expectedModel: "provider/no-thinking",
+    expectedFinalChildren: 1,
+    requireUniqueSiblingIds: false,
+    requireThinking: false,
+    shape,
+  });
+});

--- a/scripts/verify-pi-subagents-child-metadata.test.mjs
+++ b/scripts/verify-pi-subagents-child-metadata.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   collectSubagentEvents,
+  reportedThinkingModel,
   validateShapeContract,
 } from "./verify-pi-subagents-child-metadata.mjs";
 
@@ -13,6 +14,13 @@ const finalResult = {
     ],
   },
 };
+
+test("reportedThinkingModel matches the Pi model argument emitted for an explicit fixture thinking level", () => {
+  assert.equal(
+    reportedThinkingModel("provider/model-a", "low"),
+    "provider/model-a:low",
+  );
+});
 
 test("validateShapeContract matches partial and final rows by upstream identity", () => {
   const shape = collectSubagentEvents([

--- a/src/pi/pi-subagents-dependency-contract.test.ts
+++ b/src/pi/pi-subagents-dependency-contract.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertInstalledPiSubagentsMatchesRootPin,
+  isExactNpmVersion,
+  piSubagentsExtensionFiles,
+  readInstalledPiSubagentsManifest,
+  readRootPiSubagentsPin,
+  resolvePiSubagentsPackageRoot,
+} from "./pi-subagents-package.ts";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+test("root pi-subagents dependency is an exact installed pin", () => {
+  const pin = readRootPiSubagentsPin(join(rootDir, "package.json"));
+  assert.equal(isExactNpmVersion(pin), true);
+  assertInstalledPiSubagentsMatchesRootPin(join(rootDir, "package.json"));
+});
+
+test("lockfiles agree with the root pi-subagents pin", () => {
+  const pin = readRootPiSubagentsPin(join(rootDir, "package.json"));
+  for (const filename of ["package-lock.json", "npm-shrinkwrap.json"]) {
+    const lockfile = readJson(join(rootDir, filename)) as {
+      packages?: Record<
+        string,
+        { version?: string; dependencies?: Record<string, string> }
+      >;
+    };
+    assert.equal(lockfile.packages?.[""]?.dependencies?.["pi-subagents"], pin);
+    assert.equal(
+      lockfile.packages?.["node_modules/pi-subagents"]?.version,
+      pin,
+    );
+  }
+});
+
+test("installed pi-subagents manifest declares existing extension files", () => {
+  const packageRoot = resolvePiSubagentsPackageRoot();
+  assert.equal(packageRoot.endsWith("pi-subagents"), true);
+  const manifest = readInstalledPiSubagentsManifest();
+  assert.equal(
+    manifest.version,
+    readRootPiSubagentsPin(join(rootDir, "package.json")),
+  );
+  assert.ok(Array.isArray(manifest.pi?.extensions));
+  assert.ok((manifest.pi?.extensions ?? []).length > 0);
+  for (const extensionFile of piSubagentsExtensionFiles()) {
+    assert.equal(extensionFile.startsWith(packageRoot), true);
+    assert.equal(
+      existsSync(extensionFile),
+      true,
+      `missing extension ${extensionFile}`,
+    );
+    assert.equal(
+      statSync(extensionFile).isFile(),
+      true,
+      `not a file ${extensionFile}`,
+    );
+  }
+});
+
+test("pi loads the resolved pi-subagents extension package without model execution", () => {
+  const result = spawnSync(
+    "./node_modules/.bin/pi",
+    ["--offline", "-e", resolvePiSubagentsPackageRoot(), "--help"],
+    { cwd: rootDir, encoding: "utf8", timeout: 30_000 },
+  );
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(
+    `${result.stdout}\n${result.stderr}`,
+    /extension load failed|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+  );
+});

--- a/src/pi/pi-subagents-dependency-contract.test.ts
+++ b/src/pi/pi-subagents-dependency-contract.test.ts
@@ -68,13 +68,48 @@ test("installed pi-subagents manifest declares existing extension files", () => 
 });
 
 test("pi loads the resolved pi-subagents extension package without model execution", () => {
+  const badResult = spawnSync(
+    "./node_modules/.bin/pi",
+    [
+      "--mode",
+      "json",
+      "--print",
+      "--no-session",
+      "--offline",
+      "-ne",
+      "-e",
+      join(rootDir, "node_modules", "not-pi-subagents"),
+      "/subagents-doctor",
+    ],
+    { cwd: rootDir, encoding: "utf8", timeout: 30_000 },
+  );
+  assert.notEqual(badResult.status, 0, badResult.stdout);
+  assert.match(
+    `${badResult.stdout}\n${badResult.stderr}`,
+    /Failed to load extension|Extension path does not exist/iu,
+  );
+
   const result = spawnSync(
     "./node_modules/.bin/pi",
-    ["--offline", "-e", resolvePiSubagentsPackageRoot(), "--help"],
+    [
+      "--mode",
+      "json",
+      "--print",
+      "--no-session",
+      "--offline",
+      "-ne",
+      "-e",
+      resolvePiSubagentsPackageRoot(),
+      "/subagents-doctor",
+    ],
     { cwd: rootDir, encoding: "utf8", timeout: 30_000 },
   );
   assert.equal(result.error, undefined);
   assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /Subagents doctor report/iu,
+  );
   assert.doesNotMatch(
     `${result.stdout}\n${result.stderr}`,
     /extension load failed|Cannot find module|ERR_MODULE_NOT_FOUND/iu,

--- a/src/pi/pi-subagents-dependency-contract.test.ts
+++ b/src/pi/pi-subagents-dependency-contract.test.ts
@@ -116,7 +116,11 @@ test("pi loads the resolved pi-subagents extension package without model executi
         timeout: 30_000,
         maxBuffer: 10 * 1024 * 1024,
         env: {
-          ...process.env,
+          ...Object.fromEntries(
+            Object.entries(process.env).filter(
+              ([name]) => !name.startsWith("PI_SUBAGENT_"),
+            ),
+          ),
           HOME: homeDir,
           XDG_CONFIG_HOME: join(homeDir, ".config"),
         },

--- a/src/pi/pi-subagents-dependency-contract.test.ts
+++ b/src/pi/pi-subagents-dependency-contract.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
@@ -89,29 +96,63 @@ test("pi loads the resolved pi-subagents extension package without model executi
     /Failed to load extension|Extension path does not exist/iu,
   );
 
-  const result = spawnSync(
-    "./node_modules/.bin/pi",
-    [
-      "--mode",
-      "json",
-      "--print",
-      "--no-session",
-      "--offline",
-      "-ne",
-      "-e",
-      resolvePiSubagentsPackageRoot(),
-      "/subagents-doctor",
-    ],
-    { cwd: rootDir, encoding: "utf8", timeout: 30_000 },
-  );
-  assert.equal(result.error, undefined);
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(
-    `${result.stdout}\n${result.stderr}`,
-    /Subagents doctor report/iu,
-  );
-  assert.doesNotMatch(
-    `${result.stdout}\n${result.stderr}`,
-    /extension load failed|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
-  );
+  const homeDir = mkdtempSync(join(tmpdir(), "patchmill-pi-subagents-rpc-"));
+  try {
+    const result = spawnSync(
+      "./node_modules/.bin/pi",
+      [
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--offline",
+        "-ne",
+        "-e",
+        resolvePiSubagentsPackageRoot(),
+      ],
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+        input: '{"type":"get_commands"}\n',
+        timeout: 30_000,
+        maxBuffer: 10 * 1024 * 1024,
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          XDG_CONFIG_HOME: join(homeDir, ".config"),
+        },
+      },
+    );
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const responses = result.stdout
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type?: string;
+            command?: string;
+            success?: boolean;
+            data?: { commands?: Array<{ name?: string; source?: string }> };
+          },
+      );
+    const commandResponse = responses.find(
+      (response) =>
+        response.type === "response" && response.command === "get_commands",
+    );
+    assert.equal(commandResponse?.success, true, result.stdout);
+    assert.ok(
+      commandResponse?.data?.commands?.some(
+        (command) =>
+          command.name === "subagents-doctor" && command.source === "extension",
+      ),
+      result.stdout,
+    );
+    assert.doesNotMatch(
+      `${result.stdout}\n${result.stderr}`,
+      /extension load failed|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+    );
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
 });

--- a/src/pi/pi-subagents-package.ts
+++ b/src/pi/pi-subagents-package.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, relative, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 const require = createRequire(import.meta.url);
 export const PI_SUBAGENTS_PACKAGE_NAME = "pi-subagents";
@@ -56,7 +56,12 @@ export function resolvePiSubagentsPackageJson(): string {
 function joinPackageRoot(entry: string): string {
   const packageRoot = resolvePiSubagentsPackageRoot();
   const candidate = resolve(packageRoot, entry);
-  if (relative(packageRoot, candidate).startsWith("..")) {
+  const relativePath = relative(packageRoot, candidate);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
     throw new Error(
       `${PI_SUBAGENTS_PACKAGE_NAME} path escapes package root: ${entry}`,
     );

--- a/src/pi/pi-subagents-package.ts
+++ b/src/pi/pi-subagents-package.ts
@@ -1,0 +1,100 @@
+import { readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, relative, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+export const PI_SUBAGENTS_PACKAGE_NAME = "pi-subagents";
+
+export type PiSubagentsPackageManifest = {
+  name?: string;
+  version: string;
+  pi?: {
+    extensions?: string[];
+    skills?: string[];
+    prompts?: string[];
+  };
+};
+
+export function isExactNpmVersion(spec: string | undefined): spec is string {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+    spec ?? "",
+  );
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+export function readRootPiSubagentsPin(
+  rootPackageJsonPath = resolve("package.json"),
+): string {
+  const packageJson = readJson<{ dependencies?: Record<string, string> }>(
+    rootPackageJsonPath,
+  );
+  const spec = packageJson.dependencies?.[PI_SUBAGENTS_PACKAGE_NAME];
+  if (!isExactNpmVersion(spec)) {
+    throw new Error(
+      `${PI_SUBAGENTS_PACKAGE_NAME} must be pinned to an exact version; found ${spec ?? "missing"}`,
+    );
+  }
+  return spec;
+}
+
+/**
+ * Finds the package directory through the public package entry. pi-subagents
+ * intentionally does not export package.json, so resolving that subpath would
+ * violate its export map.
+ */
+export function resolvePiSubagentsPackageRoot(): string {
+  return dirname(require.resolve(PI_SUBAGENTS_PACKAGE_NAME));
+}
+
+export function resolvePiSubagentsPackageJson(): string {
+  return joinPackageRoot("package.json");
+}
+
+function joinPackageRoot(entry: string): string {
+  const packageRoot = resolvePiSubagentsPackageRoot();
+  const candidate = resolve(packageRoot, entry);
+  if (relative(packageRoot, candidate).startsWith("..")) {
+    throw new Error(
+      `${PI_SUBAGENTS_PACKAGE_NAME} path escapes package root: ${entry}`,
+    );
+  }
+  return candidate;
+}
+
+export function readInstalledPiSubagentsManifest(): PiSubagentsPackageManifest {
+  return readJson<PiSubagentsPackageManifest>(resolvePiSubagentsPackageJson());
+}
+
+export function piSubagentsExtensionFiles(): string[] {
+  const manifest = readInstalledPiSubagentsManifest();
+  const extensions = manifest.pi?.extensions ?? [];
+  if (extensions.length === 0) {
+    throw new Error(
+      `${PI_SUBAGENTS_PACKAGE_NAME} manifest declares no Pi extensions`,
+    );
+  }
+  return extensions.map((entry) => {
+    const extensionPath = joinPackageRoot(entry);
+    if (!statSync(extensionPath).isFile()) {
+      throw new Error(
+        `${PI_SUBAGENTS_PACKAGE_NAME} extension is not a regular file: ${extensionPath}`,
+      );
+    }
+    return extensionPath;
+  });
+}
+
+export function assertInstalledPiSubagentsMatchesRootPin(
+  rootPackageJsonPath = resolve("package.json"),
+): void {
+  const expected = readRootPiSubagentsPin(rootPackageJsonPath);
+  const manifest = readInstalledPiSubagentsManifest();
+  if (manifest.version !== expected) {
+    throw new Error(
+      `${PI_SUBAGENTS_PACKAGE_NAME} resolved ${manifest.version} but package.json pins ${expected}`,
+    );
+  }
+}

--- a/src/pi/resource-profiles.compiled.test.ts
+++ b/src/pi/resource-profiles.compiled.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { findPackageRoot } from "../package-root.ts";
@@ -85,6 +85,17 @@ test(
         ),
         [true, true],
       );
+      const piSubagentsRoot = profile.additionalExtensionPaths[0];
+      assert.equal(basename(piSubagentsRoot), "pi-subagents");
+      const piSubagentsManifest = JSON.parse(
+        readFileSync(join(piSubagentsRoot, "package.json"), "utf8"),
+      ) as { pi?: { extensions?: string[] } };
+      assert.ok((piSubagentsManifest.pi?.extensions ?? []).length > 0);
+      for (const extension of piSubagentsManifest.pi?.extensions ?? []) {
+        const extensionPath = join(piSubagentsRoot, extension);
+        assert.equal(existsSync(extensionPath), true);
+        assert.equal(statSync(extensionPath).isFile(), true);
+      }
       assert.equal(
         profile.additionalExtensionPaths[1]
           ?.replaceAll("\\", "/")

--- a/src/pi/resource-profiles.compiled.test.ts
+++ b/src/pi/resource-profiles.compiled.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -78,6 +78,11 @@ test(
       assert.equal(build.status, 0, build.stderr || build.stdout);
 
       const compiled = await import(pathToFileURL(compiledProfile).href);
+      const compiledPiPackage = await import(
+        pathToFileURL(
+          join(packageRoot, "dist", "src", "pi", "pi-subagents-package.js"),
+        ).href
+      );
       const profile = compiled.runOncePlanningPiProfile(skills, packageRoot);
       assert.deepEqual(
         profile.additionalExtensionPaths.map((path: string) =>
@@ -87,15 +92,11 @@ test(
       );
       const piSubagentsRoot = profile.additionalExtensionPaths[0];
       assert.equal(basename(piSubagentsRoot), "pi-subagents");
-      const piSubagentsManifest = JSON.parse(
-        readFileSync(join(piSubagentsRoot, "package.json"), "utf8"),
-      ) as { pi?: { extensions?: string[] } };
-      assert.ok((piSubagentsManifest.pi?.extensions ?? []).length > 0);
-      for (const extension of piSubagentsManifest.pi?.extensions ?? []) {
-        const extensionPath = join(piSubagentsRoot, extension);
-        assert.equal(existsSync(extensionPath), true);
-        assert.equal(statSync(extensionPath).isFile(), true);
-      }
+      assert.equal(
+        piSubagentsRoot,
+        compiledPiPackage.resolvePiSubagentsPackageRoot(),
+      );
+      assert.ok(compiledPiPackage.piSubagentsExtensionFiles().length > 0);
       assert.equal(
         profile.additionalExtensionPaths[1]
           ?.replaceAll("\\", "/")

--- a/src/pi/resource-profiles.test.ts
+++ b/src/pi/resource-profiles.test.ts
@@ -5,6 +5,10 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { test } from "node:test";
 import {
+  piSubagentsExtensionFiles,
+  resolvePiSubagentsPackageRoot,
+} from "./pi-subagents-package.ts";
+import {
   doctorPiResourceProfiles,
   profileContextArgs,
   profileExtensionArgs,
@@ -22,6 +26,15 @@ async function withRepo<T>(fn: (repoRoot: string) => Promise<T>): Promise<T> {
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }
+}
+
+function assertRunOnceExtensionOrder(extensionPaths: string[]): void {
+  assert.equal(extensionPaths.length, 2);
+  assert.equal(extensionPaths[0], resolvePiSubagentsPackageRoot());
+  assert.equal(
+    extensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"),
+    true,
+  );
 }
 
 const skills: PatchmillSkillsConfig = {
@@ -42,17 +55,12 @@ test("run-once planning profile includes context and Patchmill run-once extensio
     assert.equal(profile.id, "run-once-planning");
     assert.equal(profile.noContextFiles, false);
     assert.equal(profile.noPromptTemplates, false);
-    assert.equal(profile.additionalExtensionPaths.length, 2);
+    assertRunOnceExtensionOrder(profile.additionalExtensionPaths);
     assert.equal(
       basename(profile.additionalExtensionPaths[0] ?? ""),
       "pi-subagents",
     );
-    assert.equal(
-      profile.additionalExtensionPaths[1]
-        ?.replaceAll("\\", "/")
-        .endsWith("/extensions/todos.ts"),
-      true,
-    );
+    assert.ok(piSubagentsExtensionFiles().length > 0);
     for (const extensionPath of profile.additionalExtensionPaths) {
       assert.equal(
         existsSync(extensionPath),

--- a/src/pi/resource-profiles.ts
+++ b/src/pi/resource-profiles.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { findPackageRoot } from "../package-root.ts";
@@ -7,11 +6,13 @@ import {
   skillInvocationPaths,
   type PatchmillSkillsConfig,
 } from "../workflow/skills.ts";
+import {
+  piSubagentsExtensionFiles,
+  resolvePiSubagentsPackageRoot,
+} from "./pi-subagents-package.ts";
 
-const require = createRequire(import.meta.url);
-const PI_SUBAGENTS_PACKAGE_ROOT = dirname(
-  require.resolve("pi-subagents/package.json"),
-);
+const PI_SUBAGENTS_PACKAGE_ROOT = resolvePiSubagentsPackageRoot();
+piSubagentsExtensionFiles();
 function requireRegularFile(path: string): string {
   const stats = fs.statSync(path);
   if (!stats.isFile()) {


### PR DESCRIPTION
## Summary
- Pin `pi-subagents` to exact `0.39.0` across npm lockfiles and Nix.
- Add a shared package-contract helper reused by source, compiled, packed, and Nix checks.
- Harden live child metadata validation to require upstream `model`, `thinking`, stable `index` identity/order, and successful child exits.

## Validation
- `node --test src/pi/resource-profiles.test.ts`
- `node --test src/pi/pi-subagents-dependency-contract.test.ts`
- `node --test src/pi/resource-profiles.compiled.test.ts`
- `node --test scripts/verify-pi-subagents-child-metadata.test.mjs`
- `PATCHMILL_PI_SUBAGENTS_CONTRACT_MODEL="openai-codex/gpt-5.5" PATCHMILL_PI_SUBAGENTS_CONTRACT_THINKING="low" PATCHMILL_PI_SUBAGENTS_CONTRACT_NO_THINKING_MODEL="openai-codex/gpt-5.5" node scripts/verify-pi-subagents-child-metadata.mjs`
- `npm test` (1146/1146)
- `node scripts/smoke-packed-artifact.mjs`
- `npm run lint`
- `scripts/update-npm-deps-hash.sh`
- `git diff --exit-code -- nix/package.nix`
- dependency agreement command: root/lockfiles/installed all `0.39.0`
- `nix build .#patchmill --print-build-logs`
- `nix flake check --print-build-logs`

Closes #122
