### PR TITLE
chore(deps): update Pi runtime packages to 0.84.1

### DIFF
--- a/.github/workflows/pi-dependency-upgrade.yml
+++ b/.github/workflows/pi-dependency-upgrade.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .tmp
-          args=(--summary-json .tmp/pi-deps-summary.json)
+          args=(--summary-json .tmp/pi-deps-summary.json --skip-nix-hash)
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             args+=(--mode manual)
             [[ -n "${TARGET_VERSION:-}" ]] && args+=(--target-version "$TARGET_VERSION")
@@ -106,6 +106,10 @@ jobs:
         if: steps.update.outputs.no_update != 'true'
         run: npm run lint
 
+      - name: Update Nix npm dependency hash
+        if: steps.update.outputs.no_update != 'true'
+        run: scripts/update-npm-deps-hash.sh
+
       - name: Verify Nix npm dependency hash
         if: steps.update.outputs.no_update != 'true'
         run: |
@@ -119,6 +123,10 @@ jobs:
       - name: Build Nix package
         if: steps.update.outputs.no_update != 'true'
         run: nix build .#patchmill --print-build-logs
+
+      - name: Run full flake check
+        if: steps.update.outputs.no_update != 'true'
+        run: nix flake check --accept-flake-config --print-build-logs
 
       - name: Render pull request body
         if: >-

--- a/docs/plans/2026-08-07-pi-tui-084-migration.md
+++ b/docs/plans/2026-08-07-pi-tui-084-migration.md
@@ -1,0 +1,635 @@
+# Pi-tui 0.84 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the pi-tui 0.84.1 upgrade, migrate every Patchmill consumer of
+the removed `TUI` value export, and make future Pi API removals fail before the
+nightly workflow starts a Nix build.
+
+**Architecture:** pi-tui 0.84 replaces the old inline-screen `TUI` class with
+`TuiMainScreen` while keeping `TUI` as a type-only interface. Apply the exact
+pin bump and all source migrations together, extend the existing dependency
+contract to every pi-tui runtime value used by init or the bundled todos
+extension, and pass `--skip-nix-hash` in CI so fast checks run before the
+workflow updates and verifies the Nix hash.
+
+**Tech Stack:** Node 24 ESM TypeScript (run directly via `node --test`), npm
+exact pins, GitHub Actions, Nix package builds and flake checks.
+
+**Spec:** `docs/specs/2026-08-07-pi-tui-084-migration-design.md` (issue #144)
+
+## Global Constraints
+
+- Pin both `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` to
+  exactly `0.84.1`.
+- Apply the local bump with
+  `node scripts/update-pi-deps.mjs --mode manual --target-version 0.84.1 --skip-nix-hash`.
+  The outer updater failure path is not transactional; inspect
+  `.tmp/pi-deps-summary.json` and `git status --short` after any failure.
+- Migrate all four runtime consumers: the three init modules and
+  `extensions/todos.ts`.
+- Do not adopt `TuiAltScreen`, change selector UX, or add a dual-version
+  compatibility factory.
+- Keep existing `tui: TUI` annotations as type-only imports. Do not change
+  `stopTui` signatures or exported function signatures.
+- Do not add an automated test that only asserts workflow YAML content. Verify
+  the workflow with formatter checks, existing updater tests, and real PR CI.
+- The workflow must run its Pi compatibility contract before any Nix build.
+- Because packaged Pi dependencies change, completion requires both
+  `nix build .#patchmill --print-build-logs` and
+  `nix flake check --accept-flake-config --print-build-logs`.
+- Merge intent: squash-merge title
+  `chore(deps): update Pi runtime packages to 0.84.1` (no release on merge).
+
+---
+
+### Task 1: Apply the Pi 0.84.1 bump, migrate all consumers, and extend the contract
+
+The dependency bump, source migrations, contract test, and initial hash refresh
+form one atomic deliverable. Neither source intermediate can run: old code asks
+0.84.1 for the removed `TUI` value, while migrated constructor code asks 0.83.0
+for `TuiMainScreen`.
+
+**Files:**
+
+- Modify: `package.json` (via updater)
+- Modify: `npm-shrinkwrap.json`, `package-lock.json` (via updater)
+- Modify: `nix/package.nix` (via hash helper)
+- Modify: `src/cli/commands/init/pi-auth-dialog.ts`
+- Modify: `src/cli/commands/init/pi-auth-selector.ts`
+- Modify: `src/cli/commands/init/pi-model-selector.ts`
+- Modify: `extensions/todos.ts`
+- Test: `src/cli/commands/init/pi-dependency-contract.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: Pi runtime packages pinned and installed at 0.84.1; unchanged init
+  function signatures; the todos extension imports `TUI` only as a type; a
+  contract for all 15 pi-tui runtime values Patchmill uses; refreshed
+  `npmDepsHash`.
+
+- [ ] **Step 1: Bootstrap the issue worktree**
+
+```bash
+npm ci
+```
+
+Expected: clean install of the current 0.83.0 pins.
+
+- [ ] **Step 2: Apply the 0.84.1 metadata bump without starting Nix**
+
+```bash
+mkdir -p .tmp
+node scripts/update-pi-deps.mjs \
+  --mode manual \
+  --target-version 0.84.1 \
+  --skip-nix-hash \
+  --summary-json .tmp/pi-deps-summary.json
+```
+
+Expected output includes:
+
+```text
+Current Pi pins: @earendil-works/pi-coding-agent=0.83.0, @earendil-works/pi-tui=0.83.0
+Selected Pi targets: @earendil-works/pi-coding-agent=0.84.1, @earendil-works/pi-tui=0.84.1
+```
+
+If the command fails, inspect rather than assuming rollback:
+
+```bash
+cat .tmp/pi-deps-summary.json
+git status --short
+```
+
+To abandon a partial metadata update:
+
+```bash
+git restore -- package.json package-lock.json npm-shrinkwrap.json nix/package.nix
+npm ci
+```
+
+- [ ] **Step 3: Verify the exact pins and reinstall**
+
+```bash
+node -e "const p=require('./package.json'); console.log(p.dependencies['@earendil-works/pi-coding-agent'], p.dependencies['@earendil-works/pi-tui'])"
+npm ci
+```
+
+Expected: prints `0.84.1 0.84.1`; reinstall succeeds.
+
+- [ ] **Step 4: Confirm the pre-migration regression**
+
+```bash
+node --test \
+  src/cli/commands/init/pi-model-selector.test.ts \
+  test-support/todos-extension.test.ts
+```
+
+Expected: FAIL at module load with
+`SyntaxError: The requested module '@earendil-works/pi-tui' does not provide an export named 'TUI'`.
+This proves both an init consumer and the bundled extension need migration.
+
+- [ ] **Step 5: Migrate `pi-auth-dialog.ts`**
+
+In `src/cli/commands/init/pi-auth-dialog.ts`, replace:
+
+```ts
+import {
+  Container,
+  Input,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  Text,
+  TUI,
+  type Focusable,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+```
+
+with:
+
+```ts
+import {
+  Container,
+  Input,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  Text,
+  TuiMainScreen,
+  type Focusable,
+  type Terminal,
+  type TUI,
+} from "@earendil-works/pi-tui";
+```
+
+Replace both constructors:
+
+```ts
+const tui = new TUI(terminal, true);
+const tui = new TUI(terminal, false);
+```
+
+with their argument-preserving equivalents:
+
+```ts
+const tui = new TuiMainScreen(terminal, true);
+const tui = new TuiMainScreen(terminal, false);
+```
+
+Leave `stopTui(tui: TUI, terminal: Terminal)` unchanged.
+
+- [ ] **Step 6: Migrate `pi-auth-selector.ts`**
+
+In `src/cli/commands/init/pi-auth-selector.ts`, replace:
+
+```ts
+import {
+  Container,
+  Input,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  Text,
+  TruncatedText,
+  TUI,
+  type Focusable,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+```
+
+with:
+
+```ts
+import {
+  Container,
+  Input,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  Text,
+  TruncatedText,
+  TuiMainScreen,
+  type Focusable,
+  type Terminal,
+  type TUI,
+} from "@earendil-works/pi-tui";
+```
+
+Replace both constructors:
+
+```ts
+const tui = new TUI(terminal, false);
+const tui = new TUI(terminal, true);
+```
+
+with:
+
+```ts
+const tui = new TuiMainScreen(terminal, false);
+const tui = new TuiMainScreen(terminal, true);
+```
+
+Leave `stopTui(tui: TUI, terminal: Terminal)` unchanged.
+
+- [ ] **Step 7: Migrate `pi-model-selector.ts`**
+
+In `src/cli/commands/init/pi-model-selector.ts`, replace the value import `TUI`
+with `TuiMainScreen`; do not add `type TUI` because this file has no `TUI`
+annotation. The complete import remains:
+
+```ts
+import {
+  Container,
+  Input,
+  ProcessTerminal,
+  Text,
+  TruncatedText,
+  TuiMainScreen,
+  getKeybindings,
+  type Focusable,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+```
+
+Replace:
+
+```ts
+const tui = new TUI(terminal, true);
+```
+
+with:
+
+```ts
+const tui = new TuiMainScreen(terminal, true);
+```
+
+- [ ] **Step 8: Make the bundled todos extension's TUI import type-only**
+
+In the pi-tui import block in `extensions/todos.ts`, replace:
+
+```ts
+TUI,
+```
+
+with:
+
+```ts
+type TUI,
+```
+
+Do not change the extension's `TUI` annotations or any UI construction. The
+extension never instantiates the removed class.
+
+- [ ] **Step 9: Add the complete pi-tui runtime contract**
+
+In `src/cli/commands/init/pi-dependency-contract.test.ts`, add this namespace
+import after the existing pi-coding-agent namespace import:
+
+```ts
+import * as piTui from "@earendil-works/pi-tui";
+```
+
+Add this constant after `REQUIRED_INIT_RUNTIME_EXPORTS`:
+
+```ts
+const REQUIRED_PI_TUI_RUNTIME_EXPORTS = [
+  "TuiMainScreen",
+  "Container",
+  "Input",
+  "Key",
+  "matchesKey",
+  "ProcessTerminal",
+  "Text",
+  "TruncatedText",
+  "getKeybindings",
+  "Markdown",
+  "SelectList",
+  "Spacer",
+  "fuzzyMatch",
+  "truncateToWidth",
+  "visibleWidth",
+] as const;
+```
+
+Add the test after the existing pi-coding-agent export test:
+
+```ts
+test("resolved pi-tui exports the runtime symbols used by patchmill", () => {
+  for (const exportName of REQUIRED_PI_TUI_RUNTIME_EXPORTS) {
+    assert.equal(
+      exportName in piTui,
+      true,
+      `@earendil-works/pi-tui must export ${exportName}`,
+    );
+    assert.notEqual(
+      piTui[exportName],
+      undefined,
+      `@earendil-works/pi-tui export ${exportName} must be defined`,
+    );
+  }
+});
+```
+
+- [ ] **Step 10: Run the contract before broader tests**
+
+```bash
+node --test src/cli/commands/init/pi-dependency-contract.test.ts
+```
+
+Expected: PASS, including the 15-value pi-tui runtime contract.
+
+- [ ] **Step 11: Run focused init and extension tests**
+
+```bash
+node --test \
+  src/cli/commands/init/pi-auth-dialog.test.ts \
+  src/cli/commands/init/pi-auth-selector.test.ts \
+  src/cli/commands/init/pi-model-selector.test.ts \
+  test-support/todos-extension.test.ts
+```
+
+Expected: PASS. The todos test imports and registers `extensions/todos.ts`, so
+this is the direct runtime-load check for the bundled extension.
+
+- [ ] **Step 12: Run all fast verification before Nix**
+
+```bash
+npm test
+node scripts/smoke-packed-artifact.mjs
+npm run lint
+```
+
+Expected: all commands pass. `npm run lint` also verifies the new spec and plan
+are Prettier- and Markdownlint-clean.
+
+- [ ] **Step 13: Refresh the Nix npm dependency hash**
+
+```bash
+scripts/update-npm-deps-hash.sh
+```
+
+Expected: the helper updates `npmDepsHash` in `nix/package.nix` and its final
+Nix build succeeds. If it fails, inspect `git status --short`; a new hash may
+remain in `nix/package.nix` and must not be assumed rolled back.
+
+- [ ] **Step 14: Commit the atomic compatibility change**
+
+```bash
+git add \
+  package.json \
+  package-lock.json \
+  npm-shrinkwrap.json \
+  nix/package.nix \
+  extensions/todos.ts \
+  src/cli/commands/init/pi-auth-dialog.ts \
+  src/cli/commands/init/pi-auth-selector.ts \
+  src/cli/commands/init/pi-model-selector.ts \
+  src/cli/commands/init/pi-dependency-contract.test.ts
+git commit -m "chore(deps): update Pi runtime packages to 0.84.1"
+```
+
+### Task 2: Reorder the nightly workflow for fail-fast Pi validation
+
+**Files:**
+
+- Modify: `.github/workflows/pi-dependency-upgrade.yml`
+- Modify: `scripts/update-pi-deps.mjs` (`validationCommands` only)
+- Test: existing `scripts/update-pi-deps.test.mjs`
+- Test: existing `scripts/pi-dependency-upgrade-lib.test.mjs`
+
+**Interfaces:**
+
+- Consumes: the compatibility contract and 0.84.1 pins from Task 1.
+- Produces: updater metadata changes without an early Nix build; contract and
+  Node tests before hash work; accepted then idempotency-checked Nix hash;
+  reported and executed full flake verification.
+
+- [ ] **Step 1: Make the updater skip its internal Nix hash build in CI**
+
+In `.github/workflows/pi-dependency-upgrade.yml`, replace:
+
+```yaml
+args=(--summary-json .tmp/pi-deps-summary.json)
+```
+
+with:
+
+```yaml
+args=(--summary-json .tmp/pi-deps-summary.json --skip-nix-hash)
+```
+
+This applies to scheduled, manual, and validate-only dispatches. The flag is
+harmless for validate-only because that mode already skips metadata mutation.
+
+- [ ] **Step 2: Update and then verify the Nix hash after fast checks**
+
+Insert this step after `Run lint` and before the existing
+`Verify Nix npm dependency hash` step:
+
+```yaml
+- name: Update Nix npm dependency hash
+  if: steps.update.outputs.no_update != 'true'
+  run: scripts/update-npm-deps-hash.sh
+```
+
+Keep the existing verification step unchanged. It copies the now-updated
+`nix/package.nix`, reruns the helper, and explicitly exits 1 if the file changes
+again. Keep the existing `Build Nix package` step after hash verification.
+
+- [ ] **Step 3: Add the required full flake check to CI**
+
+Insert after `Build Nix package`:
+
+```yaml
+- name: Run full flake check
+  if: steps.update.outputs.no_update != 'true'
+  run: nix flake check --accept-flake-config --print-build-logs
+```
+
+- [ ] **Step 4: Report the full flake check in generated PR bodies**
+
+In `scripts/update-pi-deps.mjs`, append this exact command to
+`validationCommands` after the package build:
+
+```js
+"nix flake check --accept-flake-config --print-build-logs",
+```
+
+The final array tail is:
+
+```js
+"scripts/update-npm-deps-hash.sh",
+"nix build .#patchmill --print-build-logs",
+"nix flake check --accept-flake-config --print-build-logs",
+```
+
+- [ ] **Step 5: Run updater behavior tests**
+
+```bash
+node --test \
+  scripts/update-pi-deps.test.mjs \
+  scripts/pi-dependency-upgrade-lib.test.mjs
+```
+
+Expected: PASS. Do not add a test that merely matches workflow YAML text; this
+change is verified directly and by PR CI per the Testing Value Gate.
+
+- [ ] **Step 6: Verify formatting of the workflow and updater**
+
+```bash
+npx prettier --check \
+  .github/workflows/pi-dependency-upgrade.yml \
+  scripts/update-pi-deps.mjs
+```
+
+Expected: both files use repository formatting.
+
+- [ ] **Step 7: Commit the workflow reorder**
+
+```bash
+git add .github/workflows/pi-dependency-upgrade.yml scripts/update-pi-deps.mjs
+git commit -m "fix(ci): run Pi contract before upgrade Nix builds"
+```
+
+### Task 3: Run full verification and open the pull request
+
+**Files:** none modified; verification and publication only.
+
+**Interfaces:**
+
+- Consumes: Tasks 1 and 2.
+- Produces: verified branch and a pull request that closes issue #144.
+
+- [ ] **Step 1: Run the Node-side verification set**
+
+```bash
+node --test src/cli/commands/init/pi-dependency-contract.test.ts
+node --test test-support/todos-extension.test.ts
+npm test
+node scripts/smoke-packed-artifact.mjs
+npm run lint
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Verify Nix hash freshness with fail-fast shell semantics**
+
+```bash
+set -euo pipefail
+before_hash_file="$(mktemp)"
+trap 'rm -f "$before_hash_file"' EXIT
+cp nix/package.nix "$before_hash_file"
+scripts/update-npm-deps-hash.sh
+if ! cmp --silent "$before_hash_file" nix/package.nix; then
+  echo "npmDepsHash changed during freshness verification" >&2
+  git diff -- nix/package.nix >&2
+  exit 1
+fi
+echo "npmDepsHash fresh"
+```
+
+Expected: prints `npmDepsHash fresh`. Any changed hash exits before later builds
+can mask the failure.
+
+- [ ] **Step 3: Run package and full flake verification**
+
+```bash
+nix build .#patchmill --print-build-logs
+nix flake check --accept-flake-config --print-build-logs
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 4: Push and open the pull request**
+
+```bash
+git push -u origin agent/issue-144-pi-084-tui-class-export-removed
+gh pr create --title "chore(deps): update Pi runtime packages to 0.84.1" --label dependencies --body "$(cat <<'EOF'
+## Summary
+
+- Bumps `@earendil-works/pi-coding-agent` and
+  `@earendil-works/pi-tui` to 0.84.1 and migrates init constructors to
+  `TuiMainScreen` while making the bundled todos extension's `TUI` import
+  type-only.
+- Extends the Pi compatibility contract to all 15 pi-tui runtime values used
+  by init and the bundled extension.
+- Reorders the nightly upgrade so the contract and Node checks run before any
+  Nix build, then updates and verifies `npmDepsHash` and runs the full flake
+  check.
+
+Unblocks failed nightly run 31154881630.
+
+## Verification
+
+- `node --test src/cli/commands/init/pi-dependency-contract.test.ts`
+- `node --test test-support/todos-extension.test.ts`
+- `npm test`
+- `node scripts/smoke-packed-artifact.mjs`
+- `npm run lint`
+- `scripts/update-npm-deps-hash.sh` freshness check
+- `nix build .#patchmill --print-build-logs`
+- `nix flake check --accept-flake-config --print-build-logs`
+
+Closes #144
+EOF
+)"
+```
+
+- [ ] **Step 5: Watch pull-request CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: CI passes, including the Nix package build and full flake check.
+
+- [ ] **Step 6: Verify recovery with the next scheduled run**
+
+After squash merge, wait until the next cron-triggered Pi dependency upgrade run
+completes. Then run:
+
+```bash
+set -euo pipefail
+merged_at="$(gh pr view --json mergedAt --jq .mergedAt)"
+run_id="$(
+  gh run list \
+    --workflow=pi-dependency-upgrade.yml \
+    --event schedule \
+    --limit 20 \
+    --json databaseId,createdAt,status,conclusion \
+    --jq ".[] | select(.createdAt > \"$merged_at\" and .status == \"completed\" and .conclusion == \"success\") | .databaseId" \
+    | head -n 1
+)"
+if [[ -z "$run_id" ]]; then
+  echo "No successful scheduled Pi upgrade run exists after the merge; wait for the next cron run" >&2
+  exit 1
+fi
+log_file="$(mktemp)"
+trap 'rm -f "$log_file"' EXIT
+gh run view "$run_id" --log >"$log_file"
+grep -F "Selected Pi targets:" "$log_file"
+if grep -Fq "No Pi dependency update available" "$log_file"; then
+  echo "Scheduled upgrade recovered with no update"
+else
+  pr_step_conclusion="$(
+    gh run view "$run_id" --json jobs \
+      --jq '[.jobs[].steps[] | select(.name == "Create or update Pi dependency upgrade PR") | .conclusion][0]'
+  )"
+  if [[ "$pr_step_conclusion" != "success" ]]; then
+    echo "Scheduled upgrade neither reported no-update nor completed its PR step" >&2
+    exit 1
+  fi
+  echo "Scheduled upgrade recovered and processed a newer Pi target"
+fi
+```
+
+Expected: the command finds a successful scheduled run created after the merge.
+If 0.84.1 is still latest, it reports no-update; if a newer version is
+available, the create-or-update-PR step succeeds. A blank or targeted manual
+dispatch is not an equivalent scheduled-mode recovery check.

--- a/docs/specs/2026-08-07-pi-tui-084-migration-design.md
+++ b/docs/specs/2026-08-07-pi-tui-084-migration-design.md
@@ -1,0 +1,196 @@
+# Pi 0.84 pi-tui migration design
+
+Issue: #144 — Pi 0.84 removes TUI class export: migrate Patchmill consumers to
+unblock the nightly dependency upgrade.
+
+## Problem
+
+The nightly Pi dependency upgrade workflow fails when bumping
+`@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` from 0.83.0 to
+0.84.1. In pi-tui 0.84, the `TUI` class was removed from the package's value
+exports; `TUI` is now a type-only interface. The former inline-screen class
+lives on as `TuiMainScreen`, alongside a new fullscreen `TuiAltScreen`. Both
+extend an abstract `TuiBase` whose constructor is unchanged:
+`(terminal, showHardwareCursor?, logDirectory?)`.
+
+Four Patchmill modules import `TUI` as a value:
+
+- `pi-auth-dialog.ts`, `pi-auth-selector.ts`, and `pi-model-selector.ts`
+  instantiate it with `new TUI(terminal, ...)`.
+- `extensions/todos.ts` uses `TUI` only in type positions but does not mark the
+  import as type-only. With verbatim ESM imports, Node still requests the
+  missing runtime export.
+
+Under 0.84.1, test files that load these modules fail at module load:
+
+```text
+SyntaxError: The requested module '@earendil-works/pi-tui' does not provide an export named 'TUI'
+```
+
+Evidence: failed run 31154881630 (2026-08-07), step "Update Pi dependency
+metadata". The Nix build's test phase failed both the init tests and
+`test-support/todos-extension.test.ts`.
+
+The workflow currently calls `update-pi-deps.mjs` without `--skip-nix-hash`.
+That script invokes `scripts/update-npm-deps-hash.sh`, which starts the Nix
+build before the workflow reaches its Pi compatibility contract. The proposed
+contract would therefore not fail fast unless the workflow order also changes.
+
+A later Nix-hash or build failure does not roll back metadata. The updater's
+inner metadata operation restores package files only when that operation itself
+fails; its outer catch records changed files but does not restore them. The hash
+helper can also leave `nix/package.nix` changed if its final build fails after
+writing a discovered hash. CI discards its failed checkout, but a local run can
+retain a partial update.
+
+## Goal
+
+Land the pi-tui 0.84.1 upgrade with all required code migrations in one atomic
+change, make future missing pi-tui exports fail at the workflow's contract step
+before any Nix build, and keep the nightly upgrade workflow able to update and
+verify `npmDepsHash` after the fast checks pass.
+
+## Non-goals
+
+- Adopting `TuiAltScreen` or changing selector UX. `TuiMainScreen` (mode
+  `"regular"`) is the behavioral equivalent of the removed class.
+- A version-tolerant factory that supports both 0.83 and 0.84. Pins are exact
+  and the swap is atomic, so dual-version support is dead weight.
+- Runtime assertions for type-only imports (`Focusable`, `SelectItem`,
+  `Terminal`, `TUI`). Type-only symbols cannot be checked at runtime.
+- Adding a test that merely asserts workflow YAML text. Verify the workflow
+  change with formatting, existing updater tests, and the real CI run instead.
+- Cutting a release on merge. The squash-merge commit uses
+  `chore(deps): update Pi runtime packages to 0.84.1`, matching prior upgrade
+  PRs; 0.84.1 ships to npm users with the next feat/fix release. Published
+  patchmill 0.19.0 pins pi-tui 0.83.0 exactly, so installs are unaffected today.
+
+## Design
+
+### Code migration
+
+The three init modules replace the value import `TUI` with `TuiMainScreen`.
+`pi-auth-dialog.ts` and `pi-auth-selector.ts` retain their `tui: TUI` type
+annotations through a `type TUI` import. Constructor calls keep their current
+arguments. `pi-model-selector.ts` does not use `TUI` as a type and drops it
+entirely.
+
+`extensions/todos.ts` does not construct a TUI. It changes `TUI` to `type TUI`
+in its existing pi-tui import so Node no longer requests the removed runtime
+export.
+
+| File                                         | Migration                                                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| `src/cli/commands/init/pi-auth-dialog.ts`    | `TuiMainScreen` at constructor calls 130 and 174; `type TUI` for `stopTui` |
+| `src/cli/commands/init/pi-auth-selector.ts`  | `TuiMainScreen` at constructor calls 163 and 190; `type TUI` for `stopTui` |
+| `src/cli/commands/init/pi-model-selector.ts` | `TuiMainScreen` at constructor call 130; remove `TUI`                      |
+| `extensions/todos.ts`                        | Change the value import `TUI` to `type TUI`; no constructor change         |
+
+The three init test files import only `type Terminal` and need no edits.
+`test-support/todos-extension.test.ts` already imports and registers the bundled
+extension, so it remains the direct runtime-load check for the extension.
+
+### Contract test extension
+
+Add a sibling test to `src/cli/commands/init/pi-dependency-contract.test.ts`
+that namespace-imports `@earendil-works/pi-tui` and asserts every pi-tui value
+export used by the init code or bundled todos extension is present and defined:
+
+- Existing init values: `TuiMainScreen`, `Container`, `Input`, `Key`,
+  `matchesKey`, `ProcessTerminal`, `Text`, `TruncatedText`, `getKeybindings`.
+- Extension-only values: `Markdown`, `SelectList`, `Spacer`, `fuzzyMatch`,
+  `truncateToWidth`, `visibleWidth`.
+
+The namespace-import-plus-`in` pattern turns a missing export into a clear
+assertion failure instead of an import-time crash. The test passes the Testing
+Value Gate: it asserts an external API contract, fails for a meaningful
+regression, and is cheap to maintain.
+
+### Upgrade workflow ordering
+
+Change `.github/workflows/pi-dependency-upgrade.yml` so no Nix build starts
+before the contract and Node tests:
+
+1. Always include `--skip-nix-hash` in the updater's argument list.
+2. Reinstall updated dependencies.
+3. Run the Pi compatibility contract.
+4. Run Node tests, packed-artifact smoke test, and lint.
+5. Run a new `Update Nix npm dependency hash` step that accepts the expected
+   `nix/package.nix` change from `scripts/update-npm-deps-hash.sh`.
+6. Keep a separate idempotency step: copy the updated `nix/package.nix`, rerun
+   the helper, and fail explicitly if the file changes again.
+7. Build `.#patchmill`.
+8. Run `nix flake check --accept-flake-config --print-build-logs`.
+9. Render and create the upgrade pull request.
+
+The existing PR `add-paths` already includes `nix/package.nix`, so the hash
+change created after the contract test is included in the automated PR. Update
+the updater summary's `validationCommands` list with the full flake check so
+generated PR bodies report the same evidence CI runs.
+
+### Local bump sequencing and recovery
+
+Neither intermediate source state is valid: migrated code cannot run against
+pi-tui 0.83.0 (`TuiMainScreen` missing), and bumped pins cannot run against
+unmigrated code (`TUI` missing). Apply the local change in this order:
+
+1. Run
+   `node scripts/update-pi-deps.mjs --mode manual --target-version 0.84.1 --skip-nix-hash`.
+2. Reinstall with `npm ci`.
+3. Migrate the three init modules and bundled todos extension.
+4. Extend and run the contract test, then run the focused init and extension
+   tests.
+5. Run the full Node-side verification set.
+6. Run `scripts/update-npm-deps-hash.sh` to refresh `nix/package.nix` after the
+   fast checks pass.
+7. Verify hash idempotency, build `.#patchmill`, and run the full flake check.
+
+After any failed local updater or hash-helper invocation, inspect
+`.tmp/pi-deps-summary.json` and `git status --short`; do not assume rollback.
+The implementer may continue from the recorded changes after fixing the failure.
+To abandon the partial bump, restore only the automation-managed files and
+reinstall the original pins:
+
+```bash
+git restore -- package.json package-lock.json npm-shrinkwrap.json nix/package.nix
+npm ci
+```
+
+Source migrations and contract-test edits are not part of this recovery command
+and must be reviewed separately before restoration.
+
+## Error handling
+
+No new runtime error paths; the source migration changes imports only. The
+workflow now prevents an upstream API removal from entering a Nix build before
+its explicit contract runs. CI failures leave only an ephemeral checkout. The
+local recovery procedure above handles the updater's non-transactional outer
+failure path and the hash helper's possible partial write.
+
+## Verification
+
+- `node --test src/cli/commands/init/pi-dependency-contract.test.ts`
+- `node --test src/cli/commands/init/pi-model-selector.test.ts test-support/todos-extension.test.ts`
+- `npm test`
+- `node scripts/smoke-packed-artifact.mjs`
+- `npm run lint`
+- After the refreshed `npmDepsHash` is committed, a fail-fast re-run of
+  `scripts/update-npm-deps-hash.sh` must leave `nix/package.nix` unchanged.
+- `nix build .#patchmill --print-build-logs`
+- `nix flake check --accept-flake-config --print-build-logs`
+- Pull-request CI must pass the reordered upgrade and package checks.
+- After merge, wait for the next scheduled Pi dependency upgrade run, verify its
+  creation time is after the merge, and require a successful conclusion. If
+  0.84.1 is still latest, logs must contain `No Pi dependency update available`;
+  if a newer version exists, the create-or-update-PR step must succeed. Do not
+  use a blank or targeted manual dispatch as a substitute for scheduled-mode
+  recovery.
+
+## Chosen approach and alternatives
+
+Chosen: direct migration to `TuiMainScreen` for constructors, type-only `TUI`
+where only the interface is needed, a complete runtime-export contract, and a
+workflow reorder that defers Nix work until after fast checks. Rejected
+alternatives are a version-tolerant `createTui()` factory (YAGNI under exact
+pins and an atomic swap) and reworking selectors onto `TuiAltScreen` (UX change
+and scope creep).

--- a/extensions/todos.ts
+++ b/extensions/todos.ts
@@ -56,7 +56,7 @@ import {
 	Spacer,
 	type SelectItem,
 	Text,
-	TUI,
+	type TUI,
 	fuzzyMatch,
 	matchesKey,
 	truncateToWidth,

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,7 +26,7 @@ buildNpmPackageNode24 rec {
         || baseName == "result");
   };
 
-  npmDepsHash = "sha256-spzRPnZ3diUDeqWFF52ARRH5N6QyfGYomfZF/YiTQMs=";
+  npmDepsHash = "sha256-YYn2W0uWehVrMldGdJ3otgtDEQ5v9HvClHW45/zkOtE=";
   npmDepsFetcherVersion = 2;
 
   dontNpmBuild = true;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,8 +9,8 @@
       "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "0.83.0",
-        "@earendil-works/pi-tui": "0.83.0",
+        "@earendil-works/pi-coding-agent": "0.84.1",
+        "@earendil-works/pi-tui": "0.84.1",
         "pi-subagents": "0.39.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.2.0.tar.gz"
       },
@@ -33,20 +33,23 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
-      "integrity": "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
+      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.83.0",
-        "@earendil-works/pi-ai": "^0.83.0",
-        "@earendil-works/pi-tui": "^0.83.0",
+        "@earendil-works/pi-agent-core": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-client": "^0.84.1",
+        "@earendil-works/pi-protocol": "^0.84.1",
+        "@earendil-works/pi-tui": "^0.84.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
         "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
         "ignore": "7.0.5",
@@ -55,7 +58,7 @@
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
         "typebox": "1.3.7",
-        "undici": "8.5.0",
+        "undici": "8.9.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -504,12 +507,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
-      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.83.0",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -517,16 +520,17 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
-      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
@@ -542,12 +546,45 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ=="
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A=="
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww=="
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
-      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -555,7 +592,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",
@@ -1056,15 +1094,15 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -1309,6 +1347,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
       "version": "10.7.3",
@@ -1747,9 +1794,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -1855,9 +1902,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
-      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "0.83.0",
-        "@earendil-works/pi-tui": "0.83.0",
+        "@earendil-works/pi-coding-agent": "0.84.1",
+        "@earendil-works/pi-tui": "0.84.1",
         "pi-subagents": "0.39.0",
         "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.2.0.tar.gz"
       },
@@ -33,20 +33,23 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
-      "integrity": "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
+      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.83.0",
-        "@earendil-works/pi-ai": "^0.83.0",
-        "@earendil-works/pi-tui": "^0.83.0",
+        "@earendil-works/pi-agent-core": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-client": "^0.84.1",
+        "@earendil-works/pi-protocol": "^0.84.1",
+        "@earendil-works/pi-tui": "^0.84.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
         "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
         "ignore": "7.0.5",
@@ -55,7 +58,7 @@
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
         "typebox": "1.3.7",
-        "undici": "8.5.0",
+        "undici": "8.9.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -504,12 +507,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
-      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.83.0",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -517,16 +520,17 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
-      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
@@ -542,12 +546,45 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ=="
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A=="
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww=="
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
-      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -555,7 +592,8 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
+      },
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA=="
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
       "version": "1.52.0",
@@ -1056,15 +1094,15 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -1309,6 +1347,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
       "version": "10.7.3",
@@ -1747,9 +1794,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -1855,9 +1902,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
-      "integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "typescript-eslint": "^8.59.4"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "0.83.0",
-    "@earendil-works/pi-tui": "0.83.0",
+    "@earendil-works/pi-coding-agent": "0.84.1",
+    "@earendil-works/pi-tui": "0.84.1",
     "pi-subagents": "0.39.0",
     "superpowers": "https://github.com/obra/superpowers/archive/refs/tags/v6.2.0.tar.gz"
   }

--- a/scripts/update-pi-deps.mjs
+++ b/scripts/update-pi-deps.mjs
@@ -32,6 +32,7 @@ const validationCommands = [
   "npm run lint",
   "scripts/update-npm-deps-hash.sh",
   "nix build .#patchmill --print-build-logs",
+  "nix flake check --accept-flake-config --print-build-logs",
 ];
 
 function summaryPathFromArgs(args) {

--- a/src/cli/commands/init/pi-auth-dialog.ts
+++ b/src/cli/commands/init/pi-auth-dialog.ts
@@ -6,9 +6,10 @@ import {
   matchesKey,
   ProcessTerminal,
   Text,
-  TUI,
+  TuiMainScreen,
   type Focusable,
   type Terminal,
+  type TUI,
 } from "@earendil-works/pi-tui";
 import type { OAuthLoginCallbacksLike } from "./pi-auth-flow.ts";
 
@@ -127,7 +128,7 @@ async function promptText(options: {
   signal?: AbortSignal;
 }): Promise<string | undefined> {
   const terminal = options.terminal ?? new ProcessTerminal();
-  const tui = new TUI(terminal, true);
+  const tui = new TuiMainScreen(terminal, true);
 
   return new Promise((resolve) => {
     let finished = false;
@@ -171,7 +172,7 @@ async function selectOption(options: {
   terminal?: Terminal;
 }): Promise<string | undefined> {
   const terminal = options.terminal ?? new ProcessTerminal();
-  const tui = new TUI(terminal, false);
+  const tui = new TuiMainScreen(terminal, false);
 
   return new Promise((resolve) => {
     let finished = false;

--- a/src/cli/commands/init/pi-auth-selector.ts
+++ b/src/cli/commands/init/pi-auth-selector.ts
@@ -6,9 +6,10 @@ import {
   ProcessTerminal,
   Text,
   TruncatedText,
-  TUI,
+  TuiMainScreen,
   type Focusable,
   type Terminal,
+  type TUI,
 } from "@earendil-works/pi-tui";
 import {
   AUTH_METHOD_CHOICES,
@@ -160,7 +161,7 @@ export async function selectAuthMethodInteractively(
   } = {},
 ): Promise<AuthMode | undefined> {
   const terminal = options.terminal ?? new ProcessTerminal();
-  const tui = new TUI(terminal, false);
+  const tui = new TuiMainScreen(terminal, false);
 
   return new Promise((resolve) => {
     let finished = false;
@@ -187,7 +188,7 @@ export async function selectProviderInteractively(options: {
   terminal?: Terminal;
 }): Promise<AuthProviderChoice | undefined> {
   const terminal = options.terminal ?? new ProcessTerminal();
-  const tui = new TUI(terminal, true);
+  const tui = new TuiMainScreen(terminal, true);
   const title =
     options.mode === "oauth"
       ? "Select subscription provider to configure:"

--- a/src/cli/commands/init/pi-dependency-contract.test.ts
+++ b/src/cli/commands/init/pi-dependency-contract.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import * as piCodingAgent from "@earendil-works/pi-coding-agent";
+import * as piTui from "@earendil-works/pi-tui";
 
 const PI_PACKAGES = [
   "@earendil-works/pi-coding-agent",
@@ -20,6 +21,24 @@ const REQUIRED_INIT_RUNTIME_EXPORTS = [
   "ModelRegistry",
   "readStoredCredential",
   "getAgentDir",
+] as const;
+
+const REQUIRED_PI_TUI_RUNTIME_EXPORTS = [
+  "TuiMainScreen",
+  "Container",
+  "Input",
+  "Key",
+  "matchesKey",
+  "ProcessTerminal",
+  "Text",
+  "TruncatedText",
+  "getKeybindings",
+  "Markdown",
+  "SelectList",
+  "Spacer",
+  "fuzzyMatch",
+  "truncateToWidth",
+  "visibleWidth",
 ] as const;
 
 type PackageJson = {
@@ -102,6 +121,21 @@ test("resolved pi-coding-agent exports the runtime symbols used by patchmill ini
 
   assert.equal(typeof piCodingAgent.ModelRuntime.create, "function");
   assert.equal(typeof piCodingAgent.ModelRegistry, "function");
+});
+
+test("resolved pi-tui exports the runtime symbols used by patchmill", () => {
+  for (const exportName of REQUIRED_PI_TUI_RUNTIME_EXPORTS) {
+    assert.equal(
+      exportName in piTui,
+      true,
+      `@earendil-works/pi-tui must export ${exportName}`,
+    );
+    assert.notEqual(
+      piTui[exportName],
+      undefined,
+      `@earendil-works/pi-tui export ${exportName} must be defined`,
+    );
+  }
 });
 
 test("patchmill no longer requires the removed AuthStorage root export", () => {

--- a/src/cli/commands/init/pi-model-selector.ts
+++ b/src/cli/commands/init/pi-model-selector.ts
@@ -4,7 +4,7 @@ import {
   ProcessTerminal,
   Text,
   TruncatedText,
-  TUI,
+  TuiMainScreen,
   getKeybindings,
   type Focusable,
   type Terminal,
@@ -127,7 +127,7 @@ export async function selectModelInteractively(options: {
   terminal?: Terminal;
 }): Promise<PiModelChoice | undefined> {
   const terminal = options.terminal ?? new ProcessTerminal();
-  const tui = new TUI(terminal, true);
+  const tui = new TuiMainScreen(terminal, true);
 
   return new Promise((resolve) => {
     let finished = false;


### PR DESCRIPTION
## Summary

- Bumps `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` to 0.84.1 and migrates init constructors to `TuiMainScreen` while making the bundled todos extension's `TUI` import type-only.
- Extends the Pi compatibility contract to all 15 pi-tui runtime values used by init and the bundled extension.
- Reorders the nightly upgrade so the contract and Node checks run before any Nix build, then updates and verifies `npmDepsHash` and runs the full flake check.

Unblocks failed nightly run 31154881630.

## Validation

- Exact Pi pins: `0.84.1 0.84.1`
- `node --test src/cli/commands/init/pi-dependency-contract.test.ts`
- Focused auth/model/todos tests (16/16)
- Updater behavior tests (11/11)
- Workflow/updater Prettier check
- `npm test` (1,244/1,244)
- `node scripts/smoke-packed-artifact.mjs`
- `npm run lint`
- `scripts/update-npm-deps-hash.sh` freshness check
- `nix build .#patchmill --print-build-logs`
- `nix flake check --accept-flake-config --print-build-logs`

## Reviews

- Final Codex full-worktree review: pass, no findings.
- Final thermo-nuclear full-worktree review: pass, no findings.
- Final validation-readiness review: pass, all required commands succeeded.

Closes #144

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Development environment | gpt-5.6-sol | 162,531 | 2,219 | $0.3723 |
| Implementation | gpt-5.6-sol | 2,683,412 | 35,345 | $4.0288 |
| Implementation | gpt-5.6-terra | 1,244,796 | 5,767 | $0.5110 |
| **Implementation subtotal** |  | **3,928,208** | **41,112** | **$4.5398** |
| **Total** |  | **4,090,739** | **43,331** | **$4.9121** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->