### PR TITLE
feat(pi): persist safe subagent runtime metadata

### DIFF
--- a/docs/plans/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks.md
+++ b/docs/plans/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks.md
@@ -18,7 +18,7 @@ load the production entry point through Pi's loader and runner before proving
 full profile startup with a packaged sentinel fixture.
 
 **Tech Stack:** TypeScript 6, Node.js 24 and `node:test`,
-`@earendil-works/pi-coding-agent` 0.83.0, `pi-subagents` 0.39.0, npm package
+`@earendil-works/pi-coding-agent` 0.84.1, `pi-subagents` 0.39.0, npm package
 smokes, and Nix install checks.
 
 ## Global Constraints
@@ -1147,7 +1147,7 @@ retained-state mutation.
 - [ ] **Step 4: Test the default export through Pi's real loader and runner**
 
 Create `src/pi/extensions/run-once-subagent-progress.runner.test.ts` so append
-failures follow Pi 0.83's production error path rather than a direct handler
+failures follow Pi 0.84.1's production error path rather than a direct handler
 rejection:
 
 ```ts

--- a/docs/plans/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks.md
+++ b/docs/plans/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks.md
@@ -1,0 +1,1827 @@
+# Persist Safe Subagent Runtime Metadata from Pi Lifecycle Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a bounded, authoritative projection of `pi-subagents` child identity and reported runtime metadata in the active parent Pi session for every non-triage run-once profile.
+
+**Architecture:** A pure module validates and bounds unknown `result.details.results` values without retaining unrestricted input. The default Pi extension factory observes partial and terminal lifecycle events, appends unseen custom entries, and applies explicit parent, child, key, transition, and session-entry back-pressure. Source and installed-layout checks load the production entry point through Pi's loader and runner before proving full profile startup with a packaged sentinel fixture.
+
+**Tech Stack:** TypeScript 6, Node.js 24 and `node:test`, `@earendil-works/pi-coding-agent` 0.83.0, `pi-subagents` 0.39.0, npm package smokes, and Nix install checks.
+
+## Global Constraints
+
+- Patchmill relies on the `pi-subagents` 0.39.0 contract adopted by issue #122:
+- Patchmill must not infer missing values from parent or agent configuration.
+- The upstream `runId` is therefore unnecessary for this bridge and is not allowed in the persisted projection.
+- Accepted strings remain verbatim after validation. Patchmill will not remove a provider prefix, split a model suffix, constrain thinking to a local enum, truncate a reported identifier, or backfill a missing value.
+- A valid row with only `index` and `agent` produces an identity-only entry:
+- The projection never reads or copies task, output, prompt, credential, usage, cost, path, error, message, full-result, event-argument, or other incidental properties.
+- This structural guarantee does not inspect the meaning of an otherwise valid allowlisted identifier supplied by trusted `pi-subagents`.
+- The key is based on the upstream child index, never the row's array position.
+- Before allocating or appending state, the observer enforces these ceilings:
+  - 256 active parent tool calls;
+  - 1,024 child indexes for one parent tool call;
+  - 4,096 active child states across all parents;
+  - 16,384 active serialized tuple keys;
+  - 32 persisted transitions for one `(toolCallId, childIndex)`; and
+  - 65,536 `patchmill-subagent-progress` entries in one Pi session.
+- Any state or session-entry ceiling breach throws the stable `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` identifier before persistence or state mutation.
+- The observer calls `pi.appendEntry()` before recording the key or incrementing any counter.
+- The append call is the only local translation boundary: if it throws, the observer rethrows an error whose stable message is `PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED` and retains the original error as its `cause`.
+- `tool_execution_end` is parsed even when the tool reports an error because the result may still contain valid authoritative child metadata.
+- Parent state is released only after terminal processing succeeds.
+- On `session_start`, the observer clears active deduplication state and counts existing custom entries with `customType === "patchmill-subagent-progress"` from `ctx.sessionManager.getEntries()`.
+- The shared run-once extension order will be:
+  1. resolved `pi-subagents` package root;
+  2. `extensions/todos.ts`; and
+  3. `src/pi/extensions/run-once-subagent-progress.ts`.
+- The following profiles use that list:
+  - `run-once-planning`;
+  - `run-once-development-environment`; and
+  - `run-once-implementation`.
+- The `triage` profile retains an empty extension list.
+- Create `fixtures/run-once-extension-load-sentinel.ts`. It is a test fixture, not an auto-discovered extension.
+- Its factory will require the `PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL` environment variable and write the exact UTF-8 payload `patchmill-run-once-extensions-loaded\n`, including the final line feed, to that path.
+- The fixture will not register a command, append a session entry, alter production behavior, or expose a production test flag.
+- The fixture will be included in both distribution paths without changing their file lists because npm already includes `fixtures` and the Nix install already copies that directory.
+- A single-quoted shell heredoc will carry the JavaScript verification program without shell rewriting its imports, string literals, or RPC JSON.
+- No new test will merely restate Nix source text or package metadata. The Nix build itself is the direct installed-layout verification.
+
+---
+
+### Task 1: Pure Safe Subagent Progress Normalizer
+
+**Files:**
+
+- Create: `src/pi/subagent-progress.ts`
+- Create: `src/pi/subagent-progress.test.ts`
+
+**Interfaces:**
+
+- Consumes: unknown Pi tool result values, plus the parent `toolCallId: string`.
+- Produces: `SUBAGENT_PROGRESS_CUSTOM_TYPE`, `SUBAGENT_PROGRESS_LIMIT_ERROR`, `SUBAGENT_PROGRESS_LIMITS`, `SubagentProgress`, `parseSubagentProgressResults(result: unknown, toolCallId: string): SubagentProgress[]`, and `subagentProgressKey(progress: SubagentProgress): string`.
+- Privacy boundary: the returned value contains only `toolCallId`, `childIndex`, `agent`, optional `model`, and optional `thinking`; trusted allowlisted values are bounded but not semantically classified.
+
+- [ ] **Step 1: Write the failing normalizer and privacy tests**
+
+Create `src/pi/subagent-progress.test.ts` with explicit coverage for valid rows,
+identity-only rows, malformed containers, malformed siblings, optional fields,
+verbatim strings, upstream indexes, discarded source fields, exact identifier
+boundaries, batch limits, and key collisions:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  parseSubagentProgressResults,
+  SUBAGENT_PROGRESS_LIMIT_ERROR,
+  SUBAGENT_PROGRESS_LIMITS,
+  subagentProgressKey,
+  type SubagentProgress,
+} from "./subagent-progress.ts";
+
+function resultWithRows(rows: unknown[]): unknown {
+  return { details: { results: rows } };
+}
+
+function isLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
+  );
+}
+
+test("projects valid rows in upstream order and preserves upstream indexes", () => {
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        { index: 7, agent: "worker", model: "openai/gpt-5", thinking: "high" },
+        { index: 2, agent: "reviewer", model: "anthropic/claude:beta" },
+        { index: 12, agent: "scout", thinking: "future-level" },
+      ]),
+      "call-parent",
+    ),
+    [
+      {
+        toolCallId: "call-parent",
+        childIndex: 7,
+        agent: "worker",
+        model: "openai/gpt-5",
+        thinking: "high",
+      },
+      {
+        toolCallId: "call-parent",
+        childIndex: 2,
+        agent: "reviewer",
+        model: "anthropic/claude:beta",
+      },
+      {
+        toolCallId: "call-parent",
+        childIndex: 12,
+        agent: "scout",
+        thinking: "future-level",
+      },
+    ],
+  );
+});
+
+test("keeps identity-only rows and preserves accepted strings verbatim", () => {
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        { index: 3, agent: " worker ", model: " provider/model:suffix ", thinking: " future-level " },
+        { index: 9, agent: "scout" },
+      ]),
+      " call-with-spaces ",
+    ),
+    [
+      {
+        toolCallId: " call-with-spaces ",
+        childIndex: 3,
+        agent: " worker ",
+        model: " provider/model:suffix ",
+        thinking: " future-level ",
+      },
+      { toolCallId: " call-with-spaces ", childIndex: 9, agent: "scout" },
+    ],
+  );
+});
+
+test("fails closed for malformed containers and blank parent tool call IDs", () => {
+  const malformed: unknown[] = [
+    undefined,
+    null,
+    [],
+    {},
+    { details: null },
+    { details: [] },
+    { details: {} },
+    { details: { results: null } },
+    { details: { results: {} } },
+  ];
+  for (const value of malformed) {
+    assert.deepEqual(parseSubagentProgressResults(value, "call-1"), []);
+  }
+  assert.deepEqual(
+    parseSubagentProgressResults(resultWithRows([{ index: 0, agent: "worker" }]), ""),
+    [],
+  );
+  assert.deepEqual(
+    parseSubagentProgressResults(resultWithRows([{ index: 0, agent: "worker" }]), "   "),
+    [],
+  );
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([{ index: 0, agent: "worker" }]),
+      undefined as unknown as string,
+    ),
+    [],
+  );
+});
+
+test("skips malformed rows without suppressing valid siblings", () => {
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        null,
+        [],
+        { agent: "missing-index" },
+        { index: -1, agent: "negative" },
+        { index: 1.5, agent: "fraction" },
+        { index: Number.MAX_SAFE_INTEGER + 1, agent: "unsafe" },
+        { index: 4 },
+        { index: 5, agent: "" },
+        { index: 6, agent: "   " },
+        { index: 11, agent: "valid", model: 42, thinking: { level: "high" } },
+      ]),
+      "call-1",
+    ),
+    [{ toolCallId: "call-1", childIndex: 11, agent: "valid" }],
+  );
+});
+
+test("never substitutes array position for upstream identity", () => {
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([{ agent: "missing-index" }, { index: 42, agent: "worker" }]),
+      "call-1",
+    ),
+    [{ toolCallId: "call-1", childIndex: 42, agent: "worker" }],
+  );
+});
+
+test("serialized projections do not copy discarded row properties", () => {
+  const serialized = JSON.stringify(
+    parseSubagentProgressResults(
+      resultWithRows([
+        {
+          index: 1,
+          agent: "worker",
+          model: "reported-model",
+          thinking: "reported-thinking",
+          task: "SECRET_TASK",
+          output: "SECRET_OUTPUT",
+          prompt: "SECRET_PROMPT",
+          credentials: "SECRET_CREDENTIAL",
+          path: "/secret/session.jsonl",
+          usage: { cost: "SECRET_COST" },
+          error: "SECRET_ERROR",
+          args: { token: "SECRET_TOKEN" },
+        },
+      ]),
+      "call-safe",
+    ),
+  );
+  assert.equal(serialized, JSON.stringify([{ toolCallId: "call-safe", childIndex: 1, agent: "worker", model: "reported-model", thinking: "reported-thinking" }]));
+  for (const forbidden of [
+    "SECRET_TASK",
+    "SECRET_OUTPUT",
+    "SECRET_PROMPT",
+    "SECRET_CREDENTIAL",
+    "/secret/session.jsonl",
+    "SECRET_COST",
+    "SECRET_ERROR",
+    "SECRET_TOKEN",
+  ]) {
+    assert.equal(serialized.includes(forbidden), false);
+  }
+});
+
+test("enforces identifier and result-row ceilings without truncation", () => {
+  const limits = SUBAGENT_PROGRESS_LIMITS;
+  const acceptedToolCallId = "t".repeat(limits.maxToolCallIdCodeUnits);
+  const acceptedAgent = "a".repeat(limits.maxAgentCodeUnits);
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        {
+          index: 0,
+          agent: acceptedAgent,
+          model: "m".repeat(limits.maxModelCodeUnits),
+          thinking: "h".repeat(limits.maxThinkingCodeUnits),
+        },
+      ]),
+      acceptedToolCallId,
+    ),
+    [
+      {
+        toolCallId: acceptedToolCallId,
+        childIndex: 0,
+        agent: acceptedAgent,
+        model: "m".repeat(limits.maxModelCodeUnits),
+        thinking: "h".repeat(limits.maxThinkingCodeUnits),
+      },
+    ],
+  );
+
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        {
+          index: 0,
+          agent: `${acceptedAgent}x`,
+        },
+        {
+          index: 1,
+          agent: "worker",
+          model: "m".repeat(limits.maxModelCodeUnits + 1),
+          thinking: "h".repeat(limits.maxThinkingCodeUnits + 1),
+        },
+      ]),
+      acceptedToolCallId,
+    ),
+    [{ toolCallId: acceptedToolCallId, childIndex: 1, agent: "worker" }],
+  );
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([{ index: 0, agent: "worker" }]),
+      `${acceptedToolCallId}x`,
+    ),
+    [],
+  );
+
+  assert.equal(
+    parseSubagentProgressResults(
+      resultWithRows(
+        Array.from({ length: limits.maxResultRows }, (_, index) => ({
+          index,
+          agent: "worker",
+        })),
+      ),
+      "call-max-rows",
+    ).length,
+    limits.maxResultRows,
+  );
+  assert.throws(
+    () =>
+      parseSubagentProgressResults(
+        resultWithRows(
+          Array.from({ length: limits.maxResultRows + 1 }, (_, index) => ({
+            index,
+            agent: "worker",
+          })),
+        ),
+        "call-too-many-rows",
+      ),
+    isLimitError,
+  );
+});
+
+test("serializes fixed-position collision-safe keys with absent optionals", () => {
+  const identity: SubagentProgress = {
+    toolCallId: "call|1",
+    childIndex: 3,
+    agent: "worker,reviewer",
+  };
+  assert.equal(
+    subagentProgressKey(identity),
+    '["call|1",3,"worker,reviewer",null,null]',
+  );
+  assert.notEqual(
+    subagentProgressKey(identity),
+    subagentProgressKey({ ...identity, model: "" }),
+  );
+  assert.notEqual(
+    subagentProgressKey({ ...identity, model: "model", thinking: "high" }),
+    subagentProgressKey({ ...identity, model: "model:high" }),
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the red state**
+
+Run:
+
+```sh
+node --test src/pi/subagent-progress.test.ts
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `src/pi/subagent-progress.ts`.
+
+- [ ] **Step 3: Implement the pure allowlist normalizer**
+
+Create `src/pi/subagent-progress.ts` with no Pi imports or retained raw values:
+
+```ts
+export const SUBAGENT_PROGRESS_CUSTOM_TYPE = "patchmill-subagent-progress";
+export const SUBAGENT_PROGRESS_LIMIT_ERROR =
+  "PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED";
+export const SUBAGENT_PROGRESS_LIMITS = {
+  maxToolCallIdCodeUnits: 1024,
+  maxAgentCodeUnits: 256,
+  maxModelCodeUnits: 512,
+  maxThinkingCodeUnits: 128,
+  maxResultRows: 1024,
+  maxActiveParents: 256,
+  maxChildrenPerParent: 1024,
+  maxActiveChildren: 4096,
+  maxActiveKeys: 16384,
+  maxTransitionsPerChild: 32,
+  maxEntriesPerSession: 65536,
+} as const;
+
+export type SubagentProgress = {
+  toolCallId: string;
+  childIndex: number;
+  agent: string;
+  model?: string;
+  thinking?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBoundedNonblankString(
+  value: unknown,
+  maxCodeUnits: number,
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= maxCodeUnits &&
+    value.trim().length > 0
+  );
+}
+
+export function parseSubagentProgressResults(
+  result: unknown,
+  toolCallId: string,
+): SubagentProgress[] {
+  if (
+    !isBoundedNonblankString(
+      toolCallId,
+      SUBAGENT_PROGRESS_LIMITS.maxToolCallIdCodeUnits,
+    ) ||
+    !isRecord(result)
+  ) {
+    return [];
+  }
+  const details = result.details;
+  if (!isRecord(details) || !Array.isArray(details.results)) return [];
+  if (details.results.length > SUBAGENT_PROGRESS_LIMITS.maxResultRows) {
+    throw new Error(SUBAGENT_PROGRESS_LIMIT_ERROR);
+  }
+
+  const projections: SubagentProgress[] = [];
+  for (const row of details.results) {
+    if (!isRecord(row)) continue;
+    if (
+      typeof row.index !== "number" ||
+      !Number.isSafeInteger(row.index) ||
+      row.index < 0 ||
+      !isBoundedNonblankString(
+        row.agent,
+        SUBAGENT_PROGRESS_LIMITS.maxAgentCodeUnits,
+      )
+    ) {
+      continue;
+    }
+
+    const projection: SubagentProgress = {
+      toolCallId,
+      childIndex: row.index,
+      agent: row.agent,
+    };
+    if (
+      isBoundedNonblankString(
+        row.model,
+        SUBAGENT_PROGRESS_LIMITS.maxModelCodeUnits,
+      )
+    ) {
+      projection.model = row.model;
+    }
+    if (
+      isBoundedNonblankString(
+        row.thinking,
+        SUBAGENT_PROGRESS_LIMITS.maxThinkingCodeUnits,
+      )
+    ) {
+      projection.thinking = row.thinking;
+    }
+    projections.push(projection);
+  }
+  return projections;
+}
+
+export function subagentProgressKey(progress: SubagentProgress): string {
+  return JSON.stringify([
+    progress.toolCallId,
+    progress.childIndex,
+    progress.agent,
+    progress.model ?? null,
+    progress.thinking ?? null,
+  ]);
+}
+```
+
+Do not read any row property other than `index`, `agent`, `model`, and
+`thinking`. Use trimming only to validate nonblank strings; return accepted
+strings unchanged and never truncate overlong values. A batch above 1,024 rows
+throws the stable limit identifier before inspecting any row.
+
+- [ ] **Step 4: Run the normalizer tests and lint the focused files**
+
+Run:
+
+```sh
+node --test src/pi/subagent-progress.test.ts
+npx eslint src/pi/subagent-progress.ts src/pi/subagent-progress.test.ts --max-warnings=0
+```
+
+Expected: all normalizer tests PASS and ESLint exits 0.
+
+- [ ] **Step 5: Commit the independently testable normalizer**
+
+```sh
+git add src/pi/subagent-progress.ts src/pi/subagent-progress.test.ts
+git commit -m "feat(pi): normalize safe subagent progress metadata"
+```
+
+### Task 2: Thin Pi Lifecycle Observer
+
+**Files:**
+
+- Create: `src/pi/extensions/run-once-subagent-progress.ts`
+- Create: `src/pi/extensions/run-once-subagent-progress.test.ts`
+- Create: `src/pi/extensions/run-once-subagent-progress.runner.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Pick<ExtensionAPI, "on" | "appendEntry">`, `ctx.sessionManager.getEntries()`, and the Task 1 normalizer exports.
+- Produces: the default Pi extension factory and stable `SUBAGENT_PROGRESS_APPEND_ERROR` identifier; there is no test-only registration entry point.
+- Event contract: `session_start`, `tool_execution_update.partialResult`, and `tool_execution_end.result`; only `toolName === "subagent"` is observed.
+
+- [ ] **Step 1: Write the failing observer tests with a narrow Pi harness**
+
+Create `src/pi/extensions/run-once-subagent-progress.test.ts`. The harness must
+record handlers and appended entries without creating a real Pi session:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  SUBAGENT_PROGRESS_CUSTOM_TYPE,
+  SUBAGENT_PROGRESS_LIMIT_ERROR,
+  SUBAGENT_PROGRESS_LIMITS,
+} from "../subagent-progress.ts";
+import runOnceSubagentProgressExtension, {
+  SUBAGENT_PROGRESS_APPEND_ERROR,
+} from "./run-once-subagent-progress.ts";
+
+type ObserverPi = Pick<ExtensionAPI, "on" | "appendEntry">;
+type ObserverHandler = (event: unknown, context: unknown) => unknown;
+
+type AppendedEntry = { customType: string; data: unknown };
+
+function isLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
+  );
+}
+
+function subagentResult(rows: unknown[]): unknown {
+  return { details: { results: rows } };
+}
+
+function createHarness() {
+  const handlers = new Map<string, ObserverHandler>();
+  const entries: AppendedEntry[] = [];
+  const existingSessionEntries: unknown[] = [];
+  let nextAppendError: Error | undefined;
+  const pi = {
+    on(event: string, handler: ObserverHandler) {
+      handlers.set(event, handler);
+    },
+    appendEntry(customType: string, data?: unknown) {
+      if (nextAppendError) {
+        const error = nextAppendError;
+        nextAppendError = undefined;
+        throw error;
+      }
+      entries.push({ customType, data });
+    },
+  } as unknown as ObserverPi;
+
+  runOnceSubagentProgressExtension(pi as ExtensionAPI);
+  return {
+    entries,
+    existingSessionEntries,
+    handlers,
+    failNextAppend(error: Error) {
+      nextAppendError = error;
+    },
+    async emit(name: string, event: unknown) {
+      const handler = handlers.get(name);
+      assert.ok(handler, `missing ${name} handler`);
+      await handler(event, {
+        sessionManager: { getEntries: () => existingSessionEntries },
+      });
+    },
+  };
+}
+
+test("registers only the required lifecycle handlers", () => {
+  const harness = createHarness();
+  assert.deepEqual([...harness.handlers.keys()], [
+    "session_start",
+    "tool_execution_update",
+    "tool_execution_end",
+  ]);
+});
+
+test("persists the first valid partial projection immediately", async () => {
+  const harness = createHarness();
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "call-1",
+    partialResult: subagentResult([
+      { index: 4, agent: "worker", model: "provider/model", thinking: "high" },
+    ]),
+  });
+  assert.deepEqual(harness.entries, [
+    {
+      customType: "patchmill-subagent-progress",
+      data: {
+        toolCallId: "call-1",
+        childIndex: 4,
+        agent: "worker",
+        model: "provider/model",
+        thinking: "high",
+      },
+    },
+  ]);
+});
+
+test("uses terminal results as fallback and accepts failed terminal events", async () => {
+  const harness = createHarness();
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-terminal",
+    result: subagentResult([{ index: 1, agent: "reviewer" }]),
+    isError: true,
+  });
+  assert.deepEqual(harness.entries, [
+    {
+      customType: "patchmill-subagent-progress",
+      data: { toolCallId: "call-terminal", childIndex: 1, agent: "reviewer" },
+    },
+  ]);
+});
+
+test("suppresses exact repeats and appends changed authoritative tuples", async () => {
+  const harness = createHarness();
+  const partial = {
+    toolName: "subagent",
+    toolCallId: "call-1",
+    partialResult: subagentResult([{ index: 0, agent: "worker", model: "model-a" }]),
+  };
+  await harness.emit("tool_execution_update", partial);
+  await harness.emit("tool_execution_update", partial);
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-1",
+    result: subagentResult([{ index: 0, agent: "worker", model: "model-a" }]),
+    isError: false,
+  });
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-1",
+    result: subagentResult([
+      { index: 0, agent: "worker", model: "model-a", thinking: "high" },
+    ]),
+    isError: false,
+  });
+  assert.deepEqual(
+    harness.entries.map((entry) => entry.data),
+    [
+      { toolCallId: "call-1", childIndex: 0, agent: "worker", model: "model-a" },
+      {
+        toolCallId: "call-1",
+        childIndex: 0,
+        agent: "worker",
+        model: "model-a",
+        thinking: "high",
+      },
+    ],
+  );
+});
+
+test("isolates sibling indexes and concurrent parent tool calls", async () => {
+  const harness = createHarness();
+  for (const toolCallId of ["call-a", "call-b"]) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId,
+      partialResult: subagentResult([
+        { index: 0, agent: "worker" },
+        { index: 1, agent: "reviewer" },
+      ]),
+    });
+  }
+  assert.equal(harness.entries.length, 4);
+  assert.deepEqual(
+    harness.entries.map((entry) => entry.data),
+    [
+      { toolCallId: "call-a", childIndex: 0, agent: "worker" },
+      { toolCallId: "call-a", childIndex: 1, agent: "reviewer" },
+      { toolCallId: "call-b", childIndex: 0, agent: "worker" },
+      { toolCallId: "call-b", childIndex: 1, agent: "reviewer" },
+    ],
+  );
+});
+
+test("clears deduplication on session start", async () => {
+  const harness = createHarness();
+  const event = {
+    toolName: "subagent",
+    toolCallId: "call-1",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  };
+  await harness.emit("tool_execution_update", event);
+  await harness.emit("session_start", { type: "session_start", reason: "reload" });
+  await harness.emit("tool_execution_update", event);
+  assert.equal(harness.entries.length, 2);
+});
+
+test("ignores unrelated and malformed lifecycle events", async () => {
+  const harness = createHarness();
+  await harness.emit("tool_execution_update", {
+    toolName: "bash",
+    toolCallId: "call-1",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: " ",
+    partialResult: { details: { results: "not-an-array" } },
+  });
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-2",
+    result: null,
+    isError: false,
+  });
+  assert.deepEqual(harness.entries, []);
+});
+
+test("rethrows append failure with a stable message and original cause", async () => {
+  const harness = createHarness();
+  const cause = new Error("unstable storage detail");
+  harness.failNextAppend(cause);
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "call-cause",
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    }),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === SUBAGENT_PROGRESS_APPEND_ERROR &&
+      error.cause === cause,
+  );
+  assert.deepEqual(harness.entries, []);
+});
+
+test("caps metadata transitions for one child", async () => {
+  const harness = createHarness();
+  for (
+    let transition = 0;
+    transition < SUBAGENT_PROGRESS_LIMITS.maxTransitionsPerChild;
+    transition += 1
+  ) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "call-churn",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: `model-${transition}` },
+      ]),
+    });
+  }
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "call-churn",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "one-transition-too-many" },
+      ]),
+    }),
+    isLimitError,
+  );
+});
+
+test("bounds parent and child state and releases it after terminal success", async () => {
+  const harness = createHarness();
+  for (
+    let parent = 0;
+    parent < SUBAGENT_PROGRESS_LIMITS.maxActiveParents;
+    parent += 1
+  ) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: `call-${parent}`,
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    });
+  }
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "call-over-parent-limit",
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    }),
+    isLimitError,
+  );
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-0",
+    result: subagentResult([{ index: 0, agent: "worker" }]),
+    isError: false,
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "call-after-release",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  });
+
+  const perParent = createHarness();
+  await perParent.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "call-many-children",
+    partialResult: subagentResult(
+      Array.from(
+        { length: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent },
+        (_, index) => ({ index, agent: "worker" }),
+      ),
+    ),
+  });
+  await assert.rejects(
+    perParent.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "call-many-children",
+      partialResult: subagentResult([
+        {
+          index: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent,
+          agent: "worker",
+        },
+      ]),
+    }),
+    isLimitError,
+  );
+});
+
+test("bounds active child and serialized-key state", async () => {
+  const children = createHarness();
+  const fullParentRows = Array.from(
+    { length: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent },
+    (_, index) => ({ index, agent: "worker" }),
+  );
+  const parentCount =
+    SUBAGENT_PROGRESS_LIMITS.maxActiveChildren /
+    SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent;
+  for (let parent = 0; parent < parentCount; parent += 1) {
+    await children.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: `active-${parent}`,
+      partialResult: subagentResult(fullParentRows),
+    });
+  }
+  await assert.rejects(
+    children.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "active-over-limit",
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    }),
+    isLimitError,
+  );
+
+  const keys = createHarness();
+  const transitions =
+    SUBAGENT_PROGRESS_LIMITS.maxActiveKeys /
+    SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent;
+  for (let transition = 0; transition < transitions; transition += 1) {
+    await keys.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "key-cap",
+      partialResult: subagentResult(
+        fullParentRows.map((row) => ({
+          ...row,
+          model: `model-${transition}`,
+        })),
+      ),
+    });
+  }
+  await assert.rejects(
+    keys.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "key-cap",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "key-over-limit" },
+      ]),
+    }),
+    isLimitError,
+  );
+});
+
+test("restores and increments the persisted-entry count at its boundary", async () => {
+  const harness = createHarness();
+  for (
+    let entry = 1;
+    entry < SUBAGENT_PROGRESS_LIMITS.maxEntriesPerSession;
+    entry += 1
+  ) {
+    harness.existingSessionEntries.push({
+      type: "custom",
+      customType: SUBAGENT_PROGRESS_CUSTOM_TYPE,
+    });
+  }
+  await harness.emit("session_start", {
+    type: "session_start",
+    reason: "reload",
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "call-after-reload",
+    partialResult: subagentResult([
+      { index: 0, agent: "worker", model: "first" },
+    ]),
+  });
+  assert.equal(harness.entries.length, 1);
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "call-after-reload",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "second" },
+      ]),
+    }),
+    isLimitError,
+  );
+  assert.equal(harness.entries.length, 1);
+});
+```
+
+- [ ] **Step 2: Run the observer test and verify the red state**
+
+Run:
+
+```sh
+node --test src/pi/extensions/run-once-subagent-progress.test.ts
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for
+`src/pi/extensions/run-once-subagent-progress.ts`.
+
+- [ ] **Step 3: Implement the lifecycle adapter and append-before-dedup rule**
+
+Create `src/pi/extensions/run-once-subagent-progress.ts`:
+
+```ts
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  parseSubagentProgressResults,
+  SUBAGENT_PROGRESS_CUSTOM_TYPE,
+  SUBAGENT_PROGRESS_LIMIT_ERROR,
+  SUBAGENT_PROGRESS_LIMITS,
+  subagentProgressKey,
+  type SubagentProgress,
+} from "../subagent-progress.ts";
+
+export const SUBAGENT_PROGRESS_APPEND_ERROR =
+  "PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED";
+
+type SubagentProgressPi = Pick<ExtensionAPI, "on" | "appendEntry">;
+type ChildState = { keys: Set<string> };
+type ParentState = Map<number, ChildState>;
+
+type ObservedToolEvent = {
+  toolCallId: string;
+  toolName: string;
+};
+
+function limitExceeded(): never {
+  throw new Error(SUBAGENT_PROGRESS_LIMIT_ERROR);
+}
+
+export default function runOnceSubagentProgressExtension(
+  pi: SubagentProgressPi,
+): void {
+  const parents = new Map<string, ParentState>();
+  let activeChildren = 0;
+  let activeKeys = 0;
+  let sessionEntries = 0;
+
+  function appendProgress(progress: SubagentProgress): void {
+    let parent = parents.get(progress.toolCallId);
+    const needsParent = parent === undefined;
+    if (needsParent && parents.size >= SUBAGENT_PROGRESS_LIMITS.maxActiveParents) {
+      limitExceeded();
+    }
+    parent ??= new Map<number, ChildState>();
+
+    let child = parent.get(progress.childIndex);
+    const needsChild = child === undefined;
+    if (
+      needsChild &&
+      (parent.size >= SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent ||
+        activeChildren >= SUBAGENT_PROGRESS_LIMITS.maxActiveChildren)
+    ) {
+      limitExceeded();
+    }
+    child ??= { keys: new Set<string>() };
+
+    const key = subagentProgressKey(progress);
+    if (child.keys.has(key)) return;
+    if (
+      child.keys.size >= SUBAGENT_PROGRESS_LIMITS.maxTransitionsPerChild ||
+      activeKeys >= SUBAGENT_PROGRESS_LIMITS.maxActiveKeys ||
+      sessionEntries >= SUBAGENT_PROGRESS_LIMITS.maxEntriesPerSession
+    ) {
+      limitExceeded();
+    }
+
+    try {
+      pi.appendEntry(SUBAGENT_PROGRESS_CUSTOM_TYPE, progress);
+    } catch (cause) {
+      throw new Error(SUBAGENT_PROGRESS_APPEND_ERROR, { cause });
+    }
+
+    if (needsParent) parents.set(progress.toolCallId, parent);
+    if (needsChild) {
+      parent.set(progress.childIndex, child);
+      activeChildren += 1;
+    }
+    child.keys.add(key);
+    activeKeys += 1;
+    sessionEntries += 1;
+  }
+
+  function appendResult(event: ObservedToolEvent, result: unknown): void {
+    for (const progress of parseSubagentProgressResults(
+      result,
+      event.toolCallId,
+    )) {
+      appendProgress(progress);
+    }
+  }
+
+  function releaseParent(toolCallId: string): void {
+    const parent = parents.get(toolCallId);
+    if (!parent) return;
+    for (const child of parent.values()) activeKeys -= child.keys.size;
+    activeChildren -= parent.size;
+    parents.delete(toolCallId);
+  }
+
+  pi.on("session_start", (_event, ctx) => {
+    parents.clear();
+    activeChildren = 0;
+    activeKeys = 0;
+    sessionEntries = ctx.sessionManager
+      .getEntries()
+      .filter(
+        (entry) =>
+          entry.type === "custom" &&
+          entry.customType === SUBAGENT_PROGRESS_CUSTOM_TYPE,
+      ).length;
+  });
+  pi.on("tool_execution_update", (event) => {
+    if (event.toolName !== "subagent") return;
+    appendResult(event, event.partialResult);
+  });
+  pi.on("tool_execution_end", (event) => {
+    if (event.toolName !== "subagent") return;
+    appendResult(event, event.result);
+    releaseParent(event.toolCallId);
+  });
+}
+```
+
+Do not branch on `event.isError`, inspect `event.args`, or log an event/result
+value. The `appendEntry()` catch is the one explicit boundary translation: it
+retains the original failure as `cause`, rethrows a stable identifier, and does
+not recover locally. Every limit error is thrown directly before persistence or
+retained-state mutation.
+
+- [ ] **Step 4: Test the default export through Pi's real loader and runner**
+
+Create `src/pi/extensions/run-once-subagent-progress.runner.test.ts` so append
+failures follow Pi 0.83's production error path rather than a direct handler
+rejection:
+
+```ts
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  discoverAndLoadExtensions,
+  ExtensionRunner,
+} from "@earendil-works/pi-coding-agent";
+import { findPackageRoot } from "../../package-root.ts";
+import {
+  SUBAGENT_PROGRESS_APPEND_ERROR,
+} from "./run-once-subagent-progress.ts";
+
+const rootDir = findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+
+test("Pi reports append failure and a terminal event retries the tuple", async () => {
+  const homeDir = mkdtempSync(join(tmpdir(), "patchmill-progress-runner-"));
+  try {
+    const observerPath = join(
+      rootDir,
+      "src",
+      "pi",
+      "extensions",
+      "run-once-subagent-progress.ts",
+    );
+    const loaded = await discoverAndLoadExtensions(
+      [observerPath],
+      rootDir,
+      join(homeDir, "agent"),
+    );
+    assert.deepEqual(loaded.errors, []);
+
+    const appended: Array<{ customType: string; data: unknown }> = [];
+    let failNextAppend = true;
+    loaded.runtime.appendEntry = (customType, data) => {
+      if (failNextAppend) {
+        failNextAppend = false;
+        throw new Error("unstable storage detail");
+      }
+      appended.push({ customType, data });
+    };
+
+    const runner = new ExtensionRunner(
+      loaded.extensions,
+      loaded.runtime,
+      rootDir,
+      { getEntries: () => [] } as never,
+      {} as never,
+    );
+    const errors: Array<{
+      extensionPath: string;
+      event: string;
+      error: string;
+    }> = [];
+    runner.onError((error) => errors.push(error));
+    for (const eventName of [
+      "session_start",
+      "tool_execution_update",
+      "tool_execution_end",
+    ]) {
+      assert.equal(runner.hasHandlers(eventName), true);
+    }
+
+    await runner.emit({ type: "session_start", reason: "startup" });
+    await runner.emit({
+      type: "tool_execution_update",
+      toolName: "subagent",
+      toolCallId: "call-1",
+      args: {},
+      partialResult: { details: { results: [{ index: 0, agent: "worker" }] } },
+    });
+    assert.equal(appended.length, 0);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]?.event, "tool_execution_update");
+    assert.equal(errors[0]?.error, SUBAGENT_PROGRESS_APPEND_ERROR);
+    assert.match(
+      errors[0]?.extensionPath ?? "",
+      /run-once-subagent-progress\.ts$/u,
+    );
+
+    await runner.emit({
+      type: "tool_execution_end",
+      toolName: "subagent",
+      toolCallId: "call-1",
+      result: { details: { results: [{ index: 0, agent: "worker" }] } },
+      isError: false,
+    });
+    assert.deepEqual(appended, [
+      {
+        customType: "patchmill-subagent-progress",
+        data: { toolCallId: "call-1", childIndex: 0, agent: "worker" },
+      },
+    ]);
+    assert.equal(errors.length, 1);
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+```
+
+The observer catches only `appendEntry()` to replace an unstable storage
+message with a stable public identifier while preserving the original error as
+`cause`. `ExtensionRunner.emit()` resolves after notifying `onError`; the test
+must not expect a rejection from Pi's host boundary.
+
+- [ ] **Step 5: Run normalizer, observer, runner, and focused lint checks**
+
+Run:
+
+```sh
+node --test \
+  src/pi/subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.runner.test.ts
+npx eslint \
+  src/pi/subagent-progress.ts \
+  src/pi/subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.ts \
+  src/pi/extensions/run-once-subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.runner.test.ts \
+  --max-warnings=0
+```
+
+Expected: all tests PASS and ESLint exits 0. The runner test must observe the
+stable append error once, then persist the equivalent terminal tuple.
+
+- [ ] **Step 6: Commit the independently testable observer**
+
+```sh
+git add \
+  src/pi/extensions/run-once-subagent-progress.ts \
+  src/pi/extensions/run-once-subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.runner.test.ts
+git commit -m "feat(pi): observe bounded subagent progress events"
+```
+
+### Task 3: Run-Once Profile Wiring and Source/Compiled Load Proof
+
+**Files:**
+
+- Create: `fixtures/run-once-extension-load-sentinel.ts`
+- Create: `src/pi/extensions/run-once-subagent-progress.load.test.ts`
+- Modify: `src/pi/resource-profiles.ts:16-48`
+- Modify: `src/pi/resource-profiles.test.ts:31-38,51-75,107-136`
+- Modify: `src/pi/resource-profiles.compiled.test.ts:28-137`
+- Modify: `src/cli/commands/run-once/pi.test.ts:82-87,104-201`
+
+**Interfaces:**
+
+- Consumes: the default observer factory from Task 2, `findPackageRoot()`, `requireRegularFile()`, `profileExtensionArgs()`, and `resolveBundledPiCommand()`.
+- Produces: a third ordered run-once extension path and `fixtures/run-once-extension-load-sentinel.ts` using `PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL`.
+- Load contract: real Pi offline RPC startup receives every profile extension first and the sentinel fixture last.
+
+- [ ] **Step 1: Add the sentinel fixture and write failing profile/load expectations**
+
+Create `fixtures/run-once-extension-load-sentinel.ts`:
+
+```ts
+import { writeFileSync } from "node:fs";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const SENTINEL_PAYLOAD = "patchmill-run-once-extensions-loaded\n";
+
+export default function runOnceExtensionLoadSentinel(_pi: ExtensionAPI): void {
+  const sentinelPath = process.env.PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL;
+  if (!sentinelPath) {
+    throw new Error("PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL is required");
+  }
+  writeFileSync(sentinelPath, SENTINEL_PAYLOAD, "utf8");
+}
+```
+
+Update `assertRunOnceExtensionOrder()` in
+`src/pi/resource-profiles.test.ts` to require three paths and the observer in
+position 2:
+
+```ts
+function assertRunOnceExtensionOrder(extensionPaths: string[]): void {
+  assert.equal(extensionPaths.length, 3);
+  assert.equal(extensionPaths[0], resolvePiSubagentsPackageRoot());
+  assert.equal(
+    extensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"),
+    true,
+  );
+  assert.equal(
+    extensionPaths[2]
+      ?.replaceAll("\\", "/")
+      .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+    true,
+  );
+}
+```
+
+Make the doctor-profile test call this helper for each of its first three
+profiles, preserve the exact empty triage assertion, and update
+`profileExtensionArgs()` to expect six ordered `-e` arguments.
+
+Update `runOnceExtensionArgs` in
+`src/cli/commands/run-once/pi.test.ts` to include:
+
+```ts
+"-e",
+"/repo/src/pi/extensions/run-once-subagent-progress.ts",
+```
+
+Change the affected argument assertions to expect:
+
+```ts
+assert.deepEqual(args.slice(0, 7), [
+  "-e",
+  args[1],
+  "-e",
+  args[3],
+  "-e",
+  args[5],
+  "-p",
+]);
+assert.match(args[1] ?? "", /node_modules\/pi-subagents$/u);
+assert.match(args[3] ?? "", /extensions\/todos\.ts$/u);
+assert.match(
+  args[5] ?? "",
+  /src\/pi\/extensions\/run-once-subagent-progress\.ts$/u,
+);
+assert.equal(args[7]?.startsWith("@"), true);
+```
+
+For the two-skill case, use `args.slice(0, 11)`, place the two `--skill` pairs
+after all six extension arguments, and assert that `args[11]` is the prompt
+file argument.
+
+Create `src/pi/extensions/run-once-subagent-progress.load.test.ts` as the real
+source-layout load proof:
+
+```ts
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  piCommandArgs,
+  resolveBundledPiCommand,
+} from "../../cli/pi-cli.ts";
+import { findPackageRoot } from "../../package-root.ts";
+import type { PatchmillSkillsConfig } from "../../workflow/skills.ts";
+import {
+  profileExtensionArgs,
+  runOncePlanningPiProfile,
+} from "../resource-profiles.ts";
+
+const rootDir = findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+const skills: PatchmillSkillsConfig = {
+  triage: "triage",
+  planning: "planning",
+  implementation: "implementation",
+  developmentEnvironment: "development-environment",
+  toolchain: "toolchain",
+  review: "review",
+  visualEvidence: "visual-evidence",
+  landing: "landing",
+};
+
+test("Pi loads the source run-once extensions before the sentinel", () => {
+  const homeDir = mkdtempSync(join(tmpdir(), "patchmill-run-once-load-"));
+  const sentinelPath = join(homeDir, "loaded.txt");
+  try {
+    const profile = runOncePlanningPiProfile(skills, rootDir);
+    assert.equal(profile.additionalExtensionPaths.length, 3);
+    const command = resolveBundledPiCommand();
+    const result = spawnSync(
+      command.command,
+      piCommandArgs(command, [
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--offline",
+        "-ne",
+        ...profileExtensionArgs(profile),
+        "-e",
+        join(rootDir, "fixtures", "run-once-extension-load-sentinel.ts"),
+      ]),
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+        input: '{"type":"get_commands"}\n',
+        timeout: 30_000,
+        maxBuffer: 10 * 1024 * 1024,
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          XDG_CONFIG_HOME: join(homeDir, "config"),
+          PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelPath,
+        },
+      },
+    );
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(
+      readFileSync(sentinelPath, "utf8"),
+      "patchmill-run-once-extensions-loaded\n",
+    );
+    assert.doesNotMatch(
+      `${result.stdout}\n${result.stderr}`,
+      /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+    );
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused tests and verify the red state**
+
+Run:
+
+```sh
+node --test \
+  src/pi/resource-profiles.test.ts \
+  src/pi/extensions/run-once-subagent-progress.load.test.ts \
+  src/cli/commands/run-once/pi.test.ts
+```
+
+Expected: FAIL because the profile still returns two extension paths; the load
+test must stop at the explicit three-path assertion before accepting the
+sentinel.
+
+- [ ] **Step 3: Resolve and validate the observer in every run-once profile**
+
+In `src/pi/resource-profiles.ts`, resolve the new observer from the Patchmill
+package root with the existing regular-file guard:
+
+```ts
+const PATCHMILL_SUBAGENT_PROGRESS_EXTENSION = requireRegularFile(
+  join(
+    PATCHMILL_PACKAGE_ROOT,
+    "src",
+    "pi",
+    "extensions",
+    "run-once-subagent-progress.ts",
+  ),
+);
+
+function runOnceExtensionPaths(): string[] {
+  return [
+    PI_SUBAGENTS_PACKAGE_ROOT,
+    PATCHMILL_TODOS_EXTENSION,
+    PATCHMILL_SUBAGENT_PROGRESS_EXTENSION,
+  ];
+}
+```
+
+Do not add the observer to `triagePiProfile()` and do not special-case
+`profileExtensionArgs()`.
+
+In `src/pi/resource-profiles.compiled.test.ts`, stage both package-owned source
+files beside the compiled modules:
+
+```ts
+const observerExtension = join(
+  packageRoot,
+  "src",
+  "pi",
+  "extensions",
+  "run-once-subagent-progress.ts",
+);
+const normalizer = join(packageRoot, "src", "pi", "subagent-progress.ts");
+
+await mkdir(dirname(observerExtension), { recursive: true });
+await copyFile(
+  join(
+    sourceRoot,
+    "src",
+    "pi",
+    "extensions",
+    "run-once-subagent-progress.ts",
+  ),
+  observerExtension,
+);
+await copyFile(join(sourceRoot, "src", "pi", "subagent-progress.ts"), normalizer);
+```
+
+Change the existence assertion to `[true, true, true]`, assert the observer is
+third, preserve the existing missing/non-file todos checks, restore the todos
+file after those checks, then verify the new observer guard independently:
+
+```ts
+await rm(todosExtension, { recursive: true, force: true });
+await copyFile(join(sourceRoot, "extensions", "todos.ts"), todosExtension);
+
+const missingObserverProfile = join(
+  dirname(compiledProfile),
+  "resource-profiles-missing-observer.js",
+);
+await copyFile(compiledProfile, missingObserverProfile);
+await rm(observerExtension);
+await assert.rejects(
+  import(pathToFileURL(missingObserverProfile).href),
+  (error: unknown) => {
+    assert.ok(error instanceof Error);
+    assert.equal((error as NodeJS.ErrnoException).code, "ENOENT");
+    assert.match(error.message, /run-once-subagent-progress\.ts/u);
+    return true;
+  },
+);
+
+await mkdir(observerExtension);
+const directoryObserverProfile = join(
+  dirname(compiledProfile),
+  "resource-profiles-directory-observer.js",
+);
+await copyFile(compiledProfile, directoryObserverProfile);
+await assert.rejects(
+  import(pathToFileURL(directoryObserverProfile).href),
+  /Patchmill extension is not a regular file: .*run-once-subagent-progress\.ts/u,
+);
+```
+
+The compiled test stages `src/pi/subagent-progress.ts` because the observer's
+relative import must remain present in the temporary package layout even though
+the profile import itself only checks regular files.
+
+- [ ] **Step 4: Run source, compiled, profile, and Pi argument verification**
+
+Run:
+
+```sh
+node --test \
+  src/pi/resource-profiles.test.ts \
+  src/pi/resource-profiles.compiled.test.ts \
+  src/pi/extensions/run-once-subagent-progress.load.test.ts \
+  src/cli/commands/run-once/pi.test.ts
+```
+
+Expected: all tests PASS; the source load test exits 0 and reads exactly
+`patchmill-run-once-extensions-loaded\n`.
+
+- [ ] **Step 5: Commit the run-once wiring and in-tree load proof**
+
+```sh
+git add \
+  fixtures/run-once-extension-load-sentinel.ts \
+  src/pi/extensions/run-once-subagent-progress.load.test.ts \
+  src/pi/resource-profiles.ts \
+  src/pi/resource-profiles.test.ts \
+  src/pi/resource-profiles.compiled.test.ts \
+  src/cli/commands/run-once/pi.test.ts
+git commit -m "feat(pi): load progress observer in run-once profiles"
+```
+
+### Task 4: npm-Packed and Nix-Installed Extension Load Proof
+
+**Files:**
+
+- Modify: `scripts/smoke-packed-artifact.mjs:1-184`
+- Modify: `nix/package.nix:65-112`
+
+**Interfaces:**
+
+- Consumes: the Task 3 profile ordering and sentinel protocol from installed package roots.
+- Produces: executable npm-packed and Nix-installed checks that load the installed observer through Pi's loader, assert its three handlers, then start the installed Pi CLI offline with profile extensions followed by the installed sentinel.
+- Testing Value Gate: strengthen the existing executable package checks; do not add a test that parses package metadata or Nix source text.
+
+- [ ] **Step 1: Extend the npm-packed smoke to start installed Pi**
+
+In `scripts/smoke-packed-artifact.mjs`, import `assert` and `spawnSync`, then add
+a synchronous RPC load helper that captures output without invoking a model:
+
+```js
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+
+function runPiExtensionLoad(command, args, options) {
+  console.log(`$ ${[command, ...args].join(" ")}`);
+  const result = spawnSync(command, args, {
+    ...options,
+    encoding: "utf8",
+    input: '{"type":"get_commands"}\n',
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(
+    `${result.stdout}\n${result.stderr}`,
+    /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+  );
+}
+```
+
+After importing the installed `runOncePlanningPiProfile`, keep the existing
+first/second path assertions, add the third observer assertion, and run the
+installed Pi binary with the installed fixture last:
+
+```js
+if (
+  !profile.additionalExtensionPaths[2]
+    ?.replaceAll("\\", "/")
+    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts")
+) {
+  throw new Error(
+    "run-once profile does not load the Patchmill subagent progress observer third",
+  );
+}
+
+const installedPi = await import(
+  pathToFileURL(
+    projectRequire.resolve("@earendil-works/pi-coding-agent"),
+  ).href
+);
+const installedAgentDir = join(smokeDir, "pi-agent");
+await mkdir(installedAgentDir, { recursive: true });
+const loadedObserver = await installedPi.discoverAndLoadExtensions(
+  [profile.additionalExtensionPaths[2]],
+  patchmillPackageRoot,
+  installedAgentDir,
+);
+assert.deepEqual(loadedObserver.errors, []);
+const observer = loadedObserver.extensions.find((extension) =>
+  extension.resolvedPath
+    .replaceAll("\\", "/")
+    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+);
+assert.ok(observer);
+for (const eventName of [
+  "session_start",
+  "tool_execution_update",
+  "tool_execution_end",
+]) {
+  assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
+}
+
+const sentinelFixture = join(
+  patchmillPackageRoot,
+  "fixtures",
+  "run-once-extension-load-sentinel.ts",
+);
+if (!existsSync(sentinelFixture)) {
+  throw new Error(`Installed sentinel fixture is missing: ${sentinelFixture}`);
+}
+const sentinelOutput = join(smokeDir, "run-once-extensions-loaded.txt");
+runPiExtensionLoad(
+  join(projectDir, "node_modules", ".bin", "pi"),
+  [
+    "--mode",
+    "rpc",
+    "--no-session",
+    "--offline",
+    "-ne",
+    ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
+    "-e",
+    sentinelFixture,
+  ],
+  {
+    cwd: projectDir,
+    env: {
+      ...environment,
+      PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelOutput,
+    },
+  },
+);
+assert.equal(
+  await readFile(sentinelOutput, "utf8"),
+  "patchmill-run-once-extensions-loaded\n",
+);
+console.log("packed run-once extensions loaded before sentinel");
+```
+
+This uses the profile and Pi loader imported from the installed tarball's
+dependency tree. The handler assertions prove the installed default export is
+not a no-op before the full Pi CLI load reaches the sentinel.
+
+- [ ] **Step 2: Extend the Nix install check to start installed Pi**
+
+In `nix/package.nix`, retain the existing copied-directory checks and add:
+
+```sh
+test -f "$out/share/${pname}/src/pi/subagent-progress.ts"
+test -f "$out/share/${pname}/src/pi/extensions/run-once-subagent-progress.ts"
+test -f "$out/share/${pname}/fixtures/run-once-extension-load-sentinel.ts"
+```
+
+Replace the existing double-quoted inline `node -e "..."` payload with a
+single-quoted heredoc. The quoted delimiter prevents the shell from removing
+JavaScript quotes or rewriting the embedded RPC JSON:
+
+```nix
+    (
+      cd "$out/share/${pname}"
+      PATCHMILL_INSTALL_CHECK_DIR="$install_check_dir" \
+        ${nodejs_24}/bin/node --input-type=module <<'PATCHMILL_NODE'
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { discoverAndLoadExtensions } from "@earendil-works/pi-coding-agent";
+import { runOncePlanningPiProfile } from "./src/pi/resource-profiles.ts";
+import {
+  assertInstalledPiSubagentsMatchesRootPin,
+  piSubagentsExtensionFiles,
+  resolvePiSubagentsPackageRoot,
+} from "./src/pi/pi-subagents-package.ts";
+
+assertInstalledPiSubagentsMatchesRootPin("./package.json");
+piSubagentsExtensionFiles();
+const piSubagentsRoot = resolvePiSubagentsPackageRoot();
+const skills = {
+  triage: "triage",
+  planning: "planning",
+  implementation: "implementation",
+  developmentEnvironment: "development-environment",
+  toolchain: "toolchain",
+  review: "review",
+  visualEvidence: "visual-evidence",
+  landing: "landing",
+};
+const profile = runOncePlanningPiProfile(skills, process.cwd());
+assert.equal(
+  realpathSync(profile.additionalExtensionPaths[0]),
+  realpathSync(piSubagentsRoot),
+);
+assert.equal(
+  profile.additionalExtensionPaths[1]
+    .replaceAll("\\", "/")
+    .endsWith("/extensions/todos.ts"),
+  true,
+);
+assert.equal(
+  profile.additionalExtensionPaths[2]
+    .replaceAll("\\", "/")
+    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+  true,
+);
+
+const installCheckDir = process.env.PATCHMILL_INSTALL_CHECK_DIR;
+assert.ok(installCheckDir);
+const agentDir = join(installCheckDir, "pi-agent");
+mkdirSync(agentDir, { recursive: true });
+const loadedObserver = await discoverAndLoadExtensions(
+  [profile.additionalExtensionPaths[2]],
+  process.cwd(),
+  agentDir,
+);
+assert.deepEqual(loadedObserver.errors, []);
+const observer = loadedObserver.extensions.find((extension) =>
+  extension.resolvedPath
+    .replaceAll("\\", "/")
+    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+);
+assert.ok(observer);
+for (const eventName of [
+  "session_start",
+  "tool_execution_update",
+  "tool_execution_end",
+]) {
+  assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
+}
+
+const sentinelPath = join(installCheckDir, "run-once-extensions-loaded.txt");
+const result = spawnSync(
+  process.execPath,
+  [
+    "./node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
+    "--mode",
+    "rpc",
+    "--no-session",
+    "--offline",
+    "-ne",
+    ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
+    "-e",
+    "./fixtures/run-once-extension-load-sentinel.ts",
+  ],
+  {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    input: '{"type":"get_commands"}\n',
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
+    env: {
+      ...process.env,
+      HOME: join(installCheckDir, "home"),
+      XDG_CONFIG_HOME: join(installCheckDir, "config"),
+      PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelPath,
+    },
+  },
+);
+assert.equal(result.error, undefined);
+assert.equal(result.status, 0, result.stderr || result.stdout);
+assert.doesNotMatch(
+  result.stdout + "\n" + result.stderr,
+  /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+);
+assert.equal(
+  readFileSync(sentinelPath, "utf8"),
+  "patchmill-run-once-extensions-loaded\n",
+);
+console.log("installed run-once extensions loaded before sentinel");
+PATCHMILL_NODE
+    )
+```
+
+Keep the heredoc terminator unindented in the rendered shell program. Avoid
+JavaScript template literals containing Nix `${...}` interpolation syntax.
+Keep the npm dependency pins, `npmDepsHash`, package file lists, and Nix copy
+layout unchanged.
+
+- [ ] **Step 3: Run direct installed-layout verification before committing**
+
+Run:
+
+```sh
+node scripts/smoke-packed-artifact.mjs
+nix build .#patchmill --no-link --print-build-logs
+```
+
+Expected: both commands exit 0; each uses Pi's installed loader to find all
+three observer handlers, then launches Pi in offline RPC mode and verifies the
+exact sentinel payload from its installed package layout.
+
+- [ ] **Step 4: Commit the installed-layout checks**
+
+```sh
+git add scripts/smoke-packed-artifact.mjs nix/package.nix
+git commit -m "test(packaging): load run-once observer in installed layouts"
+```
+
+- [ ] **Step 5: Run final regression and distribution verification**
+
+Run:
+
+```sh
+node --test \
+  src/pi/subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.runner.test.ts \
+  src/pi/extensions/run-once-subagent-progress.load.test.ts \
+  src/pi/resource-profiles.test.ts \
+  src/pi/resource-profiles.compiled.test.ts \
+  src/cli/commands/run-once/pi.test.ts
+npm test
+npm run lint
+node scripts/smoke-packed-artifact.mjs
+nix build .#patchmill --no-link --print-build-logs
+nix flake check --print-build-logs
+git diff --check
+```
+
+Expected: every command exits 0. Confirm that no dependency manifest or lockfile
+changed, `triage` still has no extensions, the runner test reports one stable
+append error before a successful terminal retry, both installed layouts load
+all three default-factory handlers and read the exact sentinel payload, and
+`git status --short` is empty after all four task commits.

--- a/docs/plans/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks.md
+++ b/docs/plans/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks.md
@@ -1,22 +1,41 @@
 # Persist Safe Subagent Runtime Metadata from Pi Lifecycle Hooks Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Persist a bounded, authoritative projection of `pi-subagents` child identity and reported runtime metadata in the active parent Pi session for every non-triage run-once profile.
+**Goal:** Persist a bounded, authoritative projection of `pi-subagents` child
+identity and reported runtime metadata in the active parent Pi session for every
+non-triage run-once profile.
 
-**Architecture:** A pure module validates and bounds unknown `result.details.results` values without retaining unrestricted input. The default Pi extension factory observes partial and terminal lifecycle events, appends unseen custom entries, and applies explicit parent, child, key, transition, and session-entry back-pressure. Source and installed-layout checks load the production entry point through Pi's loader and runner before proving full profile startup with a packaged sentinel fixture.
+**Architecture:** A pure module validates and bounds unknown
+`result.details.results` values without retaining unrestricted input. The
+default Pi extension factory observes partial and terminal lifecycle events,
+appends unseen custom entries, and applies explicit parent, child, key,
+transition, and session-entry back-pressure. Source and installed-layout checks
+load the production entry point through Pi's loader and runner before proving
+full profile startup with a packaged sentinel fixture.
 
-**Tech Stack:** TypeScript 6, Node.js 24 and `node:test`, `@earendil-works/pi-coding-agent` 0.83.0, `pi-subagents` 0.39.0, npm package smokes, and Nix install checks.
+**Tech Stack:** TypeScript 6, Node.js 24 and `node:test`,
+`@earendil-works/pi-coding-agent` 0.83.0, `pi-subagents` 0.39.0, npm package
+smokes, and Nix install checks.
 
 ## Global Constraints
 
 - Patchmill relies on the `pi-subagents` 0.39.0 contract adopted by issue #122:
 - Patchmill must not infer missing values from parent or agent configuration.
-- The upstream `runId` is therefore unnecessary for this bridge and is not allowed in the persisted projection.
-- Accepted strings remain verbatim after validation. Patchmill will not remove a provider prefix, split a model suffix, constrain thinking to a local enum, truncate a reported identifier, or backfill a missing value.
+- The upstream `runId` is therefore unnecessary for this bridge and is not
+  allowed in the persisted projection.
+- Accepted strings remain verbatim after validation. Patchmill will not remove a
+  provider prefix, split a model suffix, constrain thinking to a local enum,
+  truncate a reported identifier, or backfill a missing value.
 - A valid row with only `index` and `agent` produces an identity-only entry:
-- The projection never reads or copies task, output, prompt, credential, usage, cost, path, error, message, full-result, event-argument, or other incidental properties.
-- This structural guarantee does not inspect the meaning of an otherwise valid allowlisted identifier supplied by trusted `pi-subagents`.
+- The projection never reads or copies task, output, prompt, credential, usage,
+  cost, path, error, message, full-result, event-argument, or other incidental
+  properties.
+- This structural guarantee does not inspect the meaning of an otherwise valid
+  allowlisted identifier supplied by trusted `pi-subagents`.
 - The key is based on the upstream child index, never the row's array position.
 - Before allocating or appending state, the observer enforces these ceilings:
   - 256 active parent tool calls;
@@ -25,12 +44,21 @@
   - 16,384 active serialized tuple keys;
   - 32 persisted transitions for one `(toolCallId, childIndex)`; and
   - 65,536 `patchmill-subagent-progress` entries in one Pi session.
-- Any state or session-entry ceiling breach throws the stable `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` identifier before persistence or state mutation.
-- The observer calls `pi.appendEntry()` before recording the key or incrementing any counter.
-- The append call is the only local translation boundary: if it throws, the observer rethrows an error whose stable message is `PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED` and retains the original error as its `cause`.
-- `tool_execution_end` is parsed even when the tool reports an error because the result may still contain valid authoritative child metadata.
+- Any state or session-entry ceiling breach throws the stable
+  `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` identifier before persistence or
+  state mutation.
+- The observer calls `pi.appendEntry()` before recording the key or incrementing
+  any counter.
+- The append call is the only local translation boundary: if it throws, the
+  observer rethrows an error whose stable message is
+  `PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED` and retains the original error as
+  its `cause`.
+- `tool_execution_end` is parsed even when the tool reports an error because the
+  result may still contain valid authoritative child metadata.
 - Parent state is released only after terminal processing succeeds.
-- On `session_start`, the observer clears active deduplication state and counts existing custom entries with `customType === "patchmill-subagent-progress"` from `ctx.sessionManager.getEntries()`.
+- On `session_start`, the observer clears active deduplication state and counts
+  existing custom entries with `customType === "patchmill-subagent-progress"`
+  from `ctx.sessionManager.getEntries()`.
 - The shared run-once extension order will be:
   1. resolved `pi-subagents` package root;
   2. `extensions/todos.ts`; and
@@ -40,12 +68,21 @@
   - `run-once-development-environment`; and
   - `run-once-implementation`.
 - The `triage` profile retains an empty extension list.
-- Create `fixtures/run-once-extension-load-sentinel.ts`. It is a test fixture, not an auto-discovered extension.
-- Its factory will require the `PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL` environment variable and write the exact UTF-8 payload `patchmill-run-once-extensions-loaded\n`, including the final line feed, to that path.
-- The fixture will not register a command, append a session entry, alter production behavior, or expose a production test flag.
-- The fixture will be included in both distribution paths without changing their file lists because npm already includes `fixtures` and the Nix install already copies that directory.
-- A single-quoted shell heredoc will carry the JavaScript verification program without shell rewriting its imports, string literals, or RPC JSON.
-- No new test will merely restate Nix source text or package metadata. The Nix build itself is the direct installed-layout verification.
+- Create `fixtures/run-once-extension-load-sentinel.ts`. It is a test fixture,
+  not an auto-discovered extension.
+- Its factory will require the `PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL`
+  environment variable and write the exact UTF-8 payload
+  `patchmill-run-once-extensions-loaded\n`, including the final line feed, to
+  that path.
+- The fixture will not register a command, append a session entry, alter
+  production behavior, or expose a production test flag.
+- The fixture will be included in both distribution paths without changing their
+  file lists because npm already includes `fixtures` and the Nix install already
+  copies that directory.
+- A single-quoted shell heredoc will carry the JavaScript verification program
+  without shell rewriting its imports, string literals, or RPC JSON.
+- No new test will merely restate Nix source text or package metadata. The Nix
+  build itself is the direct installed-layout verification.
 
 ---
 
@@ -59,8 +96,13 @@
 **Interfaces:**
 
 - Consumes: unknown Pi tool result values, plus the parent `toolCallId: string`.
-- Produces: `SUBAGENT_PROGRESS_CUSTOM_TYPE`, `SUBAGENT_PROGRESS_LIMIT_ERROR`, `SUBAGENT_PROGRESS_LIMITS`, `SubagentProgress`, `parseSubagentProgressResults(result: unknown, toolCallId: string): SubagentProgress[]`, and `subagentProgressKey(progress: SubagentProgress): string`.
-- Privacy boundary: the returned value contains only `toolCallId`, `childIndex`, `agent`, optional `model`, and optional `thinking`; trusted allowlisted values are bounded but not semantically classified.
+- Produces: `SUBAGENT_PROGRESS_CUSTOM_TYPE`, `SUBAGENT_PROGRESS_LIMIT_ERROR`,
+  `SUBAGENT_PROGRESS_LIMITS`, `SubagentProgress`,
+  `parseSubagentProgressResults(result: unknown, toolCallId: string): SubagentProgress[]`,
+  and `subagentProgressKey(progress: SubagentProgress): string`.
+- Privacy boundary: the returned value contains only `toolCallId`, `childIndex`,
+  `agent`, optional `model`, and optional `thinking`; trusted allowlisted values
+  are bounded but not semantically classified.
 
 - [ ] **Step 1: Write the failing normalizer and privacy tests**
 
@@ -86,8 +128,7 @@ function resultWithRows(rows: unknown[]): unknown {
 
 function isLimitError(error: unknown): boolean {
   return (
-    error instanceof Error &&
-    error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
+    error instanceof Error && error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
   );
 }
 
@@ -129,7 +170,12 @@ test("keeps identity-only rows and preserves accepted strings verbatim", () => {
   assert.deepEqual(
     parseSubagentProgressResults(
       resultWithRows([
-        { index: 3, agent: " worker ", model: " provider/model:suffix ", thinking: " future-level " },
+        {
+          index: 3,
+          agent: " worker ",
+          model: " provider/model:suffix ",
+          thinking: " future-level ",
+        },
         { index: 9, agent: "scout" },
       ]),
       " call-with-spaces ",
@@ -163,11 +209,17 @@ test("fails closed for malformed containers and blank parent tool call IDs", () 
     assert.deepEqual(parseSubagentProgressResults(value, "call-1"), []);
   }
   assert.deepEqual(
-    parseSubagentProgressResults(resultWithRows([{ index: 0, agent: "worker" }]), ""),
+    parseSubagentProgressResults(
+      resultWithRows([{ index: 0, agent: "worker" }]),
+      "",
+    ),
     [],
   );
   assert.deepEqual(
-    parseSubagentProgressResults(resultWithRows([{ index: 0, agent: "worker" }]), "   "),
+    parseSubagentProgressResults(
+      resultWithRows([{ index: 0, agent: "worker" }]),
+      "   ",
+    ),
     [],
   );
   assert.deepEqual(
@@ -203,7 +255,10 @@ test("skips malformed rows without suppressing valid siblings", () => {
 test("never substitutes array position for upstream identity", () => {
   assert.deepEqual(
     parseSubagentProgressResults(
-      resultWithRows([{ agent: "missing-index" }, { index: 42, agent: "worker" }]),
+      resultWithRows([
+        { agent: "missing-index" },
+        { index: 42, agent: "worker" },
+      ]),
       "call-1",
     ),
     [{ toolCallId: "call-1", childIndex: 42, agent: "worker" }],
@@ -232,7 +287,18 @@ test("serialized projections do not copy discarded row properties", () => {
       "call-safe",
     ),
   );
-  assert.equal(serialized, JSON.stringify([{ toolCallId: "call-safe", childIndex: 1, agent: "worker", model: "reported-model", thinking: "reported-thinking" }]));
+  assert.equal(
+    serialized,
+    JSON.stringify([
+      {
+        toolCallId: "call-safe",
+        childIndex: 1,
+        agent: "worker",
+        model: "reported-model",
+        thinking: "reported-thinking",
+      },
+    ]),
+  );
   for (const forbidden of [
     "SECRET_TASK",
     "SECRET_OUTPUT",
@@ -507,9 +573,13 @@ git commit -m "feat(pi): normalize safe subagent progress metadata"
 
 **Interfaces:**
 
-- Consumes: `Pick<ExtensionAPI, "on" | "appendEntry">`, `ctx.sessionManager.getEntries()`, and the Task 1 normalizer exports.
-- Produces: the default Pi extension factory and stable `SUBAGENT_PROGRESS_APPEND_ERROR` identifier; there is no test-only registration entry point.
-- Event contract: `session_start`, `tool_execution_update.partialResult`, and `tool_execution_end.result`; only `toolName === "subagent"` is observed.
+- Consumes: `Pick<ExtensionAPI, "on" | "appendEntry">`,
+  `ctx.sessionManager.getEntries()`, and the Task 1 normalizer exports.
+- Produces: the default Pi extension factory and stable
+  `SUBAGENT_PROGRESS_APPEND_ERROR` identifier; there is no test-only
+  registration entry point.
+- Event contract: `session_start`, `tool_execution_update.partialResult`, and
+  `tool_execution_end.result`; only `toolName === "subagent"` is observed.
 
 - [ ] **Step 1: Write the failing observer tests with a narrow Pi harness**
 
@@ -536,8 +606,7 @@ type AppendedEntry = { customType: string; data: unknown };
 
 function isLimitError(error: unknown): boolean {
   return (
-    error instanceof Error &&
-    error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
+    error instanceof Error && error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
   );
 }
 
@@ -584,11 +653,10 @@ function createHarness() {
 
 test("registers only the required lifecycle handlers", () => {
   const harness = createHarness();
-  assert.deepEqual([...harness.handlers.keys()], [
-    "session_start",
-    "tool_execution_update",
-    "tool_execution_end",
-  ]);
+  assert.deepEqual(
+    [...harness.handlers.keys()],
+    ["session_start", "tool_execution_update", "tool_execution_end"],
+  );
 });
 
 test("persists the first valid partial projection immediately", async () => {
@@ -635,7 +703,9 @@ test("suppresses exact repeats and appends changed authoritative tuples", async 
   const partial = {
     toolName: "subagent",
     toolCallId: "call-1",
-    partialResult: subagentResult([{ index: 0, agent: "worker", model: "model-a" }]),
+    partialResult: subagentResult([
+      { index: 0, agent: "worker", model: "model-a" },
+    ]),
   };
   await harness.emit("tool_execution_update", partial);
   await harness.emit("tool_execution_update", partial);
@@ -656,7 +726,12 @@ test("suppresses exact repeats and appends changed authoritative tuples", async 
   assert.deepEqual(
     harness.entries.map((entry) => entry.data),
     [
-      { toolCallId: "call-1", childIndex: 0, agent: "worker", model: "model-a" },
+      {
+        toolCallId: "call-1",
+        childIndex: 0,
+        agent: "worker",
+        model: "model-a",
+      },
       {
         toolCallId: "call-1",
         childIndex: 0,
@@ -700,7 +775,10 @@ test("clears deduplication on session start", async () => {
     partialResult: subagentResult([{ index: 0, agent: "worker" }]),
   };
   await harness.emit("tool_execution_update", event);
-  await harness.emit("session_start", { type: "session_start", reason: "reload" });
+  await harness.emit("session_start", {
+    type: "session_start",
+    reason: "reload",
+  });
   await harness.emit("tool_execution_update", event);
   assert.equal(harness.entries.length, 2);
 });
@@ -974,7 +1052,10 @@ export default function runOnceSubagentProgressExtension(
   function appendProgress(progress: SubagentProgress): void {
     let parent = parents.get(progress.toolCallId);
     const needsParent = parent === undefined;
-    if (needsParent && parents.size >= SUBAGENT_PROGRESS_LIMITS.maxActiveParents) {
+    if (
+      needsParent &&
+      parents.size >= SUBAGENT_PROGRESS_LIMITS.maxActiveParents
+    ) {
       limitExceeded();
     }
     parent ??= new Map<number, ChildState>();
@@ -1081,9 +1162,7 @@ import {
   ExtensionRunner,
 } from "@earendil-works/pi-coding-agent";
 import { findPackageRoot } from "../../package-root.ts";
-import {
-  SUBAGENT_PROGRESS_APPEND_ERROR,
-} from "./run-once-subagent-progress.ts";
+import { SUBAGENT_PROGRESS_APPEND_ERROR } from "./run-once-subagent-progress.ts";
 
 const rootDir = findPackageRoot(dirname(fileURLToPath(import.meta.url)));
 
@@ -1172,10 +1251,10 @@ test("Pi reports append failure and a terminal event retries the tuple", async (
 });
 ```
 
-The observer catches only `appendEntry()` to replace an unstable storage
-message with a stable public identifier while preserving the original error as
-`cause`. `ExtensionRunner.emit()` resolves after notifying `onError`; the test
-must not expect a rejection from Pi's host boundary.
+The observer catches only `appendEntry()` to replace an unstable storage message
+with a stable public identifier while preserving the original error as `cause`.
+`ExtensionRunner.emit()` resolves after notifying `onError`; the test must not
+expect a rejection from Pi's host boundary.
 
 - [ ] **Step 5: Run normalizer, observer, runner, and focused lint checks**
 
@@ -1221,11 +1300,17 @@ git commit -m "feat(pi): observe bounded subagent progress events"
 
 **Interfaces:**
 
-- Consumes: the default observer factory from Task 2, `findPackageRoot()`, `requireRegularFile()`, `profileExtensionArgs()`, and `resolveBundledPiCommand()`.
-- Produces: a third ordered run-once extension path and `fixtures/run-once-extension-load-sentinel.ts` using `PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL`.
-- Load contract: real Pi offline RPC startup receives every profile extension first and the sentinel fixture last.
+- Consumes: the default observer factory from Task 2, `findPackageRoot()`,
+  `requireRegularFile()`, `profileExtensionArgs()`, and
+  `resolveBundledPiCommand()`.
+- Produces: a third ordered run-once extension path and
+  `fixtures/run-once-extension-load-sentinel.ts` using
+  `PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL`.
+- Load contract: real Pi offline RPC startup receives every profile extension
+  first and the sentinel fixture last.
 
-- [ ] **Step 1: Add the sentinel fixture and write failing profile/load expectations**
+- [ ] **Step 1: Add the sentinel fixture and write failing profile/load
+      expectations**
 
 Create `fixtures/run-once-extension-load-sentinel.ts`:
 
@@ -1244,9 +1329,8 @@ export default function runOnceExtensionLoadSentinel(_pi: ExtensionAPI): void {
 }
 ```
 
-Update `assertRunOnceExtensionOrder()` in
-`src/pi/resource-profiles.test.ts` to require three paths and the observer in
-position 2:
+Update `assertRunOnceExtensionOrder()` in `src/pi/resource-profiles.test.ts` to
+require three paths and the observer in position 2:
 
 ```ts
 function assertRunOnceExtensionOrder(extensionPaths: string[]): void {
@@ -1269,8 +1353,8 @@ Make the doctor-profile test call this helper for each of its first three
 profiles, preserve the exact empty triage assertion, and update
 `profileExtensionArgs()` to expect six ordered `-e` arguments.
 
-Update `runOnceExtensionArgs` in
-`src/cli/commands/run-once/pi.test.ts` to include:
+Update `runOnceExtensionArgs` in `src/cli/commands/run-once/pi.test.ts` to
+include:
 
 ```ts
 "-e",
@@ -1299,8 +1383,8 @@ assert.equal(args[7]?.startsWith("@"), true);
 ```
 
 For the two-skill case, use `args.slice(0, 11)`, place the two `--skill` pairs
-after all six extension arguments, and assert that `args[11]` is the prompt
-file argument.
+after all six extension arguments, and assert that `args[11]` is the prompt file
+argument.
 
 Create `src/pi/extensions/run-once-subagent-progress.load.test.ts` as the real
 source-layout load proof:
@@ -1313,10 +1397,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
-import {
-  piCommandArgs,
-  resolveBundledPiCommand,
-} from "../../cli/pi-cli.ts";
+import { piCommandArgs, resolveBundledPiCommand } from "../../cli/pi-cli.ts";
 import { findPackageRoot } from "../../package-root.ts";
 import type { PatchmillSkillsConfig } from "../../workflow/skills.ts";
 import {
@@ -1443,16 +1524,13 @@ const normalizer = join(packageRoot, "src", "pi", "subagent-progress.ts");
 
 await mkdir(dirname(observerExtension), { recursive: true });
 await copyFile(
-  join(
-    sourceRoot,
-    "src",
-    "pi",
-    "extensions",
-    "run-once-subagent-progress.ts",
-  ),
+  join(sourceRoot, "src", "pi", "extensions", "run-once-subagent-progress.ts"),
   observerExtension,
 );
-await copyFile(join(sourceRoot, "src", "pi", "subagent-progress.ts"), normalizer);
+await copyFile(
+  join(sourceRoot, "src", "pi", "subagent-progress.ts"),
+  normalizer,
+);
 ```
 
 Change the existence assertion to `[true, true, true]`, assert the observer is
@@ -1532,14 +1610,19 @@ git commit -m "feat(pi): load progress observer in run-once profiles"
 
 **Interfaces:**
 
-- Consumes: the Task 3 profile ordering and sentinel protocol from installed package roots.
-- Produces: executable npm-packed and Nix-installed checks that load the installed observer through Pi's loader, assert its three handlers, then start the installed Pi CLI offline with profile extensions followed by the installed sentinel.
-- Testing Value Gate: strengthen the existing executable package checks; do not add a test that parses package metadata or Nix source text.
+- Consumes: the Task 3 profile ordering and sentinel protocol from installed
+  package roots.
+- Produces: executable npm-packed and Nix-installed checks that load the
+  installed observer through Pi's loader, assert its three handlers, then start
+  the installed Pi CLI offline with profile extensions followed by the installed
+  sentinel.
+- Testing Value Gate: strengthen the existing executable package checks; do not
+  add a test that parses package metadata or Nix source text.
 
 - [ ] **Step 1: Extend the npm-packed smoke to start installed Pi**
 
-In `scripts/smoke-packed-artifact.mjs`, import `assert` and `spawnSync`, then add
-a synchronous RPC load helper that captures output without invoking a model:
+In `scripts/smoke-packed-artifact.mjs`, import `assert` and `spawnSync`, then
+add a synchronous RPC load helper that captures output without invoking a model:
 
 ```js
 import assert from "node:assert/strict";
@@ -1579,9 +1662,7 @@ if (
 }
 
 const installedPi = await import(
-  pathToFileURL(
-    projectRequire.resolve("@earendil-works/pi-coding-agent"),
-  ).href
+  pathToFileURL(projectRequire.resolve("@earendil-works/pi-coding-agent")).href
 );
 const installedAgentDir = join(smokeDir, "pi-agent");
 await mkdir(installedAgentDir, { recursive: true });
@@ -1775,9 +1856,9 @@ PATCHMILL_NODE
 ```
 
 Keep the heredoc terminator unindented in the rendered shell program. Avoid
-JavaScript template literals containing Nix `${...}` interpolation syntax.
-Keep the npm dependency pins, `npmDepsHash`, package file lists, and Nix copy
-layout unchanged.
+JavaScript template literals containing Nix `${...}` interpolation syntax. Keep
+the npm dependency pins, `npmDepsHash`, package file lists, and Nix copy layout
+unchanged.
 
 - [ ] **Step 3: Run direct installed-layout verification before committing**
 
@@ -1822,6 +1903,6 @@ git diff --check
 
 Expected: every command exits 0. Confirm that no dependency manifest or lockfile
 changed, `triage` still has no extensions, the runner test reports one stable
-append error before a successful terminal retry, both installed layouts load
-all three default-factory handlers and read the exact sentinel payload, and
+append error before a successful terminal retry, both installed layouts load all
+three default-factory handlers and read the exact sentinel payload, and
 `git status --short` is empty after all four task commits.

--- a/docs/specs/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks-design.md
+++ b/docs/specs/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks-design.md
@@ -1,0 +1,470 @@
+# Persist safe subagent runtime metadata from Pi lifecycle hooks design
+
+**Issue:** [#124](https://github.com/rochecompaan/patchmill/issues/124)
+**Parent:** [#116](https://github.com/rochecompaan/patchmill/issues/116)
+**Dependencies:** #121 and #122, both complete
+**Status:** Approved design
+
+## Summary
+
+Patchmill will add a small Pi extension that observes authoritative
+`pi-subagents` child metadata in parent tool lifecycle events and persists a
+strict projection as `patchmill-subagent-progress` custom session entries.
+Because the extension calls `pi.appendEntry()` inside the parent Pi process, the
+entry lands in the exact active parent session and remains outside LLM context.
+
+The implementation will separate pure validation and projection from Pi event
+handling. It will load the observer in every run-once profile, leave triage
+unchanged, and prove real extension loading in source, npm-packed, and
+Nix-installed layouts with one stable packaged sentinel fixture.
+
+## Goals
+
+- Persist the first valid authoritative partial update before parent tool
+  completion when `pi-subagents` emits one.
+- Use the terminal tool result as a fallback and suppress exact tuples already
+  persisted from partial updates.
+- Keep every child independent across sibling indexes and concurrent parent
+  tool calls.
+- Persist only parent tool-call identity, upstream child identity, agent name,
+  and reported model/thinking fields.
+- Preserve unknown runtime fields as absent and allow a valid identity-only
+  entry.
+- Bound accepted identifiers, result batches, metadata transitions,
+  deduplication state, and persisted progress entries far above normal
+  `pi-subagents` workloads.
+- Load the observer in run-once planning, development-environment, and
+  implementation profiles.
+- Prove that the same observer and its relative import load from source,
+  npm-packed, and Nix-installed package layouts.
+
+## Non-goals
+
+This issue will not:
+
+- reproduce agent, model, thinking, provider, override, default, or fallback
+  resolution;
+- follow Pi session files or use `PI_SESSION_FILE` to find the parent session;
+- correlate custom entries into Patchmill observations;
+- synthesize requested-child or unresolved-child fallbacks;
+- render progress in the console or TUI;
+- change stdout/stderr behavior;
+- load the observer in triage;
+- change the pinned `pi-subagents` dependency; or
+- modify `pi-subagents` itself.
+
+## Upstream and Pi contracts
+
+Patchmill relies on the `pi-subagents` 0.39.0 contract adopted by issue #122:
+
+- child rows are available at `result.details.results`;
+- each row has a stable non-negative integer `index` assigned by upstream;
+- sibling indexes are unique within one foreground run;
+- partial and final rows preserve child identity and ordering;
+- `agent`, `model`, and `thinking` are reported by upstream; and
+- Patchmill must not infer missing values from parent or agent configuration.
+
+The observer uses Pi's documented lifecycle and persistence APIs:
+
+- `tool_execution_update.partialResult` for near-live observations;
+- `tool_execution_end.result` for terminal fallback; and
+- `pi.appendEntry()` for custom entries that do not participate in LLM
+  context.
+
+The parent `toolCallId` scopes the upstream child index to one parent subagent
+invocation. The upstream `runId` is therefore unnecessary for this bridge and
+is not allowed in the persisted projection.
+
+`pi-subagents` is a trusted in-process dependency, but Pi exposes lifecycle
+result fields as runtime-unknown values. Patchmill guarantees that the observer
+copies no properties outside its five-field allowlist. It does not claim that
+an allowlisted `agent`, `model`, or `thinking` value is semantically free of
+secrets; that guarantee belongs to the trusted upstream producer. Patchmill
+still limits every accepted identifier so an upstream bug cannot create an
+unbounded projection.
+
+## Architecture
+
+### Pure normalization module
+
+Create `src/pi/subagent-progress.ts` with one responsibility: validate unknown
+`pi-subagents` result values and return the safe persisted projection.
+
+Its public surface will be:
+
+```ts
+export const SUBAGENT_PROGRESS_CUSTOM_TYPE = "patchmill-subagent-progress";
+export const SUBAGENT_PROGRESS_LIMIT_ERROR =
+  "PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED";
+export const SUBAGENT_PROGRESS_LIMITS = {
+  maxToolCallIdCodeUnits: 1024,
+  maxAgentCodeUnits: 256,
+  maxModelCodeUnits: 512,
+  maxThinkingCodeUnits: 128,
+  maxResultRows: 1024,
+  maxActiveParents: 256,
+  maxChildrenPerParent: 1024,
+  maxActiveChildren: 4096,
+  maxActiveKeys: 16384,
+  maxTransitionsPerChild: 32,
+  maxEntriesPerSession: 65536,
+} as const;
+
+export type SubagentProgress = {
+  toolCallId: string;
+  childIndex: number;
+  agent: string;
+  model?: string;
+  thinking?: string;
+};
+
+export function parseSubagentProgressResults(
+  result: unknown,
+  toolCallId: string,
+): SubagentProgress[];
+
+export function subagentProgressKey(progress: SubagentProgress): string;
+```
+
+The module will not import Pi, read files, inspect agent definitions, or retain
+unrestricted result objects.
+
+### Thin lifecycle observer
+
+Create `src/pi/extensions/run-once-subagent-progress.ts` with one
+responsibility: connect Pi lifecycle events to the pure normalizer and append
+unseen entries.
+
+Its default Pi extension factory owns handler registration and exports
+`SUBAGENT_PROGRESS_APPEND_ERROR` with the stable value
+`PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED`. Behavior tests call that default
+export, and integration tests load it through Pi's extension loader so a no-op
+package entry point cannot pass while an internal helper works. The adapter will
+subscribe to:
+
+- `session_start` to reset session-scoped deduplication state;
+- `tool_execution_update` to process `partialResult`; and
+- `tool_execution_end` to process `result`.
+
+The observer deliberately lives below `src/pi/extensions/`, not the package's
+conventional top-level `extensions/` directory. Patchmill will load it only
+through run-once resource profiles instead of making it an auto-discovered
+package extension.
+
+## Persisted data contract
+
+For every candidate event and row:
+
+1. Require `toolName === "subagent"`.
+2. Require a nonblank string `toolCallId` no longer than 1,024 UTF-16 code
+   units from the Pi lifecycle event.
+3. Require `result`, `result.details`, and each candidate row to be records.
+4. Require `result.details.results` to be an array with at most 1,024 rows. A
+   larger batch throws `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` before any
+   row is persisted.
+5. Require `row.index` to be a non-negative safe integer.
+6. Require `row.agent` to be a nonblank string no longer than 256 UTF-16 code
+   units.
+7. Include `row.model` only when it is a nonblank string no longer than 512
+   UTF-16 code units.
+8. Include `row.thinking` only when it is a nonblank string no longer than 128
+   UTF-16 code units.
+
+Accepted strings remain verbatim after validation. Patchmill will not remove a
+provider prefix, split a model suffix, constrain thinking to a local enum,
+truncate a reported identifier, or backfill a missing value. Overlong required
+identifiers invalidate their event or row; overlong optional fields remain
+absent. The validator checks a string's code-unit ceiling before calling
+`trim()`, so an overlong value is rejected without first scanning or copying it
+for blankness. These ceilings are deliberately far above the upstream defaults
+of eight parallel tasks, concurrency four, and global concurrency twenty.
+
+A valid row with only `index` and `agent` produces an identity-only entry:
+
+```json
+{
+  "toolCallId": "call-1",
+  "childIndex": 3,
+  "agent": "worker"
+}
+```
+
+The projection never reads or copies task, output, prompt, credential, usage,
+cost, path, error, message, full-result, event-argument, or other incidental
+properties. Invalid rows are ignored individually so one child cannot suppress
+valid siblings. This structural guarantee does not inspect the meaning of an
+otherwise valid allowlisted identifier supplied by trusted `pi-subagents`.
+
+## Lifecycle, deduplication, and back-pressure
+
+The observer keeps parent state keyed by `toolCallId`, then child state keyed by
+upstream `childIndex`. Each child stores its emitted fixed-position JSON tuple
+keys and transition count:
+
+```text
+(toolCallId, childIndex, agent, model?, thinking?)
+```
+
+The key is based on the upstream child index, never the row's array position.
+`subagentProgressKey()` will serialize a fixed-position JSON tuple so delimiter
+characters and absent optional fields cannot create collisions. Including
+`toolCallId` and `childIndex` prevents collisions between concurrent parent
+invocations and siblings. Including the complete projection gives these
+semantics:
+
+- the first valid partial tuple is appended immediately;
+- a repeated partial tuple is suppressed;
+- an identical final tuple is suppressed;
+- a final tuple that adds or changes authoritative metadata is appended; and
+- an identity-only tuple is valid and deduplicates like any other tuple.
+
+Rows are processed in the order upstream supplies them. Existing entries are
+never updated, replaced, or deleted. Before allocating or appending state, the
+observer enforces these ceilings:
+
+- 256 active parent tool calls;
+- 1,024 child indexes for one parent tool call;
+- 4,096 active child states across all parents;
+- 16,384 active serialized tuple keys;
+- 32 persisted transitions for one `(toolCallId, childIndex)`; and
+- 65,536 `patchmill-subagent-progress` entries in one Pi session.
+
+Any state or session-entry ceiling breach throws the stable
+`PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` identifier before persistence or
+state mutation. The limits are high enough to avoid normal sessions while
+providing a finite upper bound when upstream configuration removes its normal
+parallelism defaults.
+
+The observer calls `pi.appendEntry()` before recording the key or incrementing
+any counter. The append call is the only local translation boundary: if it
+throws, the observer rethrows an error whose stable message is
+`PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED` and retains the original error as
+its `cause`. Pi 0.83's `ExtensionRunner` catches that handler error and emits it
+to `onError`; it does not reject `emit()`. The failed key and counters remain
+unchanged, so an equivalent terminal update may retry. The handler stops
+processing the current event at the first persistence failure and never logs
+raw event data.
+
+`tool_execution_end` is parsed even when the tool reports an error because the
+result may still contain valid authoritative child metadata. Parent state is
+released only after terminal processing succeeds. If terminal persistence
+fails, state remains available for a later equivalent retry.
+
+On `session_start`, the observer clears active deduplication state and counts
+existing custom entries with `customType === "patchmill-subagent-progress"`
+from `ctx.sessionManager.getEntries()`. Restoring that counter prevents a
+reload or resume from bypassing the per-session persistence ceiling. Pi does
+not replay completed lifecycle events into the new extension instance.
+
+## Exact parent-session guarantee
+
+The observer runs in the same Pi process and resource profile as the parent
+`subagent` tool call. `pi.appendEntry()` writes to that process's active
+`SessionManager`, so no session discovery or file correlation is needed.
+
+The custom entry type is `custom`, not `custom_message`. Pi excludes custom
+entries from `buildSessionContext()`, which keeps the bounded projection and
+all discarded source fields outside the LLM conversation.
+
+## Run-once resource profiles
+
+Update `src/pi/resource-profiles.ts` to resolve the observer from the Patchmill
+package root and require it to be a regular file. The shared run-once extension
+order will be:
+
+1. resolved `pi-subagents` package root;
+2. `extensions/todos.ts`; and
+3. `src/pi/extensions/run-once-subagent-progress.ts`.
+
+The following profiles use that list:
+
+- `run-once-planning`;
+- `run-once-development-environment`; and
+- `run-once-implementation`.
+
+The `triage` profile retains an empty extension list. Existing argument helpers
+will render all three paths as ordered `-e` arguments without special cases.
+
+## Stable extension-load sentinel
+
+Create `fixtures/run-once-extension-load-sentinel.ts`. It is a test fixture,
+not an auto-discovered extension. Its factory will require the
+`PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL` environment variable and write the
+exact UTF-8 payload `patchmill-run-once-extensions-loaded\n`, including the
+final line feed, to that path.
+
+Every layout smoke test will pass the run-once profile's extension arguments
+first and the sentinel fixture last. Reaching the sentinel proves that Pi
+loaded `pi-subagents`, todos, the observer, and the observer's relative
+`../subagent-progress.ts` import before the probe factory ran.
+
+The checks will use isolated home/config directories and offline RPC mode with
+no model execution. The fixture will not register a command, append a session
+entry, alter production behavior, or expose a production test flag.
+
+The fixture will be included in both distribution paths without changing their
+file lists because npm already includes `fixtures` and the Nix install already
+copies that directory. Likewise, both layouts already package `src`, which will
+include the observer and normalizer.
+
+## Package-layout verification
+
+### Source layout
+
+A focused Pi load test will resolve the bundled Pi command, load the actual
+run-once profile plus the packaged sentinel fixture, close one RPC request, and
+assert the exact sentinel payload. A second integration path will load the
+observer through Pi's `discoverAndLoadExtensions()`, assert that its default
+factory registers all three lifecycle handlers, and exercise append failure
+plus final retry through `ExtensionRunner.onError`.
+
+### Compiled layout
+
+The existing compiled resource-profile test will stage the observer and
+normalizer source beside the compiled modules. It will assert that all three
+run-once extension paths exist and that missing or non-file package-owned
+extensions fail during profile import.
+
+### npm-packed layout
+
+`scripts/smoke-packed-artifact.mjs` will use the profile imported from the
+installed tarball. It will use the installed Pi loader to assert that the
+installed observer's default factory registers all three handlers, then run the
+installed Pi binary with those extension paths plus the installed sentinel
+fixture and assert the exact payload.
+
+### Nix-installed layout
+
+`nix/package.nix` will extend `installCheckPhase` to verify the observer,
+normalizer, and sentinel files under `$out/share/patchmill`. A single-quoted
+shell heredoc will carry the JavaScript verification program without shell
+rewriting its imports, string literals, or RPC JSON. That program will assert
+installed default-factory handler registration, then run Pi from the installed
+dependency tree with the installed profile and sentinel fixture and assert the
+exact payload.
+
+No new test will merely restate Nix source text or package metadata. The Nix
+build itself is the direct installed-layout verification.
+
+## Error handling
+
+- Unrelated tool events are ignored.
+- Missing or malformed result containers produce no rows.
+- A result array above 1,024 rows throws
+  `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` before row processing.
+- Malformed or overlong rows are skipped without affecting valid siblings.
+- Invalid or overlong optional model/thinking fields remain absent on an
+  otherwise valid identity entry.
+- Raw malformed values and discarded fields are never logged or persisted.
+- State and session-entry ceilings throw
+  `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` before mutation.
+- The `appendEntry()` boundary catches only to retain the original `cause` and
+  rethrow `PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED`; Pi's runner reports that
+  stable identifier through `onError` and leaves deduplication counters
+  unchanged.
+- A future upstream contract change fails closed by producing no unsafe
+  projection; Patchmill's exact dependency pin and contract verification remain
+  the guard against silent upstream drift.
+
+## Testing strategy
+
+These tests pass Patchmill's Testing Value Gate because they prove reusable
+runtime behavior, privacy boundaries, concurrency isolation, lifecycle
+fallbacks, and installed extension loading.
+
+### Pure normalizer tests
+
+Cover:
+
+- one and multiple valid rows;
+- nonsequential upstream child indexes;
+- stable upstream row order;
+- identity-only rows;
+- optional model and thinking independently;
+- verbatim model/thinking preservation;
+- malformed roots, details, arrays, and rows;
+- blank or invalid parent tool-call IDs;
+- unsafe, negative, and missing indexes;
+- blank or missing agents;
+- invalid optional field types;
+- exact accepted identifier boundaries and one-code-unit-over rejection;
+- a 1,024-row batch and a 1,025-row stable limit error;
+- no fallback to array positions; and
+- rows containing secret task, output, prompt, credential, path, usage, and
+  unrestricted metadata properties, with serialized projections proven not to
+  copy those property values. Tests will not claim that trusted allowlisted
+  values are semantically secret-free.
+
+### Observer tests
+
+Initialize the narrow in-memory Pi API harness through the default extension
+factory to cover:
+
+- handler registration through the production entry point;
+- immediate partial persistence;
+- terminal-only fallback;
+- exact partial/final duplicate suppression;
+- changed authoritative tuples;
+- sibling and parent-tool-call isolation;
+- valid metadata on failed terminal events;
+- session-start dedup reset, persisted-entry count restoration, one successful
+  append from 65,535 to 65,536, and rejection of the next distinct tuple;
+- unrelated and malformed lifecycle events;
+- active-parent, per-parent child, active-child, active-key, per-child
+  transition, and per-session entry ceilings;
+- state release after successful terminal events; and
+- oversized and rapidly changing updates.
+
+Use the default-factory harness to assert that a translated `appendEntry()`
+error retains the original failure as `cause`. Use Pi's real extension loader
+and `ExtensionRunner` error listener to cover the same append failure's stable
+surfaced identifier, unchanged counters, and a successful equivalent terminal
+retry; Pi does not expose `cause` through `onError`.
+
+### Wiring and layout tests
+
+Update existing profile, compiled-layout, and run-once Pi argument tests for the
+third ordered extension. Add the source load and runner-error tests. Extend the
+existing npm packed smoke and Nix install check with both installed
+handler-registration assertions and the stable sentinel protocol. The Nix
+JavaScript must execute from a single-quoted heredoc rather than an inline
+shell double-quoted `-e` payload.
+
+## Verification
+
+Implementation verification will include:
+
+```sh
+node --test \
+  src/pi/subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.test.ts \
+  src/pi/extensions/run-once-subagent-progress.runner.test.ts \
+  src/pi/extensions/run-once-subagent-progress.load.test.ts \
+  src/pi/resource-profiles.test.ts \
+  src/pi/resource-profiles.compiled.test.ts \
+  src/cli/commands/run-once/pi.test.ts
+npm test
+npm run lint
+node scripts/smoke-packed-artifact.mjs
+nix build .#patchmill --no-link --print-build-logs
+nix flake check --print-build-logs
+```
+
+No dependency installation, service startup, or baseline suite is needed while
+planning. Those commands belong to implementation verification.
+
+## Acceptance mapping
+
+| Acceptance criterion | Design response |
+| --- | --- |
+| First partial persists before completion | Update handler appends each first valid tuple immediately. |
+| Final fills when partial did not | End handler uses the same parser and exact-tuple state. |
+| Children remain independent | Keys include parent `toolCallId` and upstream child index. |
+| Unknown metadata stays absent | Optional fields are allowlisted only when valid; identity-only entries are allowed. |
+| Discarded source fields do not leak | Pure projection reads only five named fields; trusted allowlisted identifier values have an explicit semantic trust boundary. |
+| Memory and session growth are bounded | Generous identifier, batch, parent, child, key, transition, and session-entry ceilings fail loudly before mutation. |
+| Append failures stay visible and retryable | The append boundary rethrows a stable identifier with the original cause; Pi's runner reports it and a final event can retry. |
+| Production entry point registers behavior | Unit tests call the default factory and Pi loader checks assert its three handlers in source, npm, and Nix layouts. |
+| All run-once profiles load observer | Shared ordered extension list is used by all three run-once profiles. |
+| Triage does not load observer | Triage retains an empty extension list. |
+| Source/npm/Nix layouts load observer | Each layout runs Pi with the same packaged trailing sentinel fixture. |

--- a/docs/specs/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks-design.md
+++ b/docs/specs/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks-design.md
@@ -237,8 +237,8 @@ The observer calls `pi.appendEntry()` before recording the key or incrementing
 any counter. The append call is the only local translation boundary: if it
 throws, the observer rethrows an error whose stable message is
 `PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED` and retains the original error as
-its `cause`. Pi 0.83's `ExtensionRunner` catches that handler error and emits it
-to `onError`; it does not reject `emit()`. The failed key and counters remain
+its `cause`. Pi 0.84.1's `ExtensionRunner` catches that handler error and emits
+it to `onError`; it does not reject `emit()`. The failed key and counters remain
 unchanged, so an equivalent terminal update may retry. The handler stops
 processing the current event at the first persistence failure and never logs raw
 event data.

--- a/docs/specs/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks-design.md
+++ b/docs/specs/2026-08-09-issue-124-persist-safe-subagent-runtime-metadata-from-pi-lifecycle-hooks-design.md
@@ -2,8 +2,7 @@
 
 **Issue:** [#124](https://github.com/rochecompaan/patchmill/issues/124)
 **Parent:** [#116](https://github.com/rochecompaan/patchmill/issues/116)
-**Dependencies:** #121 and #122, both complete
-**Status:** Approved design
+**Dependencies:** #121 and #122, both complete **Status:** Approved design
 
 ## Summary
 
@@ -24,8 +23,8 @@ Nix-installed layouts with one stable packaged sentinel fixture.
   completion when `pi-subagents` emits one.
 - Use the terminal tool result as a fallback and suppress exact tuples already
   persisted from partial updates.
-- Keep every child independent across sibling indexes and concurrent parent
-  tool calls.
+- Keep every child independent across sibling indexes and concurrent parent tool
+  calls.
 - Persist only parent tool-call identity, upstream child identity, agent name,
   and reported model/thinking fields.
 - Preserve unknown runtime fields as absent and allow a valid identity-only
@@ -68,17 +67,16 @@ The observer uses Pi's documented lifecycle and persistence APIs:
 
 - `tool_execution_update.partialResult` for near-live observations;
 - `tool_execution_end.result` for terminal fallback; and
-- `pi.appendEntry()` for custom entries that do not participate in LLM
-  context.
+- `pi.appendEntry()` for custom entries that do not participate in LLM context.
 
 The parent `toolCallId` scopes the upstream child index to one parent subagent
-invocation. The upstream `runId` is therefore unnecessary for this bridge and
-is not allowed in the persisted projection.
+invocation. The upstream `runId` is therefore unnecessary for this bridge and is
+not allowed in the persisted projection.
 
 `pi-subagents` is a trusted in-process dependency, but Pi exposes lifecycle
 result fields as runtime-unknown values. Patchmill guarantees that the observer
-copies no properties outside its five-field allowlist. It does not claim that
-an allowlisted `agent`, `model`, or `thinking` value is semantically free of
+copies no properties outside its five-field allowlist. It does not claim that an
+allowlisted `agent`, `model`, or `thinking` value is semantically free of
 secrets; that guarantee belongs to the trusted upstream producer. Patchmill
 still limits every accepted identifier so an upstream bug cannot create an
 unbounded projection.
@@ -156,8 +154,8 @@ package extension.
 For every candidate event and row:
 
 1. Require `toolName === "subagent"`.
-2. Require a nonblank string `toolCallId` no longer than 1,024 UTF-16 code
-   units from the Pi lifecycle event.
+2. Require a nonblank string `toolCallId` no longer than 1,024 UTF-16 code units
+   from the Pi lifecycle event.
 3. Require `result`, `result.details`, and each candidate row to be records.
 4. Require `result.details.results` to be an array with at most 1,024 rows. A
    larger batch throws `PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED` before any
@@ -242,19 +240,19 @@ throws, the observer rethrows an error whose stable message is
 its `cause`. Pi 0.83's `ExtensionRunner` catches that handler error and emits it
 to `onError`; it does not reject `emit()`. The failed key and counters remain
 unchanged, so an equivalent terminal update may retry. The handler stops
-processing the current event at the first persistence failure and never logs
-raw event data.
+processing the current event at the first persistence failure and never logs raw
+event data.
 
 `tool_execution_end` is parsed even when the tool reports an error because the
 result may still contain valid authoritative child metadata. Parent state is
-released only after terminal processing succeeds. If terminal persistence
-fails, state remains available for a later equivalent retry.
+released only after terminal processing succeeds. If terminal persistence fails,
+state remains available for a later equivalent retry.
 
 On `session_start`, the observer clears active deduplication state and counts
-existing custom entries with `customType === "patchmill-subagent-progress"`
-from `ctx.sessionManager.getEntries()`. Restoring that counter prevents a
-reload or resume from bypassing the per-session persistence ceiling. Pi does
-not replay completed lifecycle events into the new extension instance.
+existing custom entries with `customType === "patchmill-subagent-progress"` from
+`ctx.sessionManager.getEntries()`. Restoring that counter prevents a reload or
+resume from bypassing the per-session persistence ceiling. Pi does not replay
+completed lifecycle events into the new extension instance.
 
 ## Exact parent-session guarantee
 
@@ -263,8 +261,8 @@ The observer runs in the same Pi process and resource profile as the parent
 `SessionManager`, so no session discovery or file correlation is needed.
 
 The custom entry type is `custom`, not `custom_message`. Pi excludes custom
-entries from `buildSessionContext()`, which keeps the bounded projection and
-all discarded source fields outside the LLM conversation.
+entries from `buildSessionContext()`, which keeps the bounded projection and all
+discarded source fields outside the LLM conversation.
 
 ## Run-once resource profiles
 
@@ -287,15 +285,15 @@ will render all three paths as ordered `-e` arguments without special cases.
 
 ## Stable extension-load sentinel
 
-Create `fixtures/run-once-extension-load-sentinel.ts`. It is a test fixture,
-not an auto-discovered extension. Its factory will require the
-`PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL` environment variable and write the
-exact UTF-8 payload `patchmill-run-once-extensions-loaded\n`, including the
-final line feed, to that path.
+Create `fixtures/run-once-extension-load-sentinel.ts`. It is a test fixture, not
+an auto-discovered extension. Its factory will require the
+`PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL` environment variable and write the exact
+UTF-8 payload `patchmill-run-once-extensions-loaded\n`, including the final line
+feed, to that path.
 
 Every layout smoke test will pass the run-once profile's extension arguments
-first and the sentinel fixture last. Reaching the sentinel proves that Pi
-loaded `pi-subagents`, todos, the observer, and the observer's relative
+first and the sentinel fixture last. Reaching the sentinel proves that Pi loaded
+`pi-subagents`, todos, the observer, and the observer's relative
 `../subagent-progress.ts` import before the probe factory ran.
 
 The checks will use isolated home/config directories and offline RPC mode with
@@ -315,8 +313,8 @@ A focused Pi load test will resolve the bundled Pi command, load the actual
 run-once profile plus the packaged sentinel fixture, close one RPC request, and
 assert the exact sentinel payload. A second integration path will load the
 observer through Pi's `discoverAndLoadExtensions()`, assert that its default
-factory registers all three lifecycle handlers, and exercise append failure
-plus final retry through `ExtensionRunner.onError`.
+factory registers all three lifecycle handlers, and exercise append failure plus
+final retry through `ExtensionRunner.onError`.
 
 ### Compiled layout
 
@@ -427,8 +425,8 @@ Update existing profile, compiled-layout, and run-once Pi argument tests for the
 third ordered extension. Add the source load and runner-error tests. Extend the
 existing npm packed smoke and Nix install check with both installed
 handler-registration assertions and the stable sentinel protocol. The Nix
-JavaScript must execute from a single-quoted heredoc rather than an inline
-shell double-quoted `-e` payload.
+JavaScript must execute from a single-quoted heredoc rather than an inline shell
+double-quoted `-e` payload.
 
 ## Verification
 
@@ -455,16 +453,16 @@ planning. Those commands belong to implementation verification.
 
 ## Acceptance mapping
 
-| Acceptance criterion | Design response |
-| --- | --- |
-| First partial persists before completion | Update handler appends each first valid tuple immediately. |
-| Final fills when partial did not | End handler uses the same parser and exact-tuple state. |
-| Children remain independent | Keys include parent `toolCallId` and upstream child index. |
-| Unknown metadata stays absent | Optional fields are allowlisted only when valid; identity-only entries are allowed. |
-| Discarded source fields do not leak | Pure projection reads only five named fields; trusted allowlisted identifier values have an explicit semantic trust boundary. |
-| Memory and session growth are bounded | Generous identifier, batch, parent, child, key, transition, and session-entry ceilings fail loudly before mutation. |
+| Acceptance criterion                       | Design response                                                                                                               |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| First partial persists before completion   | Update handler appends each first valid tuple immediately.                                                                    |
+| Final fills when partial did not           | End handler uses the same parser and exact-tuple state.                                                                       |
+| Children remain independent                | Keys include parent `toolCallId` and upstream child index.                                                                    |
+| Unknown metadata stays absent              | Optional fields are allowlisted only when valid; identity-only entries are allowed.                                           |
+| Discarded source fields do not leak        | Pure projection reads only five named fields; trusted allowlisted identifier values have an explicit semantic trust boundary. |
+| Memory and session growth are bounded      | Generous identifier, batch, parent, child, key, transition, and session-entry ceilings fail loudly before mutation.           |
 | Append failures stay visible and retryable | The append boundary rethrows a stable identifier with the original cause; Pi's runner reports it and a final event can retry. |
-| Production entry point registers behavior | Unit tests call the default factory and Pi loader checks assert its three handlers in source, npm, and Nix layouts. |
-| All run-once profiles load observer | Shared ordered extension list is used by all three run-once profiles. |
-| Triage does not load observer | Triage retains an empty extension list. |
-| Source/npm/Nix layouts load observer | Each layout runs Pi with the same packaged trailing sentinel fixture. |
+| Production entry point registers behavior  | Unit tests call the default factory and Pi loader checks assert its three handlers in source, npm, and Nix layouts.           |
+| All run-once profiles load observer        | Shared ordered extension list is used by all three run-once profiles.                                                         |
+| Triage does not load observer              | Triage retains an empty extension list.                                                                                       |
+| Source/npm/Nix layouts load observer       | Each layout runs Pi with the same packaged trailing sentinel fixture.                                                         |

--- a/fixtures/run-once-extension-load-sentinel.ts
+++ b/fixtures/run-once-extension-load-sentinel.ts
@@ -1,0 +1,12 @@
+import { writeFileSync } from "node:fs";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const SENTINEL_PAYLOAD = "patchmill-run-once-extensions-loaded\n";
+
+export default function runOnceExtensionLoadSentinel(_pi: ExtensionAPI): void {
+  const sentinelPath = process.env.PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL;
+  if (!sentinelPath) {
+    throw new Error("PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL is required");
+  }
+  writeFileSync(sentinelPath, SENTINEL_PAYLOAD, "utf8");
+}

--- a/fixtures/run-once-installed-extension-load.mjs
+++ b/fixtures/run-once-installed-extension-load.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+
+const SENTINEL_PAYLOAD = "patchmill-run-once-extensions-loaded\n";
+const OBSERVER_SUFFIX = "/src/pi/extensions/run-once-subagent-progress.ts";
+
+/**
+ * Verify that an installed Patchmill package loads every run-once extension
+ * before the trailing sentinel fixture.
+ */
+export async function verifyInstalledRunOnceExtensions({
+  packageRoot,
+  profile,
+  pi,
+  piSubagentsRoot,
+  piCommand,
+  piCommandArgs = [],
+  cwd,
+  agentDir,
+  sentinelPath,
+  env,
+}) {
+  assert.equal(
+    realpathSync(profile.additionalExtensionPaths[0]),
+    realpathSync(piSubagentsRoot),
+  );
+  assert.equal(
+    profile.additionalExtensionPaths[1]
+      ?.replaceAll("\\", "/")
+      .endsWith("/extensions/todos.ts"),
+    true,
+  );
+  assert.equal(
+    profile.additionalExtensionPaths[2]
+      ?.replaceAll("\\", "/")
+      .endsWith(OBSERVER_SUFFIX),
+    true,
+  );
+
+  const observerPath = profile.additionalExtensionPaths[2];
+  assert.ok(observerPath);
+  mkdirSync(agentDir, { recursive: true });
+  const loadedObserver = await pi.discoverAndLoadExtensions(
+    [observerPath],
+    packageRoot,
+    agentDir,
+  );
+  assert.deepEqual(loadedObserver.errors, []);
+  const observer = loadedObserver.extensions.find((extension) =>
+    extension.resolvedPath.replaceAll("\\", "/").endsWith(OBSERVER_SUFFIX),
+  );
+  assert.ok(observer);
+  for (const eventName of [
+    "session_start",
+    "tool_execution_update",
+    "tool_execution_end",
+  ]) {
+    assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
+  }
+
+  const sentinelFixture = join(
+    packageRoot,
+    "fixtures",
+    "run-once-extension-load-sentinel.ts",
+  );
+  assert.equal(existsSync(sentinelFixture), true);
+  const result = spawnSync(
+    piCommand,
+    [
+      ...piCommandArgs,
+      "--mode",
+      "rpc",
+      "--no-session",
+      "--offline",
+      "-ne",
+      ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
+      "-e",
+      sentinelFixture,
+    ],
+    {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...env,
+        PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelPath,
+      },
+      input: '{"type":"get_commands"}\n',
+      timeout: 30_000,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(
+    `${result.stdout}\n${result.stderr}`,
+    /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+  );
+  assert.equal(readFileSync(sentinelPath, "utf8"), SENTINEL_PAYLOAD);
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -77,36 +77,120 @@ buildNpmPackageNode24 rec {
     )
     test -f "$out/share/${pname}/fixtures/patchmill-test-repo/README.md"
     test -f "$out/share/${pname}/extensions/todos.ts"
+    test -f "$out/share/${pname}/src/pi/subagent-progress.ts"
+    test -f "$out/share/${pname}/src/pi/extensions/run-once-subagent-progress.ts"
+    test -f "$out/share/${pname}/fixtures/run-once-extension-load-sentinel.ts"
     (
       cd "$out/share/${pname}"
-      ${nodejs_24}/bin/node --input-type=module -e "
-        import { realpathSync } from 'node:fs';
-        import assert from 'node:assert/strict';
-        import { runOncePlanningPiProfile } from './src/pi/resource-profiles.ts';
-        import {
-          assertInstalledPiSubagentsMatchesRootPin,
-          piSubagentsExtensionFiles,
-          resolvePiSubagentsPackageRoot,
-        } from './src/pi/pi-subagents-package.ts';
-        assertInstalledPiSubagentsMatchesRootPin('./package.json');
-        piSubagentsExtensionFiles();
-        const piSubagentsRoot = resolvePiSubagentsPackageRoot();
-        const skills = {
-          triage: 'triage', planning: 'planning', implementation: 'implementation',
-          developmentEnvironment: 'development-environment', toolchain: 'toolchain',
-          review: 'review', visualEvidence: 'visual-evidence', landing: 'landing',
-        };
-        const profile = runOncePlanningPiProfile(skills, process.cwd());
-        assert.equal(
-          realpathSync(profile.additionalExtensionPaths[0]),
-          realpathSync(piSubagentsRoot),
-        );
-        assert.equal(
-          profile.additionalExtensionPaths[1].replaceAll('\\\\', '/').endsWith('/extensions/todos.ts'),
-          true,
-        );
-        console.log('installed pi-subagents manifest and extension order verified');
-      "
+      PATCHMILL_INSTALL_CHECK_DIR="$install_check_dir" \
+        ${nodejs_24}/bin/node --input-type=module <<'PATCHMILL_NODE'
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { discoverAndLoadExtensions } from "@earendil-works/pi-coding-agent";
+import { runOncePlanningPiProfile } from "./src/pi/resource-profiles.ts";
+import {
+  assertInstalledPiSubagentsMatchesRootPin,
+  piSubagentsExtensionFiles,
+  resolvePiSubagentsPackageRoot,
+} from "./src/pi/pi-subagents-package.ts";
+
+assertInstalledPiSubagentsMatchesRootPin("./package.json");
+piSubagentsExtensionFiles();
+const piSubagentsRoot = resolvePiSubagentsPackageRoot();
+const skills = {
+  triage: "triage",
+  planning: "planning",
+  implementation: "implementation",
+  developmentEnvironment: "development-environment",
+  toolchain: "toolchain",
+  review: "review",
+  visualEvidence: "visual-evidence",
+  landing: "landing",
+};
+const profile = runOncePlanningPiProfile(skills, process.cwd());
+assert.equal(
+  realpathSync(profile.additionalExtensionPaths[0]),
+  realpathSync(piSubagentsRoot),
+);
+assert.equal(
+  profile.additionalExtensionPaths[1]
+    .replaceAll("\\", "/")
+    .endsWith("/extensions/todos.ts"),
+  true,
+);
+assert.equal(
+  profile.additionalExtensionPaths[2]
+    .replaceAll("\\", "/")
+    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+  true,
+);
+
+const installCheckDir = process.env.PATCHMILL_INSTALL_CHECK_DIR;
+assert.ok(installCheckDir);
+const agentDir = join(installCheckDir, "pi-agent");
+mkdirSync(agentDir, { recursive: true });
+const loadedObserver = await discoverAndLoadExtensions(
+  [profile.additionalExtensionPaths[2]],
+  process.cwd(),
+  agentDir,
+);
+assert.deepEqual(loadedObserver.errors, []);
+const observer = loadedObserver.extensions.find((extension) =>
+  extension.resolvedPath
+    .replaceAll("\\", "/")
+    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+);
+assert.ok(observer);
+for (const eventName of [
+  "session_start",
+  "tool_execution_update",
+  "tool_execution_end",
+]) {
+  assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
+}
+
+const sentinelPath = join(installCheckDir, "run-once-extensions-loaded.txt");
+const result = spawnSync(
+  process.execPath,
+  [
+    "./node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
+    "--mode",
+    "rpc",
+    "--no-session",
+    "--offline",
+    "-ne",
+    ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
+    "-e",
+    "./fixtures/run-once-extension-load-sentinel.ts",
+  ],
+  {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    input: '{"type":"get_commands"}\n',
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
+    env: {
+      ...process.env,
+      HOME: join(installCheckDir, "home"),
+      XDG_CONFIG_HOME: join(installCheckDir, "config"),
+      PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelPath,
+    },
+  },
+);
+assert.equal(result.error, undefined);
+assert.equal(result.status, 0, result.stderr || result.stdout);
+assert.doesNotMatch(
+  result.stdout + "\n" + result.stderr,
+  /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+);
+assert.equal(
+  readFileSync(sentinelPath, "utf8"),
+  "patchmill-run-once-extensions-loaded\n",
+);
+console.log("installed run-once extensions loaded before sentinel");
+PATCHMILL_NODE
     )
     runHook postInstallCheck
   '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -80,16 +80,14 @@ buildNpmPackageNode24 rec {
     test -f "$out/share/${pname}/src/pi/subagent-progress.ts"
     test -f "$out/share/${pname}/src/pi/extensions/run-once-subagent-progress.ts"
     test -f "$out/share/${pname}/fixtures/run-once-extension-load-sentinel.ts"
+    test -f "$out/share/${pname}/fixtures/run-once-installed-extension-load.mjs"
     (
       cd "$out/share/${pname}"
       PATCHMILL_INSTALL_CHECK_DIR="$install_check_dir" \
         ${nodejs_24}/bin/node --input-type=module <<'PATCHMILL_NODE'
-import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
-import { discoverAndLoadExtensions } from "@earendil-works/pi-coding-agent";
 import { runOncePlanningPiProfile } from "./src/pi/resource-profiles.ts";
+import { verifyInstalledRunOnceExtensions } from "./fixtures/run-once-installed-extension-load.mjs";
 import {
   assertInstalledPiSubagentsMatchesRootPin,
   piSubagentsExtensionFiles,
@@ -110,85 +108,24 @@ const skills = {
   landing: "landing",
 };
 const profile = runOncePlanningPiProfile(skills, process.cwd());
-assert.equal(
-  realpathSync(profile.additionalExtensionPaths[0]),
-  realpathSync(piSubagentsRoot),
-);
-assert.equal(
-  profile.additionalExtensionPaths[1]
-    .replaceAll("\\", "/")
-    .endsWith("/extensions/todos.ts"),
-  true,
-);
-assert.equal(
-  profile.additionalExtensionPaths[2]
-    .replaceAll("\\", "/")
-    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
-  true,
-);
-
 const installCheckDir = process.env.PATCHMILL_INSTALL_CHECK_DIR;
-assert.ok(installCheckDir);
-const agentDir = join(installCheckDir, "pi-agent");
-mkdirSync(agentDir, { recursive: true });
-const loadedObserver = await discoverAndLoadExtensions(
-  [profile.additionalExtensionPaths[2]],
-  process.cwd(),
-  agentDir,
-);
-assert.deepEqual(loadedObserver.errors, []);
-const observer = loadedObserver.extensions.find((extension) =>
-  extension.resolvedPath
-    .replaceAll("\\", "/")
-    .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
-);
-assert.ok(observer);
-for (const eventName of [
-  "session_start",
-  "tool_execution_update",
-  "tool_execution_end",
-]) {
-  assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
-}
-
-const sentinelPath = join(installCheckDir, "run-once-extensions-loaded.txt");
-const result = spawnSync(
-  process.execPath,
-  [
-    "./node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
-    "--mode",
-    "rpc",
-    "--no-session",
-    "--offline",
-    "-ne",
-    ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
-    "-e",
-    "./fixtures/run-once-extension-load-sentinel.ts",
-  ],
-  {
-    cwd: process.cwd(),
-    encoding: "utf8",
-    input: '{"type":"get_commands"}\n',
-    timeout: 30_000,
-    maxBuffer: 10 * 1024 * 1024,
-    env: {
-      ...process.env,
-      HOME: join(installCheckDir, "home"),
-      XDG_CONFIG_HOME: join(installCheckDir, "config"),
-      PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelPath,
-    },
+if (!installCheckDir) throw new Error("PATCHMILL_INSTALL_CHECK_DIR is required");
+await verifyInstalledRunOnceExtensions({
+  packageRoot: process.cwd(),
+  profile,
+  pi: await import("@earendil-works/pi-coding-agent"),
+  piSubagentsRoot,
+  piCommand: process.execPath,
+  piCommandArgs: ["./node_modules/@earendil-works/pi-coding-agent/dist/cli.js"],
+  cwd: process.cwd(),
+  agentDir: join(installCheckDir, "pi-agent"),
+  sentinelPath: join(installCheckDir, "run-once-extensions-loaded.txt"),
+  env: {
+    ...process.env,
+    HOME: join(installCheckDir, "home"),
+    XDG_CONFIG_HOME: join(installCheckDir, "config"),
   },
-);
-assert.equal(result.error, undefined);
-assert.equal(result.status, 0, result.stderr || result.stdout);
-assert.doesNotMatch(
-  result.stdout + "\n" + result.stderr,
-  /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
-);
-assert.equal(
-  readFileSync(sentinelPath, "utf8"),
-  "patchmill-run-once-extensions-loaded\n",
-);
+});
 console.log("installed run-once extensions loaded before sentinel");
 PATCHMILL_NODE
     )

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -24,6 +25,23 @@ function run(command, args, options = {}) {
     });
     child.on("error", reject);
   });
+}
+
+function runPiExtensionLoad(command, args, options) {
+  console.log(`$ ${[command, ...args].join(" ")}`);
+  const result = spawnSync(command, args, {
+    ...options,
+    encoding: "utf8",
+    input: '{"type":"get_commands"}\n',
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(
+    `${result.stdout}\n${result.stderr}`,
+    /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+  );
 }
 
 async function main() {
@@ -164,6 +182,85 @@ async function main() {
         "run-once profile does not load the Patchmill todos extension second",
       );
     }
+    if (
+      !profile.additionalExtensionPaths[2]
+        ?.replaceAll("\\", "/")
+        .endsWith("/src/pi/extensions/run-once-subagent-progress.ts")
+    ) {
+      throw new Error(
+        "run-once profile does not load the Patchmill subagent progress observer third",
+      );
+    }
+
+    const installedPi = await import(
+      pathToFileURL(
+        join(
+          nodeModulesDir,
+          "@earendil-works",
+          "pi-coding-agent",
+          "dist",
+          "index.js",
+        ),
+      ).href
+    );
+    const installedAgentDir = join(smokeDir, "pi-agent");
+    await mkdir(installedAgentDir, { recursive: true });
+    const loadedObserver = await installedPi.discoverAndLoadExtensions(
+      [profile.additionalExtensionPaths[2]],
+      patchmillPackageRoot,
+      installedAgentDir,
+    );
+    assert.deepEqual(loadedObserver.errors, []);
+    const observer = loadedObserver.extensions.find((extension) =>
+      extension.resolvedPath
+        .replaceAll("\\", "/")
+        .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
+    );
+    assert.ok(observer);
+    for (const eventName of [
+      "session_start",
+      "tool_execution_update",
+      "tool_execution_end",
+    ]) {
+      assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
+    }
+
+    const sentinelFixture = join(
+      patchmillPackageRoot,
+      "fixtures",
+      "run-once-extension-load-sentinel.ts",
+    );
+    if (!existsSync(sentinelFixture)) {
+      throw new Error(
+        `Installed sentinel fixture is missing: ${sentinelFixture}`,
+      );
+    }
+    const sentinelOutput = join(smokeDir, "run-once-extensions-loaded.txt");
+    runPiExtensionLoad(
+      join(projectDir, "node_modules", ".bin", "pi"),
+      [
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--offline",
+        "-ne",
+        ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
+        "-e",
+        sentinelFixture,
+      ],
+      {
+        cwd: projectDir,
+        env: {
+          ...environment,
+          PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelOutput,
+        },
+      },
+    );
+    assert.equal(
+      await readFile(sentinelOutput, "utf8"),
+      "patchmill-run-once-extensions-loaded\n",
+    );
+    console.log("packed run-once extensions loaded before sentinel");
   } finally {
     if (process.env.PATCHMILL_KEEP_SMOKE_ARTIFACTS !== "1") {
       await Promise.all([

--- a/scripts/smoke-packed-artifact.mjs
+++ b/scripts/smoke-packed-artifact.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -25,23 +24,6 @@ function run(command, args, options = {}) {
     });
     child.on("error", reject);
   });
-}
-
-function runPiExtensionLoad(command, args, options) {
-  console.log(`$ ${[command, ...args].join(" ")}`);
-  const result = spawnSync(command, args, {
-    ...options,
-    encoding: "utf8",
-    input: '{"type":"get_commands"}\n',
-    timeout: 30_000,
-    maxBuffer: 10 * 1024 * 1024,
-  });
-  assert.equal(result.error, undefined);
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.doesNotMatch(
-    `${result.stdout}\n${result.stderr}`,
-    /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
-  );
 }
 
 async function main() {
@@ -165,33 +147,6 @@ async function main() {
       landing: "landing",
     };
     const profile = runOncePlanningPiProfile(skills, patchmillPackageRoot);
-    if (
-      realpathSync(profile.additionalExtensionPaths[0]) !==
-      realpathSync(piSubagentsRoot)
-    ) {
-      throw new Error(
-        "run-once profile does not load the installed pi-subagents package first",
-      );
-    }
-    if (
-      !profile.additionalExtensionPaths[1]
-        ?.replaceAll("\\", "/")
-        .endsWith("/extensions/todos.ts")
-    ) {
-      throw new Error(
-        "run-once profile does not load the Patchmill todos extension second",
-      );
-    }
-    if (
-      !profile.additionalExtensionPaths[2]
-        ?.replaceAll("\\", "/")
-        .endsWith("/src/pi/extensions/run-once-subagent-progress.ts")
-    ) {
-      throw new Error(
-        "run-once profile does not load the Patchmill subagent progress observer third",
-      );
-    }
-
     const installedPi = await import(
       pathToFileURL(
         join(
@@ -203,63 +158,26 @@ async function main() {
         ),
       ).href
     );
-    const installedAgentDir = join(smokeDir, "pi-agent");
-    await mkdir(installedAgentDir, { recursive: true });
-    const loadedObserver = await installedPi.discoverAndLoadExtensions(
-      [profile.additionalExtensionPaths[2]],
-      patchmillPackageRoot,
-      installedAgentDir,
+    const { verifyInstalledRunOnceExtensions } = await import(
+      pathToFileURL(
+        join(
+          patchmillPackageRoot,
+          "fixtures",
+          "run-once-installed-extension-load.mjs",
+        ),
+      ).href
     );
-    assert.deepEqual(loadedObserver.errors, []);
-    const observer = loadedObserver.extensions.find((extension) =>
-      extension.resolvedPath
-        .replaceAll("\\", "/")
-        .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
-    );
-    assert.ok(observer);
-    for (const eventName of [
-      "session_start",
-      "tool_execution_update",
-      "tool_execution_end",
-    ]) {
-      assert.ok((observer.handlers.get(eventName)?.length ?? 0) > 0);
-    }
-
-    const sentinelFixture = join(
-      patchmillPackageRoot,
-      "fixtures",
-      "run-once-extension-load-sentinel.ts",
-    );
-    if (!existsSync(sentinelFixture)) {
-      throw new Error(
-        `Installed sentinel fixture is missing: ${sentinelFixture}`,
-      );
-    }
-    const sentinelOutput = join(smokeDir, "run-once-extensions-loaded.txt");
-    runPiExtensionLoad(
-      join(projectDir, "node_modules", ".bin", "pi"),
-      [
-        "--mode",
-        "rpc",
-        "--no-session",
-        "--offline",
-        "-ne",
-        ...profile.additionalExtensionPaths.flatMap((path) => ["-e", path]),
-        "-e",
-        sentinelFixture,
-      ],
-      {
-        cwd: projectDir,
-        env: {
-          ...environment,
-          PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelOutput,
-        },
-      },
-    );
-    assert.equal(
-      await readFile(sentinelOutput, "utf8"),
-      "patchmill-run-once-extensions-loaded\n",
-    );
+    await verifyInstalledRunOnceExtensions({
+      packageRoot: patchmillPackageRoot,
+      profile,
+      pi: installedPi,
+      piSubagentsRoot,
+      piCommand: join(projectDir, "node_modules", ".bin", "pi"),
+      cwd: projectDir,
+      agentDir: join(smokeDir, "pi-agent"),
+      sentinelPath: join(smokeDir, "run-once-extensions-loaded.txt"),
+      env: environment,
+    });
     console.log("packed run-once extensions loaded before sentinel");
   } finally {
     if (process.env.PATCHMILL_KEEP_SMOKE_ARTIFACTS !== "1") {

--- a/src/cli/commands/run-once/pi.test.ts
+++ b/src/cli/commands/run-once/pi.test.ts
@@ -84,6 +84,8 @@ const runOnceExtensionArgs = [
   "/repo/node_modules/pi-subagents",
   "-e",
   "/repo/extensions/todos.ts",
+  "-e",
+  "/repo/src/pi/extensions/run-once-subagent-progress.ts",
 ];
 
 async function writeTodo(
@@ -105,9 +107,21 @@ test("runPiPrompt writes the prompt to a temp file and surfaces nonzero pi failu
   const runner = createMockRunner(async (call) => {
     const args = assertBundledPiCall(call);
     assert.equal(call.cwd, "/repo/worktree");
-    assert.deepEqual(args.slice(0, 5), ["-e", args[1], "-e", args[3], "-p"]);
+    assert.deepEqual(args.slice(0, 7), [
+      "-e",
+      args[1],
+      "-e",
+      args[3],
+      "-e",
+      args[5],
+      "-p",
+    ]);
     assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
     assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
+    assert.match(
+      args[5] ?? "",
+      /src\/pi\/extensions\/run-once-subagent-progress\.ts$/,
+    );
     const prompt = await readFile(promptPath(args), "utf8");
     assert.equal(prompt, "prompt body");
     return { code: 9, stdout: "", stderr: "pi exploded" };
@@ -125,10 +139,22 @@ test("runPiPrompt writes the prompt to a temp file and surfaces nonzero pi failu
 test("runPiPrompt loads bundled Pi extensions before the prompt argument", async () => {
   const runner = createMockRunner(async (call) => {
     const args = assertBundledPiCall(call);
-    assert.deepEqual(args.slice(0, 5), ["-e", args[1], "-e", args[3], "-p"]);
+    assert.deepEqual(args.slice(0, 7), [
+      "-e",
+      args[1],
+      "-e",
+      args[3],
+      "-e",
+      args[5],
+      "-p",
+    ]);
     assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
     assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
-    assert.equal(args[5]?.startsWith("@"), true);
+    assert.match(
+      args[5] ?? "",
+      /src\/pi\/extensions\/run-once-subagent-progress\.ts$/,
+    );
+    assert.equal(args[7]?.startsWith("@"), true);
     return {
       code: 0,
       stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
@@ -169,11 +195,13 @@ test("runPiPrompt can parse development environment results", async () => {
 test("runPiPrompt passes configured skill files before the prompt argument", async () => {
   const runner = createMockRunner(async (call) => {
     const args = assertBundledPiCall(call);
-    assert.deepEqual(args.slice(0, 9), [
+    assert.deepEqual(args.slice(0, 11), [
       "-e",
       args[1],
       "-e",
       args[3],
+      "-e",
+      args[5],
       "--skill",
       "/repo/.patchmill/skills/writing-plans/SKILL.md",
       "--skill",
@@ -182,7 +210,11 @@ test("runPiPrompt passes configured skill files before the prompt argument", asy
     ]);
     assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
     assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
-    assert.equal(args[9]?.startsWith("@"), true);
+    assert.match(
+      args[5] ?? "",
+      /src\/pi\/extensions\/run-once-subagent-progress\.ts$/,
+    );
+    assert.equal(args[11]?.startsWith("@"), true);
     return {
       code: 0,
       stdout: '{"status":"plan-created","planPath":"docs/plans/p.md"}',
@@ -294,9 +326,21 @@ test("runPiPrompt streams messages appended to the prompted pi session JSONL", a
   const streamed: string[] = [];
   const runner = createMockRunner(async (call) => {
     const args = assertBundledPiCall(call);
-    assert.deepEqual(args.slice(0, 5), ["-e", args[1], "-e", args[3], "-p"]);
+    assert.deepEqual(args.slice(0, 7), [
+      "-e",
+      args[1],
+      "-e",
+      args[3],
+      "-e",
+      args[5],
+      "-p",
+    ]);
     assert.match(args[1] ?? "", /node_modules\/pi-subagents$/);
     assert.match(args[3] ?? "", /extensions\/todos\.ts$/);
+    assert.match(
+      args[5] ?? "",
+      /src\/pi\/extensions\/run-once-subagent-progress\.ts$/,
+    );
     assert.equal(args.includes("--mode"), false);
     const sessionDirIndex = args.indexOf("--session-dir");
     assert.ok(

--- a/src/pi/extensions/run-once-subagent-progress.load.test.ts
+++ b/src/pi/extensions/run-once-subagent-progress.load.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { piCommandArgs, resolveBundledPiCommand } from "../../cli/pi-cli.ts";
+import { findPackageRoot } from "../../package-root.ts";
+import type { PatchmillSkillsConfig } from "../../workflow/skills.ts";
+import {
+  profileExtensionArgs,
+  runOncePlanningPiProfile,
+} from "../resource-profiles.ts";
+
+const rootDir = findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+const skills: PatchmillSkillsConfig = {
+  triage: "triage",
+  planning: "planning",
+  implementation: "implementation",
+  developmentEnvironment: "development-environment",
+  toolchain: "toolchain",
+  review: "review",
+  visualEvidence: "visual-evidence",
+  landing: "landing",
+};
+
+test("Pi loads the source run-once extensions before the sentinel", () => {
+  const homeDir = mkdtempSync(join(tmpdir(), "patchmill-run-once-load-"));
+  const sentinelPath = join(homeDir, "loaded.txt");
+  try {
+    const profile = runOncePlanningPiProfile(skills, rootDir);
+    assert.equal(profile.additionalExtensionPaths.length, 3);
+    const command = resolveBundledPiCommand();
+    const result = spawnSync(
+      command.command,
+      piCommandArgs(command, [
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--offline",
+        "-ne",
+        ...profileExtensionArgs(profile),
+        "-e",
+        join(rootDir, "fixtures", "run-once-extension-load-sentinel.ts"),
+      ]),
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+        input: '{"type":"get_commands"}\n',
+        timeout: 30_000,
+        maxBuffer: 10 * 1024 * 1024,
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          XDG_CONFIG_HOME: join(homeDir, "config"),
+          PATCHMILL_RUN_ONCE_EXTENSION_SENTINEL: sentinelPath,
+        },
+      },
+    );
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(
+      readFileSync(sentinelPath, "utf8"),
+      "patchmill-run-once-extensions-loaded\n",
+    );
+    assert.doesNotMatch(
+      `${result.stdout}\n${result.stderr}`,
+      /Failed to load extension|Cannot find module|ERR_MODULE_NOT_FOUND/iu,
+    );
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+});

--- a/src/pi/extensions/run-once-subagent-progress.runner.test.ts
+++ b/src/pi/extensions/run-once-subagent-progress.runner.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  discoverAndLoadExtensions,
+  ExtensionRunner,
+} from "@earendil-works/pi-coding-agent";
+import { findPackageRoot } from "../../package-root.ts";
+import { SUBAGENT_PROGRESS_APPEND_ERROR } from "./run-once-subagent-progress.ts";
+
+const rootDir = findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+
+test("Pi reports append failure and a terminal event retries the tuple", async () => {
+  const homeDir = mkdtempSync(join(tmpdir(), "patchmill-progress-runner-"));
+  try {
+    const observerPath = join(
+      rootDir,
+      "src",
+      "pi",
+      "extensions",
+      "run-once-subagent-progress.ts",
+    );
+    const loaded = await discoverAndLoadExtensions(
+      [observerPath],
+      rootDir,
+      join(homeDir, "agent"),
+    );
+    assert.deepEqual(loaded.errors, []);
+
+    const appended: Array<{ customType: string; data: unknown }> = [];
+    let failNextAppend = true;
+    loaded.runtime.appendEntry = (customType, data) => {
+      if (failNextAppend) {
+        failNextAppend = false;
+        throw new Error("unstable storage detail");
+      }
+      appended.push({ customType, data });
+    };
+
+    const runner = new ExtensionRunner(
+      loaded.extensions,
+      loaded.runtime,
+      rootDir,
+      { getEntries: () => [] } as never,
+      {} as never,
+    );
+    const errors: Array<{
+      extensionPath: string;
+      event: string;
+      error: string;
+    }> = [];
+    runner.onError((error) => errors.push(error));
+    for (const eventName of [
+      "session_start",
+      "tool_execution_update",
+      "tool_execution_end",
+    ]) {
+      assert.equal(runner.hasHandlers(eventName), true);
+    }
+
+    await runner.emit({ type: "session_start", reason: "startup" });
+    await runner.emit({
+      type: "tool_execution_update",
+      toolName: "subagent",
+      toolCallId: "call-1",
+      args: {},
+      partialResult: { details: { results: [{ index: 0, agent: "worker" }] } },
+    });
+    assert.equal(appended.length, 0);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]?.event, "tool_execution_update");
+    assert.equal(errors[0]?.error, SUBAGENT_PROGRESS_APPEND_ERROR);
+    assert.match(
+      errors[0]?.extensionPath ?? "",
+      /run-once-subagent-progress\.ts$/u,
+    );
+
+    await runner.emit({
+      type: "tool_execution_end",
+      toolName: "subagent",
+      toolCallId: "call-1",
+      result: { details: { results: [{ index: 0, agent: "worker" }] } },
+      isError: false,
+    });
+    assert.deepEqual(appended, [
+      {
+        customType: "patchmill-subagent-progress",
+        data: { toolCallId: "call-1", childIndex: 0, agent: "worker" },
+      },
+    ]);
+    assert.equal(errors.length, 1);
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+});

--- a/src/pi/extensions/run-once-subagent-progress.test.ts
+++ b/src/pi/extensions/run-once-subagent-progress.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  SUBAGENT_PROGRESS_CUSTOM_TYPE,
+  SUBAGENT_PROGRESS_LIMIT_ERROR,
+  SUBAGENT_PROGRESS_LIMITS,
+} from "../subagent-progress.ts";
+import runOnceSubagentProgressExtension, {
+  SUBAGENT_PROGRESS_APPEND_ERROR,
+} from "./run-once-subagent-progress.ts";
+
+type ObserverPi = Pick<ExtensionAPI, "on" | "appendEntry">;
+type ObserverHandler = (event: any, context: any) => unknown;
+type AppendedEntry = { customType: string; data: unknown };
+
+function isLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
+  );
+}
+
+function subagentResult(rows: unknown[]): unknown {
+  return { details: { results: rows } };
+}
+
+function createHarness() {
+  const handlers = new Map<string, ObserverHandler>();
+  const entries: AppendedEntry[] = [];
+  const existingSessionEntries: unknown[] = [];
+  let nextAppendError: Error | undefined;
+  const pi = {
+    on(event: string, handler: ObserverHandler) {
+      handlers.set(event, handler);
+    },
+    appendEntry(customType: string, data?: unknown) {
+      if (nextAppendError) {
+        const error = nextAppendError;
+        nextAppendError = undefined;
+        throw error;
+      }
+      entries.push({ customType, data });
+    },
+  } as unknown as ObserverPi;
+
+  runOnceSubagentProgressExtension(pi);
+  return {
+    entries,
+    existingSessionEntries,
+    handlers,
+    failNextAppend(error: Error) {
+      nextAppendError = error;
+    },
+    async emit(name: string, event: unknown) {
+      const handler = handlers.get(name);
+      assert.ok(handler, `missing ${name} handler`);
+      await handler(event, {
+        sessionManager: { getEntries: () => existingSessionEntries },
+      });
+    },
+  };
+}
+
+test("registers only the required lifecycle handlers", () => {
+  assert.deepEqual(
+    [...createHarness().handlers.keys()],
+    ["session_start", "tool_execution_update", "tool_execution_end"],
+  );
+});
+
+test("persists authoritative partials immediately and terminal fallback on errors", async () => {
+  const harness = createHarness();
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "call-partial",
+    partialResult: subagentResult([
+      { index: 4, agent: "worker", model: "provider/model", thinking: "high" },
+    ]),
+  });
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-terminal",
+    isError: true,
+    result: subagentResult([{ index: 1, agent: "reviewer" }]),
+  });
+  assert.deepEqual(harness.entries, [
+    {
+      customType: SUBAGENT_PROGRESS_CUSTOM_TYPE,
+      data: {
+        toolCallId: "call-partial",
+        childIndex: 4,
+        agent: "worker",
+        model: "provider/model",
+        thinking: "high",
+      },
+    },
+    {
+      customType: SUBAGENT_PROGRESS_CUSTOM_TYPE,
+      data: { toolCallId: "call-terminal", childIndex: 1, agent: "reviewer" },
+    },
+  ]);
+});
+
+test("suppresses exact tuples while preserving changed metadata and isolation", async () => {
+  const harness = createHarness();
+  for (const toolCallId of ["call-a", "call-b"]) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId,
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "model-a" },
+        { index: 1, agent: "reviewer" },
+      ]),
+    });
+  }
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "call-a",
+    partialResult: subagentResult([
+      { index: 0, agent: "worker", model: "model-a" },
+    ]),
+  });
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-a",
+    isError: false,
+    result: subagentResult([
+      { index: 0, agent: "worker", model: "model-a", thinking: "high" },
+    ]),
+  });
+  assert.deepEqual(
+    harness.entries.map((entry) => entry.data),
+    [
+      {
+        toolCallId: "call-a",
+        childIndex: 0,
+        agent: "worker",
+        model: "model-a",
+      },
+      { toolCallId: "call-a", childIndex: 1, agent: "reviewer" },
+      {
+        toolCallId: "call-b",
+        childIndex: 0,
+        agent: "worker",
+        model: "model-a",
+      },
+      { toolCallId: "call-b", childIndex: 1, agent: "reviewer" },
+      {
+        toolCallId: "call-a",
+        childIndex: 0,
+        agent: "worker",
+        model: "model-a",
+        thinking: "high",
+      },
+    ],
+  );
+});
+
+test("resets session deduplication and restores persisted entry capacity", async () => {
+  const harness = createHarness();
+  const event = {
+    toolName: "subagent",
+    toolCallId: "call-1",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  };
+  await harness.emit("tool_execution_update", event);
+  await harness.emit("session_start", {
+    type: "session_start",
+    reason: "reload",
+  });
+  await harness.emit("tool_execution_update", event);
+  assert.equal(harness.entries.length, 2);
+
+  const capacity = createHarness();
+  for (
+    let entry = 1;
+    entry < SUBAGENT_PROGRESS_LIMITS.maxEntriesPerSession;
+    entry += 1
+  ) {
+    capacity.existingSessionEntries.push({
+      type: "custom",
+      customType: SUBAGENT_PROGRESS_CUSTOM_TYPE,
+    });
+  }
+  await capacity.emit("session_start", {
+    type: "session_start",
+    reason: "reload",
+  });
+  await capacity.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "capacity",
+    partialResult: subagentResult([
+      { index: 0, agent: "worker", model: "first" },
+    ]),
+  });
+  await assert.rejects(
+    capacity.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "capacity",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "second" },
+      ]),
+    }),
+    isLimitError,
+  );
+});
+
+test("rejects append errors without recording retry state", async () => {
+  const harness = createHarness();
+  const cause = new Error("unstable storage detail");
+  harness.failNextAppend(cause);
+  const event = {
+    toolName: "subagent",
+    toolCallId: "call-retry",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  };
+  await assert.rejects(
+    harness.emit("tool_execution_update", event),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === SUBAGENT_PROGRESS_APPEND_ERROR &&
+      error.cause === cause,
+  );
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "call-retry",
+    result: event.partialResult,
+    isError: false,
+  });
+  assert.deepEqual(harness.entries, [
+    {
+      customType: SUBAGENT_PROGRESS_CUSTOM_TYPE,
+      data: { toolCallId: "call-retry", childIndex: 0, agent: "worker" },
+    },
+  ]);
+});
+
+test("ignores malformed events and bounds state before append", async () => {
+  const harness = createHarness();
+  await harness.emit("tool_execution_update", {
+    toolName: "bash",
+    toolCallId: "call-1",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: " ",
+    partialResult: { details: { results: "not-an-array" } },
+  });
+  assert.deepEqual(harness.entries, []);
+
+  for (
+    let transition = 0;
+    transition < SUBAGENT_PROGRESS_LIMITS.maxTransitionsPerChild;
+    transition += 1
+  ) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "churn",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: `model-${transition}` },
+      ]),
+    });
+  }
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "churn",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "over" },
+      ]),
+    }),
+    isLimitError,
+  );
+});
+
+test("bounds active parents and releases state after successful terminal processing", async () => {
+  const harness = createHarness();
+  for (
+    let parent = 0;
+    parent < SUBAGENT_PROGRESS_LIMITS.maxActiveParents;
+    parent += 1
+  ) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: `parent-${parent}`,
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    });
+  }
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "parent-over",
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    }),
+    isLimitError,
+  );
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "parent-0",
+    result: subagentResult([{ index: 0, agent: "worker" }]),
+    isError: false,
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "parent-new",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  });
+});

--- a/src/pi/extensions/run-once-subagent-progress.test.ts
+++ b/src/pi/extensions/run-once-subagent-progress.test.ts
@@ -122,6 +122,16 @@ test("suppresses exact tuples while preserving changed metadata and isolation", 
   });
   await harness.emit("tool_execution_end", {
     toolName: "subagent",
+    toolCallId: "call-b",
+    isError: false,
+    result: subagentResult([
+      { index: 0, agent: "worker", model: "model-a" },
+      { index: 1, agent: "reviewer" },
+    ]),
+  });
+  assert.equal(harness.entries.length, 4);
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
     toolCallId: "call-a",
     isError: false,
     result: subagentResult([
@@ -304,6 +314,128 @@ test("bounds active parents and releases state after successful terminal process
   await harness.emit("tool_execution_update", {
     toolName: "subagent",
     toolCallId: "parent-new",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  });
+});
+
+test("bounds children per parent and frees them after terminal processing", async () => {
+  const harness = createHarness();
+  const rows = Array.from(
+    { length: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent },
+    (_, index) => ({ index, agent: "worker" }),
+  );
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "children",
+    partialResult: subagentResult(rows),
+  });
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "children",
+      partialResult: subagentResult([
+        {
+          index: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent,
+          agent: "worker",
+        },
+      ]),
+    }),
+    isLimitError,
+  );
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "children",
+    result: subagentResult(rows),
+    isError: false,
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "children",
+    partialResult: subagentResult([
+      {
+        index: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent,
+        agent: "worker",
+      },
+    ]),
+  });
+});
+
+test("bounds active children and frees them after terminal processing", async () => {
+  const harness = createHarness();
+  const rows = Array.from(
+    { length: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent },
+    (_, index) => ({ index, agent: "worker" }),
+  );
+  const parentCount =
+    SUBAGENT_PROGRESS_LIMITS.maxActiveChildren /
+    SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent;
+  for (let parent = 0; parent < parentCount; parent += 1) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: `active-${parent}`,
+      partialResult: subagentResult(rows),
+    });
+  }
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "active-over",
+      partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+    }),
+    isLimitError,
+  );
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "active-0",
+    result: subagentResult(rows),
+    isError: false,
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "active-new",
+    partialResult: subagentResult([{ index: 0, agent: "worker" }]),
+  });
+});
+
+test("bounds active serialized keys and frees them after terminal processing", async () => {
+  const harness = createHarness();
+  const rows = Array.from(
+    { length: SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent },
+    (_, index) => ({ index, agent: "worker" }),
+  );
+  const transitionCount =
+    SUBAGENT_PROGRESS_LIMITS.maxActiveKeys /
+    SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent;
+  for (let transition = 0; transition < transitionCount; transition += 1) {
+    await harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "keys",
+      partialResult: subagentResult(
+        rows.map((row) => ({ ...row, model: `model-${transition}` })),
+      ),
+    });
+  }
+  await assert.rejects(
+    harness.emit("tool_execution_update", {
+      toolName: "subagent",
+      toolCallId: "keys",
+      partialResult: subagentResult([
+        { index: 0, agent: "worker", model: "one-key-too-many" },
+      ]),
+    }),
+    isLimitError,
+  );
+  await harness.emit("tool_execution_end", {
+    toolName: "subagent",
+    toolCallId: "keys",
+    result: subagentResult(
+      rows.map((row) => ({ ...row, model: `model-${transitionCount - 1}` })),
+    ),
+    isError: false,
+  });
+  await harness.emit("tool_execution_update", {
+    toolName: "subagent",
+    toolCallId: "keys-new",
     partialResult: subagentResult([{ index: 0, agent: "worker" }]),
   });
 });

--- a/src/pi/extensions/run-once-subagent-progress.ts
+++ b/src/pi/extensions/run-once-subagent-progress.ts
@@ -1,0 +1,121 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  parseSubagentProgressResults,
+  SUBAGENT_PROGRESS_CUSTOM_TYPE,
+  SUBAGENT_PROGRESS_LIMIT_ERROR,
+  SUBAGENT_PROGRESS_LIMITS,
+  subagentProgressKey,
+  type SubagentProgress,
+} from "../subagent-progress.ts";
+
+export const SUBAGENT_PROGRESS_APPEND_ERROR =
+  "PATCHMILL_SUBAGENT_PROGRESS_APPEND_FAILED";
+
+type SubagentProgressPi = Pick<ExtensionAPI, "on" | "appendEntry">;
+type ChildState = { keys: Set<string> };
+type ParentState = Map<number, ChildState>;
+
+type ObservedToolEvent = {
+  toolCallId: string;
+  toolName: string;
+};
+
+function limitExceeded(): never {
+  throw new Error(SUBAGENT_PROGRESS_LIMIT_ERROR);
+}
+
+export default function runOnceSubagentProgressExtension(
+  pi: SubagentProgressPi,
+): void {
+  const parents = new Map<string, ParentState>();
+  let activeChildren = 0;
+  let activeKeys = 0;
+  let sessionEntries = 0;
+
+  function appendProgress(progress: SubagentProgress): void {
+    let parent = parents.get(progress.toolCallId);
+    const needsParent = parent === undefined;
+    if (
+      needsParent &&
+      parents.size >= SUBAGENT_PROGRESS_LIMITS.maxActiveParents
+    ) {
+      limitExceeded();
+    }
+    parent ??= new Map<number, ChildState>();
+
+    let child = parent.get(progress.childIndex);
+    const needsChild = child === undefined;
+    if (
+      needsChild &&
+      (parent.size >= SUBAGENT_PROGRESS_LIMITS.maxChildrenPerParent ||
+        activeChildren >= SUBAGENT_PROGRESS_LIMITS.maxActiveChildren)
+    ) {
+      limitExceeded();
+    }
+    child ??= { keys: new Set<string>() };
+
+    const key = subagentProgressKey(progress);
+    if (child.keys.has(key)) return;
+    if (
+      child.keys.size >= SUBAGENT_PROGRESS_LIMITS.maxTransitionsPerChild ||
+      activeKeys >= SUBAGENT_PROGRESS_LIMITS.maxActiveKeys ||
+      sessionEntries >= SUBAGENT_PROGRESS_LIMITS.maxEntriesPerSession
+    ) {
+      limitExceeded();
+    }
+
+    try {
+      pi.appendEntry(SUBAGENT_PROGRESS_CUSTOM_TYPE, progress);
+    } catch (cause) {
+      throw new Error(SUBAGENT_PROGRESS_APPEND_ERROR, { cause });
+    }
+
+    if (needsParent) parents.set(progress.toolCallId, parent);
+    if (needsChild) {
+      parent.set(progress.childIndex, child);
+      activeChildren += 1;
+    }
+    child.keys.add(key);
+    activeKeys += 1;
+    sessionEntries += 1;
+  }
+
+  function appendResult(event: ObservedToolEvent, result: unknown): void {
+    for (const progress of parseSubagentProgressResults(
+      result,
+      event.toolCallId,
+    )) {
+      appendProgress(progress);
+    }
+  }
+
+  function releaseParent(toolCallId: string): void {
+    const parent = parents.get(toolCallId);
+    if (!parent) return;
+    for (const child of parent.values()) activeKeys -= child.keys.size;
+    activeChildren -= parent.size;
+    parents.delete(toolCallId);
+  }
+
+  pi.on("session_start", (_event, ctx) => {
+    parents.clear();
+    activeChildren = 0;
+    activeKeys = 0;
+    sessionEntries = ctx.sessionManager
+      .getEntries()
+      .filter(
+        (entry) =>
+          entry.type === "custom" &&
+          entry.customType === SUBAGENT_PROGRESS_CUSTOM_TYPE,
+      ).length;
+  });
+  pi.on("tool_execution_update", (event) => {
+    if (event.toolName !== "subagent") return;
+    appendResult(event, event.partialResult);
+  });
+  pi.on("tool_execution_end", (event) => {
+    if (event.toolName !== "subagent") return;
+    appendResult(event, event.result);
+    releaseParent(event.toolCallId);
+  });
+}

--- a/src/pi/resource-profiles.compiled.test.ts
+++ b/src/pi/resource-profiles.compiled.test.ts
@@ -40,9 +40,18 @@ test(
       "resource-profiles.js",
     );
     const todosExtension = join(packageRoot, "extensions", "todos.ts");
+    const observerExtension = join(
+      packageRoot,
+      "src",
+      "pi",
+      "extensions",
+      "run-once-subagent-progress.ts",
+    );
+    const normalizer = join(packageRoot, "src", "pi", "subagent-progress.ts");
 
     try {
       await mkdir(dirname(todosExtension), { recursive: true });
+      await mkdir(dirname(observerExtension), { recursive: true });
       await copyFile(
         join(sourceRoot, "package.json"),
         join(packageRoot, "package.json"),
@@ -50,6 +59,20 @@ test(
       await copyFile(
         join(sourceRoot, "extensions", "todos.ts"),
         todosExtension,
+      );
+      await copyFile(
+        join(
+          sourceRoot,
+          "src",
+          "pi",
+          "extensions",
+          "run-once-subagent-progress.ts",
+        ),
+        observerExtension,
+      );
+      await copyFile(
+        join(sourceRoot, "src", "pi", "subagent-progress.ts"),
+        normalizer,
       );
       await symlink(
         join(sourceRoot, "node_modules"),
@@ -88,7 +111,7 @@ test(
         profile.additionalExtensionPaths.map((path: string) =>
           existsSync(path),
         ),
-        [true, true],
+        [true, true, true],
       );
       const piSubagentsRoot = profile.additionalExtensionPaths[0];
       assert.equal(basename(piSubagentsRoot), "pi-subagents");
@@ -101,6 +124,12 @@ test(
         profile.additionalExtensionPaths[1]
           ?.replaceAll("\\", "/")
           .endsWith("/extensions/todos.ts"),
+        true,
+      );
+      assert.equal(
+        profile.additionalExtensionPaths[2]
+          ?.replaceAll("\\", "/")
+          .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
         true,
       );
 
@@ -134,6 +163,38 @@ test(
           `Patchmill extension is not a regular file: .*extensions[\\\\/]todos\\.ts`,
           "u",
         ),
+      );
+
+      await rm(todosExtension, { recursive: true, force: true });
+      await copyFile(
+        join(sourceRoot, "extensions", "todos.ts"),
+        todosExtension,
+      );
+      const missingObserverProfile = join(
+        dirname(compiledProfile),
+        "resource-profiles-missing-observer.js",
+      );
+      await copyFile(compiledProfile, missingObserverProfile);
+      await rm(observerExtension);
+      await assert.rejects(
+        import(pathToFileURL(missingObserverProfile).href),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.equal((error as NodeJS.ErrnoException).code, "ENOENT");
+          assert.match(error.message, /run-once-subagent-progress\.ts/u);
+          return true;
+        },
+      );
+
+      await mkdir(observerExtension);
+      const directoryObserverProfile = join(
+        dirname(compiledProfile),
+        "resource-profiles-directory-observer.js",
+      );
+      await copyFile(compiledProfile, directoryObserverProfile);
+      await assert.rejects(
+        import(pathToFileURL(directoryObserverProfile).href),
+        /Patchmill extension is not a regular file: .*run-once-subagent-progress\.ts/u,
       );
     } finally {
       await rm(packageRoot, { recursive: true, force: true });

--- a/src/pi/resource-profiles.test.ts
+++ b/src/pi/resource-profiles.test.ts
@@ -13,6 +13,7 @@ import {
   profileContextArgs,
   profileExtensionArgs,
   profileSkillArgs,
+  runOnceDevelopmentEnvironmentPiProfile,
   runOnceImplementationPiProfile,
   runOncePlanningPiProfile,
   triagePiProfile,
@@ -29,10 +30,16 @@ async function withRepo<T>(fn: (repoRoot: string) => Promise<T>): Promise<T> {
 }
 
 function assertRunOnceExtensionOrder(extensionPaths: string[]): void {
-  assert.equal(extensionPaths.length, 2);
+  assert.equal(extensionPaths.length, 3);
   assert.equal(extensionPaths[0], resolvePiSubagentsPackageRoot());
   assert.equal(
     extensionPaths[1]?.replaceAll("\\", "/").endsWith("/extensions/todos.ts"),
+    true,
+  );
+  assert.equal(
+    extensionPaths[2]
+      ?.replaceAll("\\", "/")
+      .endsWith("/src/pi/extensions/run-once-subagent-progress.ts"),
     true,
   );
 }
@@ -76,15 +83,23 @@ test("run-once planning profile includes context and Patchmill run-once extensio
 
 test("run-once implementation profile includes every implementation-stage skill slot", async () => {
   await withRepo(async (repoRoot) => {
-    assert.deepEqual(
-      runOnceImplementationPiProfile(skills, repoRoot).additionalSkillPaths,
-      [
-        join(repoRoot, "skills", "toolchain", "SKILL.md"),
-        join(repoRoot, "skills", "implementation", "SKILL.md"),
-        join(repoRoot, "skills", "review", "SKILL.md"),
-        join(repoRoot, "skills", "visual-evidence", "SKILL.md"),
-        join(repoRoot, "skills", "landing", "SKILL.md"),
-      ],
+    const profile = runOnceImplementationPiProfile(skills, repoRoot);
+    assertRunOnceExtensionOrder(profile.additionalExtensionPaths);
+    assert.deepEqual(profile.additionalSkillPaths, [
+      join(repoRoot, "skills", "toolchain", "SKILL.md"),
+      join(repoRoot, "skills", "implementation", "SKILL.md"),
+      join(repoRoot, "skills", "review", "SKILL.md"),
+      join(repoRoot, "skills", "visual-evidence", "SKILL.md"),
+      join(repoRoot, "skills", "landing", "SKILL.md"),
+    ]);
+  });
+});
+
+test("run-once development environment profile has the shared extensions", async () => {
+  await withRepo(async (repoRoot) => {
+    assertRunOnceExtensionOrder(
+      runOnceDevelopmentEnvironmentPiProfile(skills, repoRoot)
+        .additionalExtensionPaths,
     );
   });
 });
@@ -113,6 +128,8 @@ test("profile argument helpers render extension and skill flags", async () => {
       profile.additionalExtensionPaths[0],
       "-e",
       profile.additionalExtensionPaths[1],
+      "-e",
+      profile.additionalExtensionPaths[2],
     ]);
     assert.deepEqual(profileSkillArgs(profile), [
       "--skill",

--- a/src/pi/resource-profiles.ts
+++ b/src/pi/resource-profiles.ts
@@ -27,6 +27,15 @@ const PATCHMILL_PACKAGE_ROOT = findPackageRoot(
 const PATCHMILL_TODOS_EXTENSION = requireRegularFile(
   join(PATCHMILL_PACKAGE_ROOT, "extensions", "todos.ts"),
 );
+const PATCHMILL_SUBAGENT_PROGRESS_EXTENSION = requireRegularFile(
+  join(
+    PATCHMILL_PACKAGE_ROOT,
+    "src",
+    "pi",
+    "extensions",
+    "run-once-subagent-progress.ts",
+  ),
+);
 
 export type PatchmillPiResourceProfileId =
   | "run-once-planning"
@@ -44,7 +53,11 @@ export type PatchmillPiResourceProfile = {
 };
 
 function runOnceExtensionPaths(): string[] {
-  return [PI_SUBAGENTS_PACKAGE_ROOT, PATCHMILL_TODOS_EXTENSION];
+  return [
+    PI_SUBAGENTS_PACKAGE_ROOT,
+    PATCHMILL_TODOS_EXTENSION,
+    PATCHMILL_SUBAGENT_PROGRESS_EXTENSION,
+  ];
 }
 
 function profile(

--- a/src/pi/subagent-progress.test.ts
+++ b/src/pi/subagent-progress.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  parseSubagentProgressResults,
+  SUBAGENT_PROGRESS_LIMIT_ERROR,
+  SUBAGENT_PROGRESS_LIMITS,
+  subagentProgressKey,
+  type SubagentProgress,
+} from "./subagent-progress.ts";
+
+function resultWithRows(rows: unknown[]): unknown {
+  return { details: { results: rows } };
+}
+
+function isLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === SUBAGENT_PROGRESS_LIMIT_ERROR
+  );
+}
+
+test("projects valid rows in upstream order and preserves upstream indexes", () => {
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        { index: 7, agent: "worker", model: "openai/gpt-5", thinking: "high" },
+        { index: 2, agent: "reviewer", model: "anthropic/claude:beta" },
+        { index: 12, agent: "scout", thinking: "future-level" },
+      ]),
+      "call-parent",
+    ),
+    [
+      {
+        toolCallId: "call-parent",
+        childIndex: 7,
+        agent: "worker",
+        model: "openai/gpt-5",
+        thinking: "high",
+      },
+      {
+        toolCallId: "call-parent",
+        childIndex: 2,
+        agent: "reviewer",
+        model: "anthropic/claude:beta",
+      },
+      {
+        toolCallId: "call-parent",
+        childIndex: 12,
+        agent: "scout",
+        thinking: "future-level",
+      },
+    ],
+  );
+});
+
+test("keeps identity-only rows and accepted strings verbatim", () => {
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        {
+          index: 3,
+          agent: " worker ",
+          model: " provider/model:suffix ",
+          thinking: " future-level ",
+        },
+        { index: 9, agent: "scout" },
+      ]),
+      " call-with-spaces ",
+    ),
+    [
+      {
+        toolCallId: " call-with-spaces ",
+        childIndex: 3,
+        agent: " worker ",
+        model: " provider/model:suffix ",
+        thinking: " future-level ",
+      },
+      { toolCallId: " call-with-spaces ", childIndex: 9, agent: "scout" },
+    ],
+  );
+});
+
+test("fails closed for malformed containers, parent IDs, and malformed siblings", () => {
+  for (const value of [
+    undefined,
+    null,
+    [],
+    {},
+    { details: null },
+    { details: [] },
+    { details: {} },
+    { details: { results: null } },
+    { details: { results: {} } },
+  ]) {
+    assert.deepEqual(parseSubagentProgressResults(value, "call-1"), []);
+  }
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([{ index: 0, agent: "worker" }]),
+      " ",
+    ),
+    [],
+  );
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        null,
+        [],
+        { agent: "missing" },
+        { index: -1, agent: "negative" },
+        { index: 1.5, agent: "fraction" },
+        { index: Number.MAX_SAFE_INTEGER + 1, agent: "unsafe" },
+        { index: 4 },
+        { index: 5, agent: "" },
+        { index: 6, agent: "   " },
+        { index: 11, agent: "valid", model: 42, thinking: { level: "high" } },
+      ]),
+      "call-1",
+    ),
+    [{ toolCallId: "call-1", childIndex: 11, agent: "valid" }],
+  );
+});
+
+test("never substitutes array position and never copies discarded properties", () => {
+  const projection = parseSubagentProgressResults(
+    resultWithRows([
+      { agent: "missing-index", task: "SECRET_TASK" },
+      {
+        index: 42,
+        agent: "worker",
+        model: "reported-model",
+        thinking: "reported-thinking",
+        task: "SECRET_TASK",
+        output: "SECRET_OUTPUT",
+        prompt: "SECRET_PROMPT",
+        credentials: "SECRET_CREDENTIAL",
+        path: "/secret/session.jsonl",
+        usage: { cost: "SECRET_COST" },
+        error: "SECRET_ERROR",
+        args: { token: "SECRET_TOKEN" },
+      },
+    ]),
+    "call-safe",
+  );
+  assert.deepEqual(projection, [
+    {
+      toolCallId: "call-safe",
+      childIndex: 42,
+      agent: "worker",
+      model: "reported-model",
+      thinking: "reported-thinking",
+    },
+  ]);
+  const serialized = JSON.stringify(projection);
+  for (const forbidden of [
+    "SECRET_TASK",
+    "SECRET_OUTPUT",
+    "SECRET_PROMPT",
+    "SECRET_CREDENTIAL",
+    "/secret/session.jsonl",
+    "SECRET_COST",
+    "SECRET_ERROR",
+    "SECRET_TOKEN",
+  ]) {
+    assert.equal(serialized.includes(forbidden), false);
+  }
+});
+
+test("enforces identifier and result-row ceilings without truncation", () => {
+  const limits = SUBAGENT_PROGRESS_LIMITS;
+  const toolCallId = "t".repeat(limits.maxToolCallIdCodeUnits);
+  const agent = "a".repeat(limits.maxAgentCodeUnits);
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        {
+          index: 0,
+          agent,
+          model: "m".repeat(limits.maxModelCodeUnits),
+          thinking: "h".repeat(limits.maxThinkingCodeUnits),
+        },
+      ]),
+      toolCallId,
+    ),
+    [
+      {
+        toolCallId,
+        childIndex: 0,
+        agent,
+        model: "m".repeat(limits.maxModelCodeUnits),
+        thinking: "h".repeat(limits.maxThinkingCodeUnits),
+      },
+    ],
+  );
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([
+        { index: 0, agent: `${agent}x` },
+        {
+          index: 1,
+          agent: "worker",
+          model: "m".repeat(limits.maxModelCodeUnits + 1),
+          thinking: "h".repeat(limits.maxThinkingCodeUnits + 1),
+        },
+      ]),
+      toolCallId,
+    ),
+    [{ toolCallId, childIndex: 1, agent: "worker" }],
+  );
+  assert.deepEqual(
+    parseSubagentProgressResults(
+      resultWithRows([{ index: 0, agent: "worker" }]),
+      `${toolCallId}x`,
+    ),
+    [],
+  );
+  assert.equal(
+    parseSubagentProgressResults(
+      resultWithRows(
+        Array.from({ length: limits.maxResultRows }, (_, index) => ({
+          index,
+          agent: "worker",
+        })),
+      ),
+      "call-max",
+    ).length,
+    limits.maxResultRows,
+  );
+  assert.throws(
+    () =>
+      parseSubagentProgressResults(
+        resultWithRows(
+          Array.from({ length: limits.maxResultRows + 1 }, (_, index) => ({
+            index,
+            agent: "worker",
+          })),
+        ),
+        "call-over",
+      ),
+    isLimitError,
+  );
+});
+
+test("serializes fixed-position collision-safe keys", () => {
+  const identity: SubagentProgress = {
+    toolCallId: "call|1",
+    childIndex: 3,
+    agent: "worker,reviewer",
+  };
+  assert.equal(
+    subagentProgressKey(identity),
+    '["call|1",3,"worker,reviewer",null,null]',
+  );
+  assert.notEqual(
+    subagentProgressKey(identity),
+    subagentProgressKey({ ...identity, model: "" }),
+  );
+  assert.notEqual(
+    subagentProgressKey({ ...identity, model: "model", thinking: "high" }),
+    subagentProgressKey({ ...identity, model: "model:high" }),
+  );
+});

--- a/src/pi/subagent-progress.ts
+++ b/src/pi/subagent-progress.ts
@@ -1,0 +1,110 @@
+export const SUBAGENT_PROGRESS_CUSTOM_TYPE = "patchmill-subagent-progress";
+export const SUBAGENT_PROGRESS_LIMIT_ERROR =
+  "PATCHMILL_SUBAGENT_PROGRESS_LIMIT_EXCEEDED";
+export const SUBAGENT_PROGRESS_LIMITS = {
+  maxToolCallIdCodeUnits: 1024,
+  maxAgentCodeUnits: 256,
+  maxModelCodeUnits: 512,
+  maxThinkingCodeUnits: 128,
+  maxResultRows: 1024,
+  maxActiveParents: 256,
+  maxChildrenPerParent: 1024,
+  maxActiveChildren: 4096,
+  maxActiveKeys: 16384,
+  maxTransitionsPerChild: 32,
+  maxEntriesPerSession: 65536,
+} as const;
+
+export type SubagentProgress = {
+  toolCallId: string;
+  childIndex: number;
+  agent: string;
+  model?: string;
+  thinking?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBoundedNonblankString(
+  value: unknown,
+  maxCodeUnits: number,
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= maxCodeUnits &&
+    value.trim().length > 0
+  );
+}
+
+export function parseSubagentProgressResults(
+  result: unknown,
+  toolCallId: string,
+): SubagentProgress[] {
+  if (
+    !isBoundedNonblankString(
+      toolCallId,
+      SUBAGENT_PROGRESS_LIMITS.maxToolCallIdCodeUnits,
+    ) ||
+    !isRecord(result)
+  ) {
+    return [];
+  }
+
+  const details = result.details;
+  if (!isRecord(details) || !Array.isArray(details.results)) return [];
+  if (details.results.length > SUBAGENT_PROGRESS_LIMITS.maxResultRows) {
+    throw new Error(SUBAGENT_PROGRESS_LIMIT_ERROR);
+  }
+
+  const projections: SubagentProgress[] = [];
+  for (const row of details.results) {
+    if (!isRecord(row)) continue;
+    if (
+      typeof row.index !== "number" ||
+      !Number.isSafeInteger(row.index) ||
+      row.index < 0 ||
+      !isBoundedNonblankString(
+        row.agent,
+        SUBAGENT_PROGRESS_LIMITS.maxAgentCodeUnits,
+      )
+    ) {
+      continue;
+    }
+
+    const projection: SubagentProgress = {
+      toolCallId,
+      childIndex: row.index,
+      agent: row.agent,
+    };
+    if (
+      isBoundedNonblankString(
+        row.model,
+        SUBAGENT_PROGRESS_LIMITS.maxModelCodeUnits,
+      )
+    ) {
+      projection.model = row.model;
+    }
+    if (
+      isBoundedNonblankString(
+        row.thinking,
+        SUBAGENT_PROGRESS_LIMITS.maxThinkingCodeUnits,
+      )
+    ) {
+      projection.thinking = row.thinking;
+    }
+    projections.push(projection);
+  }
+  return projections;
+}
+
+export function subagentProgressKey(progress: SubagentProgress): string {
+  return JSON.stringify([
+    progress.toolCallId,
+    progress.childIndex,
+    progress.agent,
+    progress.model ?? null,
+    progress.thinking ?? null,
+  ]);
+}


### PR DESCRIPTION
## Summary

- normalize bounded, allowlisted subagent runtime metadata from authoritative Pi lifecycle results
- persist deduplicated partial and terminal progress entries in the exact parent session
- load the observer in all non-triage run-once profiles
- verify production extension loading in source, npm-packed, and Nix-installed layouts

## Validation

- focused seven-file Node suite: 66 tests passed
- `npm test`: 1,263 tests passed
- `npm run lint`
- `node scripts/smoke-packed-artifact.mjs`
- `nix build .#patchmill --no-link --print-build-logs`
- `nix flake check --print-build-logs`
- `git diff --check`

## Reviews

- Final Codex full-worktree re-review: pass
- Final thermo-nuclear full-worktree re-review: pass
- Final validation-readiness review: pass

Closes #124

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Development environment | gpt-5.6-sol | 1,108,517 | 3,962 | $1.2055 |
| Implementation | gpt-5.6-sol | 17,035,298 | 81,075 | $15.3530 |
| Implementation | gpt-5.6-terra | 7,888,963 | 35,951 | $2.9807 |
| **Implementation subtotal** |  | **24,924,261** | **117,026** | **$18.3337** |
| **Total** |  | **26,032,778** | **120,988** | **$19.5392** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->