### PR TITLE
feat(run-once): format final results for terminals

### DIFF
--- a/docs/plans/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output.md
+++ b/docs/plans/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output.md
@@ -1,0 +1,1244 @@
+# Readable Run-Once Final Result Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace compact JSON on interactive `run-once` stdout with a readable,
+width-aware, status-aware terminal report while preserving compact JSON for
+non-interactive consumers and the full structured summary in the resolved JSONL
+run log.
+
+**Architecture:** Keep `summarizeResult()` as the canonical machine-result
+boundary, but extract it from the already-large CLI entry module. Build the
+human report as a pure semantic formatter over that summary, with a focused
+layout module for sanitization, ANSI-aware wrapping, hanging indents, and style
+roles. A small output shell will append the structured result event first, then
+select terminal text or compact JSON; the console progress reporter will defer
+only the interactive final step and expose its captured header metrics.
+
+**Tech Stack:** Node.js 22.19+, TypeScript ESM, `node:test`, Node `fs/promises`,
+the existing `@earendil-works/pi-tui` 0.84.2 `wrapTextWithAnsi()`,
+`visibleWidth()`, and `stripTerminalSequences()` utilities, and existing
+Patchmill run-once progress and JSONL reporters.
+
+**Spec:**
+`docs/specs/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output-design.md`
+
+## Global Constraints
+
+- Interactive output means `process.stdout.isTTY === true`; redirected or
+  otherwise non-interactive stdout remains exactly one compact
+  `JSON.stringify(summary)` line.
+- `NO_COLOR` changes styling only. Color is enabled only when stdout is a TTY,
+  `NO_COLOR` is absent, and `TERM !== "dumb"`.
+- Keep every current non-interactive summary field name and shape unchanged. Add
+  only the existing CLI `{ status: "error", error, causes?, logPath? }` object
+  to the shared result-summary union.
+- Do not change pipeline statuses, exit codes, Run recovery state, pipeline
+  stages, Pi session logs, or historical JSONL events.
+- Do not add an output-format flag, pager, table, spinner, alternate screen,
+  terminal hyperlink, truncation, or ellipsis.
+- Strip terminal control sequences from human-rendered dynamic values only;
+  structured JSON and JSONL data must retain the original summary strings.
+- Use the already-declared `@earendil-works/pi-tui` dependency. Do not add a
+  color, width, wrapping, or ANSI dependency.
+- Keep responsibilities split: structured mapping in `result-summary.ts`,
+  semantic section selection in `terminal-result.ts`, low-level layout in
+  `terminal-result-layout.ts`, final persistence/output selection in
+  `result-output.ts`, and CLI orchestration in `main.ts`.
+- Apply Patchmill's Testing Value Gate. Formatter, sanitization, progress
+  handoff, output-mode, JSONL, error, and exit-code tests are required because
+  they prove reusable user-visible behavior, security boundaries, and machine
+  contracts that can meaningfully regress. Do not add tests that merely assert
+  documentation prose; verify help and site documentation directly.
+- No npm dependency change is planned. If `package.json`, `package-lock.json`,
+  or `npm-shrinkwrap.json` changes, retain it only when necessary and run
+  `nix build .#patchmill --print-build-logs` as required by `AGENTS.md`.
+
+---
+
+## File Structure
+
+- `src/cli/commands/run-once/result-summary.ts` will own the public structured
+  result union, normal pipeline-result mapping, error-result mapping, and
+  question normalization.
+- `src/cli/commands/run-once/result-summary.test.ts` will protect the existing
+  compact machine contract and the newly shared error shape.
+- `src/cli/commands/run-once/terminal-result.ts` will own status labels,
+  severity, section order, and conversion from a structured summary to semantic
+  fields and lists.
+- `src/cli/commands/run-once/terminal-result-layout.ts` will own focused layout
+  primitives, sanitization, local SGR roles, ANSI-aware wrapping, aligned versus
+  stacked fields, hanging indents, and visible-width guarantees.
+- `src/cli/commands/run-once/terminal-result.test.ts` will exercise the public
+  formatter across every status, wide and narrow widths, optional fields,
+  arrays, literal-value preservation, color, and hostile terminal strings.
+- `src/cli/commands/run-once/console-progress.ts` will optionally reserve and
+  capture a `final result <status>` step instead of writing it.
+- `src/cli/commands/run-once/console-progress.test.ts` will protect ordinary
+  progress output and the deferred final-step snapshot.
+- `src/cli/commands/run-once/result-output.ts` will append the final JSONL
+  event, select interactive versus compact output, derive width/color options,
+  write one final stdout payload, and expose the unchanged status-to-exit-code
+  rule.
+- `src/cli/commands/run-once/result-output.test.ts` will use fake stdout streams
+  and real temporary JSONL files to verify output and persistence behavior.
+- `src/cli/commands/run-once/main.ts` will remain the process/filesystem shell,
+  re-export `summarizeResult()`, configure progress deferral, resolve the final
+  log path, and route both normal and error summaries through one output helper.
+- `src/cli/commands/run-once/args.test.ts` will stop owning structured-summary
+  tests after they move to the focused test module; existing argument and help
+  behavior coverage remains.
+- `site/src/content/docs/using-patchmill/run-once.md` and `HELP_TEXT` in
+  `main.ts` will document formatted interactive stdout, redirected compact JSON,
+  quiet mode, color gating, and final JSONL result persistence.
+
+---
+
+### Task 1: Extract the Canonical Structured Result Summary
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/result-summary.ts`
+- Create: `src/cli/commands/run-once/result-summary.test.ts`
+- Modify: `src/cli/commands/run-once/main.ts:42-239`
+- Modify: `src/cli/commands/run-once/args.test.ts:8,159-292`
+
+**Interfaces:**
+
+- Consumes: `AgentIssuePipelineResult` and unknown CLI errors formatted through
+  the existing `formatErrorWithCauses()` helper.
+- Produces:
+
+  ```ts
+  export type RunOnceResultSummary =
+    | RunOncePipelineResultSummary
+    | {
+        status: "error";
+        error: string;
+        causes?: string[];
+        logPath?: string;
+      };
+
+  export type RunOnceResultStatus = RunOnceResultSummary["status"];
+
+  export function summarizeResult(
+    result: AgentIssuePipelineResult,
+  ): RunOncePipelineResultSummary;
+
+  export function summarizeErrorResult(
+    error: unknown,
+    logPath?: string,
+  ): Extract<RunOnceResultSummary, { status: "error" }>;
+  ```
+
+- Later tasks consume only `RunOnceResultSummary`, not pipeline result types.
+- `main.ts` must continue to export `summarizeResult` so existing importers do
+  not break.
+
+- [ ] **Step 1: Write focused structured-summary tests before moving code**
+
+  Create `result-summary.test.ts`. Move the current merged, spec-created,
+  approval-required, and development-environment-not-ready assertions from
+  `args.test.ts` without changing their literal expected objects. Add a complete
+  `pr-created` case that protects arrays and optional visual evidence, plus this
+  error case:
+
+  ```ts
+  test("summarizeErrorResult preserves aggregate causes and the resolved log path", () => {
+    const summary = summarizeErrorResult(
+      new AggregateError(
+        [new Error("observer failed"), new Error("cleanup failed")],
+        "Pi run failed",
+      ),
+      "/repo/.patchmill/runs/issue-174/run.jsonl",
+    );
+
+    assert.deepEqual(summary, {
+      status: "error",
+      error: "Pi run failed",
+      causes: ["observer failed", "cleanup failed"],
+      logPath: "/repo/.patchmill/runs/issue-174/run.jsonl",
+    });
+  });
+  ```
+
+  In the PR case, use this expected machine shape so extraction cannot
+  accidentally rename or add fields:
+
+  ```ts
+  {
+    status: "pr-created",
+    issueNumber: 174,
+    specPath: "docs/specs/result-design.md",
+    planPath: "docs/plans/result-plan.md",
+    branch: "agent/issue-174-readable-result",
+    prUrl: "https://example.test/patchmill/pulls/174",
+    worktreePath: ".worktrees/patchmill-issue-174-readable-result",
+    commits: ["abc123", "def456"],
+    validation: ["npm test passed", "npm run lint passed"],
+    reviewSummary: "All findings resolved.",
+    landingDecision: "PR required for CLI output change.",
+    visualEvidence: [
+      {
+        screenshotPath: "docs/reference-screenshots/result.png",
+        caption: "Readable final result",
+        referencePaths: ["docs/reference-screenshots/before.png"],
+        url: "https://example.test/evidence/174",
+      },
+    ],
+    logPath: "/repo/.patchmill/runs/issue-174/run.jsonl",
+    piSessionPath: "/repo/.patchmill/runs/issue-174/run-pi-sessions",
+  }
+  ```
+
+- [ ] **Step 2: Run the focused test and verify the new module is missing**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/result-summary.test.ts
+  ```
+
+  Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `result-summary.ts`; the
+  failure must be due to the new boundary not existing, not a malformed fixture.
+
+- [ ] **Step 3: Move the structured union and mapping into the focused module**
+
+  Move `JsonResultLog`, `JsonResult`, `questionText()`, and `summarizeResult()`
+  from `main.ts` into `result-summary.ts`. Rename the exported union to
+  `RunOnceResultSummary`, retain every current switch branch and optional-field
+  rule, and implement the shared error constructor exactly as follows:
+
+  ```ts
+  export function summarizeErrorResult(
+    error: unknown,
+    logPath?: string,
+  ): Extract<RunOnceResultSummary, { status: "error" }> {
+    const formatted = formatErrorWithCauses(error);
+    return {
+      status: "error",
+      error: formatted.message,
+      ...(formatted.causes ? { causes: formatted.causes } : {}),
+      ...(logPath ? { logPath } : {}),
+    };
+  }
+  ```
+
+  In `main.ts`, import both summary functions for local use and preserve the old
+  API with:
+
+  ```ts
+  export { summarizeResult } from "./result-summary.ts";
+  ```
+
+  Update `args.test.ts` to remove the moved summary fixtures and keep only
+  argument, configuration, and help behavior.
+
+- [ ] **Step 4: Run focused and existing argument tests**
+
+  Run:
+
+  ```sh
+  node --test \
+    src/cli/commands/run-once/result-summary.test.ts \
+    src/cli/commands/run-once/args.test.ts
+  ```
+
+  Expected: PASS. The compact expected objects must remain byte-shape compatible
+  after `JSON.stringify()`; no title or presentation-only field is added to
+  normal summaries.
+
+- [ ] **Step 5: Commit the structured-summary extraction**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/result-summary.ts \
+    src/cli/commands/run-once/result-summary.test.ts \
+    src/cli/commands/run-once/main.ts \
+    src/cli/commands/run-once/args.test.ts
+  git commit -m "refactor(run-once): extract structured result summary"
+  ```
+
+---
+
+### Task 2: Render Plain Semantic Terminal Reports at Wide and Narrow Widths
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/terminal-result.ts`
+- Create: `src/cli/commands/run-once/terminal-result-layout.ts`
+- Create: `src/cli/commands/run-once/terminal-result.test.ts`
+
+**Interfaces:**
+
+- Consumes: `RunOnceResultSummary` from Task 1.
+- Produces:
+
+  ```ts
+  export type TerminalResultSeverity = "success" | "warning" | "failure";
+
+  export type TerminalResultOptions = {
+    width: number;
+    color: boolean;
+    stepNumber?: number;
+    totalOutputTokens?: number;
+    elapsedSeconds?: number;
+  };
+
+  export function terminalResultSeverity(
+    status: RunOnceResultStatus,
+  ): TerminalResultSeverity;
+
+  export function formatTerminalResult(
+    summary: RunOnceResultSummary,
+    options: TerminalResultOptions,
+  ): string;
+  ```
+
+- `terminal-result-layout.ts` exposes only the semantic model and one renderer
+  to `terminal-result.ts`:
+
+  ```ts
+  export type TerminalValue = {
+    text: string;
+    role?: "plain" | "url" | "path" | "commit";
+  };
+
+  export type TerminalField = {
+    label?: string;
+    value: TerminalValue;
+  };
+
+  export type TerminalListItem = {
+    value: TerminalValue;
+    details?: TerminalField[];
+  };
+
+  export type TerminalSectionBlock =
+    | { kind: "value"; value: TerminalValue }
+    | { kind: "fields"; fields: TerminalField[] }
+    | {
+        kind: "list";
+        marker: "•" | "✓" | "!" | "→" | "✗";
+        markerSeverity?: TerminalResultSeverity;
+        items: TerminalListItem[];
+      };
+
+  export type TerminalSection = {
+    heading: string;
+    count?: number;
+    blocks: TerminalSectionBlock[];
+  };
+  ```
+
+- The layout renderer accepts header label/severity/metrics, sections, width,
+  and color. It returns a string without a trailing newline; the output shell in
+  Task 5 owns the final newline.
+
+- [ ] **Step 1: Write status, section-order, and vertical-list tests**
+
+  In `terminal-result.test.ts`, define literal summaries for every status and
+  assert these exact marker/label pairs:
+
+  | Status                              | Marker | Human label                         |
+  | ----------------------------------- | ------ | ----------------------------------- |
+  | `no-issue`                          | `✓`    | `No eligible issue`                 |
+  | `dry-run`                           | `✓`    | `Dry run`                           |
+  | `spec-created`                      | `✓`    | `Specification created`             |
+  | `spec-found`                        | `✓`    | `Specification found`               |
+  | `plan-created`                      | `✓`    | `Implementation plan created`       |
+  | `plan-found`                        | `✓`    | `Implementation plan found`         |
+  | `pr-created`                        | `✓`    | `PR created`                        |
+  | `merged`                            | `✓`    | `Merged`                            |
+  | `approval-required`                 | `!`    | `Approval required`                 |
+  | `development-environment-not-ready` | `!`    | `Development environment not ready` |
+  | `blocked`                           | `✗`    | `Blocked`                           |
+  | `error`                             | `✗`    | `Error`                             |
+
+  For a full `pr-created` fixture, assert headings occur in this order:
+  `Pull request`, `Issue and workspace`, `Artifacts`, `Validation (2)`,
+  `Review`, `Landing decision`, `Commits (2)`, `Visual evidence (1)`, and
+  `Run files`. Assert validation and commit entries occupy separate physical
+  lines:
+
+  ```ts
+  assert.match(output, /^  ✓ npm test passed$/mu);
+  assert.match(output, /^  ✓ npm run lint passed$/mu);
+  assert.match(output, /^  • abc123$/mu);
+  assert.match(output, /^  • def456$/mu);
+  ```
+
+  Add smaller fixtures and assertions for:
+  - dry-run `Transition` with issue number and title;
+  - spec/plan `Artifacts` without unrelated sections;
+  - approval `Approval` with kind and missing label;
+  - environment `Environment readiness`, evidence, and remediation;
+  - blocked `Failure` and `Questions (N)`;
+  - error `Failure` and causes;
+  - merged `Landing decision` with merge commit;
+  - `no-issue` with no empty section after the header.
+
+- [ ] **Step 2: Write wrapping, header-metric, and omission tests**
+
+  Use `visibleWidth()` from `@earendil-works/pi-tui` in the tests. Render a full
+  summary at widths 100, 40, 32, and 24, and assert every output line satisfies:
+
+  ```ts
+  for (const line of output.split("\n")) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `${visibleWidth(line)} > ${width}: ${JSON.stringify(line)}`,
+    );
+  }
+  ```
+
+  Assert width 100 uses aligned inline labels, width 24 stacks `Branch:` above
+  its value, and a long URL, path, commit ID, and prose value remain recoverable
+  by joining their wrapped value fragments after removing layout whitespace.
+  Assert no output contains `...` or the Unicode ellipsis `…`.
+
+  Cover the header with:
+
+  ```ts
+  assert.match(
+    formatTerminalResult(summary, {
+      width: 80,
+      color: false,
+      stepNumber: 11,
+      totalOutputTokens: 56_000,
+      elapsedSeconds: 15_602,
+    }),
+    /^11  Final result: ✓ PR created\n    56\.0k tokens · elapsed 4h20m02s/mu,
+  );
+  ```
+
+  Also assert an unnumbered header when `stepNumber` is absent, elapsed-only
+  metrics when token accounting is unavailable, and no metrics line when both
+  metrics are unavailable.
+
+  Supply undefined, blank-string, and empty-array optional values and assert
+  they do not produce headings, `(0)` counts, bullets, duplicate blank blocks,
+  or trailing whitespace.
+
+- [ ] **Step 3: Run formatter tests and verify the public module is missing**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/terminal-result.test.ts
+  ```
+
+  Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `terminal-result.ts`.
+
+- [ ] **Step 4: Implement the semantic status and section model**
+
+  In `terminal-result.ts`, define one exhaustive status descriptor map whose
+  values match Step 1 and whose severities are:
+
+  ```ts
+  const STATUS = {
+    "no-issue": { label: "No eligible issue", severity: "success" },
+    "dry-run": { label: "Dry run", severity: "success" },
+    "spec-created": { label: "Specification created", severity: "success" },
+    "spec-found": { label: "Specification found", severity: "success" },
+    "plan-created": {
+      label: "Implementation plan created",
+      severity: "success",
+    },
+    "plan-found": {
+      label: "Implementation plan found",
+      severity: "success",
+    },
+    "pr-created": { label: "PR created", severity: "success" },
+    merged: { label: "Merged", severity: "success" },
+    "approval-required": {
+      label: "Approval required",
+      severity: "warning",
+    },
+    "development-environment-not-ready": {
+      label: "Development environment not ready",
+      severity: "warning",
+    },
+    blocked: { label: "Blocked", severity: "failure" },
+    error: { label: "Error", severity: "failure" },
+  } as const satisfies Record<
+    RunOnceResultStatus,
+    { label: string; severity: TerminalResultSeverity }
+  >;
+  ```
+
+  Assemble sections in the spec order from fields present on the canonical
+  summary. Use these exact semantic rules:
+  - `Pull request`: one URL value for `prUrl`.
+  - `Issue and workspace`: `Issue` as `#<issueNumber>`, then `Title`, `Branch`,
+    and `Worktree` when those summary fields exist and are nonblank.
+  - `Artifacts`: one `•` item named `Specification` or `Implementation plan`,
+    with its path as an indented detail.
+  - `Transition`: dry-run transition as a field.
+  - `Approval`: approval kind and missing label as fields.
+  - `Environment readiness`: reason as a field, evidence as `!` items, and
+    remediation as `→` items.
+  - `Failure`: blocked reason or CLI error; error causes become `✗` items.
+  - `Questions (N)`: one `✗` item per blocker question.
+  - `Validation (N)`: one green-capable `✓` item per validation string.
+  - `Review`: one prose value.
+  - `Landing decision`: landing prose and merged `Merge commit`.
+  - `Commits (N)`: one `•` commit-role item per ID.
+  - `Visual evidence (N)`: one `•` item per record. Use its caption as the item
+    text when present; otherwise use the screenshot path. When a caption is
+    present, add `Screenshot` as a path detail. Add each reference as a
+    `Reference` path detail and the optional URL as a URL detail.
+  - `Run files`: `Log` and `Pi sessions` bullets, each with one path detail.
+
+  Filter blank strings, empty arrays, empty detail collections, empty blocks,
+  and empty sections before rendering.
+
+- [ ] **Step 5: Implement width-aware layout without color**
+
+  In `terminal-result-layout.ts`, implement these named primitives:
+
+  ```ts
+  function cleanValue(value: string): string;
+  function wrapValue(
+    value: TerminalValue,
+    firstPrefix: string,
+    continuationPrefix: string,
+    width: number,
+    color: boolean,
+  ): string[];
+  function renderFields(
+    fields: TerminalField[],
+    width: number,
+    color: boolean,
+    indent: number,
+  ): string[];
+  function renderList(
+    block: Extract<TerminalSectionBlock, { kind: "list" }>,
+    width: number,
+    color: boolean,
+  ): string[];
+  export function renderTerminalDocument(input: TerminalDocument): string;
+  ```
+
+  Normalize the supplied width to a positive integer. Use two-space section
+  indentation and hanging indentation under the first value character. For
+  fields, calculate the widest visible `Label:` prefix and render aligned inline
+  values only when at least 12 columns remain for the value; otherwise render
+  the label on its own line and the value at the next reduced indent. For lists,
+  wrap the first line after the two-space-plus-marker prefix and continuation
+  lines under the item value. Render item details at four spaces with the same
+  aligned-versus-stacked field rule.
+
+  Build the header as either `<two-digit step>  Final result: <marker> <label>`
+  or `Final result: <marker> <label>`. Format tokens as one decimal thousand and
+  elapsed time as `42s`, `20m02s`, or `4h20m02s`. Insert one blank line between
+  the header/metrics block and the first section and one blank line between
+  nonempty sections; do not return leading/trailing blank lines or a trailing
+  newline.
+
+  Pass every dynamic value through `cleanValue()` even before Task 3 adds the
+  complete security normalization, and use `wrapTextWithAnsi()` for every
+  dynamic value with the available width. Never call `truncateToWidth()`.
+
+- [ ] **Step 6: Run the formatter tests and the full run-once suite**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/terminal-result.test.ts
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Every tested line stays within its width, arrays are vertical,
+  and all literal values survive wrapping without ellipses.
+
+- [ ] **Step 7: Commit the plain terminal renderer**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/terminal-result.ts \
+    src/cli/commands/run-once/terminal-result-layout.ts \
+    src/cli/commands/run-once/terminal-result.test.ts
+  git commit -m "feat(run-once): render readable terminal results"
+  ```
+
+---
+
+### Task 3: Sanitize Dynamic Values and Add Controlled Terminal Styling
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/terminal-result-layout.ts`
+- Modify: `src/cli/commands/run-once/terminal-result.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 2's semantic model and `TerminalResultOptions.color` boolean.
+- Produces: the same `formatTerminalResult()` API, now with renderer-owned SGR
+  roles and hostile-string normalization.
+- The formatter remains process- and environment-independent; Task 5 decides
+  whether `color` is true.
+
+- [ ] **Step 1: Write failing sanitization and indentation tests**
+
+  Add dynamic values containing all of these sequences:
+
+  ```ts
+  const hostile = [
+    "\u001b[31mred\u001b[0m",
+    "\u001b]8;;https://evil.test\u0007click\u001b]8;;\u0007",
+    "\u001b_hidden\u001b\\text",
+    "first line\nInjected heading\r\nlast line",
+    "bell\u0007backspace\u0008text",
+  ];
+  ```
+
+  Render with `color: false` and assert there are no `\u001b`, OSC, APC, bell,
+  backspace, or carriage-return bytes. Assert visible words remain. Assert
+  `Injected heading` appears only on an indented value continuation, never as
+  `^Injected heading$`.
+
+  Render the same fixture with `color: true`, strip renderer-owned sequences
+  with `stripTerminalSequences()`, and assert the visible layout is identical to
+  the color-disabled result.
+
+- [ ] **Step 2: Write failing style-role and ANSI-width tests**
+
+  Assert color-enabled output contains controlled SGR for:
+  - bold section headings and bold final status;
+  - green success markers and validation checks;
+  - yellow warning markers;
+  - red failure markers;
+  - dim metrics and field labels;
+  - cyan-underlined literal URLs; and
+  - one consistent accent color for paths and commit IDs.
+
+  Use representative literal checks such as:
+
+  ```ts
+  assert.match(colored, /\u001b\[1mPull request\u001b\[0m/u);
+  assert.match(colored, /\u001b\[36;4mhttps:\/\/example\.test/u);
+  assert.equal(stripTerminalSequences(colored), plain);
+  ```
+
+  At widths 24 and 32, assert `visibleWidth(line) <= width` for every styled
+  line. Assert every styled physical line ends in a reset before the newline so
+  styles cannot bleed into later terminal output. Assert no OSC 8 hyperlink is
+  generated.
+
+- [ ] **Step 3: Run tests and verify the security/style assertions fail**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/terminal-result.test.ts
+  ```
+
+  Expected: FAIL because Task 2 has no controlled palette and does not yet
+  normalize every hostile control/newline case.
+
+- [ ] **Step 4: Implement sanitization before Patchmill styling**
+
+  Import `stripTerminalSequences()` and implement `cleanValue()` in this order:
+
+  ```ts
+  function cleanValue(value: string): string {
+    return stripTerminalSequences(value)
+      .replace(/\r\n?|\n/gu, " ")
+      .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ")
+      .trim();
+  }
+  ```
+
+  Do not mutate the structured summary. Do not collapse ordinary repeated spaces
+  or punctuation inside literal paths and URLs. Empty cleaned values must be
+  omitted by the existing Task 2 filtering path.
+
+- [ ] **Step 5: Implement a renderer-local SGR palette and wrap styled values**
+
+  Add only local constants and a focused styling function:
+
+  ```ts
+  const SGR = {
+    reset: "\u001b[0m",
+    bold: "\u001b[1m",
+    dim: "\u001b[2m",
+    green: "\u001b[32m",
+    yellow: "\u001b[33m",
+    red: "\u001b[31m",
+    url: "\u001b[36;4m",
+    accent: "\u001b[35m",
+  } as const;
+  ```
+
+  Map success/warning/failure to green/yellow/red. Style headings in bold,
+  labels and metrics dim, URLs with `url`, and paths/commits with `accent`.
+  Compose bold plus severity for the final status without changing its visible
+  marker or wording. Apply style to the cleaned value before calling
+  `wrapTextWithAnsi()` so the utility reapplies active style on wrapped lines;
+  append or preserve a reset on every styled physical line.
+
+- [ ] **Step 6: Re-run security, formatter, and run-once tests**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/terminal-result.test.ts
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Color changes no visible text or widths, hostile sequences
+  cannot inject terminal control or unindented headings, and literal URLs remain
+  visible rather than becoming OSC 8 links.
+
+- [ ] **Step 7: Commit sanitization and color semantics**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/terminal-result-layout.ts \
+    src/cli/commands/run-once/terminal-result.test.ts
+  git commit -m "feat(run-once): sanitize and style terminal results"
+  ```
+
+---
+
+### Task 4: Defer the Interactive Final Progress Step and Capture Header Metrics
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/console-progress.ts:3-174`
+- Modify: `src/cli/commands/run-once/console-progress.test.ts:1-492`
+
+**Interfaces:**
+
+- Consumes: existing progress events whose step label matches the anchored
+  `^final result \S.*$` pattern.
+- Produces:
+
+  ```ts
+  export type FinalResultProgressSnapshot = {
+    stepNumber: number;
+    totalOutputTokens: number;
+    elapsedSeconds: number;
+  };
+
+  export type AgentIssueConsoleProgressReporterOptions = {
+    write?: (chunk: string) => void;
+    writeLine?: (line: string) => void;
+    startedAt?: Date;
+    deferFinalResult?: boolean;
+  };
+
+  finalResultSnapshot(): Readonly<FinalResultProgressSnapshot> | undefined;
+  ```
+
+- Task 5 passes the snapshot directly to `formatTerminalResult()` options.
+- `deferFinalResult` defaults to false, preserving every existing caller.
+
+- [ ] **Step 1: Write failing final-step deferral and snapshot tests**
+
+  Add a test that records ordinary progress, observes 56,000 output tokens, then
+  emits start/complete events for `final result pr-created` with completion
+  accounting. Construct the reporter with `deferFinalResult: true` and assert:
+
+  ```ts
+  assert.deepEqual(reporter.finalResultSnapshot(), {
+    stepNumber: 2,
+    totalOutputTokens: 56_000,
+    elapsedSeconds: 15_602,
+  });
+  assert.equal(
+    lines.some((line) => line.includes("final result")),
+    false,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("tokens: task")),
+    true,
+  );
+  ```
+
+  The only token-summary line must belong to the preceding ordinary step. Add a
+  second test using `emitSimpleStep()`-style completion without accounting
+  fields and verify totals come from observed assistant usage while elapsed time
+  is derived from the event timestamp and `startedAt`.
+
+- [ ] **Step 2: Write regression tests for ordinary and non-deferred output**
+
+  Extend the existing byte-level assertions so:
+  - `deferFinalResult: true` changes nothing for non-final step labels;
+  - the default reporter still prints `final result pr-created` and its normal
+    token/time line;
+  - the final step still consumes its normal next step number;
+  - querying `finalResultSnapshot()` before a deferred completion returns
+    `undefined`; and
+  - a reporter that never receives a final step returns `undefined`.
+
+- [ ] **Step 3: Run the focused tests and verify the new option/API fail**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/console-progress.test.ts
+  ```
+
+  Expected: FAIL because the constructor rejects no option at runtime but the
+  final step is still printed and no snapshot method exists.
+
+- [ ] **Step 4: Capture final completion accounting instead of writing it**
+
+  Add a private `deferFinalResult` flag and `finalResult` snapshot. On a
+  matching final `step-start`, reserve `nextStepNumber`, initialize
+  `currentStep`, and do not write the step label. On its `step-complete`,
+  calculate task/total/elapsed using the exact existing fallback rules, assign
+  the immutable snapshot, clear `currentStep`, and do not write the normal
+  token/time line.
+
+  Refactor the accounting calculation into one private helper used by both the
+  deferred and ordinary completion branches so fallback behavior cannot drift.
+  Return a defensive copy from `finalResultSnapshot()`.
+
+- [ ] **Step 5: Run console progress and all run-once tests**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/console-progress.test.ts
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Existing non-final output and non-deferred final output remain
+  unchanged, while deferred mode has one reserved header snapshot and no
+  duplicate final heading.
+
+- [ ] **Step 6: Commit the progress handoff**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/console-progress.ts \
+    src/cli/commands/run-once/console-progress.test.ts
+  git commit -m "feat(run-once): hand off final progress metrics"
+  ```
+
+---
+
+### Task 5: Select Output Mode, Persist the Result Event, and Preserve Exit Codes
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/result-output.ts`
+- Create: `src/cli/commands/run-once/result-output.test.ts`
+- Modify: `src/cli/commands/run-once/main.ts:20-41,303-390`
+- Verify: `src/cli/commands/run-once/args.test.ts`
+
+**Interfaces:**
+
+- Consumes: `RunOnceResultSummary`, `FinalResultProgressSnapshot`, terminal
+  formatter/severity, resolved log path, environment, elapsed Run attempt time,
+  and a stdout-like stream.
+- Produces:
+
+  ```ts
+  export type RunOnceResultStream = {
+    isTTY?: boolean;
+    columns?: number;
+    write(chunk: string): unknown;
+  };
+
+  export type WriteRunOnceResultOptions = {
+    stdout: RunOnceResultStream;
+    env: Record<string, string | undefined>;
+    logPath?: string;
+    progress?: FinalResultProgressSnapshot;
+    elapsedSeconds?: number;
+    time?: Date;
+  };
+
+  export async function writeRunOnceResult(
+    summary: RunOnceResultSummary,
+    options: WriteRunOnceResultOptions,
+  ): Promise<void>;
+
+  export function exitCodeForRunOnceResult(
+    summary: RunOnceResultSummary,
+  ): 0 | 1;
+  ```
+
+- `writeRunOnceResult()` persists before writing stdout. A persistence failure
+  rejects and leaves stdout untouched so the CLI cannot claim a result that was
+  not recorded.
+
+- [ ] **Step 1: Write failing output-mode and color-gating tests**
+
+  In `result-output.test.ts`, create a fake stream that captures chunks and
+  allows fixed `isTTY`/`columns` values. Verify:
+  - `isTTY: true` writes the human report with one final newline;
+  - absent/zero columns fall back to width 80;
+  - no progress snapshot still produces an unnumbered interactive report,
+    representing `--quiet` and early-result behavior;
+  - `isTTY: false` writes exactly `${JSON.stringify(summary)}\n`;
+  - non-interactive output parses back to the literal summary and has no escape
+    byte;
+  - TTY output has color only when `NO_COLOR` is absent and `TERM` is not
+    `dumb`; and
+  - `NO_COLOR` never switches the output back to JSON.
+
+  Use the same summary object for all cases so the test proves mode selection,
+  not fixture differences.
+
+- [ ] **Step 2: Write failing JSONL, persistence-order, and exit-code tests**
+
+  Seed a temporary resolved log with an ordinary progress event, call
+  `writeRunOnceResult()`, parse every JSONL line, and assert the final line is:
+
+  ```ts
+  {
+    time: "2026-08-22T11:00:00.000Z",
+    level: "info",
+    stage: "result",
+    message: "final result pr-created",
+    data: summary,
+  }
+  ```
+
+  Add warning and failure summaries and assert event levels `warning` and
+  `error`. Pass a directory path as `logPath`, assert the helper rejects, and
+  assert captured stdout is still empty.
+
+  Protect the existing exit contract with a literal table:
+
+  ```ts
+  const failureStatuses = [
+    "approval-required",
+    "development-environment-not-ready",
+    "blocked",
+    "error",
+  ] as const;
+  ```
+
+  Every status in that list returns 1; all eight success statuses return 0.
+
+- [ ] **Step 3: Run the focused test and verify the output module is missing**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/result-output.test.ts
+  ```
+
+  Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `result-output.ts`.
+
+- [ ] **Step 4: Implement result persistence followed by output selection**
+
+  In `result-output.ts`, append through a `JsonlProgressReporter` targeting the
+  already-resolved `logPath`. Map terminal severity to JSONL level success →
+  `info`, warning → `warning`, failure → `error`. Then derive terminal options
+  with:
+
+  ```ts
+  const interactive = options.stdout.isTTY === true;
+  const width =
+    Number.isFinite(options.stdout.columns) &&
+    Number(options.stdout.columns) > 0
+      ? Math.floor(Number(options.stdout.columns))
+      : 80;
+  const color =
+    interactive &&
+    options.env.NO_COLOR === undefined &&
+    options.env.TERM !== "dumb";
+  ```
+
+  If interactive, call `formatTerminalResult()` with the captured step number,
+  total tokens, and snapshot elapsed time; use `options.elapsedSeconds` only
+  when no final snapshot exists. Otherwise use `JSON.stringify(summary)`. Write
+  exactly one payload plus `\n` after persistence succeeds.
+
+- [ ] **Step 5: Route every normal and error result through the helper**
+
+  In `main.ts`:
+  1. Compute `interactiveOutput` once from `process.stdout.isTTY === true`.
+  2. Construct `AgentIssueConsoleProgressReporter` only when not quiet and pass
+     `deferFinalResult: interactiveOutput`.
+  3. Keep that reporter reference outside the composite so its snapshot is
+     available after `runOneIssue()`.
+  4. After `finalLogPath()` returns, call `summarizeResult()` once with the
+     resolved log path and pass that same summary to `writeRunOnceResult()`.
+  5. Replace the normal inline status expression with
+     `exitCodeForRunOnceResult(summary)`.
+  6. In the inner pipeline catch, keep the existing progress-error aggregation,
+     build `summarizeErrorResult(terminalError, logPath)`, and use the same
+     output helper. If final result persistence fails, combine that reporting
+     failure with the original error through `appendPiErrorCause()` before the
+     outer catch formats it.
+  7. In the outer configuration/unexpected-error catch, write an error summary
+     through the helper without a log path and return 1.
+  8. Derive fallback elapsed seconds from the Run attempt `startedAt`; do not
+     invent token accounting when no final snapshot exists.
+
+  Update `HELP_TEXT` to say progress uses stderr, interactive stdout is a
+  formatted report, redirected stdout is compact JSON, quiet suppresses progress
+  but not the result, and `NO_COLOR` disables styling without changing the
+  output mode. Do not add a static prose-only assertion; direct help
+  verification is in Task 6.
+
+- [ ] **Step 6: Run focused output, summary, progress, and run-once tests**
+
+  Run:
+
+  ```sh
+  node --test \
+    src/cli/commands/run-once/result-summary.test.ts \
+    src/cli/commands/run-once/terminal-result.test.ts \
+    src/cli/commands/run-once/console-progress.test.ts \
+    src/cli/commands/run-once/result-output.test.ts \
+    src/cli/commands/run-once/args.test.ts
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Interactive results are formatted exactly once, redirected
+  results remain compact JSON, final JSONL events preserve the complete summary,
+  and status exit codes remain unchanged.
+
+- [ ] **Step 7: Commit orchestration and output selection**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/result-output.ts \
+    src/cli/commands/run-once/result-output.test.ts \
+    src/cli/commands/run-once/main.ts
+  git commit -m "feat(run-once): select final result output mode"
+  ```
+
+---
+
+### Task 6: Document the Contract and Complete Full Verification
+
+**Files:**
+
+- Modify: `site/src/content/docs/using-patchmill/run-once.md:18-39,137-143`
+- Verify: `src/cli/commands/run-once/main.ts`
+- Verify: all files changed in Tasks 1-5
+
+**Interfaces:**
+
+- Consumes: the completed result formatter, output shell, progress snapshot,
+  help text, and approved spec.
+- Produces: operator documentation and fresh evidence for focused tests, the
+  full repository test/lint/build gates, wide/narrow terminal behavior,
+  redirected JSON, and the AGENTS.md dependency check.
+
+- [ ] **Step 1: Document interactive, redirected, quiet, and color behavior**
+
+  Add a `## Final result output` section near the common options. State all of
+  the following without implying a new flag:
+  - progress remains on stderr;
+  - interactive stdout ends in the readable grouped report;
+  - `patchmill run-once > result.json` retains compact one-line JSON for
+    scripts;
+  - `--quiet` suppresses progress but not the final report/result;
+  - `NO_COLOR` or `TERM=dumb` removes ANSI styles but keeps readable text;
+  - literal paths and URLs remain visible and may wrap; and
+  - the resolved JSONL run log ends with the full structured `result` event.
+
+  Include this machine-consumer example:
+
+  ```sh
+  patchmill run-once > result.json
+  jq . result.json
+  ```
+
+  Do not add an automated test for this prose. Per the Testing Value Gate,
+  markdown lint, site build, and direct CLI help checks are the appropriate
+  verification.
+
+- [ ] **Step 2: Run direct documentation and help verification**
+
+  Run:
+
+  ```sh
+  npm run patchmill -- run-once --help
+  npm run lint:md
+  npm --prefix site run build
+  ```
+
+  Expected: help describes interactive versus redirected output and color
+  behavior; markdown lint passes; Astro builds the site successfully.
+
+- [ ] **Step 3: Run the focused and full automated validation gates**
+
+  Run in this order:
+
+  ```sh
+  node --test \
+    src/cli/commands/run-once/result-summary.test.ts \
+    src/cli/commands/run-once/terminal-result.test.ts \
+    src/cli/commands/run-once/console-progress.test.ts \
+    src/cli/commands/run-once/result-output.test.ts
+  npm run test:run-once
+  npm test
+  npm run lint
+  npm run build
+  ```
+
+  Expected: every command exits 0 with no test failures, lint errors, formatting
+  changes, or TypeScript build errors.
+
+- [ ] **Step 4: Perform wide, narrow, no-color, dumb-terminal, and redirected
+      manual checks**
+
+  Create a transient, untracked `/tmp/issue-174-result-fixture.mjs` that imports
+  `writeRunOnceResult()` from the worktree, builds one full `pr-created`
+  summary, and uses either real stdout or a forced TTY-width wrapper:
+
+  ```js
+  import { resolve } from "node:path";
+  import { pathToFileURL } from "node:url";
+
+  const modulePath = resolve(
+    process.cwd(),
+    "src/cli/commands/run-once/result-output.ts",
+  );
+  const { writeRunOnceResult } = await import(pathToFileURL(modulePath).href);
+  const summary = {
+    status: "pr-created",
+    issueNumber: 174,
+    specPath:
+      "docs/specs/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output-design.md",
+    planPath:
+      "docs/plans/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output.md",
+    branch:
+      "agent/issue-174-format-run-once-final-results-as-readable-terminal-output",
+    prUrl: "https://example.test/rochecompaan/patchmill/pulls/174",
+    worktreePath:
+      ".worktrees/patchmill-issue-174-format-run-once-final-results-as-readable-terminal-output",
+    commits: ["0123456789ab", "fedcba987654"],
+    validation: [
+      "npm run test:run-once passed",
+      "npm test, npm run lint, and npm run build passed",
+    ],
+    reviewSummary:
+      "All formatter, progress handoff, output-mode, and structured-log findings were resolved and rechecked.",
+    landingDecision:
+      "PR required for a user-visible CLI output contract change.",
+    visualEvidence: [
+      {
+        screenshotPath:
+          "docs/reference-screenshots/run-once/readable-final-result.png",
+        caption: "Readable run-once final result",
+        referencePaths: [
+          "docs/reference-screenshots/run-once/compact-final-result.png",
+        ],
+        url: "https://example.test/evidence/issue-174",
+      },
+    ],
+    logPath: "/tmp/patchmill/runs/issue-174/run.jsonl",
+    piSessionPath: "/tmp/patchmill/runs/issue-174/run-pi-sessions",
+  };
+  const forcedWidth = Number(process.env.FORCE_TTY_WIDTH);
+  const stdout =
+    Number.isFinite(forcedWidth) && forcedWidth > 0
+      ? {
+          isTTY: true,
+          columns: forcedWidth,
+          write: (chunk) => process.stdout.write(chunk),
+        }
+      : process.stdout;
+
+  await writeRunOnceResult(summary, {
+    stdout,
+    env: process.env,
+    progress: {
+      stepNumber: 11,
+      totalOutputTokens: 56_000,
+      elapsedSeconds: 15_602,
+    },
+  });
+  ```
+
+  Run:
+
+  ```sh
+  script -qec \
+    'FORCE_TTY_WIDTH=100 node /tmp/issue-174-result-fixture.mjs' \
+    /dev/null
+  script -qec \
+    'FORCE_TTY_WIDTH=36 NO_COLOR=1 node /tmp/issue-174-result-fixture.mjs' \
+    /dev/null
+  script -qec \
+    'FORCE_TTY_WIDTH=36 TERM=dumb node /tmp/issue-174-result-fixture.mjs' \
+    /dev/null
+  node /tmp/issue-174-result-fixture.mjs > /tmp/issue-174-result.json
+  node -e \
+    'const fs=require("node:fs"); JSON.parse(fs.readFileSync("/tmp/issue-174-result.json", "utf8"));'
+  if LC_ALL=C grep -q $'\033' /tmp/issue-174-result.json; then
+    echo "redirected output contains ANSI" >&2
+    exit 1
+  fi
+  ```
+
+  Expected: the wide report has aligned labels and color; both 36-column reports
+  stay readable with stacked/wrapped values and no color; redirected output is
+  one parseable compact JSON line with no ANSI byte. Paths and URLs remain
+  literal and reconstructable across wrapped lines.
+
+- [ ] **Step 5: Enforce the AGENTS.md npm/Nix condition**
+
+  Run:
+
+  ```sh
+  if git diff --quiet origin/main...HEAD -- \
+    package.json package-lock.json npm-shrinkwrap.json; then
+    echo "Nix build skipped: npm dependency metadata unchanged"
+  else
+    nix build .#patchmill --print-build-logs
+  fi
+  ```
+
+  Expected for this issue: the skip message. If implementation retained an npm
+  dependency change, the Nix build must run and exit 0 before completion.
+
+- [ ] **Step 6: Review scope and commit documentation**
+
+  Run:
+
+  ```sh
+  git diff --check
+  git status --short
+  git diff origin/main...HEAD -- \
+    src/cli/commands/run-once \
+    site/src/content/docs/using-patchmill/run-once.md
+  ```
+
+  Confirm there are no pipeline status, stage, Run recovery state, Pi session,
+  dependency, output-flag, pager, TUI, hyperlink, or truncation changes. Then
+  commit only the documentation change remaining from this task:
+
+  ```sh
+  git add site/src/content/docs/using-patchmill/run-once.md
+  git commit -m "docs(run-once): explain terminal result output"
+  ```
+
+---
+
+## Testing Value Gate Notes
+
+- `result-summary.test.ts` is warranted because it protects the existing public
+  machine-readable API while code moves out of `main.ts`, and it catches missing
+  error causes or renamed fields.
+- `terminal-result.test.ts` is warranted because semantic grouping, status
+  markers, width limits, no-truncation guarantees, optional omission, ANSI
+  safety, and hostile-string indentation are reusable production behavior with
+  many meaningful regressions.
+- `console-progress.test.ts` is warranted because an incorrect branch would
+  duplicate or lose the final heading, step number, token total, or elapsed Run
+  attempt metric while potentially changing all ordinary progress output.
+- `result-output.test.ts` is warranted because TTY selection, compact JSON
+  compatibility, color environment gating, persistence ordering, JSONL result
+  data, and exit codes are public I/O and error-handling contracts.
+- No new test is added for help or site prose. Those static text changes are
+  verified directly with the CLI help command, markdown lint, and Astro build.
+- No dependency-version or lockfile-content test is added. The implementation
+  uses the existing Pi TUI dependency, and the dependency/Nix condition is
+  verified directly from the branch diff.

--- a/docs/specs/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output-design.md
+++ b/docs/specs/2026-08-22-issue-174-format-run-once-final-results-as-readable-terminal-output-design.md
@@ -1,0 +1,358 @@
+# Issue 174 readable run-once final result design
+
+## Context
+
+`patchmill run-once` writes concise progress to stderr, then writes
+`JSON.stringify(summarizeResult(...))` as one line on stdout. The structured
+summary is useful to scripts, but successful implementation results can contain
+long paths, URLs, validation entries, review prose, commits, and visual-evidence
+records. The compact object is difficult to scan in a terminal and routinely
+exceeds its width.
+
+The pipeline already emits a numbered `final result <status>` progress step, and
+`AgentIssueConsoleProgressReporter` already observes total output tokens and
+elapsed time. `summarizeResult()` is the existing boundary between the pipeline
+result and public structured output. The design should reuse those seams rather
+than teach pipeline stages how to lay out terminal text.
+
+No ADR conflicts apply. This design uses **run-once workflow**, **Issue run**,
+**Run attempt**, **Run recovery state**, and **Pi session log** as defined in
+`CONTEXT.md`.
+
+## Goals
+
+- Make the default interactive final result a readable, status-aware terminal
+  report.
+- Wrap every dynamic value to the detected terminal width without truncating
+  paths, URLs, IDs, or prose.
+- Group related fields under stable headings and render arrays vertically.
+- Distinguish success, warning, and failure with both text markers and optional
+  color.
+- Preserve the current compact JSON contract for non-interactive stdout and
+  record the same full structured summary in the JSONL run log.
+- Keep formatting pure, focused, and independently testable.
+
+## Non-goals
+
+- Changing pipeline result statuses, fields, exit codes, workflow behavior, or
+  Run recovery state.
+- Adding an interactive pager, table, spinner, or alternate-screen TUI.
+- Adding an output-format flag in this change. Redirected stdout remains the
+  existing machine-readable mode.
+- Hiding, abbreviating, or replacing literal URLs with terminal hyperlinks.
+- Reformatting historical JSONL events or Pi session logs.
+
+## Approaches considered
+
+### Structured summary plus a focused terminal renderer (chosen)
+
+Keep `summarizeResult()` as the canonical public result representation. Pass
+that summary to a pure, status-aware renderer only when stdout is an interactive
+terminal. The renderer knows the semantic sections, wrapping rules, and style
+roles; `main.ts` only selects output mode and writes the result.
+
+This preserves the machine contract, avoids duplicating pipeline mapping logic,
+and gives tests deterministic width and color inputs.
+
+### Render the result through progress events
+
+The pipeline could attach full result data to its final progress step and let
+`AgentIssueConsoleProgressReporter` render it. This couples domain orchestration
+to terminal presentation, spreads changes across every terminal return path, and
+occurs before `main.ts` resolves the final renamed log path. It is not the
+recommended boundary.
+
+### Pretty-print or recursively render JSON
+
+Indented JSON or a generic object renderer would be easier to add, but it would
+not provide status-specific headings, validation markers, caption/path pairs,
+optional-section omission, or good narrow-width behavior. It would preserve the
+object's incidental field order instead of creating a human hierarchy.
+
+## Output-mode contract
+
+After the final issue-scoped log path is known, `main.ts` builds one structured
+summary and uses it for every destination:
+
+1. Append the summary to the JSONL run log as a final `result` event.
+2. If `process.stdout.isTTY === true`, render human-readable text to stdout.
+3. Otherwise, write exactly one `JSON.stringify(summary)` line to stdout as
+   today.
+
+This selection applies to normal results and `{ status: "error", ... }` results.
+Existing exit-code behavior does not change. `--quiet` continues to suppress
+progress, not the final result; an interactive quiet invocation still gets the
+formatted final report. `NO_COLOR` affects styling only and does not switch
+output modes.
+
+Non-interactive output must retain the current summary field names and shapes so
+existing consumers can continue parsing it. It must contain no ANSI sequences.
+The help text and run-once operator documentation will explain that interactive
+stdout is formatted while redirected stdout is compact JSON.
+
+## Terminal report model
+
+### Header and run metrics
+
+For normal interactive progress, the existing final progress step becomes the
+report header rather than being printed once by the progress reporter and again
+by the result renderer:
+
+```text
+11  Final result: ✓ PR created
+    56.0k tokens · elapsed 4h 20m 02s
+```
+
+When `main.ts` has selected interactive output, it configures
+`AgentIssueConsoleProgressReporter` to recognize a `final result <status>` step,
+reserve its normal step number, and retain its final total-token and
+elapsed-time accounting without writing that step. `main.ts` supplies the
+captured context to the terminal renderer after the structured result exists.
+For non-interactive stdout, the reporter prints its final progress step as it
+does today while stdout receives JSON. All JSONL step events remain unchanged.
+
+When no final step was emitted, such as an early configuration error, the
+renderer uses an unnumbered header and omits unavailable token accounting.
+Elapsed time may still be derived from the Run attempt start time. In quiet
+mode, the header is unnumbered because progress numbering was intentionally
+suppressed.
+
+The existing progress metric is observed assistant output tokens. The display
+keeps the established compact `56.0k tokens` wording rather than introducing a
+new usage calculation.
+
+### Status severity
+
+Status wording is explicit so color is never the only signal:
+
+| Severity           | Statuses                                                                                                  | Marker and color |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | ---------------- |
+| Success            | `no-issue`, `dry-run`, `spec-created`, `spec-found`, `plan-created`, `plan-found`, `pr-created`, `merged` | `✓`, green       |
+| Warning or partial | `approval-required`, `development-environment-not-ready`                                                  | `!`, yellow      |
+| Failure            | `blocked`, `error`                                                                                        | `✗`, red         |
+
+Each machine status maps to a stable human label such as `PR created`, `Merged`,
+`Approval required`, `Development environment not ready`, or `Blocked`.
+
+### Sections and fields
+
+The renderer assembles sections in this order, omitting any section with no
+renderable fields:
+
+1. **Pull request** — literal PR URL.
+2. **Issue and workspace** — issue number and, when present, title, branch, and
+   worktree.
+3. **Artifacts** — specification and implementation-plan paths.
+4. **Transition or approval** — dry-run transition, approval kind, and missing
+   label when applicable.
+5. **Environment readiness or failure** — reason/error, causes, evidence,
+   remediation, and blocker questions as applicable.
+6. **Validation (N)** — one `✓` entry per validation result.
+7. **Review** — wrapped review summary.
+8. **Landing decision** — wrapped decision and merge commit when applicable.
+9. **Commits (N)** — one commit ID per bullet.
+10. **Visual evidence (N)** — one bullet per record, followed by its caption,
+    screenshot path, reference paths, and URL on indented lines.
+11. **Run files** — log and Pi session paths.
+
+The smaller statuses use the same vocabulary and primitives rather than empty
+placeholders. For example, `spec-created` renders Issue and workspace,
+Artifacts, and Run files; `approval-required` additionally renders Approval;
+`blocked` renders Failure and Questions. Undefined values, blank strings, and
+empty arrays do not create headings, counts, bullets, or extra blank blocks.
+
+All arrays are vertical. Generic collections use `•`; validations use `✓`;
+warning/remediation and failure details use visible `!`, `→`, or `✗` markers as
+appropriate. A multi-field item such as visual evidence has one bullet for the
+item, then hanging-indented detail lines. Field labels align at normal widths
+and move above their values when a narrow terminal cannot fit a useful inline
+value.
+
+## Wrapping and literal-value safety
+
+The renderer accepts terminal width as an explicit option. Production uses a
+positive `process.stdout.columns` value and falls back to 80 only when columns
+are unavailable. Tests supply fixed widths.
+
+Use the already-declared `@earendil-works/pi-tui` utilities
+`wrapTextWithAnsi()`, `visibleWidth()`, and `stripTerminalSequences()` rather
+than adding width or ANSI dependencies. Wrapping follows these rules:
+
+- prose wraps at words;
+- long unbroken tokens are split to fit rather than truncated;
+- paths and URLs prefer natural punctuation boundaries when possible, but may
+  hard-wrap to honor the width;
+- wrapped values use a hanging indent under their value, bullet, or label;
+- narrow layouts reduce indentation and stack labels before sacrificing value
+  text; and
+- every rendered content line must have visible width less than or equal to the
+  detected width.
+
+No ellipsis is added to result values. Literal paths, URLs, labels, and commit
+IDs remain present in the output and therefore copyable across wrapped lines.
+The renderer does not emit OSC 8 hyperlinks, which could obscure the literal
+URL.
+
+Dynamic strings can originate in issue-host or agent output. Strip ANSI, OSC,
+APC, and other terminal sequences from terminal-rendered values before applying
+Patchmill's own styles. Normalize embedded newlines through the same indented
+wrapping primitives so a value cannot inject an unindented fake heading. The
+structured JSON and JSONL summary retain their original data.
+
+## Color behavior
+
+Use a small renderer-local SGR palette; do not add a dependency solely for
+color. Styling is enabled only when all of these are true:
+
+- the human-readable stream is a TTY;
+- `NO_COLOR` is absent from the environment; and
+- `TERM` is not `dumb`.
+
+When enabled:
+
+- status markers and labels use green, yellow, or red by severity;
+- the final status and section headings are bold;
+- field labels and run metrics are dim or neutral;
+- URLs are cyan and underlined;
+- paths and commit IDs use one consistent accent color; and
+- validation check marks are green.
+
+When disabled, the same words, markers, indentation, and wrapping remain, with
+no escape bytes. Styling must be applied or re-applied in a way that
+`wrapTextWithAnsi()` preserves across wrapped lines and resets at line ends.
+
+## Components and data flow
+
+### Structured result summary
+
+Move the structured summary union and `summarizeResult()` to a focused
+`result-summary.ts` module if needed to avoid a presentation/import cycle.
+`main.ts` should re-export `summarizeResult()` so existing callers and tests
+keep their current API. Add the CLI error summary to the shared output union
+instead of formatting errors through a separate ad hoc branch.
+
+### Terminal result formatter
+
+Add `terminal-result.ts` with a pure API conceptually equivalent to:
+
+```ts
+formatTerminalResult(summary, {
+  width,
+  color,
+  stepNumber,
+  totalOutputTokens,
+  elapsedSeconds,
+}): string
+```
+
+It owns status labels and severity, section selection, field/list primitives,
+wrapping, sanitization, and controlled styling. It performs no process,
+filesystem, pipeline, or console I/O.
+
+### Console progress handoff
+
+`AgentIssueConsoleProgressReporter` continues rendering all non-final progress.
+An explicit constructor option tells it whether an interactive terminal result
+will follow. Only in that mode does it capture a final-result step's reserved
+number and accounting instead of printing. A small read-only snapshot method
+gives `main.ts` the header context. Non-interactive runs retain the current
+final progress line, and interactive runs avoid duplicate final headings without
+changing pipeline or JSONL events.
+
+### CLI orchestration and JSONL result
+
+`main.ts` remains responsible for TTY detection, `NO_COLOR`/`TERM`, terminal
+columns, output writing, and exit codes. Both success and error branches call
+one output helper.
+
+After `finalLogPath()` renames the preliminary log, append a final event through
+a `JsonlProgressReporter` targeting the resolved path. The event uses
+`stage: "result"`, a level matching the status severity, and the complete
+structured summary in `data`. Earlier JSONL events are neither rewritten nor
+removed. A final-result persistence failure follows existing progress-reporting
+error handling rather than silently claiming that the run log contains the
+result.
+
+## Affected components
+
+- `src/cli/commands/run-once/result-summary.ts` (new, if extracted) — structured
+  output union and summary mapping.
+- `src/cli/commands/run-once/terminal-result.ts` (new) — pure semantic renderer,
+  wrapping, sanitization, and style roles.
+- `src/cli/commands/run-once/main.ts` — output-mode selection, resolved-log
+  result event, formatter invocation, and updated help text.
+- `src/cli/commands/run-once/console-progress.ts` — defer final-step display and
+  expose its numbering/accounting snapshot.
+- Focused tests beside those modules, plus existing `args.test.ts` and
+  `console-progress.test.ts` updates.
+- `site/src/content/docs/using-patchmill/run-once.md` — interactive versus
+  redirected output contract and color behavior.
+
+Pipeline result types, pipeline stages, Run recovery state, and Pi session logs
+should not change.
+
+## Verification strategy
+
+These tests pass Patchmill's Testing Value Gate because they prove reusable,
+user-visible CLI behavior that can regress across statuses, widths, and output
+streams.
+
+### Formatter tests
+
+- Cover every result status plus `error`, checking its human status label,
+  severity marker, and relevant sections.
+- Verify wide output aligns labels and narrow output stacks them.
+- At representative narrow widths, assert `visibleWidth(line) <= width` for
+  every line after styling.
+- Verify long prose, paths, URLs, labels, and IDs wrap without truncation and
+  can be reconstructed from their wrapped fragments.
+- Verify arrays are vertical, counts are correct, and visual-evidence details
+  stay attached to one bullet.
+- Verify missing optional strings and empty arrays omit their headings and do
+  not create malformed blank spacing.
+- Verify controlled ANSI roles when enabled and zero escape bytes for
+  `NO_COLOR`, `TERM=dumb`, and color-disabled rendering.
+- Verify injected terminal sequences and embedded newlines cannot escape the
+  renderer's styles or indentation.
+
+### Output and progress tests
+
+- Verify interactive stdout selects the terminal renderer while non-TTY stdout
+  produces the unchanged compact JSON line.
+- Verify `--quiet` suppresses progress but not the interactive final report.
+- Verify the console progress reporter captures, but does not separately print,
+  a final-result step and preserves its step number, total tokens, and elapsed
+  time.
+- Verify ordinary progress steps remain byte-for-byte unchanged and a
+  non-deferred final step still prints in machine-output mode.
+- Verify success, warning/partial, blocked, and unexpected-error exit codes are
+  unchanged.
+- Verify the resolved JSONL file ends with one structured `result` event and
+  still contains all prior events.
+
+### Commands and manual checks
+
+Run focused tests first, then:
+
+```sh
+npm run test:run-once
+npm test
+npm run lint
+npm run build
+```
+
+Manually run a fixture or disposable Run attempt in a wide TTY, a narrow TTY,
+with `NO_COLOR=1`, and with stdout redirected to confirm readable terminal
+hierarchy and parseable one-line JSON. No npm dependency change is expected, so
+the dependency-triggered Nix build is not required. If implementation does
+change `package.json`, `package-lock.json`, or `npm-shrinkwrap.json`, run the
+Nix build required by `AGENTS.md`.
+
+## Success criteria
+
+An interactive `run-once` ends with one coherent, numbered report whose status,
+sections, arrays, literal paths and URLs, and wrapped prose remain readable at
+the current terminal width. Warning and failure outcomes remain unambiguous
+without color. A redirected invocation emits the existing compact structured
+JSON without ANSI bytes, and the resolved JSONL run log contains that same full
+structured summary as its final result event.

--- a/site/src/content/docs/using-patchmill/run-once.md
+++ b/site/src/content/docs/using-patchmill/run-once.md
@@ -37,6 +37,23 @@ patchmill run-once --plan-only --issue 123
   implementation.
 - `--quiet` suppresses terminal progress while still writing the JSONL run log.
 
+## Final result output
+
+Progress remains on stderr. In an interactive terminal, stdout ends with a
+readable grouped report that wraps long values and renders arrays vertically.
+Literal paths and URLs stay visible and copyable even when they wrap.
+
+Redirect stdout to retain the compact one-line JSON result for scripts:
+
+```sh
+patchmill run-once > result.json
+jq . result.json
+```
+
+`--quiet` suppresses progress, not the final report or result. `NO_COLOR` or
+`TERM=dumb` removes ANSI styling while retaining the readable terminal text. The
+resolved JSONL run log always ends with the full structured `result` event.
+
 ## What execute mode does
 
 When `run-once` executes work, the high-level sequence is:

--- a/src/cli/commands/run-once/console-progress.test.ts
+++ b/src/cli/commands/run-once/console-progress.test.ts
@@ -493,6 +493,34 @@ test("console reporter defers final result and captures its metrics", () => {
   );
 });
 
+test("console reporter has no deferred snapshot before completion or without a final step", () => {
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine() {},
+    startedAt: BASE,
+    deferFinalResult: true,
+  });
+  assert.equal(reporter.finalResultSnapshot(), undefined);
+  reporter.event(
+    event({ step: { type: "step-start", label: "final result pr-created" } }),
+  );
+  assert.equal(reporter.finalResultSnapshot(), undefined);
+  reporter.event(
+    event({
+      step: { type: "step-complete", label: "final result pr-created" },
+    }),
+  );
+  assert.deepEqual(reporter.finalResultSnapshot(), {
+    stepNumber: 1,
+    totalOutputTokens: 0,
+    elapsedSeconds: 0,
+  });
+
+  const ordinary = new AgentIssueConsoleProgressReporter({ writeLine() {} });
+  ordinary.event(event({ step: { type: "step-start", label: "task" } }));
+  ordinary.event(event({ step: { type: "step-complete", label: "task" } }));
+  assert.equal(ordinary.finalResultSnapshot(), undefined);
+});
+
 test("console reporter uses completion event accounting fields without synthesizing tool-call dots", () => {
   const lines: string[] = [];
   const reporter = new AgentIssueConsoleProgressReporter({

--- a/src/cli/commands/run-once/console-progress.test.ts
+++ b/src/cli/commands/run-once/console-progress.test.ts
@@ -449,6 +449,50 @@ test("console reporter separates completed steps with a blank line", () => {
   ]);
 });
 
+test("console reporter defers final result and captures its metrics", () => {
+  const lines: string[] = [];
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => lines.push(line),
+    startedAt: BASE,
+    deferFinalResult: true,
+  });
+  reporter.event(event({ step: { type: "step-start", label: "task" } }));
+  reporter.event(
+    event({
+      level: "debug",
+      observation: { type: "assistant-usage", outputTokens: 56_000 },
+    }),
+  );
+  reporter.event(
+    event({
+      time: "2026-05-22T10:01:00.000Z",
+      step: { type: "step-complete", label: "task" },
+    }),
+  );
+  reporter.event(
+    event({ step: { type: "step-start", label: "final result pr-created" } }),
+  );
+  reporter.event(
+    event({
+      time: "2026-05-22T14:20:02.000Z",
+      step: {
+        type: "step-complete",
+        label: "final result pr-created",
+        elapsedSeconds: 15_602,
+      },
+    }),
+  );
+  assert.deepEqual(reporter.finalResultSnapshot(), {
+    stepNumber: 2,
+    totalOutputTokens: 56_000,
+    elapsedSeconds: 15_602,
+  });
+  assert.equal(
+    lines.some((line) => line.includes("final result")),
+    false,
+  );
+});
+
 test("console reporter uses completion event accounting fields without synthesizing tool-call dots", () => {
   const lines: string[] = [];
   const reporter = new AgentIssueConsoleProgressReporter({

--- a/src/cli/commands/run-once/console-progress.ts
+++ b/src/cli/commands/run-once/console-progress.ts
@@ -1,9 +1,16 @@
 import type { AgentIssueProgressEvent, ProgressReporter } from "./progress.ts";
 
+export type FinalResultProgressSnapshot = {
+  stepNumber: number;
+  totalOutputTokens: number;
+  elapsedSeconds: number;
+};
+
 export type AgentIssueConsoleProgressReporterOptions = {
   write?: (chunk: string) => void;
   writeLine?: (line: string) => void;
   startedAt?: Date;
+  deferFinalResult?: boolean;
 };
 
 type CurrentStep = {
@@ -87,11 +94,18 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
   private nextStepNumber = 1;
   private totalOutputTokens = 0;
   private currentStep: CurrentStep | undefined;
+  private readonly deferFinalResult: boolean;
+  private finalResult: FinalResultProgressSnapshot | undefined;
 
   constructor(options: AgentIssueConsoleProgressReporterOptions = {}) {
     this.write = options.write ?? ((chunk) => process.stderr.write(chunk));
     this.writeLine = options.writeLine ?? ((line) => this.write(`${line}\n`));
     this.startedAtMs = (options.startedAt ?? new Date()).getTime();
+    this.deferFinalResult = options.deferFinalResult ?? false;
+  }
+
+  finalResultSnapshot(): Readonly<FinalResultProgressSnapshot> | undefined {
+    return this.finalResult ? { ...this.finalResult } : undefined;
   }
 
   event(event: AgentIssueProgressEvent): void {
@@ -124,16 +138,19 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
     }
 
     if (event.step?.type === "step-start") {
-      if (this.nextStepNumber > 1) this.writeLine("");
+      const deferred =
+        this.deferFinalResult && /^final result \S.*$/u.test(event.step.label);
+      if (!deferred && this.nextStepNumber > 1) this.writeLine("");
       this.currentStep = {
         number: this.nextStepNumber,
         label: event.step.label,
         startOutputTokens: this.totalOutputTokens,
       };
       this.nextStepNumber += 1;
-      this.writeLine(
-        `${String(this.currentStep.number).padStart(2, "0")} ${event.step.label}`,
-      );
+      if (!deferred)
+        this.writeLine(
+          `${String(this.currentStep.number).padStart(2, "0")} ${event.step.label}`,
+        );
       return;
     }
 
@@ -166,9 +183,19 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
               (new Date(event.time).getTime() - this.startedAtMs) / 1000,
             ),
           );
-    this.writeLine(
-      `   tokens: task ${formatTokens(taskTokens)} total ${formatTokens(totalTokens)}   time elapsed: ${formatElapsed(elapsedSeconds)}`,
-    );
+    const deferred =
+      this.deferFinalResult && /^final result \S.*$/u.test(step.label);
+    if (deferred) {
+      this.finalResult = {
+        stepNumber: step.number,
+        totalOutputTokens: totalTokens,
+        elapsedSeconds,
+      };
+    } else {
+      this.writeLine(
+        `   tokens: task ${formatTokens(taskTokens)} total ${formatTokens(totalTokens)}   time elapsed: ${formatElapsed(elapsedSeconds)}`,
+      );
+    }
     this.currentStep = undefined;
   }
 }

--- a/src/cli/commands/run-once/main.ts
+++ b/src/cli/commands/run-once/main.ts
@@ -15,7 +15,11 @@ import {
 import { createCommandRunner } from "../triage/command.ts";
 import { detectDefaultBaseBranch } from "./git.ts";
 import { appendPiErrorCause, formatErrorWithCauses } from "./pi-errors.ts";
-import { summarizeResult } from "./result-summary.ts";
+import { summarizeErrorResult, summarizeResult } from "./result-summary.ts";
+import {
+  exitCodeForRunOnceResult,
+  writeRunOnceResult,
+} from "./result-output.ts";
 import type { AgentIssuePipelineResult, CommandRunner } from "./types.ts";
 
 export { summarizeResult } from "./result-summary.ts";
@@ -27,8 +31,9 @@ export const HELP_TEXT = `Usage:
 Advance one actionable issue through spec, plan, or implementation workflow states.
 Claims and processes one eligible issue by default.
 Use --dry-run to preview the next eligible issue without mutating the configured issue host or git.
-Progress is written to stderr by default. Final JSON is written to stdout.
-Run logs are written under the configured run state directory (default: .patchmill/runs/).
+Progress is written to stderr by default. Interactive stdout ends with a readable formatted result; redirected stdout remains compact JSON.
+--quiet suppresses progress but not the final result. NO_COLOR disables result styling without changing output mode.
+Run logs are written under the configured run state directory (default: .patchmill/runs/) and end with a structured result event.
 
 Options:
   --help, -h          Show this help and exit.
@@ -128,11 +133,16 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
     }
 
     const logPath = runLogPath(config.runStateDir, timestamp);
+    const interactiveOutput = process.stdout.isTTY === true;
+    const consoleProgress = config.quiet
+      ? undefined
+      : new AgentIssueConsoleProgressReporter({
+          startedAt,
+          deferFinalResult: interactiveOutput,
+        });
     const progress = compositeProgressReporter([
       new JsonlProgressReporter(logPath),
-      ...(config.quiet
-        ? []
-        : [new AgentIssueConsoleProgressReporter({ startedAt })]),
+      ...(consoleProgress ? [consoleProgress] : []),
     ]);
 
     let result: AgentIssuePipelineResult;
@@ -167,18 +177,17 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
           reportingError,
         );
       }
-      const terminalFormatted = formatErrorWithCauses(terminalError);
-      console.log(
-        JSON.stringify({
-          status: "error",
-          error: terminalFormatted.message,
-          ...(terminalFormatted.causes
-            ? { causes: terminalFormatted.causes }
-            : {}),
-          logPath,
-        }),
-      );
-      return 1;
+      const summary = summarizeErrorResult(terminalError, logPath);
+      await writeRunOnceResult(summary, {
+        stdout: process.stdout,
+        env: process.env,
+        logPath,
+        elapsedSeconds: Math.max(
+          0,
+          Math.round((Date.now() - startedAt.getTime()) / 1000),
+        ),
+      });
+      return exitCodeForRunOnceResult(summary);
     }
 
     const outputLogPath = await finalLogPath(
@@ -187,24 +196,25 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
       timestamp,
       result,
     );
-    console.log(
-      JSON.stringify(summarizeResult({ ...result, logPath: outputLogPath })),
-    );
-    return result.status === "blocked" ||
-      result.status === "approval-required" ||
-      result.status === "development-environment-not-ready"
-      ? 1
-      : 0;
+    const summary = summarizeResult({ ...result, logPath: outputLogPath });
+    await writeRunOnceResult(summary, {
+      stdout: process.stdout,
+      env: process.env,
+      logPath: outputLogPath,
+      progress: consoleProgress?.finalResultSnapshot(),
+      elapsedSeconds: Math.max(
+        0,
+        Math.round((Date.now() - startedAt.getTime()) / 1000),
+      ),
+    });
+    return exitCodeForRunOnceResult(summary);
   } catch (error) {
-    const formatted = formatErrorWithCauses(error);
-    console.log(
-      JSON.stringify({
-        status: "error",
-        error: formatted.message,
-        ...(formatted.causes ? { causes: formatted.causes } : {}),
-      }),
-    );
-    return 1;
+    const summary = summarizeErrorResult(error);
+    await writeRunOnceResult(summary, {
+      stdout: process.stdout,
+      env: process.env,
+    });
+    return exitCodeForRunOnceResult(summary);
   }
 }
 

--- a/src/cli/commands/run-once/main.ts
+++ b/src/cli/commands/run-once/main.ts
@@ -15,11 +15,10 @@ import {
 import { createCommandRunner } from "../triage/command.ts";
 import { detectDefaultBaseBranch } from "./git.ts";
 import { appendPiErrorCause, formatErrorWithCauses } from "./pi-errors.ts";
-import type {
-  AgentIssuePipelineResult,
-  AgentIssueVisualEvidence,
-  CommandRunner,
-} from "./types.ts";
+import { summarizeResult } from "./result-summary.ts";
+import type { AgentIssuePipelineResult, CommandRunner } from "./types.ts";
+
+export { summarizeResult } from "./result-summary.ts";
 
 export const HELP_TEXT = `Usage:
   patchmill run-once [options]
@@ -47,92 +46,8 @@ Environment:
 
 type Env = Record<string, string | undefined>;
 
-type JsonResultLog = { logPath?: string; piSessionPath?: string };
-
-type JsonResult = JsonResultLog &
-  (
-    | { status: "no-issue" }
-    | {
-        status: "dry-run";
-        issueNumber: number;
-        title: string;
-        transition: string;
-      }
-    | {
-        status: "spec-created" | "spec-found";
-        issueNumber: number;
-        specPath: string;
-      }
-    | {
-        status: "plan-created" | "plan-found";
-        issueNumber: number;
-        specPath?: string;
-        planPath: string;
-      }
-    | {
-        status: "pr-created";
-        issueNumber: number;
-        specPath?: string;
-        planPath: string;
-        branch: string;
-        prUrl: string;
-        worktreePath: string;
-        commits: string[];
-        validation: string[];
-        reviewSummary?: string;
-        landingDecision?: string;
-        visualEvidence?: AgentIssueVisualEvidence[];
-      }
-    | {
-        status: "merged";
-        issueNumber: number;
-        specPath?: string;
-        planPath: string;
-        branch: string;
-        mergeCommit: string;
-        worktreePath: string;
-        commits: string[];
-        validation: string[];
-        reviewSummary?: string;
-        landingDecision?: string;
-      }
-    | {
-        status: "approval-required";
-        issueNumber: number;
-        approvalKind: "spec" | "plan";
-        missingLabel: string;
-      }
-    | {
-        status: "development-environment-not-ready";
-        issueNumber: number;
-        specPath?: string;
-        planPath: string;
-        branch?: string;
-        worktreePath?: string;
-        reason: string;
-        evidence: string[];
-        remediation: string[];
-      }
-    | {
-        status: "blocked";
-        issueNumber: number;
-        reason: string;
-        questions: string[];
-      }
-  );
-
 function isHelpOnlyInvocation(args: string[]): boolean {
   return args.includes("--help") || args.includes("-h");
-}
-
-function questionText(
-  question: string | { question: string; recommendedAnswer?: string },
-): string {
-  return typeof question === "string"
-    ? question
-    : question.recommendedAnswer
-      ? `${question.question} (recommended: ${question.recommendedAnswer})`
-      : question.question;
 }
 
 function issueNumberFromResult(
@@ -156,105 +71,6 @@ async function finalLogPath(
   await mkdir(dirname(issueLogPath), { recursive: true });
   await rename(preliminaryLogPath, issueLogPath).catch(() => undefined);
   return issueLogPath;
-}
-
-export function summarizeResult(result: AgentIssuePipelineResult): JsonResult {
-  const withLogPath = {
-    ...(result.logPath ? { logPath: result.logPath } : {}),
-    ...(result.piSessionPath ? { piSessionPath: result.piSessionPath } : {}),
-  };
-
-  switch (result.status) {
-    case "no-issue":
-      return { status: result.status, ...withLogPath };
-    case "dry-run":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        title: result.issue.title,
-        transition: result.transition,
-        ...withLogPath,
-      };
-    case "spec-created":
-    case "spec-found":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        specPath: result.specPath,
-        ...withLogPath,
-      };
-    case "plan-created":
-    case "plan-found":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
-        planPath: result.planPath,
-        ...withLogPath,
-      };
-    case "pr-created":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
-        planPath: result.planPath,
-        branch: result.branch,
-        prUrl: result.prUrl,
-        worktreePath: result.worktreePath,
-        commits: result.commits,
-        validation: result.validation,
-        reviewSummary: result.reviewSummary,
-        landingDecision: result.landingDecision,
-        visualEvidence: result.visualEvidence,
-        ...withLogPath,
-      };
-    case "merged":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
-        planPath: result.planPath,
-        branch: result.branch,
-        mergeCommit: result.mergeCommit,
-        worktreePath: result.worktreePath,
-        commits: result.commits,
-        validation: result.validation,
-        reviewSummary: result.reviewSummary,
-        landingDecision: result.landingDecision,
-        ...withLogPath,
-      };
-    case "approval-required":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        approvalKind: result.approvalKind,
-        missingLabel: result.missingLabel,
-        ...withLogPath,
-      };
-    case "development-environment-not-ready":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
-        planPath: result.planPath,
-        ...(result.branch !== undefined ? { branch: result.branch } : {}),
-        ...(result.worktreePath !== undefined
-          ? { worktreePath: result.worktreePath }
-          : {}),
-        reason: result.reason,
-        evidence: result.evidence,
-        remediation: result.remediation,
-        ...withLogPath,
-      };
-    case "blocked":
-      return {
-        status: result.status,
-        issueNumber: result.issue.number,
-        reason: result.reason,
-        questions: result.questions.map(questionText),
-        ...withLogPath,
-      };
-  }
 }
 
 async function resolveRunOnceConfigBaseBranch(

--- a/src/cli/commands/run-once/main.ts
+++ b/src/cli/commands/run-once/main.ts
@@ -20,6 +20,7 @@ import {
   exitCodeForRunOnceResult,
   writeRunOnceResult,
 } from "./result-output.ts";
+import type { WriteRunOnceResultOptions } from "./result-output.ts";
 import type { AgentIssuePipelineResult, CommandRunner } from "./types.ts";
 
 export { summarizeResult } from "./result-summary.ts";
@@ -61,7 +62,7 @@ function issueNumberFromResult(
   return "issue" in result ? result.issue.number : undefined;
 }
 
-async function finalLogPath(
+export async function finalLogPath(
   preliminaryLogPath: string,
   runStateDir: string,
   timestamp: string,
@@ -74,8 +75,22 @@ async function finalLogPath(
   if (issueLogPath === preliminaryLogPath) return preliminaryLogPath;
 
   await mkdir(dirname(issueLogPath), { recursive: true });
-  await rename(preliminaryLogPath, issueLogPath).catch(() => undefined);
+  await rename(preliminaryLogPath, issueLogPath);
   return issueLogPath;
+}
+
+export async function writePipelineFailureResult(
+  error: unknown,
+  logPath: string,
+  options: Omit<WriteRunOnceResultOptions, "logPath">,
+): Promise<0 | 1> {
+  const summary = summarizeErrorResult(error, logPath);
+  try {
+    await writeRunOnceResult(summary, { ...options, logPath });
+  } catch (reportingError) {
+    throw appendPiErrorCause(error, "result reporting", reportingError);
+  }
+  return exitCodeForRunOnceResult(summary);
 }
 
 async function resolveRunOnceConfigBaseBranch(
@@ -177,17 +192,14 @@ export async function main(args = process.argv.slice(2)): Promise<number> {
           reportingError,
         );
       }
-      const summary = summarizeErrorResult(terminalError, logPath);
-      await writeRunOnceResult(summary, {
+      return writePipelineFailureResult(terminalError, logPath, {
         stdout: process.stdout,
         env: process.env,
-        logPath,
         elapsedSeconds: Math.max(
           0,
           Math.round((Date.now() - startedAt.getTime()) / 1000),
         ),
       });
-      return exitCodeForRunOnceResult(summary);
     }
 
     const outputLogPath = await finalLogPath(

--- a/src/cli/commands/run-once/result-output.test.ts
+++ b/src/cli/commands/run-once/result-output.test.ts
@@ -3,6 +3,9 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { formatErrorWithCauses } from "./pi-errors.ts";
+import { finalLogPath, writePipelineFailureResult } from "./main.ts";
+import type { AgentIssuePipelineResult } from "./types.ts";
 import {
   exitCodeForRunOnceResult,
   writeRunOnceResult,
@@ -38,6 +41,150 @@ test("writes human TTY output but exact compact JSON when redirected", async () 
   });
   assert.equal(redirected.join(""), `${JSON.stringify(summary)}\n`);
 });
+test("persistence rejection leaves stdout untouched and preserves pipeline causes", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-result-directory-"));
+  const output: string[] = [];
+  const pipelineError = new AggregateError(
+    [
+      new Error("pipeline failed"),
+      new Error("error reporting: observer failed"),
+    ],
+    "pipeline failed",
+  );
+
+  await assert.rejects(
+    writePipelineFailureResult(pipelineError, dir, {
+      stdout: { isTTY: false, write: (chunk) => output.push(String(chunk)) },
+      env: {},
+    }),
+    (error: unknown) => {
+      assert.deepEqual(formatErrorWithCauses(error), {
+        message: "pipeline failed",
+        causes: [
+          "pipeline failed",
+          "error reporting: observer failed",
+          `result reporting: EISDIR: illegal operation on a directory, open '${dir}'`,
+        ],
+      });
+      return true;
+    },
+  );
+  assert.deepEqual(output, []);
+});
+
+test("fails rather than splitting a result log when its preliminary log cannot rename", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-final-log-"));
+  const preliminaryLogPath = join(dir, "missing.jsonl");
+  await assert.rejects(
+    finalLogPath(preliminaryLogPath, dir, "2026-08-22T11:00:00.000Z", {
+      status: "spec-created",
+      issue: {
+        number: 174,
+        title: "Issue",
+        body: "",
+        labels: [],
+        state: "open",
+      },
+      specPath: "docs/specs/result.md",
+    } satisfies AgentIssuePipelineResult),
+    /ENOENT/u,
+  );
+});
+
+test("gates terminal color without changing TTY mode and falls back to width 80", async () => {
+  for (const env of [{ NO_COLOR: "1" }, { TERM: "dumb" }]) {
+    const output: string[] = [];
+    await writeRunOnceResult(summary, {
+      stdout: {
+        isTTY: true,
+        columns: 0,
+        write: (chunk) => output.push(String(chunk)),
+      },
+      env,
+    });
+    assert.match(output.join(""), /Final result: ✓ PR created/u);
+    assert.doesNotMatch(output.join(""), /\u001b\[/u);
+  }
+  const redirected: string[] = [];
+  await writeRunOnceResult(summary, {
+    stdout: { isTTY: false, write: (chunk) => redirected.push(String(chunk)) },
+    env: {},
+  });
+  assert.doesNotMatch(redirected.join(""), /\u001b\[/u);
+});
+
+test("writes severity-specific complete JSONL result events", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-result-level-"));
+  const cases: Array<[RunOnceResultSummary, "warning" | "error"]> = [
+    [
+      {
+        status: "approval-required",
+        issueNumber: 174,
+        approvalKind: "spec",
+        missingLabel: "spec-approved",
+      },
+      "warning",
+    ],
+    [{ status: "error", error: "failed" }, "error"],
+  ];
+  for (const [result, level] of cases) {
+    const path = join(dir, `${result.status}.jsonl`);
+    await writeRunOnceResult(result, {
+      stdout: { isTTY: false, write() {} },
+      env: {},
+      logPath: path,
+      time: new Date("2026-08-22T11:00:00.000Z"),
+    });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+      time: "2026-08-22T11:00:00.000Z",
+      level,
+      stage: "result",
+      message: `final result ${result.status}`,
+      data: result,
+    });
+  }
+});
+
+test("preserves the exit-code contract for every status", () => {
+  const cases: Array<[RunOnceResultSummary, 0 | 1]> = [
+    [{ status: "no-issue" }, 0],
+    [
+      { status: "dry-run", issueNumber: 1, title: "Issue", transition: "plan" },
+      0,
+    ],
+    [{ status: "spec-created", issueNumber: 1, specPath: "spec.md" }, 0],
+    [{ status: "spec-found", issueNumber: 1, specPath: "spec.md" }, 0],
+    [{ status: "plan-created", issueNumber: 1, planPath: "plan.md" }, 0],
+    [{ status: "plan-found", issueNumber: 1, planPath: "plan.md" }, 0],
+    [summary, 0],
+    [{ ...summary, status: "merged", mergeCommit: "abc" }, 0],
+    [
+      {
+        status: "approval-required",
+        issueNumber: 1,
+        approvalKind: "spec",
+        missingLabel: "ok",
+      },
+      1,
+    ],
+    [
+      {
+        status: "development-environment-not-ready",
+        issueNumber: 1,
+        planPath: "plan.md",
+        reason: "no",
+        evidence: [],
+        remediation: [],
+      },
+      1,
+    ],
+    [{ status: "blocked", issueNumber: 1, reason: "no", questions: [] }, 1],
+    [{ status: "error", error: "no" }, 1],
+  ];
+  for (const [result, code] of cases)
+    assert.equal(exitCodeForRunOnceResult(result), code);
+});
+
 test("persists structured result before stdout and maps exit status", async () => {
   const dir = await mkdtemp(join(tmpdir(), "patchmill-result-"));
   const path = join(dir, "run.jsonl");

--- a/src/cli/commands/run-once/result-output.test.ts
+++ b/src/cli/commands/run-once/result-output.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  exitCodeForRunOnceResult,
+  writeRunOnceResult,
+} from "./result-output.ts";
+import type { RunOnceResultSummary } from "./result-summary.ts";
+
+const summary: RunOnceResultSummary = {
+  status: "pr-created",
+  issueNumber: 174,
+  planPath: "docs/plans/plan.md",
+  branch: "agent/issue-174",
+  prUrl: "https://example.test/pulls/174",
+  worktreePath: ".worktrees/issue-174",
+  commits: ["abc123"],
+  validation: ["npm test passed"],
+};
+test("writes human TTY output but exact compact JSON when redirected", async () => {
+  const interactive: string[] = [];
+  await writeRunOnceResult(summary, {
+    stdout: {
+      isTTY: true,
+      columns: 80,
+      write: (chunk) => interactive.push(String(chunk)),
+    },
+    env: { TERM: "xterm" },
+  });
+  assert.match(interactive.join(""), /Final result:.*PR created/u);
+  assert.match(interactive.join(""), /\u001b\[/u);
+  const redirected: string[] = [];
+  await writeRunOnceResult(summary, {
+    stdout: { isTTY: false, write: (chunk) => redirected.push(String(chunk)) },
+    env: { TERM: "xterm" },
+  });
+  assert.equal(redirected.join(""), `${JSON.stringify(summary)}\n`);
+});
+test("persists structured result before stdout and maps exit status", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "patchmill-result-"));
+  const path = join(dir, "run.jsonl");
+  const output: string[] = [];
+  await writeRunOnceResult(summary, {
+    stdout: { isTTY: false, write: (chunk) => output.push(String(chunk)) },
+    env: {},
+    logPath: path,
+    time: new Date("2026-08-22T11:00:00.000Z"),
+  });
+  const event = JSON.parse((await readFile(path, "utf8")).trim());
+  assert.deepEqual(event.data, summary);
+  assert.equal(event.stage, "result");
+  assert.equal(event.level, "info");
+  assert.equal(exitCodeForRunOnceResult(summary), 0);
+  assert.equal(
+    exitCodeForRunOnceResult({
+      status: "blocked",
+      issueNumber: 1,
+      reason: "no",
+      questions: [],
+    }),
+    1,
+  );
+});

--- a/src/cli/commands/run-once/result-output.ts
+++ b/src/cli/commands/run-once/result-output.ts
@@ -1,0 +1,70 @@
+import { JsonlProgressReporter } from "./progress.ts";
+import type { FinalResultProgressSnapshot } from "./console-progress.ts";
+import type { RunOnceResultSummary } from "./result-summary.ts";
+import {
+  formatTerminalResult,
+  terminalResultSeverity,
+} from "./terminal-result.ts";
+
+export type RunOnceResultStream = {
+  isTTY?: boolean;
+  columns?: number;
+  write(chunk: string): unknown;
+};
+export type WriteRunOnceResultOptions = {
+  stdout: RunOnceResultStream;
+  env: Record<string, string | undefined>;
+  logPath?: string;
+  progress?: FinalResultProgressSnapshot;
+  elapsedSeconds?: number;
+  time?: Date;
+};
+export function exitCodeForRunOnceResult(summary: RunOnceResultSummary): 0 | 1 {
+  return summary.status === "approval-required" ||
+    summary.status === "development-environment-not-ready" ||
+    summary.status === "blocked" ||
+    summary.status === "error"
+    ? 1
+    : 0;
+}
+
+export async function writeRunOnceResult(
+  summary: RunOnceResultSummary,
+  options: WriteRunOnceResultOptions,
+): Promise<void> {
+  const severity = terminalResultSeverity(summary.status);
+  if (options.logPath)
+    await new JsonlProgressReporter(options.logPath).event({
+      time: (options.time ?? new Date()).toISOString(),
+      level:
+        severity === "success"
+          ? "info"
+          : severity === "warning"
+            ? "warning"
+            : "error",
+      stage: "result",
+      message: `final result ${summary.status}`,
+      data: summary,
+    });
+  const interactive = options.stdout.isTTY === true;
+  const width =
+    Number.isFinite(options.stdout.columns) &&
+    Number(options.stdout.columns) > 0
+      ? Math.floor(Number(options.stdout.columns))
+      : 80;
+  const color =
+    interactive &&
+    options.env.NO_COLOR === undefined &&
+    options.env.TERM !== "dumb";
+  const output = interactive
+    ? formatTerminalResult(summary, {
+        width,
+        color,
+        stepNumber: options.progress?.stepNumber,
+        totalOutputTokens: options.progress?.totalOutputTokens,
+        elapsedSeconds:
+          options.progress?.elapsedSeconds ?? options.elapsedSeconds,
+      })
+    : JSON.stringify(summary);
+  options.stdout.write(`${output}\n`);
+}

--- a/src/cli/commands/run-once/result-summary.test.ts
+++ b/src/cli/commands/run-once/result-summary.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { summarizeErrorResult, summarizeResult } from "./result-summary.ts";
+
+test("summaries preserve the established PR machine shape", () => {
+  assert.deepEqual(
+    summarizeResult({
+      status: "pr-created",
+      issue: {
+        number: 174,
+        title: "Title",
+        body: "",
+        labels: [],
+        state: "open",
+      },
+      specPath: "docs/specs/result-design.md",
+      planPath: "docs/plans/result-plan.md",
+      branch: "agent/issue-174-readable-result",
+      prUrl: "https://example.test/patchmill/pulls/174",
+      worktreePath: ".worktrees/patchmill-issue-174-readable-result",
+      commits: ["abc123", "def456"],
+      validation: ["npm test passed", "npm run lint passed"],
+      reviewSummary: "All findings resolved.",
+      landingDecision: "PR required for CLI output change.",
+      visualEvidence: [
+        {
+          screenshotPath: "docs/reference-screenshots/result.png",
+          caption: "Readable final result",
+          referencePaths: ["docs/reference-screenshots/before.png"],
+          url: "https://example.test/evidence/174",
+        },
+      ],
+      logPath: "/repo/.patchmill/runs/issue-174/run.jsonl",
+      piSessionPath: "/repo/.patchmill/runs/issue-174/run-pi-sessions",
+    }),
+    {
+      status: "pr-created",
+      issueNumber: 174,
+      specPath: "docs/specs/result-design.md",
+      planPath: "docs/plans/result-plan.md",
+      branch: "agent/issue-174-readable-result",
+      prUrl: "https://example.test/patchmill/pulls/174",
+      worktreePath: ".worktrees/patchmill-issue-174-readable-result",
+      commits: ["abc123", "def456"],
+      validation: ["npm test passed", "npm run lint passed"],
+      reviewSummary: "All findings resolved.",
+      landingDecision: "PR required for CLI output change.",
+      visualEvidence: [
+        {
+          screenshotPath: "docs/reference-screenshots/result.png",
+          caption: "Readable final result",
+          referencePaths: ["docs/reference-screenshots/before.png"],
+          url: "https://example.test/evidence/174",
+        },
+      ],
+      logPath: "/repo/.patchmill/runs/issue-174/run.jsonl",
+      piSessionPath: "/repo/.patchmill/runs/issue-174/run-pi-sessions",
+    },
+  );
+});
+
+test("summarizeErrorResult preserves aggregate causes and resolved log path", () => {
+  assert.deepEqual(
+    summarizeErrorResult(
+      new AggregateError(
+        [new Error("observer failed"), new Error("cleanup failed")],
+        "Pi run failed",
+      ),
+      "/repo/.patchmill/runs/issue-174/run.jsonl",
+    ),
+    {
+      status: "error",
+      error: "Pi run failed",
+      causes: ["observer failed", "cleanup failed"],
+      logPath: "/repo/.patchmill/runs/issue-174/run.jsonl",
+    },
+  );
+});

--- a/src/cli/commands/run-once/result-summary.ts
+++ b/src/cli/commands/run-once/result-summary.ts
@@ -1,0 +1,207 @@
+import { formatErrorWithCauses } from "./pi-errors.ts";
+import type {
+  AgentIssuePipelineResult,
+  AgentIssueVisualEvidence,
+} from "./types.ts";
+
+export type RunOnceResultLog = { logPath?: string; piSessionPath?: string };
+
+export type RunOncePipelineResultSummary = RunOnceResultLog &
+  (
+    | { status: "no-issue" }
+    | {
+        status: "dry-run";
+        issueNumber: number;
+        title: string;
+        transition: string;
+      }
+    | {
+        status: "spec-created" | "spec-found";
+        issueNumber: number;
+        specPath: string;
+      }
+    | {
+        status: "plan-created" | "plan-found";
+        issueNumber: number;
+        specPath?: string;
+        planPath: string;
+      }
+    | {
+        status: "pr-created";
+        issueNumber: number;
+        specPath?: string;
+        planPath: string;
+        branch: string;
+        prUrl: string;
+        worktreePath: string;
+        commits: string[];
+        validation: string[];
+        reviewSummary?: string;
+        landingDecision?: string;
+        visualEvidence?: AgentIssueVisualEvidence[];
+      }
+    | {
+        status: "merged";
+        issueNumber: number;
+        specPath?: string;
+        planPath: string;
+        branch: string;
+        mergeCommit: string;
+        worktreePath: string;
+        commits: string[];
+        validation: string[];
+        reviewSummary?: string;
+        landingDecision?: string;
+      }
+    | {
+        status: "approval-required";
+        issueNumber: number;
+        approvalKind: "spec" | "plan";
+        missingLabel: string;
+      }
+    | {
+        status: "development-environment-not-ready";
+        issueNumber: number;
+        specPath?: string;
+        planPath: string;
+        branch?: string;
+        worktreePath?: string;
+        reason: string;
+        evidence: string[];
+        remediation: string[];
+      }
+    | {
+        status: "blocked";
+        issueNumber: number;
+        reason: string;
+        questions: string[];
+      }
+  );
+
+export type RunOnceResultSummary =
+  | RunOncePipelineResultSummary
+  | { status: "error"; error: string; causes?: string[]; logPath?: string };
+export type RunOnceResultStatus = RunOnceResultSummary["status"];
+
+function questionText(
+  question: string | { question: string; recommendedAnswer?: string },
+): string {
+  return typeof question === "string"
+    ? question
+    : question.recommendedAnswer
+      ? `${question.question} (recommended: ${question.recommendedAnswer})`
+      : question.question;
+}
+
+export function summarizeResult(
+  result: AgentIssuePipelineResult,
+): RunOncePipelineResultSummary {
+  const withLogPath = {
+    ...(result.logPath ? { logPath: result.logPath } : {}),
+    ...(result.piSessionPath ? { piSessionPath: result.piSessionPath } : {}),
+  };
+  switch (result.status) {
+    case "no-issue":
+      return { status: result.status, ...withLogPath };
+    case "dry-run":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        title: result.issue.title,
+        transition: result.transition,
+        ...withLogPath,
+      };
+    case "spec-created":
+    case "spec-found":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        specPath: result.specPath,
+        ...withLogPath,
+      };
+    case "plan-created":
+    case "plan-found":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
+        planPath: result.planPath,
+        ...withLogPath,
+      };
+    case "pr-created":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
+        planPath: result.planPath,
+        branch: result.branch,
+        prUrl: result.prUrl,
+        worktreePath: result.worktreePath,
+        commits: result.commits,
+        validation: result.validation,
+        reviewSummary: result.reviewSummary,
+        landingDecision: result.landingDecision,
+        visualEvidence: result.visualEvidence,
+        ...withLogPath,
+      };
+    case "merged":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
+        planPath: result.planPath,
+        branch: result.branch,
+        mergeCommit: result.mergeCommit,
+        worktreePath: result.worktreePath,
+        commits: result.commits,
+        validation: result.validation,
+        reviewSummary: result.reviewSummary,
+        landingDecision: result.landingDecision,
+        ...withLogPath,
+      };
+    case "approval-required":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        approvalKind: result.approvalKind,
+        missingLabel: result.missingLabel,
+        ...withLogPath,
+      };
+    case "development-environment-not-ready":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        ...(result.specPath !== undefined ? { specPath: result.specPath } : {}),
+        planPath: result.planPath,
+        ...(result.branch !== undefined ? { branch: result.branch } : {}),
+        ...(result.worktreePath !== undefined
+          ? { worktreePath: result.worktreePath }
+          : {}),
+        reason: result.reason,
+        evidence: result.evidence,
+        remediation: result.remediation,
+        ...withLogPath,
+      };
+    case "blocked":
+      return {
+        status: result.status,
+        issueNumber: result.issue.number,
+        reason: result.reason,
+        questions: result.questions.map(questionText),
+        ...withLogPath,
+      };
+  }
+}
+
+export function summarizeErrorResult(
+  error: unknown,
+  logPath?: string,
+): Extract<RunOnceResultSummary, { status: "error" }> {
+  const formatted = formatErrorWithCauses(error);
+  return {
+    status: "error",
+    error: formatted.message,
+    ...(formatted.causes ? { causes: formatted.causes } : {}),
+    ...(logPath ? { logPath } : {}),
+  };
+}

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -107,71 +107,31 @@ function isLiteralRole(role: TerminalValue["role"]): boolean {
   return role === "url" || role === "path" || role === "commit";
 }
 
-function literalWhitespacePlaceholder(
+function wrapLiteralValue(
   text: string,
-  used: Set<string>,
-  width: number,
-): string {
-  const ranges =
-    width === 0
-      ? [
-          [0x200b, 0x200f],
-          [0x2060, 0x2064],
-        ]
-      : width === 1
-        ? [[0xe000, 0xf8ff]]
-        : width === 2
-          ? [
-              [0x3001, 0x303f],
-              [0xff01, 0xff60],
-              [0x4e00, 0x9fff],
-            ]
-          : [];
-  for (const [start, end] of ranges)
-    for (let codePoint = start; codePoint <= end; codePoint += 1) {
-      const marker = String.fromCodePoint(codePoint);
-      if (
-        !text.includes(marker) &&
-        !used.has(marker) &&
-        !/[\p{White_Space}\uFEFF]/u.test(marker) &&
-        visibleWidth(marker) === width
-      )
-        return marker;
+  firstCapacity: number,
+  continuationCapacity: number,
+): string[] {
+  const lines: string[] = [];
+  let line = "";
+  let lineWidth = 0;
+  let capacity = firstCapacity;
+
+  for (const { segment } of new Intl.Segmenter(undefined, {
+    granularity: "grapheme",
+  }).segment(text)) {
+    const segmentWidth = visibleWidth(segment);
+    if (line && segmentWidth > 0 && lineWidth + segmentWidth > capacity) {
+      lines.push(line);
+      line = "";
+      lineWidth = 0;
+      capacity = continuationCapacity;
     }
-  throw new Error("no literal whitespace placeholder is available");
-}
-
-function protectLiteralWhitespace(text: string, role: TerminalValue["role"]) {
-  if (!isLiteralRole(role)) return { text, restore: (value: string) => value };
-
-  const replacements = new Map<string, string>();
-  const used = new Set<string>();
-  const protectedText = text.replace(
-    /[\p{White_Space}\uFEFF]/gu,
-    (whitespace) => {
-      const existing = [...replacements].find(
-        ([, original]) => original === whitespace,
-      )?.[0];
-      if (existing) return existing;
-      const marker = literalWhitespacePlaceholder(
-        text,
-        used,
-        visibleWidth(whitespace),
-      );
-      used.add(marker);
-      replacements.set(marker, whitespace);
-      return marker;
-    },
-  );
-  return {
-    text: protectedText,
-    restore: (value: string) =>
-      [...replacements].reduce(
-        (restored, [marker, whitespace]) =>
-          restored.replaceAll(marker, whitespace),
-        value,
-      ),
-  };
+    line += segment;
+    lineWidth += segmentWidth;
+  }
+  if (line) lines.push(line);
+  return lines;
 }
 
 function wrap(
@@ -198,17 +158,19 @@ function wrap(
     text,
     Math.min(firstAvailable, continuationAvailable),
   );
-  const protectedText = protectLiteralWhitespace(encodedText, value.role);
-  const lines = wrapTextWithAnsi(protectedText.text, firstAvailable);
+  const lines = isLiteralRole(value.role)
+    ? wrapLiteralValue(encodedText, firstAvailable, continuationAvailable)
+    : wrapTextWithAnsi(encodedText, firstAvailable);
   return [
     ...prefixes,
     ...lines.flatMap((line, index) => {
       const prefix = index === 0 ? first : continuation;
       const available = index === 0 ? firstAvailable : continuationAvailable;
-      return wrapTextWithAnsi(line, available).map(
-        (part) =>
-          `${prefix}${style(protectedText.restore(part), value.role, color)}`,
-      );
+      return isLiteralRole(value.role)
+        ? [`${prefix}${style(line, value.role, color)}`]
+        : wrapTextWithAnsi(line, available).map(
+            (part) => `${prefix}${style(part, value.role, color)}`,
+          );
     }),
   ];
 }

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -1,5 +1,6 @@
 import {
   stripTerminalSequences,
+  visibleWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import type { TerminalResultSeverity } from "./terminal-result.ts";
@@ -69,11 +70,21 @@ export function cleanValue(value: string): string {
     .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ")
     .trim();
 }
+
 function normalizeWidth(width: number): number {
   return Number.isFinite(width) && width > 0
     ? Math.max(1, Math.floor(width))
     : 80;
 }
+
+function fittingPrefix(prefix: string, width: number): string {
+  if (visibleWidth(prefix) < width) return prefix;
+  const unindented = prefix.replace(/^ +/u, "");
+  if (visibleWidth(unindented) < width) return unindented;
+  const compact = unindented.replace(/ +$/u, "");
+  return visibleWidth(compact) < width ? compact : "";
+}
+
 function wrap(
   value: TerminalValue,
   firstPrefix: string,
@@ -83,22 +94,27 @@ function wrap(
 ): string[] {
   const text = cleanValue(value.text);
   if (!text) return [];
-  const first = Math.min(
-    stripTerminalSequences(firstPrefix).length,
-    Math.max(0, width - 1),
+  const first = fittingPrefix(firstPrefix, width);
+  const continuation = fittingPrefix(continuationPrefix, width);
+  const standalonePrefix =
+    !first && cleanValue(stripTerminalSequences(firstPrefix))
+      ? firstPrefix.replace(/^ +| +$/gu, "")
+      : undefined;
+  const prefixes = standalonePrefix ? [standalonePrefix] : [];
+  const lines = wrapTextWithAnsi(
+    text,
+    Math.max(1, width - visibleWidth(first)),
   );
-  const continuation = Math.min(
-    stripTerminalSequences(continuationPrefix).length,
-    Math.max(0, width - 1),
-  );
-  const lines = wrapTextWithAnsi(text, Math.max(1, width - first));
-  return lines.flatMap((line, index) => {
-    const prefix = index === 0 ? firstPrefix : continuationPrefix;
-    const available = Math.max(1, width - (index === 0 ? first : continuation));
-    return wrapTextWithAnsi(line, available).map(
-      (part) => `${prefix}${style(part, value.role, color)}`,
-    );
-  });
+  return [
+    ...prefixes,
+    ...lines.flatMap((line, index) => {
+      const prefix = index === 0 ? first : continuation;
+      const available = Math.max(1, width - visibleWidth(prefix));
+      return wrapTextWithAnsi(line, available).map(
+        (part) => `${prefix}${style(part, value.role, color)}`,
+      );
+    }),
+  ];
 }
 
 function renderFields(
@@ -120,7 +136,9 @@ function renderFields(
     if (!label) return wrap(field.value, pad, pad, width, color);
     if (!inline)
       return [
-        styled(`${pad}${label}`, SGR.dim, color),
+        ...wrap({ text: label }, pad, pad, width, false).map((line) =>
+          styled(line, SGR.dim, color),
+        ),
         ...wrap(field.value, `${pad}  `, `${pad}  `, width, color),
       ];
     const labelText = `${pad}${label.padEnd(maxLabel)} `;
@@ -160,6 +178,12 @@ function formatElapsed(seconds: number): string {
   const s = value % 60;
   if (m < 60) return `${m}m${String(s).padStart(2, "0")}s`;
   return `${Math.floor(m / 60)}h${m % 60}m${String(s).padStart(2, "0")}s`;
+}
+
+function resetLine(line: string, color: boolean): string {
+  return color && line.includes("\u001b[") && !line.endsWith(SGR.reset)
+    ? `${line}${SGR.reset}`
+    : line;
 }
 
 export function renderTerminalDocument(input: TerminalDocument): string {
@@ -203,14 +227,14 @@ export function renderTerminalDocument(input: TerminalDocument): string {
             ? renderFields(block.fields, width, color, 2)
             : renderList(block, width, color),
       );
+      const heading =
+        section.count === undefined
+          ? section.heading
+          : `${section.heading} (${section.count})`;
       return body.length
         ? [
-            styled(
-              section.count === undefined
-                ? section.heading
-                : `${section.heading} (${section.count})`,
-              SGR.bold,
-              color,
+            ...wrap({ text: heading }, "", "", width, false).map((line) =>
+              styled(line, SGR.bold, color),
             ),
             ...body,
           ].join("\n")
@@ -221,5 +245,9 @@ export function renderTerminalDocument(input: TerminalDocument): string {
     ...lines,
     ...metrics,
     ...(sections.length ? ["", sections.join("\n\n")] : []),
-  ].join("\n");
+  ]
+    .join("\n")
+    .split("\n")
+    .map((line) => resetLine(line, color))
+    .join("\n");
 }

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -67,7 +67,7 @@ const styled = (value: string, prefix: string, color: boolean) =>
 export function cleanValue(value: string): string {
   return stripTerminalSequences(value)
     .replace(/\r\n?|\n/gu, " ")
-    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ")
+    .replace(/[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ")
     .trim();
 }
 
@@ -85,19 +85,18 @@ function fittingPrefix(prefix: string, width: number): string {
   return visibleWidth(compact) < width ? compact : "";
 }
 
-function encodeOversizeGraphemes(text: string, width: number): string {
+function encodeNarrowGraphemes(text: string, width: number): string {
+  if (width >= 2) return text;
   return [
     ...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text),
   ]
-    .map(({ segment }) =>
-      visibleWidth(segment) > width
-        ? [...segment]
-            .map(
-              (codePoint) => `\\u{${codePoint.codePointAt(0)?.toString(16)}}`,
-            )
-            .join("")
-        : segment,
-    )
+    .map(({ segment }) => {
+      if (visibleWidth(segment) > width)
+        return [...segment]
+          .map((codePoint) => `\\u{${codePoint.codePointAt(0)?.toString(16)}}`)
+          .join("");
+      return segment.replaceAll("\\", "\\\\");
+    })
     .join("");
 }
 
@@ -131,22 +130,19 @@ function wrap(
       : undefined;
   const prefixes = standalonePrefix ? [standalonePrefix] : [];
   const protectedText = protectLiteralWhitespace(text, value.role);
-  const lines = wrapTextWithAnsi(
-    encodeOversizeGraphemes(
-      protectedText.text,
-      Math.max(1, width - visibleWidth(first)),
-    ),
-    Math.max(1, width - visibleWidth(first)),
+  const firstAvailable = Math.max(1, width - visibleWidth(first));
+  const continuationAvailable = Math.max(1, width - visibleWidth(continuation));
+  const encodedText = encodeNarrowGraphemes(
+    protectedText.text,
+    Math.min(firstAvailable, continuationAvailable),
   );
+  const lines = wrapTextWithAnsi(encodedText, firstAvailable);
   return [
     ...prefixes,
     ...lines.flatMap((line, index) => {
       const prefix = index === 0 ? first : continuation;
-      const available = Math.max(1, width - visibleWidth(prefix));
-      return wrapTextWithAnsi(
-        encodeOversizeGraphemes(line, available),
-        available,
-      ).map(
+      const available = index === 0 ? firstAvailable : continuationAvailable;
+      return wrapTextWithAnsi(line, available).map(
         (part) =>
           `${prefix}${style(protectedText.restore(part), value.role, color)}`,
       );

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -201,30 +201,32 @@ export function renderTerminalDocument(input: TerminalDocument): string {
       ),
     );
   }
-  const sections = input.sections.flatMap((section) => {
-    const body = section.blocks.flatMap((block) =>
-      block.kind === "value"
-        ? wrap(block.value, "  ", "  ", width, color)
-        : block.kind === "fields"
-          ? renderFields(block.fields, width, color, 2)
-          : renderList(block, width, color),
-    );
-    return body.length
-      ? [
-          styled(
-            section.count === undefined
-              ? section.heading
-              : `${section.heading} (${section.count})`,
-            SGR.bold,
-            color,
-          ),
-          ...body,
-        ]
-      : [];
-  });
+  const sections = input.sections
+    .map((section) => {
+      const body = section.blocks.flatMap((block) =>
+        block.kind === "value"
+          ? wrap(block.value, "  ", "  ", width, color)
+          : block.kind === "fields"
+            ? renderFields(block.fields, width, color, 2)
+            : renderList(block, width, color),
+      );
+      return body.length
+        ? [
+            styled(
+              section.count === undefined
+                ? section.heading
+                : `${section.heading} (${section.count})`,
+              SGR.bold,
+              color,
+            ),
+            ...body,
+          ].join("\n")
+        : undefined;
+    })
+    .filter((section): section is string => section !== undefined);
   return [
     ...lines,
     ...metrics,
-    ...(sections.length ? ["", ...sections.join("\n").split("\n")] : []),
+    ...(sections.length ? ["", sections.join("\n\n")] : []),
   ].join("\n");
 }

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -64,11 +64,14 @@ const style = (value: string, role: string | undefined, color: boolean) =>
 const styled = (value: string, prefix: string, color: boolean) =>
   color ? `${prefix}${value}${SGR.reset}` : value;
 
-export function cleanValue(value: string): string {
+function sanitizeTerminalValue(value: string): string {
   return stripTerminalSequences(value)
     .replace(/\r\n?|\n/gu, " ")
-    .replace(/[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ")
-    .trim();
+    .replace(/[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ");
+}
+
+export function cleanValue(value: string): string {
+  return sanitizeTerminalValue(value).trim();
 }
 
 function normalizeWidth(width: number): number {
@@ -100,16 +103,44 @@ function encodeNarrowGraphemes(text: string, width: number): string {
     .join("");
 }
 
-function protectLiteralWhitespace(text: string, role: TerminalValue["role"]) {
-  if (role !== "url" && role !== "path" && role !== "commit")
-    return { text, restore: (value: string) => value };
+function isLiteralRole(role: TerminalValue["role"]): boolean {
+  return role === "url" || role === "path" || role === "commit";
+}
 
-  let marker = "\uE000";
-  while (text.includes(marker))
-    marker = String.fromCodePoint(marker.codePointAt(0)! + 1);
+function literalWhitespacePlaceholder(text: string, used: Set<string>): string {
+  for (let codePoint = 0xe000; codePoint <= 0xf8ff; codePoint += 1) {
+    const marker = String.fromCodePoint(codePoint);
+    if (!text.includes(marker) && !used.has(marker)) return marker;
+  }
+  throw new Error("no literal whitespace placeholder is available");
+}
+
+function protectLiteralWhitespace(text: string, role: TerminalValue["role"]) {
+  if (!isLiteralRole(role)) return { text, restore: (value: string) => value };
+
+  const replacements = new Map<string, string>();
+  const used = new Set<string>();
+  const protectedText = text.replace(
+    /[\p{White_Space}\uFEFF]/gu,
+    (whitespace) => {
+      const existing = [...replacements].find(
+        ([, original]) => original === whitespace,
+      )?.[0];
+      if (existing) return existing;
+      const marker = literalWhitespacePlaceholder(text, used);
+      used.add(marker);
+      replacements.set(marker, whitespace);
+      return marker;
+    },
+  );
   return {
-    text: text.replaceAll(" ", marker),
-    restore: (value: string) => value.replaceAll(marker, " "),
+    text: protectedText,
+    restore: (value: string) =>
+      [...replacements].reduce(
+        (restored, [marker, whitespace]) =>
+          restored.replaceAll(marker, whitespace),
+        value,
+      ),
   };
 }
 
@@ -120,8 +151,10 @@ function wrap(
   width: number,
   color: boolean,
 ): string[] {
-  const text = cleanValue(value.text);
-  if (!text) return [];
+  const text = isLiteralRole(value.role)
+    ? sanitizeTerminalValue(value.text)
+    : cleanValue(value.text);
+  if (!cleanValue(text)) return [];
   const first = fittingPrefix(firstPrefix, width);
   const continuation = fittingPrefix(continuationPrefix, width);
   const standalonePrefix =

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -107,11 +107,37 @@ function isLiteralRole(role: TerminalValue["role"]): boolean {
   return role === "url" || role === "path" || role === "commit";
 }
 
-function literalWhitespacePlaceholder(text: string, used: Set<string>): string {
-  for (let codePoint = 0xe000; codePoint <= 0xf8ff; codePoint += 1) {
-    const marker = String.fromCodePoint(codePoint);
-    if (!text.includes(marker) && !used.has(marker)) return marker;
-  }
+function literalWhitespacePlaceholder(
+  text: string,
+  used: Set<string>,
+  width: number,
+): string {
+  const ranges =
+    width === 0
+      ? [
+          [0x200b, 0x200f],
+          [0x2060, 0x2064],
+        ]
+      : width === 1
+        ? [[0xe000, 0xf8ff]]
+        : width === 2
+          ? [
+              [0x3001, 0x303f],
+              [0xff01, 0xff60],
+              [0x4e00, 0x9fff],
+            ]
+          : [];
+  for (const [start, end] of ranges)
+    for (let codePoint = start; codePoint <= end; codePoint += 1) {
+      const marker = String.fromCodePoint(codePoint);
+      if (
+        !text.includes(marker) &&
+        !used.has(marker) &&
+        !/[\p{White_Space}\uFEFF]/u.test(marker) &&
+        visibleWidth(marker) === width
+      )
+        return marker;
+    }
   throw new Error("no literal whitespace placeholder is available");
 }
 
@@ -127,7 +153,11 @@ function protectLiteralWhitespace(text: string, role: TerminalValue["role"]) {
         ([, original]) => original === whitespace,
       )?.[0];
       if (existing) return existing;
-      const marker = literalWhitespacePlaceholder(text, used);
+      const marker = literalWhitespacePlaceholder(
+        text,
+        used,
+        visibleWidth(whitespace),
+      );
       used.add(marker);
       replacements.set(marker, whitespace);
       return marker;
@@ -162,14 +192,14 @@ function wrap(
       ? firstPrefix.replace(/^ +| +$/gu, "")
       : undefined;
   const prefixes = standalonePrefix ? [standalonePrefix] : [];
-  const protectedText = protectLiteralWhitespace(text, value.role);
   const firstAvailable = Math.max(1, width - visibleWidth(first));
   const continuationAvailable = Math.max(1, width - visibleWidth(continuation));
   const encodedText = encodeNarrowGraphemes(
-    protectedText.text,
+    text,
     Math.min(firstAvailable, continuationAvailable),
   );
-  const lines = wrapTextWithAnsi(encodedText, firstAvailable);
+  const protectedText = protectLiteralWhitespace(encodedText, value.role);
+  const lines = wrapTextWithAnsi(protectedText.text, firstAvailable);
   return [
     ...prefixes,
     ...lines.flatMap((line, index) => {

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -1,0 +1,230 @@
+import {
+  stripTerminalSequences,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import type { TerminalResultSeverity } from "./terminal-result.ts";
+
+export type TerminalValue = {
+  text: string;
+  role?: "plain" | "url" | "path" | "commit";
+};
+export type TerminalField = { label?: string; value: TerminalValue };
+export type TerminalListItem = {
+  value: TerminalValue;
+  details?: TerminalField[];
+};
+export type TerminalSectionBlock =
+  | { kind: "value"; value: TerminalValue }
+  | { kind: "fields"; fields: TerminalField[] }
+  | {
+      kind: "list";
+      marker: "•" | "✓" | "!" | "→" | "✗";
+      markerSeverity?: TerminalResultSeverity;
+      items: TerminalListItem[];
+    };
+export type TerminalSection = {
+  heading: string;
+  count?: number;
+  blocks: TerminalSectionBlock[];
+};
+export type TerminalDocument = {
+  label: string;
+  severity: TerminalResultSeverity;
+  width: number;
+  color: boolean;
+  stepNumber?: number;
+  totalOutputTokens?: number;
+  elapsedSeconds?: number;
+  sections: TerminalSection[];
+};
+
+const SGR = {
+  reset: "\u001b[0m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+  green: "\u001b[32m",
+  yellow: "\u001b[33m",
+  red: "\u001b[31m",
+  url: "\u001b[36;4m",
+  accent: "\u001b[35m",
+} as const;
+const markerFor = (severity: TerminalResultSeverity) =>
+  severity === "success" ? "✓" : severity === "warning" ? "!" : "✗";
+const severityColor = (severity: TerminalResultSeverity) =>
+  severity === "success"
+    ? SGR.green
+    : severity === "warning"
+      ? SGR.yellow
+      : SGR.red;
+const style = (value: string, role: string | undefined, color: boolean) =>
+  !color
+    ? value
+    : `${role === "url" ? SGR.url : role === "path" || role === "commit" ? SGR.accent : ""}${value}${role === "url" || role === "path" || role === "commit" ? SGR.reset : ""}`;
+const styled = (value: string, prefix: string, color: boolean) =>
+  color ? `${prefix}${value}${SGR.reset}` : value;
+
+export function cleanValue(value: string): string {
+  return stripTerminalSequences(value)
+    .replace(/\r\n?|\n/gu, " ")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu, " ")
+    .trim();
+}
+function normalizeWidth(width: number): number {
+  return Number.isFinite(width) && width > 0
+    ? Math.max(1, Math.floor(width))
+    : 80;
+}
+function wrap(
+  value: TerminalValue,
+  firstPrefix: string,
+  continuationPrefix: string,
+  width: number,
+  color: boolean,
+): string[] {
+  const text = cleanValue(value.text);
+  if (!text) return [];
+  const first = Math.min(
+    stripTerminalSequences(firstPrefix).length,
+    Math.max(0, width - 1),
+  );
+  const continuation = Math.min(
+    stripTerminalSequences(continuationPrefix).length,
+    Math.max(0, width - 1),
+  );
+  const lines = wrapTextWithAnsi(text, Math.max(1, width - first));
+  return lines.flatMap((line, index) => {
+    const prefix = index === 0 ? firstPrefix : continuationPrefix;
+    const available = Math.max(1, width - (index === 0 ? first : continuation));
+    return wrapTextWithAnsi(line, available).map(
+      (part) => `${prefix}${style(part, value.role, color)}`,
+    );
+  });
+}
+
+function renderFields(
+  fields: TerminalField[],
+  width: number,
+  color: boolean,
+  indent: number,
+): string[] {
+  const valid = fields.filter((field) => cleanValue(field.value.text));
+  if (!valid.length) return [];
+  const labels = valid.map((field) =>
+    field.label ? `${cleanValue(field.label)}:` : "",
+  );
+  const maxLabel = Math.max(...labels.map((label) => label.length));
+  const inline = maxLabel > 0 && width - indent - maxLabel - 1 >= 16;
+  return valid.flatMap((field, index) => {
+    const label = labels[index];
+    const pad = " ".repeat(indent);
+    if (!label) return wrap(field.value, pad, pad, width, color);
+    if (!inline)
+      return [
+        styled(`${pad}${label}`, SGR.dim, color),
+        ...wrap(field.value, `${pad}  `, `${pad}  `, width, color),
+      ];
+    const labelText = `${pad}${label.padEnd(maxLabel)} `;
+    return wrap(
+      field.value,
+      styled(labelText, SGR.dim, color),
+      " ".repeat(labelText.length),
+      width,
+      color,
+    );
+  });
+}
+
+function renderList(
+  block: Extract<TerminalSectionBlock, { kind: "list" }>,
+  width: number,
+  color: boolean,
+): string[] {
+  const marker = styled(
+    block.marker,
+    severityColor(block.markerSeverity ?? "success"),
+    color,
+  );
+  return block.items.flatMap((item) => [
+    ...wrap(item.value, `  ${marker} `, "    ", width, color),
+    ...renderFields(item.details ?? [], width, color, 4),
+  ]);
+}
+
+function formatTokens(tokens: number): string {
+  return `${(tokens / 1000).toFixed(1)}k`;
+}
+function formatElapsed(seconds: number): string {
+  const value = Math.max(0, Math.floor(seconds));
+  if (value < 60) return `${value}s`;
+  const m = Math.floor(value / 60);
+  const s = value % 60;
+  if (m < 60) return `${m}m${String(s).padStart(2, "0")}s`;
+  return `${Math.floor(m / 60)}h${m % 60}m${String(s).padStart(2, "0")}s`;
+}
+
+export function renderTerminalDocument(input: TerminalDocument): string {
+  const width = normalizeWidth(input.width);
+  const color = input.color;
+  const headerPrefix =
+    input.stepNumber === undefined
+      ? ""
+      : `${String(input.stepNumber).padStart(2, "0")}  `;
+  const marker = styled(
+    markerFor(input.severity),
+    severityColor(input.severity),
+    color,
+  );
+  const header = `${headerPrefix}Final result: ${marker} ${styled(input.label, SGR.bold + severityColor(input.severity), color)}`;
+  const lines = wrap({ text: header }, "", "", width, false);
+  const metrics: string[] = [];
+  if (
+    input.totalOutputTokens !== undefined ||
+    input.elapsedSeconds !== undefined
+  ) {
+    const parts = [
+      input.totalOutputTokens !== undefined
+        ? `${formatTokens(input.totalOutputTokens)} tokens`
+        : undefined,
+      input.elapsedSeconds !== undefined
+        ? `elapsed ${formatElapsed(input.elapsedSeconds)}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    metrics.push(
+      ...wrap(
+        { text: styled(parts, SGR.dim, color) },
+        "    ",
+        "    ",
+        width,
+        false,
+      ),
+    );
+  }
+  const sections = input.sections.flatMap((section) => {
+    const body = section.blocks.flatMap((block) =>
+      block.kind === "value"
+        ? wrap(block.value, "  ", "  ", width, color)
+        : block.kind === "fields"
+          ? renderFields(block.fields, width, color, 2)
+          : renderList(block, width, color),
+    );
+    return body.length
+      ? [
+          styled(
+            section.count === undefined
+              ? section.heading
+              : `${section.heading} (${section.count})`,
+            SGR.bold,
+            color,
+          ),
+          ...body,
+        ]
+      : [];
+  });
+  return [
+    ...lines,
+    ...metrics,
+    ...(sections.length ? ["", ...sections.join("\n").split("\n")] : []),
+  ].join("\n");
+}

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -85,6 +85,35 @@ function fittingPrefix(prefix: string, width: number): string {
   return visibleWidth(compact) < width ? compact : "";
 }
 
+function encodeOversizeGraphemes(text: string, width: number): string {
+  return [
+    ...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text),
+  ]
+    .map(({ segment }) =>
+      visibleWidth(segment) > width
+        ? [...segment]
+            .map(
+              (codePoint) => `\\u{${codePoint.codePointAt(0)?.toString(16)}}`,
+            )
+            .join("")
+        : segment,
+    )
+    .join("");
+}
+
+function protectLiteralWhitespace(text: string, role: TerminalValue["role"]) {
+  if (role !== "url" && role !== "path" && role !== "commit")
+    return { text, restore: (value: string) => value };
+
+  let marker = "\uE000";
+  while (text.includes(marker))
+    marker = String.fromCodePoint(marker.codePointAt(0)! + 1);
+  return {
+    text: text.replaceAll(" ", marker),
+    restore: (value: string) => value.replaceAll(marker, " "),
+  };
+}
+
 function wrap(
   value: TerminalValue,
   firstPrefix: string,
@@ -101,8 +130,12 @@ function wrap(
       ? firstPrefix.replace(/^ +| +$/gu, "")
       : undefined;
   const prefixes = standalonePrefix ? [standalonePrefix] : [];
+  const protectedText = protectLiteralWhitespace(text, value.role);
   const lines = wrapTextWithAnsi(
-    text,
+    encodeOversizeGraphemes(
+      protectedText.text,
+      Math.max(1, width - visibleWidth(first)),
+    ),
     Math.max(1, width - visibleWidth(first)),
   );
   return [
@@ -110,8 +143,12 @@ function wrap(
     ...lines.flatMap((line, index) => {
       const prefix = index === 0 ? first : continuation;
       const available = Math.max(1, width - visibleWidth(prefix));
-      return wrapTextWithAnsi(line, available).map(
-        (part) => `${prefix}${style(part, value.role, color)}`,
+      return wrapTextWithAnsi(
+        encodeOversizeGraphemes(line, available),
+        available,
+      ).map(
+        (part) =>
+          `${prefix}${style(protectedText.restore(part), value.role, color)}`,
       );
     }),
   ];

--- a/src/cli/commands/run-once/terminal-result-layout.ts
+++ b/src/cli/commands/run-once/terminal-result-layout.ts
@@ -169,13 +169,10 @@ export function renderTerminalDocument(input: TerminalDocument): string {
     input.stepNumber === undefined
       ? ""
       : `${String(input.stepNumber).padStart(2, "0")}  `;
-  const marker = styled(
-    markerFor(input.severity),
-    severityColor(input.severity),
-    color,
+  const header = `${headerPrefix}Final result: ${markerFor(input.severity)} ${input.label}`;
+  const lines = wrap({ text: header }, "", "", width, false).map((line) =>
+    styled(line, SGR.bold + severityColor(input.severity), color),
   );
-  const header = `${headerPrefix}Final result: ${marker} ${styled(input.label, SGR.bold + severityColor(input.severity), color)}`;
-  const lines = wrap({ text: header }, "", "", width, false);
   const metrics: string[] = [];
   if (
     input.totalOutputTokens !== undefined ||
@@ -192,12 +189,8 @@ export function renderTerminalDocument(input: TerminalDocument): string {
       .filter(Boolean)
       .join(" · ");
     metrics.push(
-      ...wrap(
-        { text: styled(parts, SGR.dim, color) },
-        "    ",
-        "    ",
-        width,
-        false,
+      ...wrap({ text: parts }, "    ", "    ", width, false).map((line) =>
+        styled(line, SGR.dim, color),
       ),
     );
   }

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -85,6 +85,10 @@ test("sanitizes hostile strings and styles only renderer output", () => {
   assert.doesNotMatch(plain, /\u001b|\u0007|^Injected heading$/mu);
   assert.match(plain, /Injected heading/u);
   assert.equal(stripTerminalSequences(colored), plain);
+  assert.match(
+    colored,
+    /\u001b\[1m\u001b\[31mFinal result: ✗ Error\u001b\[0m/u,
+  );
   assert.match(colored, /\u001b\[31m✗/u);
   for (const line of colored.split("\n")) assert.ok(visibleWidth(line) <= 32);
 });

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
-import { renderTerminalDocument } from "./terminal-result-layout.ts";
+import {
+  cleanValue,
+  renderTerminalDocument,
+} from "./terminal-result-layout.ts";
 import {
   formatTerminalResult,
   terminalResultSeverity,
@@ -290,6 +293,44 @@ test("encodes individually too-wide graphemes only when necessary", () => {
     );
     assert.ok(wide.includes(literal));
   }
+});
+
+test("uses an unambiguous narrow codec for over-wide graphemes", () => {
+  const decodeNarrowCodec = (text: string) =>
+    text.replaceAll(
+      /\\(?:\\|u\{([\da-f]+)\})/giu,
+      (match, hex: string | undefined) =>
+        hex === undefined
+          ? "\\"
+          : String.fromCodePoint(Number.parseInt(hex, 16)),
+    );
+  const emoji = formatTerminalResult(
+    { status: "error", error: "😀" },
+    { width: 1, color: false },
+  );
+  const literalEscape = formatTerminalResult(
+    { status: "error", error: "\\u{1f600}" },
+    { width: 1, color: false },
+  );
+
+  assert.notEqual(emoji, literalEscape);
+  assert.ok(decodeNarrowCodec(emoji.replaceAll("\n", "")).includes("😀"));
+  assert.ok(
+    decodeNarrowCodec(literalEscape.replaceAll("\n", "")).includes(
+      "\\u{1f600}",
+    ),
+  );
+});
+
+test("replaces tabs in hostile terminal values before wrapping", () => {
+  assert.equal(cleanValue("first\tsecond\u0007"), "first second");
+  const output = formatTerminalResult(
+    { status: "error", error: "first\tsecond\u0007" },
+    { width: 12, color: false },
+  );
+  assert.doesNotMatch(output, /\t|\u0007/u);
+  for (const line of output.split("\n"))
+    assert.ok(visibleWidth(line) <= 12, `${visibleWidth(line)} > 12`);
 });
 
 test("preserves literal-role whitespace through narrow wrapping", () => {

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -166,6 +166,107 @@ test("maps every status to its visible severity marker and label", () => {
   assert.equal(terminalResultSeverity("blocked"), "failure");
 });
 
+test("renders each status with its relevant semantic sections", () => {
+  const cases: Array<[RunOnceResultSummary, string[]]> = [
+    [{ status: "no-issue" }, []],
+    [
+      { status: "dry-run", issueNumber: 1, title: "Issue", transition: "plan" },
+      ["Issue and workspace", "Transition"],
+    ],
+    [
+      { status: "spec-created", issueNumber: 1, specPath: "spec.md" },
+      ["Issue and workspace", "Artifacts"],
+    ],
+    [
+      { status: "spec-found", issueNumber: 1, specPath: "spec.md" },
+      ["Issue and workspace", "Artifacts"],
+    ],
+    [
+      { status: "plan-created", issueNumber: 1, planPath: "plan.md" },
+      ["Issue and workspace", "Artifacts"],
+    ],
+    [
+      { status: "plan-found", issueNumber: 1, planPath: "plan.md" },
+      ["Issue and workspace", "Artifacts"],
+    ],
+    [summary, ["Pull request", "Validation (2)", "Review", "Run files"]],
+    [
+      {
+        status: "merged",
+        issueNumber: 1,
+        planPath: "plan.md",
+        branch: "branch",
+        mergeCommit: "abc",
+        worktreePath: "worktree",
+        commits: [],
+        validation: [],
+        landingDecision: "landed",
+      },
+      ["Issue and workspace", "Artifacts", "Landing decision"],
+    ],
+    [
+      {
+        status: "approval-required",
+        issueNumber: 1,
+        approvalKind: "spec",
+        missingLabel: "spec-approved",
+      },
+      ["Issue and workspace", "Approval"],
+    ],
+    [
+      {
+        status: "development-environment-not-ready",
+        issueNumber: 1,
+        planPath: "plan.md",
+        reason: "not ready",
+        evidence: ["evidence"],
+        remediation: ["retry"],
+      },
+      ["Issue and workspace", "Artifacts", "Environment readiness"],
+    ],
+    [
+      {
+        status: "blocked",
+        issueNumber: 1,
+        reason: "blocked",
+        questions: ["what now?"],
+      },
+      ["Issue and workspace", "Failure", "Questions (1)"],
+    ],
+    [{ status: "error", error: "failed", causes: ["cause"] }, ["Failure"]],
+  ];
+  for (const [result, headings] of cases) {
+    const output = formatTerminalResult(result, { width: 100, color: false });
+    for (const heading of headings) assert.ok(output.includes(heading));
+    if (result.status === "no-issue") assert.doesNotMatch(output, /\n\n/u);
+  }
+});
+
+test("keeps every line within every positive width and resets styled lines", () => {
+  for (let width = 1; width <= 32; width += 1) {
+    const plain = formatTerminalResult(summary, { width, color: false });
+    const colored = formatTerminalResult(summary, { width, color: true });
+    for (const line of plain.split("\n"))
+      assert.ok(
+        visibleWidth(line) <= width,
+        `${visibleWidth(line)} > ${width}`,
+      );
+    assert.ok(
+      plain
+        .replaceAll(/\s+/gu, "")
+        .includes("https://example.test/patchmill/pulls/174"),
+    );
+    for (const line of colored.split("\n")) {
+      assert.ok(
+        visibleWidth(line) <= width,
+        `${visibleWidth(line)} > ${width}`,
+      );
+      if (line.includes("\u001b[")) assert.ok(line.endsWith("\u001b[0m"));
+    }
+    assert.equal(stripTerminalSequences(colored), plain);
+  }
+});
+
 test("omits optional empty sections", () => {
   const output = formatTerminalResult(
     { status: "no-issue" },

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { renderTerminalDocument } from "./terminal-result-layout.ts";
 import {
   formatTerminalResult,
   terminalResultSeverity,
@@ -265,6 +266,109 @@ test("keeps every line within every positive width and resets styled lines", () 
     }
     assert.equal(stripTerminalSequences(colored), plain);
   }
+});
+
+test("encodes individually too-wide graphemes only when necessary", () => {
+  const decodeUnicodeEscapes = (text: string) =>
+    text.replaceAll(/\\u\{([\da-f]+)\}/giu, (_, hex: string) =>
+      String.fromCodePoint(Number.parseInt(hex, 16)),
+    );
+  for (const literal of ["漢", "😀"]) {
+    const narrow = formatTerminalResult(
+      { status: "error", error: literal },
+      { width: 1, color: false },
+    );
+    for (const line of narrow.split("\n"))
+      assert.ok(visibleWidth(line) <= 1, `${visibleWidth(line)} > 1`);
+    assert.ok(
+      decodeUnicodeEscapes(narrow.replaceAll("\n", "")).includes(literal),
+    );
+
+    const wide = formatTerminalResult(
+      { status: "error", error: literal },
+      { width: 2, color: false },
+    );
+    assert.ok(wide.includes(literal));
+  }
+});
+
+test("preserves literal-role whitespace through narrow wrapping", () => {
+  const literals = {
+    url: "https://example.test/a  b",
+    path: "branch  name",
+    commit: "abc  def",
+  } as const;
+  for (const [role, literal] of Object.entries(literals)) {
+    const output = renderTerminalDocument({
+      label: "Result",
+      severity: "success",
+      width: 10,
+      color: false,
+      sections: [
+        {
+          heading: "Value",
+          blocks: [{ kind: "value", value: { text: literal, role } }],
+        },
+      ],
+    });
+    const rendered = output
+      .slice(output.indexOf("Value\n") + "Value\n".length)
+      .split("\n")
+      .map((line) => line.slice(2))
+      .join("");
+    assert.equal(rendered, literal);
+  }
+});
+
+test("counts only values that remain renderable after terminal sanitization", () => {
+  const summary: RunOnceResultSummary = {
+    status: "blocked",
+    issueNumber: 1,
+    reason: "blocked",
+    questions: ["\u001b[31m\u001b[0m", "question"],
+  };
+  const output = formatTerminalResult(summary, { width: 100, color: false });
+  assert.match(output, /Questions \(1\)/u);
+  assert.doesNotMatch(output, /Questions \(2\)/u);
+
+  const pr = formatTerminalResult(
+    {
+      status: "pr-created",
+      issueNumber: 1,
+      planPath: "plan.md",
+      branch: "branch",
+      prUrl: "https://example.test/pr/1",
+      worktreePath: "worktree",
+      commits: ["\u001b[31m\u001b[0m"],
+      validation: ["\u001b[31m\u001b[0m"],
+      visualEvidence: [
+        { screenshotPath: "\u001b[31m\u001b[0m", caption: "  " },
+      ],
+    },
+    { width: 100, color: false },
+  );
+  assert.doesNotMatch(pr, /Validation|Commits|Visual evidence/u);
+});
+
+test("uses a styled screenshot path when visual evidence caption is blank", () => {
+  const screenshotPath = "docs/screenshots/result.png";
+  const output = formatTerminalResult(
+    {
+      status: "pr-created",
+      issueNumber: 1,
+      planPath: "plan.md",
+      branch: "branch",
+      prUrl: "https://example.test/pr/1",
+      worktreePath: "worktree",
+      commits: [],
+      validation: [],
+      visualEvidence: [{ screenshotPath, caption: "  " }],
+    },
+    { width: 100, color: true },
+  );
+  assert.match(output, /Visual evidence \(1\)/u);
+  assert.match(output, new RegExp(`\\u001b\\[35m${screenshotPath}`, "u"));
+  assert.doesNotMatch(output, /Screenshot:/u);
 });
 
 test("omits optional empty sections", () => {

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -361,6 +361,50 @@ test("preserves literal-role whitespace through narrow wrapping", () => {
   }
 });
 
+test("preserves significant literal whitespace across wrapping", () => {
+  const renderLiteral = (
+    text: string,
+    role: "path" | "url" | "commit",
+    width = 5,
+  ) => {
+    const output = renderTerminalDocument({
+      label: "Result",
+      severity: "success",
+      width,
+      color: false,
+      sections: [
+        {
+          heading: "Value",
+          blocks: [{ kind: "value", value: { text, role } }],
+        },
+      ],
+    });
+    return output
+      .slice(output.indexOf("Value\n") + "Value\n".length)
+      .split("\n")
+      .map((line) => line.slice(2))
+      .join("");
+  };
+
+  for (const role of ["path", "url", "commit"] as const)
+    for (const literal of [
+      "aa\u00a0bb",
+      "aa\u2003bb",
+      "a \u00a0\u2003  b",
+      "a\uE000 \u00a0b",
+      "  /tmp/path  ",
+    ])
+      assert.equal(renderLiteral(literal, role), literal);
+
+  const normalized = renderLiteral(
+    "left\tmiddle\nright\u001b[31mred\u001b[0m\u0007",
+    "path",
+    10,
+  );
+  assert.equal(normalized, "left middle rightred ");
+  assert.doesNotMatch(normalized, /\t|\n|\r|\u001b|\u0007/u);
+});
+
 test("counts only values that remain renderable after terminal sanitization", () => {
   const summary: RunOnceResultSummary = {
     status: "blocked",

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -405,6 +405,48 @@ test("preserves significant literal whitespace across wrapping", () => {
   assert.doesNotMatch(normalized, /\t|\n|\r|\u001b|\u0007/u);
 });
 
+test("preserves two-cell literal whitespace at narrow widths", () => {
+  const decodeNarrowCodec = (text: string) =>
+    text.replaceAll(
+      /\\(?:\\|u\{([\da-f]+)\})/giu,
+      (match, hex: string | undefined) =>
+        hex === undefined
+          ? "\\"
+          : String.fromCodePoint(Number.parseInt(hex, 16)),
+    );
+  const literal = "a\u3000b";
+
+  for (const role of ["path", "url", "commit"] as const)
+    for (const width of [4, 1]) {
+      const output = renderTerminalDocument({
+        label: "",
+        severity: "success",
+        width,
+        color: false,
+        sections: [
+          {
+            heading: "",
+            blocks: [{ kind: "value", value: { text: literal, role } }],
+          },
+        ],
+      });
+      for (const line of output.split("\n"))
+        assert.ok(
+          visibleWidth(line) <= width,
+          `${visibleWidth(line)} > ${width}`,
+        );
+      const rendered = output
+        .slice(output.lastIndexOf("\n\n") + 2)
+        .split("\n")
+        .map((line) => line.replace(/^ {2}/u, ""))
+        .join("");
+      assert.equal(
+        width === 1 ? decodeNarrowCodec(rendered) : rendered,
+        literal,
+      );
+    }
+});
+
 test("counts only values that remain renderable after terminal sanitization", () => {
   const summary: RunOnceResultSummary = {
     status: "blocked",

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -93,8 +93,83 @@ test("sanitizes hostile strings and styles only renderer output", () => {
   for (const line of colored.split("\n")) assert.ok(visibleWidth(line) <= 32);
 });
 
-test("maps status severity", () => {
+test("maps every status to its visible severity marker and label", () => {
+  const cases: Array<[RunOnceResultSummary, string]> = [
+    [{ status: "no-issue" }, "✓ No eligible issue"],
+    [
+      { status: "dry-run", issueNumber: 1, title: "Issue", transition: "plan" },
+      "✓ Dry run",
+    ],
+    [
+      { status: "spec-created", issueNumber: 1, specPath: "spec.md" },
+      "✓ Specification created",
+    ],
+    [
+      { status: "spec-found", issueNumber: 1, specPath: "spec.md" },
+      "✓ Specification found",
+    ],
+    [
+      { status: "plan-created", issueNumber: 1, planPath: "plan.md" },
+      "✓ Implementation plan created",
+    ],
+    [
+      { status: "plan-found", issueNumber: 1, planPath: "plan.md" },
+      "✓ Implementation plan found",
+    ],
+    [summary, "✓ PR created"],
+    [
+      {
+        status: "merged",
+        issueNumber: 1,
+        planPath: "plan.md",
+        branch: "branch",
+        mergeCommit: "abc",
+        worktreePath: "worktree",
+        commits: [],
+        validation: [],
+      },
+      "✓ Merged",
+    ],
+    [
+      {
+        status: "approval-required",
+        issueNumber: 1,
+        approvalKind: "spec",
+        missingLabel: "spec-approved",
+      },
+      "! Approval required",
+    ],
+    [
+      {
+        status: "development-environment-not-ready",
+        issueNumber: 1,
+        planPath: "plan.md",
+        reason: "not ready",
+        evidence: [],
+        remediation: [],
+      },
+      "! Development environment not ready",
+    ],
+    [
+      { status: "blocked", issueNumber: 1, reason: "blocked", questions: [] },
+      "✗ Blocked",
+    ],
+    [{ status: "error", error: "failed" }, "✗ Error"],
+  ];
+  for (const [result, header] of cases)
+    assert.match(
+      formatTerminalResult(result, { width: 100, color: false }),
+      new RegExp(`Final result: ${header}`, "u"),
+    );
   assert.equal(terminalResultSeverity("pr-created"), "success");
   assert.equal(terminalResultSeverity("approval-required"), "warning");
   assert.equal(terminalResultSeverity("blocked"), "failure");
+});
+
+test("omits optional empty sections", () => {
+  const output = formatTerminalResult(
+    { status: "no-issue" },
+    { width: 80, color: false },
+  );
+  assert.doesNotMatch(output, /\n\n\n|\(0\)|Artifacts|Run files/u);
 });

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import {
+  formatTerminalResult,
+  terminalResultSeverity,
+} from "./terminal-result.ts";
+import type { RunOnceResultSummary } from "./result-summary.ts";
+
+const summary: RunOnceResultSummary = {
+  status: "pr-created",
+  issueNumber: 174,
+  specPath: "docs/specs/a-very-long-result-design-document.md",
+  planPath: "docs/plans/a-very-long-result-plan.md",
+  branch: "agent/issue-174-readable-terminal-result",
+  prUrl: "https://example.test/patchmill/pulls/174",
+  worktreePath: ".worktrees/patchmill-issue-174-readable-terminal-result",
+  commits: ["abc123", "def456"],
+  validation: ["npm test passed", "npm run lint passed"],
+  reviewSummary:
+    "A long review summary remains readable in a narrow terminal without losing any words.",
+  landingDecision: "PR required for a user-visible CLI output contract change.",
+  visualEvidence: [
+    {
+      screenshotPath: "docs/reference-screenshots/result.png",
+      caption: "Readable final result",
+      referencePaths: ["docs/reference-screenshots/before.png"],
+      url: "https://example.test/evidence/174",
+    },
+  ],
+  logPath: "/tmp/run.jsonl",
+  piSessionPath: "/tmp/run-pi-sessions",
+};
+
+test("renders ordered sections, vertical arrays, and header metrics", () => {
+  const output = formatTerminalResult(summary, {
+    width: 100,
+    color: false,
+    stepNumber: 11,
+    totalOutputTokens: 56_000,
+    elapsedSeconds: 15_602,
+  });
+  for (const heading of [
+    "Pull request",
+    "Issue and workspace",
+    "Artifacts",
+    "Validation (2)",
+    "Review",
+    "Landing decision",
+    "Commits (2)",
+    "Visual evidence (1)",
+    "Run files",
+  ])
+    assert.ok(output.indexOf(heading) > -1);
+  assert.match(
+    output,
+    /^11 {2}Final result: ✓ PR created\n {4}56\.0k tokens · elapsed 4h20m02s/mu,
+  );
+  assert.match(output, /^ {2}✓ npm test passed$/mu);
+  assert.match(output, /^ {2}• abc123$/mu);
+  assert.match(output, /^ {2}• def456$/mu);
+});
+
+test("wraps narrow output without truncating dynamic values", () => {
+  const output = formatTerminalResult(summary, { width: 24, color: false });
+  for (const line of output.split("\n"))
+    assert.ok(visibleWidth(line) <= 24, `${visibleWidth(line)} > 24: ${line}`);
+  assert.match(output, /Branch:\n/);
+  assert.doesNotMatch(output, /…|\.\.\./u);
+  assert.ok(
+    output
+      .replaceAll(/\s+/gu, "")
+      .includes("https://example.test/patchmill/pulls/174"),
+  );
+});
+
+test("sanitizes hostile strings and styles only renderer output", () => {
+  const hostile: RunOnceResultSummary = {
+    status: "error",
+    error: "\u001b[31mred\u001b[0m\nInjected heading\u0007",
+    causes: ["\u001b]8;;https://evil.test\u0007click\u001b]8;;\u0007"],
+  };
+  const plain = formatTerminalResult(hostile, { width: 32, color: false });
+  const colored = formatTerminalResult(hostile, { width: 32, color: true });
+  assert.doesNotMatch(plain, /\u001b|\u0007|^Injected heading$/mu);
+  assert.match(plain, /Injected heading/u);
+  assert.equal(stripTerminalSequences(colored), plain);
+  assert.match(colored, /\u001b\[31m✗/u);
+  for (const line of colored.split("\n")) assert.ok(visibleWidth(line) <= 32);
+});
+
+test("maps status severity", () => {
+  assert.equal(terminalResultSeverity("pr-created"), "success");
+  assert.equal(terminalResultSeverity("approval-required"), "warning");
+  assert.equal(terminalResultSeverity("blocked"), "failure");
+});

--- a/src/cli/commands/run-once/terminal-result.test.ts
+++ b/src/cli/commands/run-once/terminal-result.test.ts
@@ -405,6 +405,40 @@ test("preserves significant literal whitespace across wrapping", () => {
   assert.doesNotMatch(normalized, /\t|\n|\r|\u001b|\u0007/u);
 });
 
+test("preserves literal path data when all former zero-width sentinels occur", () => {
+  const formerSentinels = [
+    ...Array.from({ length: 5 }, (_, index) =>
+      String.fromCodePoint(0x200b + index),
+    ),
+    ...Array.from({ length: 5 }, (_, index) =>
+      String.fromCodePoint(0x2060 + index),
+    ),
+  ].join("");
+  const branch = `agent/${formerSentinels}\uFEFF issue`;
+  const output = formatTerminalResult(
+    {
+      status: "pr-created",
+      issueNumber: 174,
+      planPath: "plan.md",
+      branch,
+      prUrl: "https://example.test/pulls/174",
+      worktreePath: "worktree",
+      commits: [],
+      validation: [],
+    },
+    { width: 12, color: false },
+  );
+  const branchStart = output.indexOf("Branch:\n") + "Branch:\n".length;
+  const branchLines = output
+    .slice(branchStart, output.indexOf("\n  Worktree:", branchStart))
+    .split("\n")
+    .map((line) => line.slice(4));
+
+  assert.equal(branchLines.join(""), branch);
+  for (const line of output.split("\n"))
+    assert.ok(visibleWidth(line) <= 12, `${visibleWidth(line)} > 12`);
+});
+
 test("preserves two-cell literal whitespace at narrow widths", () => {
   const decodeNarrowCodec = (text: string) =>
     text.replaceAll(

--- a/src/cli/commands/run-once/terminal-result.ts
+++ b/src/cli/commands/run-once/terminal-result.ts
@@ -1,0 +1,314 @@
+import type {
+  RunOnceResultStatus,
+  RunOnceResultSummary,
+} from "./result-summary.ts";
+import { renderTerminalDocument } from "./terminal-result-layout.ts";
+import type {
+  TerminalSection,
+  TerminalValue,
+} from "./terminal-result-layout.ts";
+
+export type TerminalResultSeverity = "success" | "warning" | "failure";
+export type TerminalResultOptions = {
+  width: number;
+  color: boolean;
+  stepNumber?: number;
+  totalOutputTokens?: number;
+  elapsedSeconds?: number;
+};
+const STATUS = {
+  "no-issue": { label: "No eligible issue", severity: "success" },
+  "dry-run": { label: "Dry run", severity: "success" },
+  "spec-created": { label: "Specification created", severity: "success" },
+  "spec-found": { label: "Specification found", severity: "success" },
+  "plan-created": { label: "Implementation plan created", severity: "success" },
+  "plan-found": { label: "Implementation plan found", severity: "success" },
+  "pr-created": { label: "PR created", severity: "success" },
+  merged: { label: "Merged", severity: "success" },
+  "approval-required": { label: "Approval required", severity: "warning" },
+  "development-environment-not-ready": {
+    label: "Development environment not ready",
+    severity: "warning",
+  },
+  blocked: { label: "Blocked", severity: "failure" },
+  error: { label: "Error", severity: "failure" },
+} as const satisfies Record<
+  RunOnceResultStatus,
+  { label: string; severity: TerminalResultSeverity }
+>;
+
+const nonblank = (value: string | undefined): value is string =>
+  Boolean(value?.trim());
+const value = (
+  text: string,
+  role: TerminalValue["role"] = "plain",
+): TerminalValue => ({ text, role });
+export function terminalResultSeverity(
+  status: RunOnceResultStatus,
+): TerminalResultSeverity {
+  return STATUS[status].severity;
+}
+
+export function formatTerminalResult(
+  summary: RunOnceResultSummary,
+  options: TerminalResultOptions,
+): string {
+  const sections: TerminalSection[] = [];
+  if ("prUrl" in summary && nonblank(summary.prUrl))
+    sections.push({
+      heading: "Pull request",
+      blocks: [{ kind: "value", value: value(summary.prUrl, "url") }],
+    });
+  if ("issueNumber" in summary) {
+    const fields = [
+      { label: "Issue", value: value(`#${summary.issueNumber}`) },
+      ...("title" in summary && nonblank(summary.title)
+        ? [{ label: "Title", value: value(summary.title) }]
+        : []),
+      ...("branch" in summary && nonblank(summary.branch)
+        ? [{ label: "Branch", value: value(summary.branch, "path") }]
+        : []),
+      ...("worktreePath" in summary && nonblank(summary.worktreePath)
+        ? [{ label: "Worktree", value: value(summary.worktreePath, "path") }]
+        : []),
+    ];
+    sections.push({
+      heading: "Issue and workspace",
+      blocks: [{ kind: "fields", fields }],
+    });
+  }
+  const artifacts = [
+    "specPath" in summary && nonblank(summary.specPath)
+      ? {
+          value: value("Specification"),
+          details: [
+            { label: undefined, value: value(summary.specPath, "path") },
+          ],
+        }
+      : undefined,
+    "planPath" in summary && nonblank(summary.planPath)
+      ? {
+          value: value("Implementation plan"),
+          details: [
+            { label: undefined, value: value(summary.planPath, "path") },
+          ],
+        }
+      : undefined,
+  ].filter((item): item is NonNullable<typeof item> => item !== undefined);
+  if (artifacts.length)
+    sections.push({
+      heading: "Artifacts",
+      blocks: [{ kind: "list", marker: "•", items: artifacts }],
+    });
+  if (summary.status === "dry-run")
+    sections.push({
+      heading: "Transition",
+      blocks: [
+        {
+          kind: "fields",
+          fields: [{ label: "Transition", value: value(summary.transition) }],
+        },
+      ],
+    });
+  if (summary.status === "approval-required")
+    sections.push({
+      heading: "Approval",
+      blocks: [
+        {
+          kind: "fields",
+          fields: [
+            { label: "Kind", value: value(summary.approvalKind) },
+            { label: "Missing label", value: value(summary.missingLabel) },
+          ],
+        },
+      ],
+    });
+  if (summary.status === "development-environment-not-ready")
+    sections.push({
+      heading: "Environment readiness",
+      blocks: [
+        {
+          kind: "fields",
+          fields: [{ label: "Reason", value: value(summary.reason) }],
+        },
+        ...(summary.evidence.filter(nonblank).length
+          ? [
+              {
+                kind: "list" as const,
+                marker: "!" as const,
+                markerSeverity: "warning" as const,
+                items: summary.evidence
+                  .filter(nonblank)
+                  .map((text) => ({ value: value(text) })),
+              },
+            ]
+          : []),
+        ...(summary.remediation.filter(nonblank).length
+          ? [
+              {
+                kind: "list" as const,
+                marker: "→" as const,
+                markerSeverity: "warning" as const,
+                items: summary.remediation
+                  .filter(nonblank)
+                  .map((text) => ({ value: value(text) })),
+              },
+            ]
+          : []),
+      ],
+    });
+  if (summary.status === "blocked" || summary.status === "error") {
+    const reason =
+      summary.status === "blocked" ? summary.reason : summary.error;
+    const causes = summary.status === "error" ? (summary.causes ?? []) : [];
+    sections.push({
+      heading: "Failure",
+      blocks: [
+        { kind: "fields", fields: [{ label: "Reason", value: value(reason) }] },
+        ...(causes.filter(nonblank).length
+          ? [
+              {
+                kind: "list" as const,
+                marker: "✗" as const,
+                markerSeverity: "failure" as const,
+                items: causes
+                  .filter(nonblank)
+                  .map((text) => ({ value: value(text) })),
+              },
+            ]
+          : []),
+      ],
+    });
+  }
+  if (summary.status === "blocked" && summary.questions.filter(nonblank).length)
+    sections.push({
+      heading: "Questions",
+      count: summary.questions.filter(nonblank).length,
+      blocks: [
+        {
+          kind: "list",
+          marker: "✗",
+          markerSeverity: "failure",
+          items: summary.questions
+            .filter(nonblank)
+            .map((text) => ({ value: value(text) })),
+        },
+      ],
+    });
+  if ("validation" in summary && summary.validation.filter(nonblank).length)
+    sections.push({
+      heading: "Validation",
+      count: summary.validation.filter(nonblank).length,
+      blocks: [
+        {
+          kind: "list",
+          marker: "✓",
+          markerSeverity: "success",
+          items: summary.validation
+            .filter(nonblank)
+            .map((text) => ({ value: value(text) })),
+        },
+      ],
+    });
+  if ("reviewSummary" in summary && nonblank(summary.reviewSummary))
+    sections.push({
+      heading: "Review",
+      blocks: [{ kind: "value", value: value(summary.reviewSummary) }],
+    });
+  if (
+    ("landingDecision" in summary && nonblank(summary.landingDecision)) ||
+    summary.status === "merged"
+  )
+    sections.push({
+      heading: "Landing decision",
+      blocks: [
+        {
+          kind: "fields",
+          fields: [
+            ...("landingDecision" in summary &&
+            nonblank(summary.landingDecision)
+              ? [{ label: undefined, value: value(summary.landingDecision) }]
+              : []),
+            ...(summary.status === "merged"
+              ? [
+                  {
+                    label: "Merge commit",
+                    value: value(summary.mergeCommit, "commit"),
+                  },
+                ]
+              : []),
+          ],
+        },
+      ],
+    });
+  if ("commits" in summary && summary.commits.filter(nonblank).length)
+    sections.push({
+      heading: "Commits",
+      count: summary.commits.filter(nonblank).length,
+      blocks: [
+        {
+          kind: "list",
+          marker: "•",
+          items: summary.commits
+            .filter(nonblank)
+            .map((text) => ({ value: value(text, "commit") })),
+        },
+      ],
+    });
+  if ("visualEvidence" in summary && summary.visualEvidence?.length)
+    sections.push({
+      heading: "Visual evidence",
+      count: summary.visualEvidence.length,
+      blocks: [
+        {
+          kind: "list",
+          marker: "•",
+          items: summary.visualEvidence.map((item) => ({
+            value: value(item.caption || item.screenshotPath),
+            details: [
+              ...(item.caption
+                ? [
+                    {
+                      label: "Screenshot",
+                      value: value(item.screenshotPath, "path"),
+                    },
+                  ]
+                : []),
+              ...(item.referencePaths ?? []).filter(nonblank).map((text) => ({
+                label: "Reference",
+                value: value(text, "path"),
+              })),
+              ...(item.url && nonblank(item.url)
+                ? [{ label: "URL", value: value(item.url, "url") }]
+                : []),
+            ],
+          })),
+        },
+      ],
+    });
+  const files = [
+    "logPath" in summary && nonblank(summary.logPath)
+      ? {
+          value: value("Log"),
+          details: [{ value: value(summary.logPath, "path") }],
+        }
+      : undefined,
+    "piSessionPath" in summary && nonblank(summary.piSessionPath)
+      ? {
+          value: value("Pi sessions"),
+          details: [{ value: value(summary.piSessionPath, "path") }],
+        }
+      : undefined,
+  ].filter((item): item is NonNullable<typeof item> => item !== undefined);
+  if (files.length)
+    sections.push({
+      heading: "Run files",
+      blocks: [{ kind: "list", marker: "•", items: files }],
+    });
+  return renderTerminalDocument({
+    label: STATUS[summary.status].label,
+    severity: STATUS[summary.status].severity,
+    sections,
+    ...options,
+  });
+}

--- a/src/cli/commands/run-once/terminal-result.ts
+++ b/src/cli/commands/run-once/terminal-result.ts
@@ -2,7 +2,10 @@ import type {
   RunOnceResultStatus,
   RunOnceResultSummary,
 } from "./result-summary.ts";
-import { renderTerminalDocument } from "./terminal-result-layout.ts";
+import {
+  cleanValue,
+  renderTerminalDocument,
+} from "./terminal-result-layout.ts";
 import type {
   TerminalSection,
   TerminalValue,
@@ -37,8 +40,8 @@ const STATUS = {
   { label: string; severity: TerminalResultSeverity }
 >;
 
-const nonblank = (value: string | undefined): value is string =>
-  Boolean(value?.trim());
+const nonblank = (text: string | undefined): text is string =>
+  typeof text === "string" && Boolean(cleanValue(text));
 const value = (
   text: string,
   role: TerminalValue["role"] = "plain",
@@ -255,22 +258,23 @@ export function formatTerminalResult(
         },
       ],
     });
-  if ("visualEvidence" in summary && summary.visualEvidence?.length)
-    sections.push({
-      heading: "Visual evidence",
-      count: summary.visualEvidence.length,
-      blocks: [
-        {
-          kind: "list",
-          marker: "•",
-          items: summary.visualEvidence.map((item) => ({
-            value: value(item.caption || item.screenshotPath),
+  const visualEvidence =
+    ("visualEvidence" in summary ? summary.visualEvidence : undefined)?.flatMap(
+      (item) => {
+        const caption = nonblank(item.caption) ? item.caption : undefined;
+        const screenshotPath = nonblank(item.screenshotPath)
+          ? item.screenshotPath
+          : undefined;
+        if (!caption && !screenshotPath) return [];
+        return [
+          {
+            value: caption ? value(caption) : value(screenshotPath!, "path"),
             details: [
-              ...(item.caption
+              ...(caption && screenshotPath
                 ? [
                     {
                       label: "Screenshot",
-                      value: value(item.screenshotPath, "path"),
+                      value: value(screenshotPath, "path"),
                     },
                   ]
                 : []),
@@ -282,9 +286,15 @@ export function formatTerminalResult(
                 ? [{ label: "URL", value: value(item.url, "url") }]
                 : []),
             ],
-          })),
-        },
-      ],
+          },
+        ];
+      },
+    ) ?? [];
+  if (visualEvidence.length)
+    sections.push({
+      heading: "Visual evidence",
+      count: visualEvidence.length,
+      blocks: [{ kind: "list", marker: "•", items: visualEvidence }],
     });
   const files = [
     "logPath" in summary && nonblank(summary.logPath)


### PR DESCRIPTION
## Summary

- Render interactive `run-once` final results as grouped, status-aware, width-aware terminal reports.
- Preserve exact compact JSON for redirected stdout and append the full structured summary to the resolved JSONL run log.
- Defer the interactive final progress step, sanitize dynamic terminal values, and document TTY/color behavior.
- Add focused coverage for statuses, narrow Unicode/literal wrapping, ANSI safety, persistence failures, output modes, and exit codes.

## Validation

- `npm run patchmill -- run-once --help`
- `npm run lint:md`
- `npm --prefix site run build`
- focused run-once result tests (36/36)
- `npm run test:run-once` (506/506)
- `npm test` (1301/1301)
- `npm run lint`
- `npm run build`
- wide/color, narrow/NO_COLOR, narrow/TERM=dumb, and redirected JSON manual fixture checks
- npm dependency metadata unchanged; Nix build not required

## Reviews

- Final Codex full-worktree review passed after all findings were fixed and re-reviewed.
- Final thermo-nuclear code-quality review passed after simplifying literal wrapping.
- Final validation-readiness review passed every required command and manual output check.

## Landing decision

Human review is required because this changes the user-visible interactive CLI output contract and adds a substantial terminal formatting boundary, while preserving redirected machine output.

Closes #174

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Planning | gpt-5.6-sol | 2,941,604 | 41,302 | $3.3995 |
| Development environment | gpt-5.6-sol | 859,864 | 3,289 | $0.9742 |
| Implementation | gpt-5.6-sol | 27,509,940 | 161,938 | $27.0258 |
| Implementation | gpt-5.6-terra | 24,324,428 | 77,935 | $8.0568 |
| **Implementation subtotal** |  | **51,834,368** | **239,873** | **$35.0826** |
| **Total** |  | **55,635,836** | **284,464** | **$39.4563** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->