### PR TITLE
Render enriched subagent progress in the run-once console

### DIFF
--- a/docs/plans/2026-08-27-issue-126-render-enriched-subagent-progress-in-the-run-once-console.md
+++ b/docs/plans/2026-08-27-issue-126-render-enriched-subagent-progress-in-the-run-once-console.md
@@ -1,0 +1,1134 @@
+# Enriched Subagent Run-Once Console Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render one stable run-once console line for each distinct
+authoritative subagent child metadata tuple, or one canonical identity-only
+unresolved fallback when no authoritative agent metadata arrives.
+
+**Architecture:** Keep issue #125's validated `PersistedSubagentProgress` union,
+exact-session stream, lifecycle history, and parent accounting unchanged. Add a
+presentation-only branch and run-scoped child/tuple state to
+`AgentIssueConsoleProgressReporter`, then exercise that production reporter from
+the existing run-once pipeline scenario and keep final redirected JSON on a
+separate stdout sink.
+
+**Tech Stack:** Node.js 22.19+, TypeScript ESM, `node:test`, the existing
+`PersistedSubagentProgress` v1 contract, run-once progress reporters, exact Pi
+session test helpers, and the existing final-result output helper.
+
+**Spec:**
+`docs/specs/2026-08-27-issue-126-render-enriched-subagent-progress-in-the-run-once-console-design.md`
+
+## Global Constraints
+
+- Consume only issue #125's validated
+  `{ type: "subagent-progress", progress: PersistedSubagentProgress }`
+  observation; do not resolve, infer, normalize, or invent child metadata or
+  identity.
+- An authoritative console tuple requires `agent`; include available `model` and
+  `thinking` in fixed `agent`, `model`, `thinking` order and omit absent fields
+  cleanly.
+- Preserve accepted metadata bytes exactly. Do not trim, split, normalize,
+  truncate, remove provider prefixes, or strip nested model path segments.
+- Deduplicate by the complete canonical child identity: direct children use
+  `(kind, toolCallId, runId, childIndex)` and workflow children use
+  `(kind, toolCallId, workflowRunId, childId)`.
+- Deduplicate authoritative presentation by the fixed-position tuple
+  `(agent, model-or-absent, thinking-or-absent)`. Lifecycle state,
+  `inventoryClosed`, and `unresolved` are not tuple fields.
+- Render a workflow unresolved fallback from `childId`; render a direct fallback
+  from `runId` plus `childIndex`. Never use array position, parent arguments,
+  task text, or a placeholder agent.
+- Render an unresolved fallback only when that child has no authoritative tuple,
+  and render it at most once. Identity-only non-fallback observations produce no
+  line.
+- Keep child progress visible outside an active step; use the existing
+  three-space indentation only while a step is active.
+- Preserve ordinary parent subagent summaries, subagent management calls,
+  non-subagent tools, steps, token accounting, triage, and JSONL observations.
+- Progress remains on stderr. Redirected stdout remains exactly one compact,
+  parseable final JSON object written by `writeRunOnceResult()`.
+- Do not change `src/pi`, `pi-subagents`, lifecycle correlation, session
+  ownership, cancellation, inventory, accounting, triage, dependencies, or Nix
+  packaging.
+- Apply Patchmill's Testing Value Gate. The focused reporter and pipeline/output
+  tests below are required because they protect operator-visible runtime
+  behavior, metadata fidelity, canonical child identity, failure visibility,
+  accounting, and stdout/stderr separation; each can fail for a meaningful
+  regression and will remain useful to maintainers.
+- No npm dependency change is planned. If `package.json`, `package-lock.json`,
+  or `npm-shrinkwrap.json` changes unexpectedly, retain the change only when it
+  is necessary and run `nix build .#patchmill --print-build-logs` as required by
+  `AGENTS.md`.
+
+---
+
+## File Structure
+
+- `src/cli/commands/run-once/console-progress.ts` remains the presentation
+  boundary. It will format validated child progress and own one run-scoped map
+  of authoritative tuple keys plus one set of unresolved child keys.
+- `src/cli/commands/run-once/console-progress.test.ts` will directly drive the
+  production reporter with direct and workflow v1 observations. Although this
+  test module is already large, the new cases belong here because they test the
+  same reporter API and share its event fixture; no new production abstraction
+  is needed.
+- `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts` will extend
+  the existing exact parent-session implementation scenario. It will attach the
+  production console reporter, append real `patchmill-subagent-progress`
+  entries, and compose captured console progress with redirected final output.
+  The scenario file is large, but this is the same run-once progress
+  responsibility and extending its existing mock runner avoids a second large
+  pipeline fixture.
+- `src/cli/commands/run-once/result-output.test.ts` is verification-only for
+  this issue. The end-to-end scenario will call the production
+  `writeRunOnceResult()` helper, while this focused suite continues to protect
+  its complete existing output-mode contract.
+- No new source module is warranted: the child key, tuple key, and formatter are
+  small presentation helpers meaningful only beside the console reporter.
+
+---
+
+### Task 1: Render and Deduplicate Authoritative Child Metadata
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/console-progress.test.ts:1-263`
+- Modify: `src/cli/commands/run-once/console-progress.ts:1,16-88,90-160`
+
+**Interfaces:**
+
+- Consumes: `PersistedSubagentProgress` from `src/pi/subagent-progress.ts`,
+  specifically observations whose `agent` is present.
+- Produces these file-private helpers and reporter state:
+
+  ```ts
+  function childProgressKey(progress: PersistedSubagentProgress): string;
+  function metadataTupleKey(progress: PersistedSubagentProgress): string;
+  function formatAuthoritativeSubagentProgress(
+    progress: PersistedSubagentProgress,
+  ): string | undefined;
+
+  private readonly subagentMetadataKeysByChild: Map<string, Set<string>>;
+  ```
+
+- The public `AgentIssueConsoleProgressReporter` constructor and
+  `ProgressReporter.event()` interface remain unchanged.
+
+- [ ] **Step 1: Add a typed child-progress event fixture**
+
+  Import the persisted type and add this fixture beside the existing `event()`
+  helper in `console-progress.test.ts`:
+
+  ```ts
+  import type { PersistedSubagentProgress } from "../../../pi/subagent-progress.ts";
+
+  function childProgress(
+    progress: PersistedSubagentProgress,
+  ): AgentIssueProgressEvent {
+    return event({
+      level: "debug",
+      stage: "pi-implementation",
+      message: "subagent-progress",
+      observation: { type: "subagent-progress", progress },
+    });
+  }
+  ```
+
+- [ ] **Step 2: Write failing authoritative formatting and deduplication tests**
+
+  Add
+  `test("console reporter renders each authoritative child metadata tuple once", ...)`.
+  Start an implementation step and send these observations in order:
+
+  ```ts
+  const identity = {
+    version: 1,
+    kind: "workflow",
+    toolCallId: "call-launch",
+    workflowRunId: "workflow-1",
+    childId: "review",
+  } as const;
+  const metadata = {
+    agent: "reviewer",
+    model: "openai/team/models/gpt-5.6-sol",
+    thinking: "xhigh",
+  } as const;
+
+  for (const state of ["pending", "running", "completed"] as const) {
+    reporter.event(childProgress({ ...identity, state, ...metadata }));
+  }
+  reporter.event(
+    childProgress({ ...identity, state: "completed", ...metadata }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      inventoryClosed: true,
+      ...metadata,
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      ...metadata,
+      thinking: "high",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      ...metadata,
+      model: "openai/team/models/gpt-5.6-pro",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      ...metadata,
+      agent: "auditor",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      childId: "audit",
+      state: "failed",
+      ...metadata,
+    }),
+  );
+  ```
+
+  Assert exact, lifecycle-only, and inventory-closure repeats for `review`
+  collapse; each changed thinking, model, or agent value adds a line; and the
+  distinct `audit` child independently emits the otherwise identical tuple:
+
+  ```ts
+  assert.deepEqual(lines, [
+    "01 implement task",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol, thinking=high)",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-pro, thinking=xhigh)",
+    "   🤖 subagent (agent=auditor, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+  ]);
+  ```
+
+  Add
+  `test("console reporter omits unavailable child metadata outside a step", ...)`
+  without a step. Send three direct children under one `toolCallId` and `runId`:
+  agent only, agent plus the nested model, and agent plus thinking:
+
+  ```ts
+  const direct = {
+    version: 1,
+    kind: "direct",
+    toolCallId: "call-direct",
+    runId: "run-1",
+  } as const;
+  reporter.event(childProgress({ ...direct, childIndex: 0, agent: "worker" }));
+  reporter.event(
+    childProgress({
+      ...direct,
+      childIndex: 1,
+      agent: "worker",
+      model: "provider/team/models/gpt-5.6-sol",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...direct,
+      childIndex: 2,
+      agent: "worker",
+      thinking: "xhigh",
+    }),
+  );
+
+  assert.deepEqual(lines, [
+    "🤖 subagent (agent=worker)",
+    "🤖 subagent (agent=worker, model=provider/team/models/gpt-5.6-sol)",
+    "🤖 subagent (agent=worker, thinking=xhigh)",
+  ]);
+  ```
+
+  These tests prove behavior rather than implementation shape: field order,
+  omission, byte-preserving model output, same-child lifecycle deduplication,
+  changed tuples, child isolation, and outside-step visibility are public
+  console contracts.
+
+- [ ] **Step 3: Run the focused tests and verify the red state**
+
+  Run:
+
+  ```sh
+  node --test --test-name-pattern="authoritative|metadata" \
+    src/cli/commands/run-once/console-progress.test.ts
+  ```
+
+  Expected: FAIL because the current reporter ignores every `subagent-progress`
+  observation; no child metadata lines are present.
+
+- [ ] **Step 4: Add fixed-position child and metadata keys**
+
+  Import `PersistedSubagentProgress` in `console-progress.ts` and implement the
+  keys with JSON arrays, not delimiter concatenation:
+
+  ```ts
+  function childProgressKey(progress: PersistedSubagentProgress): string {
+    return progress.kind === "direct"
+      ? JSON.stringify([
+          "direct",
+          progress.toolCallId,
+          progress.runId,
+          progress.childIndex,
+        ])
+      : JSON.stringify([
+          "workflow",
+          progress.toolCallId,
+          progress.workflowRunId,
+          progress.childId,
+        ]);
+  }
+
+  function metadataTupleKey(progress: PersistedSubagentProgress): string {
+    return JSON.stringify([
+      progress.agent ?? null,
+      progress.model ?? null,
+      progress.thinking ?? null,
+    ]);
+  }
+  ```
+
+  Do not reuse issue #125's `subagentProgressKey()`: it intentionally includes
+  lifecycle and closure fields that this presentation key must ignore.
+
+- [ ] **Step 5: Format authoritative fields without generic argument handling**
+
+  Add a dedicated formatter that returns no result when `agent` is absent:
+
+  ```ts
+  function formatAuthoritativeSubagentProgress(
+    progress: PersistedSubagentProgress,
+  ): string | undefined {
+    if (!progress.agent) return undefined;
+    const fields = [`agent=${progress.agent}`];
+    if (progress.model) fields.push(`model=${progress.model}`);
+    if (progress.thinking) fields.push(`thinking=${progress.thinking}`);
+    return `🤖 subagent (${fields.join(", ")})`;
+  }
+  ```
+
+  Do not call `formatArgumentValue()` or `truncate()` for child metadata; issue
+  #125 has already validated and bounded every accepted field.
+
+- [ ] **Step 6: Add run-scoped tuple state and the observation branch**
+
+  Add `subagentMetadataKeysByChild` to the reporter and a private method with
+  these semantics:
+
+  ```ts
+  private writeSubagentProgress(progress: PersistedSubagentProgress): void {
+    const line = formatAuthoritativeSubagentProgress(progress);
+    if (!line) return;
+
+    const childKey = childProgressKey(progress);
+    const tupleKey = metadataTupleKey(progress);
+    const seen = this.subagentMetadataKeysByChild.get(childKey);
+    if (seen?.has(tupleKey)) return;
+    if (seen) seen.add(tupleKey);
+    else this.subagentMetadataKeysByChild.set(childKey, new Set([tupleKey]));
+
+    this.writeLine(this.currentStep ? `   ${line}` : line);
+  }
+  ```
+
+  In `event()`, handle `subagent-progress` after assistant usage and before the
+  existing ordinary `tool-call` branch:
+
+  ```ts
+  if (event.observation?.type === "subagent-progress") {
+    this.writeSubagentProgress(event.observation.progress);
+    return;
+  }
+  ```
+
+  Leave the complete ordinary tool-call branch byte-for-byte unchanged so parent
+  subagent arguments and management calls retain their current formatting.
+
+- [ ] **Step 7: Run focused reporter tests and lint the changed files**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/console-progress.test.ts
+  npx eslint \
+    src/cli/commands/run-once/console-progress.ts \
+    src/cli/commands/run-once/console-progress.test.ts \
+    --max-warnings=0
+  ```
+
+  Expected: PASS. Existing parent subagent, management-call, ordinary tool,
+  step, token, and final-result snapshot tests remain unchanged and green.
+
+- [ ] **Step 8: Commit authoritative child rendering**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/console-progress.ts \
+    src/cli/commands/run-once/console-progress.test.ts
+  git commit -m "feat(run-once): render authoritative child progress"
+  ```
+
+---
+
+### Task 2: Render Canonical Unresolved Child Fallbacks
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/console-progress.test.ts`
+- Modify: `src/cli/commands/run-once/console-progress.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1's `childProgressKey()` and authoritative tuple map, plus
+  issue #125 observations whose `unresolved === true` and `agent` is absent.
+- Produces:
+
+  ```ts
+  function formatUnresolvedSubagentProgress(
+    progress: PersistedSubagentProgress,
+  ): string;
+
+  private readonly unresolvedSubagentChildren: Set<string>;
+  ```
+
+- Authoritative progress keeps precedence: if an observation contains `agent`,
+  Task 1's tuple path handles it even if malformed future input also carries
+  `unresolved: true`.
+
+- [ ] **Step 1: Write failing workflow and direct fallback tests**
+
+  Add `test("console reporter renders unresolved child fallbacks once", ...)`.
+  Begin an active step and send a workflow identity-only observation, its first
+  unresolved seal, an exact and lifecycle-changed repeat, an authoritative child
+  followed by a seal, and one direct fallback:
+
+  ```ts
+  const workflow = {
+    version: 1,
+    kind: "workflow",
+    toolCallId: "call-workflow",
+    workflowRunId: "workflow-1",
+    childId: "review-step",
+  } as const;
+  reporter.event(
+    childProgress({
+      ...workflow,
+      state: "pending",
+      model: "not-authoritative",
+    }),
+  );
+  const unresolved = {
+    ...workflow,
+    state: "failed",
+    model: "must-not-render",
+    thinking: "must-not-render",
+    unresolved: true,
+  } as const;
+  reporter.event(childProgress(unresolved));
+  reporter.event(childProgress(unresolved));
+  reporter.event(childProgress({ ...unresolved, state: "stopped" }));
+
+  const authoritative = { ...workflow, childId: "known-child" } as const;
+  reporter.event(
+    childProgress({ ...authoritative, state: "running", agent: "reviewer" }),
+  );
+  reporter.event(
+    childProgress({
+      ...authoritative,
+      state: "failed",
+      unresolved: true,
+    }),
+  );
+  reporter.event(
+    childProgress({
+      version: 1,
+      kind: "direct",
+      toolCallId: "call-direct",
+      runId: "run-123",
+      childIndex: 0,
+      state: "failed",
+      unresolved: true,
+    }),
+  );
+
+  assert.deepEqual(lines, [
+    "01 final review",
+    "   🤖 subagent (child=review-step, unresolved=true)",
+    "   🤖 subagent (agent=reviewer)",
+    "   🤖 subagent (runId=run-123, childIndex=0, unresolved=true)",
+  ]);
+  assert.equal(
+    lines.some((line) => line.includes("model=must-not-render")),
+    false,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("thinking=must-not-render")),
+    false,
+  );
+  ```
+
+  This proves identity-only non-fallback suppression, one fallback despite
+  lifecycle repeats, no metadata invention/leakage, and fallback suppression
+  after an authoritative tuple.
+
+- [ ] **Step 2: Write a failing canonical scope and outside-step test**
+
+  Add
+  `test("console reporter keeps unresolved fallback identities scoped outside a step", ...)`.
+  Without starting a step, send two workflow unresolved entries that share
+  `childId: "review-step"` but differ in both `toolCallId` and `workflowRunId`:
+
+  ```ts
+  for (const suffix of ["a", "b"]) {
+    reporter.event(
+      childProgress({
+        version: 1,
+        kind: "workflow",
+        toolCallId: `call-${suffix}`,
+        workflowRunId: `workflow-${suffix}`,
+        childId: "review-step",
+        state: "failed",
+        unresolved: true,
+      }),
+    );
+  }
+
+  assert.deepEqual(lines, [
+    "🤖 subagent (child=review-step, unresolved=true)",
+    "🤖 subagent (child=review-step, unresolved=true)",
+  ]);
+  ```
+
+  The duplicate visible text is intentional: the two canonical workflow child
+  identities are distinct even though the fallback display is bounded to
+  `childId`.
+
+- [ ] **Step 3: Run fallback tests and verify the red state**
+
+  Run:
+
+  ```sh
+  node --test --test-name-pattern="fallback|unresolved" \
+    src/cli/commands/run-once/console-progress.test.ts
+  ```
+
+  Expected: FAIL because Task 1 deliberately ignores observations without an
+  authoritative `agent`.
+
+- [ ] **Step 4: Add the identity-only fallback formatter**
+
+  Implement the formatter directly from the validated union:
+
+  ```ts
+  function formatUnresolvedSubagentProgress(
+    progress: PersistedSubagentProgress,
+  ): string {
+    return progress.kind === "workflow"
+      ? `🤖 subagent (child=${progress.childId}, unresolved=true)`
+      : `🤖 subagent (runId=${progress.runId}, childIndex=${progress.childIndex}, unresolved=true)`;
+  }
+  ```
+
+  Do not include `toolCallId` or `workflowRunId` in displayed output; they scope
+  only the internal key. Do not inspect parent tool arguments or any raw Pi
+  result to obtain display fields.
+
+- [ ] **Step 5: Extend the reporter state machine with one fallback per child**
+
+  Add `unresolvedSubagentChildren = new Set<string>()`. Refactor
+  `writeSubagentProgress()` to use the complete authoritative and fallback
+  paths:
+
+  ```ts
+  private writeSubagentProgress(progress: PersistedSubagentProgress): void {
+    const authoritativeLine = formatAuthoritativeSubagentProgress(progress);
+    if (authoritativeLine) {
+      const childKey = childProgressKey(progress);
+      const tupleKey = metadataTupleKey(progress);
+      const seen = this.subagentMetadataKeysByChild.get(childKey);
+      if (seen?.has(tupleKey)) return;
+      if (seen) seen.add(tupleKey);
+      else this.subagentMetadataKeysByChild.set(childKey, new Set([tupleKey]));
+      this.writeLine(
+        this.currentStep ? `   ${authoritativeLine}` : authoritativeLine,
+      );
+      return;
+    }
+    if (!progress.unresolved) return;
+
+    const childKey = childProgressKey(progress);
+    if (
+      this.subagentMetadataKeysByChild.has(childKey) ||
+      this.unresolvedSubagentChildren.has(childKey)
+    ) {
+      return;
+    }
+    this.unresolvedSubagentChildren.add(childKey);
+    const fallbackLine = formatUnresolvedSubagentProgress(progress);
+    this.writeLine(this.currentStep ? `   ${fallbackLine}` : fallbackLine);
+  }
+  ```
+
+  Keep the authoritative branch first. This guarantees a validated agent tuple
+  is never downgraded to an identity fallback and a later unresolved seal cannot
+  add a fallback for a child already shown authoritatively.
+
+- [ ] **Step 6: Run all focused reporter tests and run-once unit coverage**
+
+  Run:
+
+  ```sh
+  node --test src/cli/commands/run-once/console-progress.test.ts
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Failed and stopped no-agent children remain visible once,
+  authoritative children remain tuple-based, and all existing run-once output
+  behavior stays green.
+
+- [ ] **Step 7: Commit unresolved fallback rendering**
+
+  ```sh
+  git add \
+    src/cli/commands/run-once/console-progress.ts \
+    src/cli/commands/run-once/console-progress.test.ts
+  git commit -m "feat(run-once): render unresolved child fallbacks"
+  ```
+
+---
+
+### Task 3: Prove Exact-Session Operator Output and Stdout/Stderr Separation
+
+**Files:**
+
+- Modify:
+  `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts:1-24,289-601`
+- Verify unchanged: `src/cli/commands/run-once/result-output.ts`
+- Verify unchanged: `src/cli/commands/run-once/result-output.test.ts`
+- Verify unchanged: `src/cli/commands/run-once/pipeline-progress.ts`
+
+**Interfaces:**
+
+- Consumes: Tasks 1-2's production reporter, the existing
+  `subagentProgressEntry()` helper, exact parent `--session` allocation,
+  `compositeProgressReporter()`, `summarizeResult()`, and
+  `writeRunOnceResult()`.
+- Produces: one pipeline scenario that proves parent-session custom entries
+  reach the console, lifecycle-only repeats collapse only at presentation,
+  changed tuples remain ordered, failed and unresolved children remain visible,
+  sibling/nested sessions stay excluded, parent tool accounting is unchanged,
+  and redirected stdout remains compact JSON.
+- No production output or result module API changes are expected.
+
+- [ ] **Step 1: Attach the production console reporter to the existing streamed
+      implementation scenario**
+
+  In `pipeline-progress-scenarios.test.ts`, change the existing `node:path`
+  import to `import { dirname, join } from "node:path";`, add `piSessionPath` to
+  the existing mock-runner import block, and add these run-once imports:
+
+  ```ts
+  import { AgentIssueConsoleProgressReporter } from "./console-progress.ts";
+  import { compositeProgressReporter } from "./progress.ts";
+  import { summarizeResult } from "./result-summary.ts";
+  import { writeRunOnceResult } from "./result-output.ts";
+  ```
+
+  In the existing
+  `runOneIssue moves streamed tool calls under the active implementation task`
+  scenario, rename the test to mention child outcomes. Replace the single
+  collector reporter with a composite that retains event assertions and captures
+  the production console sink as stderr evidence:
+
+  ```ts
+  const collected = collectProgressEvents();
+  const stderrLines: string[] = [];
+  const consoleProgress = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => stderrLines.push(line),
+    startedAt: NOW,
+  });
+  const progress = compositeProgressReporter([
+    collected.progress,
+    consoleProgress,
+  ]);
+  const events = collected.events;
+  ```
+
+- [ ] **Step 2: Append representative authoritative lifecycle history**
+
+  Replace the scenario's simple workflow progress rows with these exact-session
+  entries while mocked Pi is still pending:
+
+  ```ts
+  const runtime = {
+    agent: "worker",
+    model: "openai/team/models/gpt-5.6-sol",
+    thinking: "high",
+  } as const;
+
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "build",
+      state: "running",
+      ...runtime,
+    }),
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "shadow-build",
+      state: "running",
+      ...runtime,
+    }),
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "review",
+      state: "pending",
+    }),
+  );
+  ```
+
+  After the existing wait for task 2 to begin, append:
+
+  ```ts
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "build",
+      state: "completed",
+      ...runtime,
+    }),
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "build",
+      state: "completed",
+      ...runtime,
+      thinking: "xhigh",
+    }),
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "review",
+      state: "failed",
+      agent: "reviewer",
+      model: "gpt-5.6-sol",
+    }),
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "workflow",
+      toolCallId: "call-1",
+      workflowRunId: "workflow",
+      childId: "unresolved-review",
+      state: "failed",
+      unresolved: true,
+    }),
+  );
+  ```
+
+  This supplies a lifecycle-only repeat, a changed tuple, two distinct children
+  with identical tuples, a failed authoritative child, an unresolved workflow
+  child, and a nested model path without changing issue #125's persisted
+  history.
+
+- [ ] **Step 3: Add direct unresolved and foreign-session fixtures**
+
+  Append one ordinary direct parent tool call, wait until it is observed, then
+  append its identity-only lifecycle and unresolved seal:
+
+  ```ts
+  await appendPiSessionEntry(
+    call,
+    assistantToolCall("call-direct", "subagent", {}),
+  );
+  await waitForCondition(
+    () =>
+      events.some((event) => event.observation?.toolCallId === "call-direct"),
+    () => "waiting for call-direct observation",
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "direct",
+      toolCallId: "call-direct",
+      runId: "run-direct",
+      childIndex: 0,
+      state: "running",
+    }),
+  );
+  await appendPiSessionEntry(
+    call,
+    subagentProgressEntry({
+      version: 1,
+      kind: "direct",
+      toolCallId: "call-direct",
+      runId: "run-direct",
+      childIndex: 0,
+      state: "failed",
+      unresolved: true,
+    }),
+  );
+  ```
+
+  Write matching foreign entries beside, but not into, the exact parent session:
+
+  ```ts
+  const parentSessionPath = await piSessionPath(call);
+  const invocationDir = dirname(parentSessionPath);
+  await mkdir(join(invocationDir, "nested"), { recursive: true });
+  for (const [path, childId] of [
+    [join(invocationDir, "sibling.jsonl"), "foreign-sibling"],
+    [join(invocationDir, "nested", "child.jsonl"), "foreign-nested"],
+  ] as const) {
+    await writeFile(
+      path,
+      `${JSON.stringify(
+        subagentProgressEntry({
+          version: 1,
+          kind: "workflow",
+          toolCallId: "foreign-call",
+          workflowRunId: "foreign-workflow",
+          childId,
+          state: "failed",
+          unresolved: true,
+        }),
+      )}\n`,
+      "utf8",
+    );
+  }
+  ```
+
+  The production exact-session streamer must never discover these sibling or
+  nested paths.
+
+- [ ] **Step 4: Assert exact console outcomes and unchanged parent accounting**
+
+  Normalize only indentation for selecting child lines, not metadata values:
+
+  ```ts
+  const robotLines = stderrLines
+    .map((line) => (line.startsWith("   ") ? line.slice(3) : line))
+    .filter((line) => line.startsWith("🤖 subagent"));
+  const stableRuntime =
+    "🤖 subagent (agent=worker, model=openai/team/models/gpt-5.6-sol, thinking=high)";
+
+  assert.equal(robotLines.filter((line) => line === stableRuntime).length, 2);
+  assert.equal(
+    robotLines.filter(
+      (line) =>
+        line ===
+        "🤖 subagent (agent=worker, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+    ).length,
+    1,
+  );
+  assert.equal(
+    robotLines.filter(
+      (line) => line === "🤖 subagent (agent=reviewer, model=gpt-5.6-sol)",
+    ).length,
+    1,
+  );
+  assert.ok(
+    robotLines.includes(
+      "🤖 subagent (child=unresolved-review, unresolved=true)",
+    ),
+  );
+  assert.ok(
+    robotLines.includes(
+      "🤖 subagent (runId=run-direct, childIndex=0, unresolved=true)",
+    ),
+  );
+  assert.equal(
+    stderrLines.some((line) => line.includes("foreign-sibling")),
+    false,
+  );
+  assert.equal(
+    stderrLines.some((line) => line.includes("foreign-nested")),
+    false,
+  );
+  ```
+
+  Replace the scenario's old exact `['build', 'review', 'build', 'review']`
+  child-ID assertion with assertions over the richer progress history:
+
+  ```ts
+  const childProgressEvents = events.flatMap((event) =>
+    event.observation?.type === "subagent-progress"
+      ? [event.observation.progress]
+      : [],
+  );
+  assert.ok(
+    childProgressEvents.some(
+      (progress) =>
+        progress.kind === "workflow" &&
+        progress.childId === "review" &&
+        progress.state === "failed" &&
+        progress.agent === "reviewer",
+    ),
+  );
+  assert.ok(
+    childProgressEvents.some(
+      (progress) =>
+        progress.kind === "direct" &&
+        progress.runId === "run-direct" &&
+        progress.childIndex === 0 &&
+        progress.unresolved === true,
+    ),
+  );
+  ```
+
+  Retain the existing ordered step/tool assertions and add `tool:call-direct` in
+  its emitted position. Update task 2's expected `toolCalls` from 2 to 3 for
+  `call-2`, `call-status`, and the newly added parent `call-direct`. Do not
+  count any child transition. The failed-event assertion ties the rendered
+  reviewer line to a failed child, not only to fixture text.
+
+- [ ] **Step 5: Compose redirected final output on a distinct stdout sink**
+
+  After `runOneIssue()` resolves, pass its production summary to the existing
+  final writer:
+
+  ```ts
+  const summary = summarizeResult(result);
+  const stdoutChunks: string[] = [];
+  await writeRunOnceResult(summary, {
+    stdout: {
+      isTTY: false,
+      write: (chunk) => stdoutChunks.push(String(chunk)),
+    },
+    env: {},
+  });
+
+  assert.equal(stdoutChunks.join(""), `${JSON.stringify(summary)}\n`);
+  assert.doesNotMatch(stdoutChunks.join(""), /🤖 subagent|unresolved=true/u);
+  assert.deepEqual(
+    JSON.parse(stdoutChunks.join("")),
+    JSON.parse(JSON.stringify(summary)),
+  );
+  ```
+
+  The `stderrLines` reporter sink must contain every expected child outcome,
+  while stdout remains one machine-readable result object. Do not modify
+  `result-output.ts` or `main.ts` to make this test pass.
+
+- [ ] **Step 6: Run the focused scenario and output suites**
+
+  Run:
+
+  ```sh
+  node --test \
+    src/cli/commands/run-once/console-progress.test.ts \
+    src/cli/commands/run-once/pipeline-progress-scenarios.test.ts \
+    src/cli/commands/run-once/result-output.test.ts
+  ```
+
+  Expected: PASS. The console reporter emits stable child lines, the pipeline
+  retains lifecycle history and parent accounting, foreign sessions remain
+  absent, and redirected output is exactly compact JSON.
+
+- [ ] **Step 7: Commit the operator-output regression**
+
+  ```sh
+  git add src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+  git commit -m "test(run-once): cover enriched child progress output"
+  ```
+
+---
+
+### Task 4: Complete Full Verification and Scope Review
+
+**Files:**
+
+- Verify: `src/cli/commands/run-once/console-progress.ts`
+- Verify: `src/cli/commands/run-once/console-progress.test.ts`
+- Verify: `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`
+- Verify unchanged: `src/cli/commands/run-once/result-output.ts`
+- Verify unchanged: all `src/pi/**`, package metadata, Nix files, and triage
+  code
+
+**Interfaces:**
+
+- Consumes: the three completed implementation commits and the approved spec.
+- Produces: fresh focused, run-once, repository, lint, build, dependency/Nix
+  condition, and scope evidence. This task creates no validation-only commit.
+
+- [ ] **Step 1: Run the approved focused regression command**
+
+  Run exactly:
+
+  ```sh
+  node --test \
+    src/cli/commands/run-once/console-progress.test.ts \
+    src/cli/commands/run-once/pipeline-progress-scenarios.test.ts \
+    src/cli/commands/run-once/result-output.test.ts
+  ```
+
+  Expected: PASS with no failed, cancelled, or skipped issue-specific tests.
+
+- [ ] **Step 2: Run the complete run-once suite**
+
+  Run:
+
+  ```sh
+  npm run test:run-once
+  ```
+
+  Expected: PASS. Existing management-call, non-child progress, session
+  ownership, accounting, result output, and triage-adjacent run-once behavior
+  remain unchanged.
+
+- [ ] **Step 3: Run repository tests, lint, and build**
+
+  Run in this order:
+
+  ```sh
+  npm test
+  npm run lint
+  npm run build
+  ```
+
+  Expected: every command exits 0 with no test failures, ESLint or markdown
+  errors, Prettier drift, or TypeScript build errors.
+
+- [ ] **Step 4: Enforce the AGENTS.md dependency/Nix condition**
+
+  Run:
+
+  ```sh
+  if git diff --quiet origin/main...HEAD -- \
+    package.json package-lock.json npm-shrinkwrap.json; then
+    echo "Nix build skipped: npm dependency metadata unchanged"
+  else
+    nix build .#patchmill --print-build-logs
+  fi
+  ```
+
+  Expected for this issue: the skip message. If implementation unexpectedly
+  retained an npm dependency metadata change, the Nix build must run and exit 0
+  before completion.
+
+- [ ] **Step 5: Review the final diff against the issue boundary**
+
+  Run:
+
+  ```sh
+  git diff --check
+  git status --short
+  git diff --stat origin/main...HEAD
+  git diff origin/main...HEAD -- \
+    src/cli/commands/run-once/console-progress.ts \
+    src/cli/commands/run-once/console-progress.test.ts \
+    src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+  git diff --quiet origin/main...HEAD -- \
+    src/pi package.json package-lock.json npm-shrinkwrap.json nix
+  ```
+
+  Expected: `git diff --check` and the final quiet diff command exit 0; the
+  worktree is clean; production changes are limited to the console reporter;
+  test changes are limited to focused reporter and pipeline/output regression
+  coverage; no lifecycle, correlation, accounting, dependency, Nix, TUI, or
+  triage code changed.
+
+- [ ] **Step 6: Record verification evidence without a new commit**
+
+  Update the Task 4 issue todo body with the exact commands and outcomes, plus
+  any residual risks found during review, then set it to the configured terminal
+  status. Do not amend a feature commit or create a validation-only commit when
+  the worktree has no source changes.
+
+---
+
+## Testing Value Gate Notes
+
+- `console-progress.test.ts` additions are warranted because they protect an
+  operator-visible formatter contract, canonical per-child deduplication,
+  metadata fidelity, omission rules, failure visibility, and fallback privacy.
+  Each assertion can fail under realistic regressions such as global tuple
+  deduplication, lifecycle spam, provider-path truncation, or invented fallback
+  metadata.
+- `pipeline-progress-scenarios.test.ts` is warranted because pure formatter
+  tests cannot prove exact parent-session entries survive the real pipeline,
+  remain independent from sibling/nested sessions, preserve parent accounting,
+  and reach the production console sink before final output.
+- Existing `result-output.test.ts` plus the composed pipeline scenario are
+  sufficient for stdout/stderr separation. No duplicate test or production
+  result-output change is planned.
+- No tests are added for spec text, plan text, static dependency versions,
+  package lock contents, or Nix source. Plan/spec prose is reviewed directly;
+  dependency changes are detected with `git diff`; and the Nix build runs only
+  if npm dependency metadata actually changes.
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 covers authoritative field order, omission, nested
+  model preservation, same-child lifecycle deduplication, changed tuples,
+  distinct-child independence, and outside-step output. Task 2 covers
+  identity-only suppression, workflow/direct fallback identity, one fallback per
+  canonical child, no inference, and authoritative precedence. Task 3 covers
+  real exact-session delivery, failed children, foreign-session exclusion,
+  parent accounting, stderr progress, and compact stdout JSON. Task 4 covers all
+  requested validation and scope gates.
+- **Module boundaries:** Presentation keys and formatting remain private to the
+  201-line console reporter, which has one run-once console responsibility.
+  Issue #125 parsing, streaming, correlation, and accounting modules stay
+  unchanged. Large existing test modules are extended only within their current
+  reporter/scenario responsibilities.
+- **Type consistency:** Every task uses the merged `PersistedSubagentProgress`
+  fields exactly: direct `toolCallId`, `runId`, and `childIndex`; workflow
+  `toolCallId`, `workflowRunId`, `childId`, and required `state`; optional
+  `agent`, `model`, `thinking`, and literal `unresolved: true`.
+- **Placeholder scan:** Every code-changing task identifies exact files,
+  interfaces, red/green commands, expected failures, implementation behavior,
+  and a Conventional Commit message. No requirement is deferred to an
+  unspecified implementation step.

--- a/docs/specs/2026-08-27-issue-126-render-enriched-subagent-progress-in-the-run-once-console-design.md
+++ b/docs/specs/2026-08-27-issue-126-render-enriched-subagent-progress-in-the-run-once-console-design.md
@@ -1,0 +1,354 @@
+# Render enriched subagent progress in the run-once console design
+
+- **Issue:** #126
+- **Parent:** #116
+- **Dependency:** #125, complete and merged
+- **Status:** Proposed design
+
+## Summary
+
+Run-once will render the validated `subagent-progress` observations introduced
+by issue #125 as concise child-level console lines. An authoritative child
+observation renders every available `agent`, `model`, and `thinking` field in
+that order. A child that closes without authoritative agent metadata renders one
+identity-only `unresolved=true` fallback using #125's canonical child identity.
+
+The console reporter will own presentation-level deduplication. It will suppress
+lifecycle-only repeats of the same child metadata tuple, render changed metadata
+as an additional line, and keep identical tuples from different children
+independent. It will not resolve metadata, reinterpret lifecycle, or alter the
+issue #125 observation contract.
+
+## Context
+
+The merged #125 contract adds this validated run-once observation:
+
+```ts
+{ type: "subagent-progress", progress: PersistedSubagentProgress }
+```
+
+`PersistedSubagentProgress` is a bounded versioned union:
+
+- direct child identity: originating `toolCallId`, `runId`, and `childIndex`;
+- workflow child identity: originating `toolCallId`, `workflowRunId`, and
+  `childId`;
+- optional authoritative `agent`, `model`, and `thinking` metadata;
+- optional lifecycle state; and
+- a literal `unresolved: true` marker for a closed child that never acquired
+  canonical agent metadata.
+
+The exact-session streamer already validates these entries, excludes sibling and
+nested sessions, and suppresses exact persisted-entry duplicates. Its tuple key
+includes lifecycle state and closure metadata, however, so a pending, running,
+and completed entry with unchanged runtime metadata remains three valid
+observations. #126 must collapse those into one console outcome without changing
+the durable or pipeline-level history.
+
+`AgentIssueConsoleProgressReporter` currently handles assistant usage and
+ordinary tool-call observations. Parent subagent calls use the existing
+`🤖 subagent (...)` summary when their arguments expose agent names, while
+management calls such as `action=list` use normal `🔧 subagent (...)`
+formatting. The reporter does not yet handle child-level `subagent-progress`
+observations.
+
+## Goals
+
+- Render one child progress line for every distinct authoritative
+  `agent`/`model`/`thinking` tuple reported for that child.
+- Render exactly one canonical identity-only fallback for each unresolved child
+  that never reports authoritative agent metadata.
+- Preserve every available authoritative metadata field and omit unavailable
+  fields without placeholders.
+- Preserve nested provider/model path segments and all accepted identifier bytes
+  exactly as #125 reports them.
+- Suppress state-only and exact metadata repeats without collapsing distinct
+  children.
+- Keep failed and unresolved children visible.
+- Preserve existing parent tool-call, management-call, non-child, accounting,
+  triage, stdout, and stderr behavior.
+- Cover both the focused formatter behavior and the complete parent-session to
+  operator-output path.
+
+## Non-goals
+
+This issue will not:
+
+- resolve or infer agent, model, thinking, provider, or child identity;
+- parse Pi lifecycle results or change #125's persisted union;
+- change session ownership, streaming, cancellation, inventory, accounting, or
+  implementation-todo progression;
+- display child lifecycle state or closure seals;
+- change `pi-subagents` or its TUI;
+- enrich triage output; or
+- change the existing run-once final-result policy for TTY versus redirected
+  stdout.
+
+## Approaches considered
+
+### Render and deduplicate in the console reporter (chosen)
+
+Add a dedicated `subagent-progress` branch and small child/tuple key helpers to
+`AgentIssueConsoleProgressReporter`. The reporter is the presentation boundary,
+sees observations in order, and already owns run-scoped console state. It can
+ignore lifecycle-only changes while the JSONL reporter and pipeline retain the
+complete observation stream.
+
+This keeps #126 consumer-only and makes console behavior directly testable.
+
+### Deduplicate in the exact-session streamer
+
+The streamer could discard observations whose metadata is unchanged. That would
+remove valid lifecycle history from every downstream consumer, couple terminal
+presentation to session parsing, and weaken #125's accounting and todo-refresh
+contract. It is rejected.
+
+### Render every #125 observation
+
+This is the smallest code change, but state transitions and workflow closure
+seals would repeat unchanged lines. It would not satisfy stable per-child tuple
+deduplication and is rejected.
+
+## Proposed console behavior
+
+### Authoritative metadata lines
+
+A child observation is authoritative for console rendering when it contains
+`agent`. `model` and `thinking` remain independently optional. Fields appear in
+the fixed order `agent`, `model`, `thinking` and use comma-and-space separators:
+
+```text
+🤖 subagent (agent=reviewer, model=gpt-5.6-sol, thinking=xhigh)
+🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol)
+🤖 subagent (agent=reviewer, thinking=xhigh)
+🤖 subagent (agent=reviewer)
+```
+
+The formatter will not trim, split, normalize, truncate, remove a provider
+prefix, or strip model suffixes. In particular, `openai/team/models/gpt-5.6-sol`
+remains byte-for-byte unchanged.
+
+A non-fallback observation without `agent` is not promoted into an authoritative
+console tuple. The reporter waits for a later authoritative observation or the
+issue #125 unresolved marker. It never treats model or thinking as child
+identity and never fills the missing agent from parent tool arguments.
+
+### Unresolved fallback lines
+
+When `unresolved === true` arrives for a child that has produced no
+authoritative console tuple, render one identity-only fallback. Metadata and
+lifecycle state are not displayed in this fallback.
+
+Workflow children use the validated `childId` value:
+
+```text
+🤖 subagent (child=review-step, unresolved=true)
+```
+
+Direct children use both validated identity components because `childIndex` is
+scoped by `runId`:
+
+```text
+🤖 subagent (runId=run-123, childIndex=0, unresolved=true)
+```
+
+The displayed workflow `child` value comes directly from `childId`; the direct
+values come directly from `runId` and `childIndex`. The reporter does not use
+array position, tool arguments, task text, a placeholder agent, or any locally
+constructed identity.
+
+Identity-only non-fallback observations, including pending async entries and
+workflow closure seals without metadata, produce no console line. #125 emits the
+unresolved marker only after authoritative inventory closure, so the reporter
+does not buffer or predict unresolved children.
+
+### Child identity and deduplication
+
+Presentation state lives for the lifetime of one console reporter, which is one
+run-once invocation. Canonical internal child keys include every #125 scoping
+component:
+
+```text
+direct:   (kind, toolCallId, runId, childIndex)
+workflow: (kind, toolCallId, workflowRunId, childId)
+```
+
+For each child, the reporter records fixed-position metadata tuple keys:
+
+```text
+(agent, model-or-absent, thinking-or-absent)
+```
+
+These rules follow:
+
+- the first authoritative tuple renders immediately;
+- an exact repeat for the same child is suppressed;
+- a state-only or `inventoryClosed` change with the same metadata is suppressed;
+- a changed agent, model, or thinking value renders an additional line;
+- earlier lines are never replaced;
+- two different children with the same metadata each render their own line; and
+- repeated unresolved entries for one child render at most one fallback.
+
+Fixed-position serialization, rather than delimiter concatenation, avoids key
+collisions when accepted values contain punctuation. The reporter does not reuse
+issue #125's full progress key because that key intentionally distinguishes
+lifecycle transitions.
+
+### Placement and existing output
+
+Child progress uses the reporter's existing indentation convention: three spaces
+inside an active step and no indentation if an observation arrives outside a
+step. It is never discarded solely because no step is active.
+
+The existing ordinary `tool-call` branch remains unchanged. Parent subagent call
+summaries, management calls such as `🔧 subagent (action=list)`, and all
+non-subagent tools retain their current formatting. Child-progress deduplication
+applies only to `subagent-progress` observations; it does not reinterpret parent
+call summaries as authoritative child metadata.
+
+The reporter continues to write through its stderr-backed `write`/`writeLine`
+sink. `writeRunOnceResult()` remains the only final-result writer on stdout.
+Redirected stdout therefore remains exactly one machine-readable JSON object;
+interactive stdout retains the terminal result behavior introduced separately
+from this issue. No child progress is written to either final-result form.
+
+## Data flow
+
+1. The #125 Pi extension appends a bounded `patchmill-subagent-progress` custom
+   entry to the exact parent session.
+2. The exact-session streamer validates the entry and emits a
+   `subagent-progress` observation.
+3. Pipeline progress records the complete observation without incrementing
+   parent `toolCalls`; implementation may refresh todos as it already does.
+4. The JSONL reporter preserves the observation for diagnostics.
+5. The console reporter derives the canonical child key and either:
+   - renders an unseen authoritative metadata tuple;
+   - renders the child's first terminal unresolved fallback; or
+   - suppresses a presentation-level repeat.
+6. Final run-once output is written separately on stdout after the pipeline
+   settles.
+
+## Affected components
+
+### `src/cli/commands/run-once/console-progress.ts`
+
+- Add focused formatting for authoritative and unresolved child observations.
+- Add run-scoped canonical child and metadata tuple state.
+- Handle `subagent-progress` before the existing ordinary tool-call branch.
+- Leave token accounting, step formatting, final-result snapshots, and generic
+  tool formatting unchanged.
+
+### `src/cli/commands/run-once/console-progress.test.ts`
+
+Add focused behavior coverage for field omission, nested model preservation,
+per-child deduplication, changed tuples, direct and workflow fallbacks, and
+existing tool-call formatting.
+
+### `src/cli/commands/run-once/pipeline-progress-scenarios.test.ts`
+
+Extend or add one operator-output scenario using real
+`patchmill-subagent-progress` parent-session entries. Attach the production
+console reporter to the pipeline's progress stream and prove that authoritative,
+failed, and unresolved child outcomes reach the console without changing parent
+accounting.
+
+### `src/cli/commands/run-once/result-output.test.ts`
+
+Only if needed to keep the end-to-end output assertion focused, compose captured
+console progress with redirected final-result output and prove that stdout
+parses as the unchanged final JSON while all child lines remain in the stderr
+sink. No production change to result output is planned.
+
+No `src/pi`, dependency, package, Nix, triage, or `pi-subagents` change belongs
+in this issue.
+
+## Failure and safety behavior
+
+- The reporter consumes only the already validated #125 projection and never
+  reads raw Pi tool results.
+- Malformed or over-limit custom entries remain filtered by the existing
+  exact-session parser and produce no console output.
+- Missing optional metadata remains absent; no placeholder text is introduced.
+- An unresolved child with no agent is still visible through canonical bounded
+  identity.
+- Failed children remain visible when #125 reports either an authoritative tuple
+  or an unresolved fallback; lifecycle state itself is not rendered.
+- Task text, output, prompts, credentials, paths, usage, and unrestricted result
+  fields never enter the formatter.
+- Reporter state is bounded by #125's existing per-session child, transition,
+  and custom-entry ceilings.
+- Console write failures retain the existing backpressured observation failure
+  behavior; this issue adds no catch that could hide them or redirect output.
+
+## Verification strategy
+
+These tests pass Patchmill's Testing Value Gate because they protect an
+operator-visible runtime contract, metadata fidelity, per-child identity, and
+stdout/stderr separation.
+
+### Focused console tests
+
+Cover:
+
+- all three authoritative fields in stable order;
+- independent omission of model and thinking;
+- a model identifier with multiple `/` path segments preserved exactly;
+- the same child and tuple repeated across pending, running, failed, or
+  completed lifecycle entries rendering once;
+- a changed agent, model, or thinking tuple rendering an additional line;
+- two children with identical metadata each rendering one line;
+- identity-only non-fallback observations producing no line;
+- one workflow fallback from `childId`;
+- one direct fallback from `runId` plus `childIndex`;
+- repeated fallback observations producing exactly one line;
+- no agent/model/thinking invention in fallbacks;
+- progress received outside an active step remaining visible; and
+- unchanged parent subagent, management-call, and ordinary tool formatting.
+
+### End-to-end regression
+
+Use the existing run-once mock runner and exact parent-session helpers to append
+real #125 custom entries while a Pi invocation is active. Include:
+
+- one child whose model/thinking tuple changes;
+- a duplicate or lifecycle-only transition;
+- one failed child with authoritative metadata;
+- unresolved workflow and direct children without agent metadata; and
+- a model with nested path segments.
+
+Assert the production pipeline plus console reporter emits exactly the expected
+child lines, keeps distinct children independent, preserves one accounting unit
+per parent tool-call ID, and does not expose sibling or nested session entries.
+Capture redirected final output separately and assert stdout is one parseable
+JSON result containing no progress text while every child line is confined to
+the stderr sink.
+
+Implementation verification should include:
+
+```sh
+node --test \
+  src/cli/commands/run-once/console-progress.test.ts \
+  src/cli/commands/run-once/pipeline-progress-scenarios.test.ts \
+  src/cli/commands/run-once/result-output.test.ts
+npm run test:run-once
+npm test
+npm run lint
+npm run build
+```
+
+No Nix build is required unless implementation unexpectedly changes an npm
+dependency file; such a dependency change is outside this design.
+
+## Acceptance mapping
+
+| Acceptance criterion                          | Design response                                                                                           |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| One line per distinct authoritative tuple     | Canonical child plus fixed-position metadata keys suppress only same-child repeats.                       |
+| Changed tuple adds a line                     | Any agent/model/thinking change creates a new presentation key; prior output remains.                     |
+| Missing fields are omitted                    | The formatter includes only available fields and never inserts placeholders.                              |
+| One fallback per unresolved child             | A per-child fallback marker renders once only on `unresolved: true`.                                      |
+| Workflow and direct fallback identity         | Workflow displays #125 `childId`; direct displays #125 `runId` and `childIndex`.                          |
+| No local resolution or inference              | Only validated observation fields are consumed; arguments and configuration are ignored.                  |
+| Nested model identifiers survive              | Rendering performs no splitting, provider stripping, normalization, or truncation.                        |
+| Failed and unresolved children remain visible | Authoritative failed tuples and identity-only unresolved fallbacks use the same child path.               |
+| Stdout/stderr remain separated                | Console progress stays on the stderr reporter; redirected final output remains one JSON object on stdout. |
+| Other run-once output is unchanged            | Existing tool-call, step, token, accounting, and final-result branches remain intact.                     |

--- a/src/cli/commands/run-once/console-progress.test.ts
+++ b/src/cli/commands/run-once/console-progress.test.ts
@@ -146,6 +146,103 @@ test("console reporter omits unavailable child metadata outside a step", () => {
   ]);
 });
 
+test("console reporter renders unresolved child fallbacks once", () => {
+  const lines: string[] = [];
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => lines.push(line),
+    startedAt: BASE,
+  });
+  const workflow = {
+    version: 1,
+    kind: "workflow",
+    toolCallId: "call-workflow",
+    workflowRunId: "workflow-1",
+    childId: "review-step",
+  } as const;
+
+  reporter.event(
+    event({ step: { type: "step-start", label: "final review" } }),
+  );
+  reporter.event(
+    childProgress({
+      ...workflow,
+      state: "pending",
+      model: "not-authoritative",
+    }),
+  );
+  const unresolved = {
+    ...workflow,
+    state: "failed",
+    model: "must-not-render",
+    thinking: "must-not-render",
+    unresolved: true,
+  } as const;
+  reporter.event(childProgress(unresolved));
+  reporter.event(childProgress(unresolved));
+  reporter.event(childProgress({ ...unresolved, state: "stopped" }));
+
+  const authoritative = { ...workflow, childId: "known-child" } as const;
+  reporter.event(
+    childProgress({ ...authoritative, state: "running", agent: "reviewer" }),
+  );
+  reporter.event(
+    childProgress({ ...authoritative, state: "failed", unresolved: true }),
+  );
+  reporter.event(
+    childProgress({
+      version: 1,
+      kind: "direct",
+      toolCallId: "call-direct",
+      runId: "run-123",
+      childIndex: 0,
+      state: "failed",
+      unresolved: true,
+    }),
+  );
+
+  assert.deepEqual(lines, [
+    "01 final review",
+    "   🤖 subagent (child=review-step, unresolved=true)",
+    "   🤖 subagent (agent=reviewer)",
+    "   🤖 subagent (runId=run-123, childIndex=0, unresolved=true)",
+  ]);
+  assert.equal(
+    lines.some((line) => line.includes("model=must-not-render")),
+    false,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("thinking=must-not-render")),
+    false,
+  );
+});
+
+test("console reporter keeps unresolved fallback identities scoped outside a step", () => {
+  const lines: string[] = [];
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => lines.push(line),
+    startedAt: BASE,
+  });
+
+  for (const suffix of ["a", "b"]) {
+    reporter.event(
+      childProgress({
+        version: 1,
+        kind: "workflow",
+        toolCallId: `call-${suffix}`,
+        workflowRunId: `workflow-${suffix}`,
+        childId: "review-step",
+        state: "failed",
+        unresolved: true,
+      }),
+    );
+  }
+
+  assert.deepEqual(lines, [
+    "🤖 subagent (child=review-step, unresolved=true)",
+    "🤖 subagent (child=review-step, unresolved=true)",
+  ]);
+});
+
 test("console reporter renders numbered steps with tool-call summaries and output token summaries", () => {
   const lines: string[] = [];
   const reporter = new AgentIssueConsoleProgressReporter({

--- a/src/cli/commands/run-once/console-progress.test.ts
+++ b/src/cli/commands/run-once/console-progress.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { AgentIssueConsoleProgressReporter } from "./console-progress.ts";
 import type { AgentIssueProgressEvent } from "./progress.ts";
+import type { PersistedSubagentProgress } from "../../../pi/subagent-progress.ts";
 
 const BASE = new Date("2026-05-22T10:00:00.000Z");
 
@@ -16,6 +17,134 @@ function event(
     ...partial,
   };
 }
+
+function childProgress(
+  progress: PersistedSubagentProgress,
+): AgentIssueProgressEvent {
+  return event({
+    level: "debug",
+    stage: "pi-implementation",
+    message: "subagent-progress",
+    observation: { type: "subagent-progress", progress },
+  });
+}
+
+test("console reporter renders each authoritative child metadata tuple once", () => {
+  const lines: string[] = [];
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => lines.push(line),
+    startedAt: BASE,
+  });
+  const identity = {
+    version: 1,
+    kind: "workflow",
+    toolCallId: "call-launch",
+    workflowRunId: "workflow-1",
+    childId: "review",
+  } as const;
+  const metadata = {
+    agent: "reviewer",
+    model: "openai/team/models/gpt-5.6-sol",
+    thinking: "xhigh",
+  } as const;
+
+  reporter.event(
+    event({ step: { type: "step-start", label: "implement task" } }),
+  );
+  for (const state of ["pending", "running", "completed"] as const) {
+    reporter.event(childProgress({ ...identity, state, ...metadata }));
+  }
+  reporter.event(
+    childProgress({ ...identity, state: "completed", ...metadata }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      inventoryClosed: true,
+      ...metadata,
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      ...metadata,
+      thinking: "high",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      ...metadata,
+      model: "openai/team/models/gpt-5.6-pro",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      state: "completed",
+      ...metadata,
+      agent: "auditor",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...identity,
+      childId: "audit",
+      state: "failed",
+      ...metadata,
+    }),
+  );
+
+  assert.deepEqual(lines, [
+    "01 implement task",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol, thinking=high)",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-pro, thinking=xhigh)",
+    "   🤖 subagent (agent=auditor, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+    "   🤖 subagent (agent=reviewer, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+  ]);
+});
+
+test("console reporter omits unavailable child metadata outside a step", () => {
+  const lines: string[] = [];
+  const reporter = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => lines.push(line),
+    startedAt: BASE,
+  });
+  const direct = {
+    version: 1,
+    kind: "direct",
+    toolCallId: "call-direct",
+    runId: "run-1",
+  } as const;
+
+  reporter.event(childProgress({ ...direct, childIndex: 0, agent: "worker" }));
+  reporter.event(
+    childProgress({
+      ...direct,
+      childIndex: 1,
+      agent: "worker",
+      model: "provider/team/models/gpt-5.6-sol",
+    }),
+  );
+  reporter.event(
+    childProgress({
+      ...direct,
+      childIndex: 2,
+      agent: "worker",
+      thinking: "xhigh",
+    }),
+  );
+
+  assert.deepEqual(lines, [
+    "🤖 subagent (agent=worker)",
+    "🤖 subagent (agent=worker, model=provider/team/models/gpt-5.6-sol)",
+    "🤖 subagent (agent=worker, thinking=xhigh)",
+  ]);
+});
 
 test("console reporter renders numbered steps with tool-call summaries and output token summaries", () => {
   const lines: string[] = [];

--- a/src/cli/commands/run-once/console-progress.ts
+++ b/src/cli/commands/run-once/console-progress.ts
@@ -1,3 +1,4 @@
+import type { PersistedSubagentProgress } from "../../../pi/subagent-progress.ts";
 import type { AgentIssueProgressEvent, ProgressReporter } from "./progress.ts";
 
 export type FinalResultProgressSnapshot = {
@@ -73,6 +74,40 @@ function formatSubagentCall(
   return undefined;
 }
 
+function childProgressKey(progress: PersistedSubagentProgress): string {
+  return progress.kind === "direct"
+    ? JSON.stringify([
+        "direct",
+        progress.toolCallId,
+        progress.runId,
+        progress.childIndex,
+      ])
+    : JSON.stringify([
+        "workflow",
+        progress.toolCallId,
+        progress.workflowRunId,
+        progress.childId,
+      ]);
+}
+
+function metadataTupleKey(progress: PersistedSubagentProgress): string {
+  return JSON.stringify([
+    progress.agent ?? null,
+    progress.model ?? null,
+    progress.thinking ?? null,
+  ]);
+}
+
+function formatAuthoritativeSubagentProgress(
+  progress: PersistedSubagentProgress,
+): string | undefined {
+  if (!progress.agent) return undefined;
+  const fields = [`agent=${progress.agent}`];
+  if (progress.model) fields.push(`model=${progress.model}`);
+  if (progress.thinking) fields.push(`thinking=${progress.thinking}`);
+  return `🤖 subagent (${fields.join(", ")})`;
+}
+
 function formatToolCall(
   toolName: string | undefined,
   args: Record<string, unknown> | undefined,
@@ -96,6 +131,7 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
   private currentStep: CurrentStep | undefined;
   private readonly deferFinalResult: boolean;
   private finalResult: FinalResultProgressSnapshot | undefined;
+  private readonly subagentMetadataKeysByChild = new Map<string, Set<string>>();
 
   constructor(options: AgentIssueConsoleProgressReporterOptions = {}) {
     this.write = options.write ?? ((chunk) => process.stderr.write(chunk));
@@ -128,6 +164,11 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
       return;
     }
 
+    if (event.observation?.type === "subagent-progress") {
+      this.writeSubagentProgress(event.observation.progress);
+      return;
+    }
+
     if (event.observation?.type === "tool-call") {
       if (this.currentStep) {
         this.writeLine(
@@ -157,6 +198,20 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
     if (event.step?.type === "step-complete") {
       this.completeCurrentStep(event);
     }
+  }
+
+  private writeSubagentProgress(progress: PersistedSubagentProgress): void {
+    const line = formatAuthoritativeSubagentProgress(progress);
+    if (!line) return;
+
+    const childKey = childProgressKey(progress);
+    const tupleKey = metadataTupleKey(progress);
+    const seen = this.subagentMetadataKeysByChild.get(childKey);
+    if (seen?.has(tupleKey)) return;
+    if (seen) seen.add(tupleKey);
+    else this.subagentMetadataKeysByChild.set(childKey, new Set([tupleKey]));
+
+    this.writeLine(this.currentStep ? `   ${line}` : line);
   }
 
   private completeCurrentStep(event: AgentIssueProgressEvent): void {

--- a/src/cli/commands/run-once/console-progress.ts
+++ b/src/cli/commands/run-once/console-progress.ts
@@ -108,6 +108,14 @@ function formatAuthoritativeSubagentProgress(
   return `🤖 subagent (${fields.join(", ")})`;
 }
 
+function formatUnresolvedSubagentProgress(
+  progress: PersistedSubagentProgress,
+): string {
+  return progress.kind === "workflow"
+    ? `🤖 subagent (child=${progress.childId}, unresolved=true)`
+    : `🤖 subagent (runId=${progress.runId}, childIndex=${progress.childIndex}, unresolved=true)`;
+}
+
 function formatToolCall(
   toolName: string | undefined,
   args: Record<string, unknown> | undefined,
@@ -132,6 +140,7 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
   private readonly deferFinalResult: boolean;
   private finalResult: FinalResultProgressSnapshot | undefined;
   private readonly subagentMetadataKeysByChild = new Map<string, Set<string>>();
+  private readonly unresolvedSubagentChildren = new Set<string>();
 
   constructor(options: AgentIssueConsoleProgressReporterOptions = {}) {
     this.write = options.write ?? ((chunk) => process.stderr.write(chunk));
@@ -201,17 +210,31 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
   }
 
   private writeSubagentProgress(progress: PersistedSubagentProgress): void {
-    const line = formatAuthoritativeSubagentProgress(progress);
-    if (!line) return;
+    const authoritativeLine = formatAuthoritativeSubagentProgress(progress);
+    if (authoritativeLine) {
+      const childKey = childProgressKey(progress);
+      const tupleKey = metadataTupleKey(progress);
+      const seen = this.subagentMetadataKeysByChild.get(childKey);
+      if (seen?.has(tupleKey)) return;
+      if (seen) seen.add(tupleKey);
+      else this.subagentMetadataKeysByChild.set(childKey, new Set([tupleKey]));
+      this.writeLine(
+        this.currentStep ? `   ${authoritativeLine}` : authoritativeLine,
+      );
+      return;
+    }
+    if (!progress.unresolved) return;
 
     const childKey = childProgressKey(progress);
-    const tupleKey = metadataTupleKey(progress);
-    const seen = this.subagentMetadataKeysByChild.get(childKey);
-    if (seen?.has(tupleKey)) return;
-    if (seen) seen.add(tupleKey);
-    else this.subagentMetadataKeysByChild.set(childKey, new Set([tupleKey]));
-
-    this.writeLine(this.currentStep ? `   ${line}` : line);
+    if (
+      this.subagentMetadataKeysByChild.has(childKey) ||
+      this.unresolvedSubagentChildren.has(childKey)
+    ) {
+      return;
+    }
+    this.unresolvedSubagentChildren.add(childKey);
+    const fallbackLine = formatUnresolvedSubagentProgress(progress);
+    this.writeLine(this.currentStep ? `   ${fallbackLine}` : fallbackLine);
   }
 
   private completeCurrentStep(event: AgentIssueProgressEvent): void {

--- a/src/cli/commands/run-once/console-progress.ts
+++ b/src/cli/commands/run-once/console-progress.ts
@@ -1,4 +1,5 @@
 import type { PersistedSubagentProgress } from "../../../pi/subagent-progress.ts";
+import { childProgressIdentity } from "../../../pi/subagent-progress-correlation-state.ts";
 import type { AgentIssueProgressEvent, ProgressReporter } from "./progress.ts";
 
 export type FinalResultProgressSnapshot = {
@@ -72,22 +73,6 @@ function formatSubagentCall(
   if (agents.length === 1) return `🤖 subagent (agent=${agents[0]})`;
   if (agents.length > 1) return `🤖 subagent (agents=${agents.join(", ")})`;
   return undefined;
-}
-
-function childProgressKey(progress: PersistedSubagentProgress): string {
-  return progress.kind === "direct"
-    ? JSON.stringify([
-        "direct",
-        progress.toolCallId,
-        progress.runId,
-        progress.childIndex,
-      ])
-    : JSON.stringify([
-        "workflow",
-        progress.toolCallId,
-        progress.workflowRunId,
-        progress.childId,
-      ]);
 }
 
 function metadataTupleKey(progress: PersistedSubagentProgress): string {
@@ -212,7 +197,7 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
   private writeSubagentProgress(progress: PersistedSubagentProgress): void {
     const authoritativeLine = formatAuthoritativeSubagentProgress(progress);
     if (authoritativeLine) {
-      const childKey = childProgressKey(progress);
+      const childKey = childProgressIdentity(progress);
       const tupleKey = metadataTupleKey(progress);
       const seen = this.subagentMetadataKeysByChild.get(childKey);
       if (seen?.has(tupleKey)) return;
@@ -225,7 +210,7 @@ export class AgentIssueConsoleProgressReporter implements ProgressReporter {
     }
     if (!progress.unresolved) return;
 
-    const childKey = childProgressKey(progress);
+    const childKey = childProgressIdentity(progress);
     if (
       this.subagentMetadataKeysByChild.has(childKey) ||
       this.unresolvedSubagentChildren.has(childKey)

--- a/src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
+++ b/src/cli/commands/run-once/pipeline-progress-scenarios.test.ts
@@ -1,8 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { AgentIssueConsoleProgressReporter } from "./console-progress.ts";
 import { runOneIssue } from "./pipeline.ts";
+import { compositeProgressReporter } from "./progress.ts";
+import { writeRunOnceResult } from "./result-output.ts";
+import { summarizeResult } from "./result-summary.ts";
 import {
   issue,
   issueListPayload,
@@ -14,6 +18,7 @@ import {
   createMockRunner,
   subagentProgressEntry,
   initializePiSession,
+  piSessionPath,
   promptPath,
   waitForCondition,
   workflowPiCalls,
@@ -286,7 +291,7 @@ test("runOneIssue emits visible implementation subtask step labels", async () =>
   assert.equal(labels.includes("implement issue"), false);
 });
 
-test("runOneIssue moves streamed tool calls under the active implementation task", async () => {
+test("runOneIssue renders streamed child outcomes under the active implementation task", async () => {
   const config = await makeConfig({
     dryRun: false,
     execute: true,
@@ -398,6 +403,11 @@ test("runOneIssue moves streamed tool calls under the active implementation task
         "issue-77-task-02-second-cycle",
         "in-progress",
       );
+      const runtime = {
+        agent: "worker",
+        model: "openai/team/models/gpt-5.6-sol",
+        thinking: "high",
+      } as const;
       await appendPiSessionEntry(
         call,
         subagentProgressEntry({
@@ -407,7 +417,19 @@ test("runOneIssue moves streamed tool calls under the active implementation task
           workflowRunId: "workflow",
           childId: "build",
           state: "running",
-          agent: "worker",
+          ...runtime,
+        }),
+      );
+      await appendPiSessionEntry(
+        call,
+        subagentProgressEntry({
+          version: 1,
+          kind: "workflow",
+          toolCallId: "call-1",
+          workflowRunId: "workflow",
+          childId: "shadow-build",
+          state: "running",
+          ...runtime,
         }),
       );
       await appendPiSessionEntry(
@@ -419,7 +441,6 @@ test("runOneIssue moves streamed tool calls under the active implementation task
           workflowRunId: "workflow",
           childId: "review",
           state: "pending",
-          agent: "reviewer",
         }),
       );
       await waitForCondition(
@@ -440,7 +461,20 @@ test("runOneIssue moves streamed tool calls under the active implementation task
           workflowRunId: "workflow",
           childId: "build",
           state: "completed",
-          agent: "worker",
+          ...runtime,
+        }),
+      );
+      await appendPiSessionEntry(
+        call,
+        subagentProgressEntry({
+          version: 1,
+          kind: "workflow",
+          toolCallId: "call-1",
+          workflowRunId: "workflow",
+          childId: "build",
+          state: "completed",
+          ...runtime,
+          thinking: "xhigh",
         }),
       );
       await appendPiSessionEntry(
@@ -453,6 +487,19 @@ test("runOneIssue moves streamed tool calls under the active implementation task
           childId: "review",
           state: "failed",
           agent: "reviewer",
+          model: "gpt-5.6-sol",
+        }),
+      );
+      await appendPiSessionEntry(
+        call,
+        subagentProgressEntry({
+          version: 1,
+          kind: "workflow",
+          toolCallId: "call-1",
+          workflowRunId: "workflow",
+          childId: "unresolved-review",
+          state: "failed",
+          unresolved: true,
         }),
       );
       await appendPiSessionEntry(
@@ -475,6 +522,64 @@ test("runOneIssue moves streamed tool calls under the active implementation task
           ),
         () => "waiting for call-status observation",
       );
+
+      await appendPiSessionEntry(
+        call,
+        assistantToolCall("call-direct", "subagent", {}),
+      );
+      await waitForCondition(
+        () =>
+          events.some(
+            (event) => event.observation?.toolCallId === "call-direct",
+          ),
+        () => "waiting for call-direct observation",
+      );
+      await appendPiSessionEntry(
+        call,
+        subagentProgressEntry({
+          version: 1,
+          kind: "direct",
+          toolCallId: "call-direct",
+          runId: "run-direct",
+          childIndex: 0,
+          state: "running",
+        }),
+      );
+      await appendPiSessionEntry(
+        call,
+        subagentProgressEntry({
+          version: 1,
+          kind: "direct",
+          toolCallId: "call-direct",
+          runId: "run-direct",
+          childIndex: 0,
+          state: "failed",
+          unresolved: true,
+        }),
+      );
+      const parentSessionPath = await piSessionPath(call);
+      const invocationDir = dirname(parentSessionPath);
+      await mkdir(join(invocationDir, "nested"), { recursive: true });
+      for (const [path, childId] of [
+        [join(invocationDir, "sibling.jsonl"), "foreign-sibling"],
+        [join(invocationDir, "nested", "child.jsonl"), "foreign-nested"],
+      ] as const) {
+        await writeFile(
+          path,
+          `${JSON.stringify(
+            subagentProgressEntry({
+              version: 1,
+              kind: "workflow",
+              toolCallId: "foreign-call",
+              workflowRunId: "foreign-workflow",
+              childId,
+              state: "failed",
+              unresolved: true,
+            }),
+          )}\n`,
+          "utf8",
+        );
+      }
 
       await writeTodo(
         worktreeRoot,
@@ -526,7 +631,17 @@ test("runOneIssue moves streamed tool calls under the active implementation task
     );
   });
 
-  const { events, progress } = collectProgressEvents();
+  const collected = collectProgressEvents();
+  const stderrLines: string[] = [];
+  const consoleProgress = new AgentIssueConsoleProgressReporter({
+    writeLine: (line) => stderrLines.push(line),
+    startedAt: NOW,
+  });
+  const progress = compositeProgressReporter([
+    collected.progress,
+    consoleProgress,
+  ]);
+  const events = collected.events;
   const result = await runOneIssue(runner, config, {
     now: NOW,
     progress,
@@ -548,16 +663,67 @@ test("runOneIssue moves streamed tool calls under the active implementation task
     })
     .filter((line): line is string => line !== undefined);
 
-  assert.deepEqual(
-    events
-      .filter((event) => event.observation?.type === "subagent-progress")
-      .map((event) =>
-        event.observation?.type === "subagent-progress" &&
-        event.observation.progress.kind === "workflow"
-          ? event.observation.progress.childId
-          : "",
-      ),
-    ["build", "review", "build", "review"],
+  const robotLines = stderrLines
+    .map((line) => (line.startsWith("   ") ? line.slice(3) : line))
+    .filter((line) => line.startsWith("🤖 subagent"));
+  const stableRuntime =
+    "🤖 subagent (agent=worker, model=openai/team/models/gpt-5.6-sol, thinking=high)";
+  assert.equal(robotLines.filter((line) => line === stableRuntime).length, 2);
+  assert.equal(
+    robotLines.filter(
+      (line) =>
+        line ===
+        "🤖 subagent (agent=worker, model=openai/team/models/gpt-5.6-sol, thinking=xhigh)",
+    ).length,
+    1,
+  );
+  assert.equal(
+    robotLines.filter(
+      (line) => line === "🤖 subagent (agent=reviewer, model=gpt-5.6-sol)",
+    ).length,
+    1,
+  );
+  assert.ok(
+    robotLines.includes(
+      "🤖 subagent (child=unresolved-review, unresolved=true)",
+    ),
+  );
+  assert.ok(
+    robotLines.includes(
+      "🤖 subagent (runId=run-direct, childIndex=0, unresolved=true)",
+    ),
+  );
+  assert.equal(
+    stderrLines.some((line) => line.includes("foreign-sibling")),
+    false,
+  );
+  assert.equal(
+    stderrLines.some((line) => line.includes("foreign-nested")),
+    false,
+  );
+
+  const childProgressEvents = events.flatMap((event) =>
+    event.observation?.type === "subagent-progress"
+      ? [event.observation.progress]
+      : [],
+  );
+  assert.ok(
+    childProgressEvents.some(
+      (progress) =>
+        progress.kind === "workflow" &&
+        progress.childId === "review" &&
+        progress.state === "failed" &&
+        progress.agent === "reviewer",
+    ),
+  );
+  assert.ok(
+    childProgressEvents.some(
+      (progress) =>
+        progress.kind === "direct" &&
+        progress.runId === "run-direct" &&
+        progress.childIndex === 0 &&
+        progress.unresolved === true,
+    ),
   );
   assert.equal(
     events.find(
@@ -573,7 +739,7 @@ test("runOneIssue moves streamed tool calls under the active implementation task
         event.step?.type === "step-complete" &&
         event.step.label === "implement task 2/3 second cycle",
     )?.step?.toolCalls,
-    2,
+    3,
   );
   assert.deepEqual(
     rendered.filter(
@@ -589,6 +755,7 @@ test("runOneIssue moves streamed tool calls under the active implementation task
       "tool:call-1",
       "complete:implement task 1/3 first cycle",
       "start:implement task 2/3 second cycle",
+      "tool:call-direct",
       "complete:implement task 2/3 second cycle",
       "start:implement task 3/3 third cycle",
       "tool:call-3",
@@ -597,6 +764,22 @@ test("runOneIssue moves streamed tool calls under the active implementation task
       "tool:call-4",
       "complete:final review and landing",
     ],
+  );
+
+  const summary = summarizeResult(result);
+  const stdoutChunks: string[] = [];
+  await writeRunOnceResult(summary, {
+    stdout: {
+      isTTY: false,
+      write: (chunk) => stdoutChunks.push(String(chunk)),
+    },
+    env: {},
+  });
+  assert.equal(stdoutChunks.join(""), `${JSON.stringify(summary)}\n`);
+  assert.doesNotMatch(stdoutChunks.join(""), /🤖 subagent|unresolved=true/u);
+  assert.deepEqual(
+    JSON.parse(stdoutChunks.join("")),
+    JSON.parse(JSON.stringify(summary)),
   );
 });
 


### PR DESCRIPTION
## Summary

- Render authoritative subagent child progress with available agent, model, and thinking metadata in stable field order.
- Deduplicate metadata tuples per canonical child while preserving changed tuples and nested model identifiers.
- Render canonical workflow and direct identity-only fallbacks for unresolved children without inventing metadata.
- Add focused reporter and exact-session pipeline coverage for failures, accounting, foreign-session exclusion, and stdout/stderr separation.

## Validation

- `node --test src/cli/commands/run-once/console-progress.test.ts src/cli/commands/run-once/pipeline-progress-scenarios.test.ts src/cli/commands/run-once/result-output.test.ts` — 29 passed
- `npm run test:run-once` — 516 passed
- `npm test` — 1,411 passed
- `npm run lint` — passed
- `npm run build` — passed
- Dependency/Nix condition — npm dependency metadata unchanged; Nix build skipped as specified
- `git diff --check` and forbidden-scope diff checks — passed

## Reviews

- Final Codex full-worktree review passed with no findings.
- Thermo-nuclear review found duplicate canonical child identity serialization; fixed by reusing `childProgressIdentity()` in `a87378a`.
- Thermo-nuclear re-review passed with no findings.
- Final validation-readiness review passed with no findings.

Closes #126

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Planning | gpt-5.6-sol | 4,370,238 | 36,292 | $4.1232 |
| Development environment | gpt-5.6-sol | 375,724 | 2,893 | $0.5991 |
| Implementation | gpt-5.6-sol | 8,179,313 | 66,689 | $9.7358 |
| Implementation | gpt-5.6-terra | 2,905,079 | 13,535 | $1.2420 |
| **Implementation subtotal** |  | **11,084,392** | **80,224** | **$10.9778** |
| **Total** |  | **15,830,354** | **119,409** | **$15.7001** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->