### PR TITLE
fix: preserve ignored state during blocked retry

### DIFF
--- a/docs/plans/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state.md
+++ b/docs/plans/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state.md
@@ -1,8 +1,8 @@
 # Preserve Ignored Agent State During Blocked-Run Retry Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use
-> `subagent-driven-development` (recommended) or `executing-plans` to implement
-> this plan task by task. Track every checkbox (`- [ ]`) as it is completed.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
+> (recommended) or `executing-plans` to implement this plan task by task. Track
+> every checkbox (`- [ ]`) as it is completed.
 
 **Goal:** Let an explicit retry resume a verified clean Issue run worktree in
 place while preserving all ignored content, without weakening safeguards for
@@ -25,8 +25,8 @@ Astro documentation; no new dependency.
 
 ## Global Constraints
 
-- Use the domain terms **Issue run**, **Run attempt**, and **Run recovery state**
-  from `CONTEXT.md`.
+- Use the domain terms **Issue run**, **Run attempt**, and **Run recovery
+  state** from `CONTEXT.md`.
 - Only an explicit, acknowledged blocked retry may use this exception; do not
   change issue selection, labels, leases, checkpoints, artifacts, or reset seed
   semantics.
@@ -52,8 +52,8 @@ Astro documentation; no new dependency.
   processes.
 - Keep `pipeline.ts` (currently about 936 lines) as narrow orchestration only.
   Put focused ignored-content tests in new files rather than expanding
-  `recovery.test.ts` (currently about 771 lines) or
-  `recovery-mutation.test.ts` (currently about 707 lines).
+  `recovery.test.ts` (currently about 771 lines) or `recovery-mutation.test.ts`
+  (currently about 707 lines).
 - `recovery-archive.ts` continues to serialize assessment evidence; no persisted
   Run recovery state schema field is added.
 - Do not change `package.json`, `package-lock.json`, or `npm-shrinkwrap.json`.
@@ -106,13 +106,15 @@ Astro documentation; no new dependency.
 
 ### Destructive recovery safety
 
-- `src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts` — add the
-  missing real-Git refresh race where ignored content appears after assessment
-  and stops detach, ref update, and publication.
-- `src/cli/commands/run/reset/reset.test.ts` — prove pre-existing ignored content
-  refuses reset before archive or mutation and reports the blocked reset action.
+- `src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts` — add
+  the missing real-Git refresh race where ignored content appears after
+  assessment and stops detach, ref update, and publication.
+- `src/cli/commands/run/reset/reset.test.ts` — prove pre-existing ignored
+  content refuses reset before archive or mutation and reports the blocked reset
+  action.
 - `src/cli/commands/run-once/recovery-mutation-helpers.ts` — intentionally
-  unchanged; its complete ordinary-plus-ignored late check remains authoritative.
+  unchanged; its complete ordinary-plus-ignored late check remains
+  authoritative.
 - `src/cli/commands/run-once/recovery-mutation-refresh.ts` and
   `src/cli/commands/run-once/recovery-mutation-reset.ts` — intentionally
   unchanged unless a new regression test exposes a real safety gap.
@@ -161,10 +163,7 @@ export type RunRecoveryAction =
   | "recreate-and-resume"
   | "archive-reset-and-start";
 
-export type RunRecoveryMutatingAction = Exclude<
-  RunRecoveryAction,
-  "resume"
->;
+export type RunRecoveryMutatingAction = Exclude<RunRecoveryAction, "resume">;
 
 export type RunRecoveryRefusalReason =
   | RunRecoveryClassification
@@ -174,8 +173,8 @@ export type RunRecoveryRefusalReason =
 
 - Replace ambiguous `worktree.clean?: boolean` with
   `worktree.ordinaryClean?: boolean`. `ordinaryClean` is true exactly when the
-  configured ordinary-status exclusions leave no blocking line; it remains
-  true when `ignoredEntries` is non-empty.
+  configured ordinary-status exclusions leave no blocking line; it remains true
+  when `ignoredEntries` is non-empty.
 - The assessment refusal variant for `reason: "ignored-worktree-content"`
   carries `blockedAction: RunRecoveryMutatingAction`. Other assessed refusals do
   not claim a blocked action. The existing `active-run` refusal remains
@@ -259,8 +258,7 @@ Add six more cases with these outcomes:
 Assert `formatRunRecoveryDecision()` says the destructive action cannot prove
 ignored content will survive, lists normalized entries, and does not contain
 `resuming in place`. Assert formatting an allowed ignored `resume` says
-`resuming in place without workspace mutation` and `preserving ignored
-entries`.
+`resuming in place without workspace mutation` and `preserving ignored entries`.
 
 - [ ] **Step 2: Run the focused test and verify the regression**
 
@@ -272,9 +270,9 @@ node --test \
 ```
 
 Expected: FAIL because ignored entries currently become the intrinsic
-`ignored-worktree-content` classification, current/commit-bearing retries refuse,
-`ordinaryClean` and `blockedAction` do not exist, and preservation formatting is
-absent.
+`ignored-worktree-content` classification, current/commit-bearing retries
+refuse, `ordinaryClean` and `blockedAction` do not exist, and preservation
+formatting is absent.
 
 - [ ] **Step 3: Clarify the recovery types**
 
@@ -313,15 +311,12 @@ Change `classify()` so its ordered decisions are:
 ```ts
 if (workspaceIdentityIsUnsafe) return "workspace-unverifiable";
 if (input.dirty) return "dirty-worktree";
-if (!input.branchExists && input.savedCommits.length)
-  return "unmerged-commits";
+if (!input.branchExists && input.savedCommits.length) return "unmerged-commits";
 if (input.active && !input.fenced) return "legacy-active-unfenced";
-if (!input.branchExists || !input.worktreeExists)
-  return "recreatable-clean";
+if (!input.branchExists || !input.worktreeExists) return "recreatable-clean";
 if (input.commits.length || (input.divergence?.ahead ?? 0) > 0)
   return "resumable-with-commits";
-if ((input.divergence?.behind ?? 0) > 0)
-  return "resumable-stale-base";
+if ((input.divergence?.behind ?? 0) > 0) return "resumable-stale-base";
 return "resumable-current";
 ```
 
@@ -384,8 +379,9 @@ dirty, commit-loss, and identity diagnostics.
 - [ ] **Step 7: Update existing typed fixtures and archived evidence coverage**
 
 Update `recovery.test.ts` assessment factories and any compile-time fixtures to
-use `ordinaryClean`. Preserve all legacy `BlockedRunRecoveryReport.worktree.clean`
-uses because that is a separate compatibility type.
+use `ordinaryClean`. Preserve all legacy
+`BlockedRunRecoveryReport.worktree.clean` uses because that is a separate
+compatibility type.
 
 In `recovery-archive.test.ts`, include an assessment fixture with
 `ordinaryClean: true`, a non-empty `ignoredStatus`, and a non-empty
@@ -470,8 +466,8 @@ onPi?: (
 ) => CommandResult | Promise<CommandResult>;
 ```
 
-Import `Call` from `mock-runner.ts`. For worktree status, use
-`ignoredStatus` only when arguments contain `--ignored=matching`; otherwise use
+Import `Call` from `mock-runner.ts`. For worktree status, use `ignoredStatus`
+only when arguments contain `--ignored=matching`; otherwise use
 `ordinaryStatus`. Retain `dirtyStatus` as a backwards-compatible fallback for
 existing tests:
 
@@ -531,18 +527,16 @@ assert.ok(
   ),
 );
 assert.equal(timeline.at(-1), "pi");
-assert.deepEqual(
-  runner.calls.filter(isRecoveryMutationCommand),
-  [],
-);
+assert.deepEqual(runner.calls.filter(isRecoveryMutationCommand), []);
 ```
 
-Define `isRecoveryMutationCommand()` to reject `git worktree add`, `git worktree
-move`, `git update-ref`, `git reset`, and `git clean`. Also assert the worktree
-root keeps the same device/inode, the result reaches `pr-created`, and the
-commit-bearing-behind case does not refresh to the base.
+Define `isRecoveryMutationCommand()` to reject `git worktree add`,
+`git worktree move`, `git update-ref`, `git reset`, and `git clean`. Also assert
+the worktree root keeps the same device/inode, the result reaches `pr-created`,
+and the commit-bearing-behind case does not refresh to the base.
 
-- [ ] **Step 3: Run the pipeline test and verify the missing outcome diagnostic**
+- [ ] **Step 3: Run the pipeline test and verify the missing outcome
+      diagnostic**
 
 Run:
 
@@ -635,7 +629,8 @@ git commit -m "fix: preserve ignored state on blocked retry"
 - Verify unchanged: `src/cli/commands/run-once/recovery-mutation-helpers.ts`
 - Verify unchanged: `src/cli/commands/run-once/recovery-mutation-refresh.ts`
 - Verify unchanged: `src/cli/commands/run-once/recovery-mutation-reset.ts`
-- Verify unchanged: `src/cli/commands/run-once/recovery-mutation.test.ts:409-466`
+- Verify unchanged:
+  `src/cli/commands/run-once/recovery-mutation.test.ts:409-466`
 
 **Interfaces:**
 
@@ -648,26 +643,31 @@ git commit -m "fix: preserve ignored state on blocked retry"
 
 - [ ] **Step 1: Add a real-Git pre-existing ignored reset test**
 
-Use the existing `resetFixture()` in `run/reset/reset.test.ts`. Add
-`.env.local` to the repository's common `.git/info/exclude`, write a sentinel in
-the registered issue worktree, and record the issue branch OID. Inject archive
-and mutation spies:
+Use the existing `resetFixture()` in `run/reset/reset.test.ts`. Add `.env.local`
+to the repository's common `.git/info/exclude`, write a sentinel in the
+registered issue worktree, and record the issue branch OID. Inject archive and
+mutation spies:
 
 ```ts
 let archiveCalled = false;
 let mutationCalled = false;
 await assert.rejects(
-  resetIssueRun(fixture.runner, fixture.runConfig, { now: NOW }, {
-    ...fixture.dependencies,
-    archiveRecovery: async () => {
-      archiveCalled = true;
-      return { path: "must-not-exist" };
+  resetIssueRun(
+    fixture.runner,
+    fixture.runConfig,
+    { now: NOW },
+    {
+      ...fixture.dependencies,
+      archiveRecovery: async () => {
+        archiveCalled = true;
+        return { path: "must-not-exist" };
+      },
+      executeMutation: async () => {
+        mutationCalled = true;
+        throw new Error("mutation must not run");
+      },
     },
-    executeMutation: async () => {
-      mutationCalled = true;
-      throw new Error("mutation must not run");
-    },
-  }),
+  ),
   (error: unknown) => {
     assert.match(String(error), /ignored-worktree-content/);
     assert.match(String(error), /archive-reset-and-start/);
@@ -686,14 +686,14 @@ positioned before both destructive reset phases.
 - [ ] **Step 2: Add the missing late-ignored refresh race test**
 
 Create `recovery-mutation-ignored-content.test.ts` with a real repository whose
-initial commit includes `.gitignore` for `.cache/`, a stale issue branch/worktree,
-and a newer base commit. Construct the existing pinned
+initial commit includes `.gitignore` for `.cache/`, a stale issue
+branch/worktree, and a newer base commit. Construct the existing pinned
 `refresh-and-resume` decision. Wrap the real-Git runner so immediately after the
-first successful `git worktree move` it writes
-`quarantine/.cache/late.bin` and records all subsequent commands.
+first successful `git worktree move` it writes `quarantine/.cache/late.bin` and
+records all subsequent commands.
 
-Invoke `executeRunRecoveryMutation()` and assert a
-`RunRecoveryMutationError`. Then assert:
+Invoke `executeRunRecoveryMutation()` and assert a `RunRecoveryMutationError`.
+Then assert:
 
 ```ts
 assert.deepEqual(
@@ -710,8 +710,7 @@ assert.equal(
   false,
 );
 assert.equal(
-  calls.filter((args) => args[0] === "worktree" && args[1] === "move")
-    .length,
+  calls.filter((args) => args[0] === "worktree" && args[1] === "move").length,
   1,
 );
 ```
@@ -878,13 +877,13 @@ git commit -m "docs: explain ignored state recovery safety"
 
 ## Acceptance Mapping
 
-| Acceptance criterion | Plan evidence |
-| --- | --- |
-| Clean commit-bearing retry resumes with ignored files | Task 1 selects `resume`; Task 2 exercises an ahead-and-behind branch through Pi. |
-| Ignored workflow bytes are identical at agent start | Task 2 reads four sentinel files and compares bytes/device/inode in the Pi callback. |
-| Retry does not refresh, reset, delete, or replace | Task 2 checks worktree identity and rejects every recovery mutation command. |
-| Current zero-ahead worktree resumes | Task 1 policy and Task 2 pipeline cases use `ahead = 0`, `behind = 0`. |
-| Destructive mutation remains fail-closed | Tasks 1 and 3 refuse stale refresh/recreate/reset and preserve reset's stronger commit refusal. |
-| Refresh/reset late races remain effective | Task 3 adds refresh race coverage and reruns the existing reset race. |
-| Diagnostics distinguish preserve from refuse | Task 1 formats separate messages; Task 2 proves preservation is emitted before Pi; Task 3 checks reset refusal action. |
-| Workflow and ordinary ignored paths are covered | Tasks 1 and 2 include `.pi/todos/`, `.superpowers/`, and `.cache/`. |
+| Acceptance criterion                                  | Plan evidence                                                                                                          |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Clean commit-bearing retry resumes with ignored files | Task 1 selects `resume`; Task 2 exercises an ahead-and-behind branch through Pi.                                       |
+| Ignored workflow bytes are identical at agent start   | Task 2 reads four sentinel files and compares bytes/device/inode in the Pi callback.                                   |
+| Retry does not refresh, reset, delete, or replace     | Task 2 checks worktree identity and rejects every recovery mutation command.                                           |
+| Current zero-ahead worktree resumes                   | Task 1 policy and Task 2 pipeline cases use `ahead = 0`, `behind = 0`.                                                 |
+| Destructive mutation remains fail-closed              | Tasks 1 and 3 refuse stale refresh/recreate/reset and preserve reset's stronger commit refusal.                        |
+| Refresh/reset late races remain effective             | Task 3 adds refresh race coverage and reruns the existing reset race.                                                  |
+| Diagnostics distinguish preserve from refuse          | Task 1 formats separate messages; Task 2 proves preservation is emitted before Pi; Task 3 checks reset refusal action. |
+| Workflow and ordinary ignored paths are covered       | Tasks 1 and 2 include `.pi/todos/`, `.superpowers/`, and `.cache/`.                                                    |

--- a/docs/plans/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state.md
+++ b/docs/plans/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state.md
@@ -1,0 +1,890 @@
+# Preserve Ignored Agent State During Blocked-Run Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `subagent-driven-development` (recommended) or `executing-plans` to implement
+> this plan task by task. Track every checkbox (`- [ ]`) as it is completed.
+
+**Goal:** Let an explicit retry resume a verified clean Issue run worktree in
+place while preserving all ignored content, without weakening safeguards for
+recovery actions that mutate workspace state.
+
+**Architecture:** Keep recovery assessment read-only and represent ordinary Git
+cleanliness, ignored inventory, and intrinsic branch/worktree shape as separate
+facts. Derive the candidate recovery action from non-ignored facts, then allow
+ignored content only for a verified `resume`; refuse every mutating candidate
+with a typed blocked action. Return the applied blocked-recovery outcome to the
+pipeline so it can report preservation before invoking Pi, while existing
+refresh/reset late-content guards remain unchanged.
+
+**Tech Stack:** TypeScript 6, Node.js 22 filesystem/process APIs, `node:test`,
+real-Git integration fixtures, the existing run-once progress pipeline, and
+Astro documentation; no new dependency.
+
+**Spec:**
+`docs/specs/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state-design.md`
+
+## Global Constraints
+
+- Use the domain terms **Issue run**, **Run attempt**, and **Run recovery state**
+  from `CONTEXT.md`.
+- Only an explicit, acknowledged blocked retry may use this exception; do not
+  change issue selection, labels, leases, checkpoints, artifacts, or reset seed
+  semantics.
+- Ordinary tracked or untracked dirty status remains a refusal even when ignored
+  entries are also present.
+- A verified current worktree and a verified commit-bearing worktree, including
+  one that is behind the base, resume in place without a worktree or ref
+  mutation.
+- A zero-ahead branch with `behind > 0` remains stale and must not resume stale
+  content merely to avoid the ignored-content guard.
+- Apply the same preservation policy to every ignored path. Do not add a
+  workflow-path allowlist, backup, hash, copy, stash, clean, or force option.
+- Ignored content must refuse `refresh-and-resume`, `recreate-and-resume`, and
+  `archive-reset-and-start`, including any future action routed through the
+  recovery mutation layer.
+- Reset of a branch with actual unique commits retains the stronger
+  `unmerged-commits` refusal even when ignored entries also exist.
+- Do not weaken or filter `assertRecoveryWorkspaceUnchanged()`; late ordinary or
+  ignored content during refresh/reset must continue to stop ref update,
+  deletion, or publication.
+- Preservation means Patchmill performs no mutation of the existing issue
+  worktree before Pi starts. It does not promise isolation from unrelated
+  processes.
+- Keep `pipeline.ts` (currently about 936 lines) as narrow orchestration only.
+  Put focused ignored-content tests in new files rather than expanding
+  `recovery.test.ts` (currently about 771 lines) or
+  `recovery-mutation.test.ts` (currently about 707 lines).
+- `recovery-archive.ts` continues to serialize assessment evidence; no persisted
+  Run recovery state schema field is added.
+- Do not change `package.json`, `package-lock.json`, or `npm-shrinkwrap.json`.
+  If a dependency file changes unexpectedly, run the Nix build required by
+  `AGENTS.md`.
+- The Testing Value Gate approves the planned automated tests: they exercise a
+  data-loss boundary, the blocked-retry regression, typed error behavior, and
+  late-content races. Do not add a test that only asserts documentation text;
+  validate documentation with lint and the site build.
+
+---
+
+## File and Module Map
+
+### Recovery assessment and policy
+
+- `src/cli/commands/run-once/types.ts` — separate intrinsic recovery
+  classification from policy refusal reasons, name ordinary cleanliness
+  unambiguously, and carry the blocked mutating action on ignored-content
+  refusals.
+- `src/cli/commands/run-once/recovery-assessment.ts` — inventory ignored entries
+  independently, classify branch/worktree shape without ignored precedence, and
+  prove whether the expected registered checkout exists.
+- `src/cli/commands/run-once/recovery-policy.ts` — derive the candidate action
+  first, defensively verify in-place resume facts, and gate ignored content by
+  whether the action mutates workspace state.
+- `src/cli/commands/run-once/recovery.ts` — format distinct in-place
+  preservation and destructive-action refusal diagnostics.
+- `src/cli/commands/run-once/recovery-ignored-content.test.ts` — focused
+  assessment, policy, path-agnostic behavior, precedence, and diagnostic tests.
+- `src/cli/commands/run-once/recovery.test.ts` — update existing typed fixtures
+  for the clarified assessment shape without adding the new matrix here.
+- `src/cli/commands/run-once/recovery-archive.test.ts` — prove archived
+  assessment evidence keeps ordinary cleanliness and ignored inventory
+  independently visible.
+
+### Pipeline preservation boundary
+
+- `src/cli/commands/run-once/pipeline-recovery.ts` — return the applied decision
+  and optional mutation result instead of discarding recovery outcome details.
+- `src/cli/commands/run-once/pipeline.ts` — emit one preservation progress event
+  for an ignored-content in-place resume before normal workspace/Pi stages.
+- `test-support/run-once/pipeline-fixtures.ts` — let blocked-retry fixtures
+  return distinct ordinary and ignored porcelain output and inspect the Pi call
+  working directory.
+- `src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts` — verify
+  current and commit-bearing retries preserve representative ignored file bytes,
+  reuse the exact checkout, perform no recovery mutation, and emit the success
+  diagnostic before Pi.
+
+### Destructive recovery safety
+
+- `src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts` — add the
+  missing real-Git refresh race where ignored content appears after assessment
+  and stops detach, ref update, and publication.
+- `src/cli/commands/run/reset/reset.test.ts` — prove pre-existing ignored content
+  refuses reset before archive or mutation and reports the blocked reset action.
+- `src/cli/commands/run-once/recovery-mutation-helpers.ts` — intentionally
+  unchanged; its complete ordinary-plus-ignored late check remains authoritative.
+- `src/cli/commands/run-once/recovery-mutation-refresh.ts` and
+  `src/cli/commands/run-once/recovery-mutation-reset.ts` — intentionally
+  unchanged unless a new regression test exposes a real safety gap.
+
+### Operator documentation
+
+- `site/src/content/docs/using-patchmill/run-once.md` — distinguish ignored
+  content preserved by in-place retry from ignored content that blocks refresh,
+  recreation, or reset.
+
+---
+
+### Task 1: Separate recovery facts and make ignored-content policy action-aware
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/types.ts:334-487`
+- Modify: `src/cli/commands/run-once/recovery-assessment.ts:70-340`
+- Modify: `src/cli/commands/run-once/recovery-policy.ts:1-176`
+- Modify: `src/cli/commands/run-once/recovery.ts:18-53`
+- Create: `src/cli/commands/run-once/recovery-ignored-content.test.ts`
+- Modify: `src/cli/commands/run-once/recovery.test.ts:394-452`
+- Modify: `src/cli/commands/run-once/recovery-archive.test.ts:1-95`
+
+**Interfaces:**
+
+- Consumes: `PlanRunRecoveryInput`, normalized `git status --porcelain=v1`
+  output, exact worktree registration evidence, divergence, unique commits, and
+  paths allocated by `createRunRecoveryPaths()`.
+- Produces:
+
+```ts
+export type RunRecoveryClassification =
+  | "resumable-current"
+  | "resumable-stale-base"
+  | "resumable-with-commits"
+  | "recreatable-clean"
+  | "dirty-worktree"
+  | "unmerged-commits"
+  | "workspace-unverifiable"
+  | "legacy-active-unfenced";
+
+export type RunRecoveryAction =
+  | "resume"
+  | "refresh-and-resume"
+  | "recreate-and-resume"
+  | "archive-reset-and-start";
+
+export type RunRecoveryMutatingAction = Exclude<
+  RunRecoveryAction,
+  "resume"
+>;
+
+export type RunRecoveryRefusalReason =
+  | RunRecoveryClassification
+  | "ignored-worktree-content"
+  | "not-blocked";
+```
+
+- Replace ambiguous `worktree.clean?: boolean` with
+  `worktree.ordinaryClean?: boolean`. `ordinaryClean` is true exactly when the
+  configured ordinary-status exclusions leave no blocking line; it remains
+  true when `ignoredEntries` is non-empty.
+- The assessment refusal variant for `reason: "ignored-worktree-content"`
+  carries `blockedAction: RunRecoveryMutatingAction`. Other assessed refusals do
+  not claim a blocked action. The existing `active-run` refusal remains
+  separate.
+- `decideRunRecovery()` remains pure and preserves its current public signature.
+  Its internal candidate is a non-refusal `RunRecoveryDecision`; the ignored
+  gate either returns that candidate or a typed refusal.
+
+- [ ] **Step 1: Add focused failing assessment and policy tests**
+
+Create `recovery-ignored-content.test.ts` with a local `planRecovery()` helper.
+The command runner must return separate status streams so ordinary status is not
+confused with ignored inventory:
+
+```ts
+if (call.args[0] === "-C" && call.args[2] === "status") {
+  return {
+    code: 0,
+    stdout: call.args.includes("--ignored=matching")
+      ? (overrides.ignoredStatus ?? "")
+      : (overrides.ordinaryStatus ?? ""),
+    stderr: "",
+  };
+}
+```
+
+Use a physically present worktree registered on the expected branch as the safe
+default. Add these named cases and exact decision assertions:
+
+```ts
+test("current blocked retry preserves ignored workflow state in place", async () => {
+  const decision = await planRecovery({
+    revList: "0\t0\n",
+    log: "",
+    ignoredStatus:
+      "!! .pi/todos/issue-211-task.md\n" +
+      "!! .superpowers/single-writer/progress.md\n",
+  });
+
+  assert.equal(decision.action, "resume");
+  assert.equal(decision.assessment.classification, "resumable-current");
+  assert.equal(decision.assessment.worktree.ordinaryClean, true);
+  assert.deepEqual(decision.assessment.worktree.ignoredEntries, [
+    ".pi/todos/issue-211-task.md",
+    ".superpowers/single-writer/progress.md",
+  ]);
+});
+
+test("commit-bearing blocked retry preserves unknown ignored content in place", async () => {
+  const decision = await planRecovery({
+    revList: "3\t2\n",
+    log: "def456 verify recovery\nabc123 implement recovery\n",
+    ignoredStatus: "!! .cache/generated.bin\n",
+  });
+
+  assert.equal(decision.action, "resume");
+  assert.equal(decision.assessment.classification, "resumable-with-commits");
+  assert.deepEqual(decision.assessment.divergence, {
+    behind: 3,
+    ahead: 2,
+  });
+});
+```
+
+Add six more cases with these outcomes:
+
+1. Ordinary `" M src/index.ts\n"` plus ignored entries returns a
+   `dirty-worktree` refusal.
+2. `behind: 3, ahead: 0` plus ignored entries returns
+   `reason: "ignored-worktree-content"` and
+   `blockedAction: "refresh-and-resume"`.
+3. Current reset plus ignored entries returns the same reason with
+   `blockedAction: "archive-reset-and-start"`.
+4. Reset with actual unique commits plus ignored entries keeps
+   `reason: "unmerged-commits"`.
+5. A synthetic `recreatable-clean` assessment with ignored entries blocks
+   `"recreate-and-resume"`, proving future mutation actions use the same gate.
+6. Workflow paths and `.cache/generated.bin` produce the same candidate action
+   and refusal rules.
+
+Assert `formatRunRecoveryDecision()` says the destructive action cannot prove
+ignored content will survive, lists normalized entries, and does not contain
+`resuming in place`. Assert formatting an allowed ignored `resume` says
+`resuming in place without workspace mutation` and `preserving ignored
+entries`.
+
+- [ ] **Step 2: Run the focused test and verify the regression**
+
+Run:
+
+```sh
+node --test \
+  src/cli/commands/run-once/recovery-ignored-content.test.ts
+```
+
+Expected: FAIL because ignored entries currently become the intrinsic
+`ignored-worktree-content` classification, current/commit-bearing retries refuse,
+`ordinaryClean` and `blockedAction` do not exist, and preservation formatting is
+absent.
+
+- [ ] **Step 3: Clarify the recovery types**
+
+In `types.ts`, add the action/refusal aliases above, remove
+`"ignored-worktree-content"` from `RunRecoveryClassification`, and replace
+`worktree.clean` with `worktree.ordinaryClean`. Split the assessed refusal union
+so TypeScript requires a blocked action for ignored content:
+
+```ts
+| {
+    action: "refuse";
+    assessment: RunRecoveryAssessment;
+    reason: "ignored-worktree-content";
+    blockedAction: RunRecoveryMutatingAction;
+    guidance: string[];
+  }
+| {
+    action: "refuse";
+    assessment: RunRecoveryAssessment;
+    reason: Exclude<RunRecoveryRefusalReason, "ignored-worktree-content">;
+    guidance: string[];
+  }
+```
+
+Keep `ignoredStatus` and `ignoredEntries` on the assessment. Do not add either
+field to persisted `AgentIssueRunState`.
+
+- [ ] **Step 4: Make assessment classify non-ignored facts only**
+
+In `recovery-assessment.ts`, continue issuing both status reads. Set
+`ordinaryClean: !dirtyStatus` whenever the expected registered worktree can be
+read, regardless of ignored entries.
+
+Change `classify()` so its ordered decisions are:
+
+```ts
+if (workspaceIdentityIsUnsafe) return "workspace-unverifiable";
+if (input.dirty) return "dirty-worktree";
+if (!input.branchExists && input.savedCommits.length)
+  return "unmerged-commits";
+if (input.active && !input.fenced) return "legacy-active-unfenced";
+if (!input.branchExists || !input.worktreeExists)
+  return "recreatable-clean";
+if (input.commits.length || (input.divergence?.ahead ?? 0) > 0)
+  return "resumable-with-commits";
+if ((input.divergence?.behind ?? 0) > 0)
+  return "resumable-stale-base";
+return "resumable-current";
+```
+
+Do not pass ignored entries into `classify()`. Continue returning their complete
+inventory on `assessment.worktree`. Moving recreatable shape before unique
+commits ensures a missing checkout uses `recreate-and-resume` rather than a
+nominal `resume` followed by an incidental later worktree add.
+
+- [ ] **Step 5: Derive the action before applying the ignored-content gate**
+
+Refactor `decideRunRecovery()` into three explicit phases:
+
+1. Refuse non-blocked retry and intrinsic unsafe classifications.
+2. Preserve the reset-specific `unmerged-commits` precedence, then derive the
+   existing resume/refresh/recreate/reset candidate.
+3. Apply ignored-content policy to the candidate.
+
+Use a defensive in-place predicate:
+
+```ts
+function canResumeInPlace(assessment: RunRecoveryAssessment): boolean {
+  return (
+    assessment.worktree.exists &&
+    assessment.worktree.registered &&
+    assessment.worktree.ordinaryClean === true &&
+    assessment.worktree.registeredBranch ===
+      assessment.expectedWorkspace.branch &&
+    assessment.branch.checkedOutAt !== undefined &&
+    (assessment.classification === "resumable-current" ||
+      assessment.classification === "resumable-with-commits")
+  );
+}
+```
+
+If a candidate says `resume` without these facts, return
+`workspace-unverifiable`. If ignored inventory is empty, return the candidate.
+If ignored inventory is present and the candidate is a verified `resume`, return
+it unchanged. Otherwise return `ignored-worktree-content` with
+`blockedAction: candidate.action` and guidance naming both the action and
+inventory. Keep the unique-commit reset refusal before this generic gate.
+
+- [ ] **Step 6: Format preservation and destructive refusal distinctly**
+
+In `recovery.ts`, format an ignored in-place resume as:
+
+```text
+Issue #45 is resuming in place without workspace mutation; preserving ignored entries: .pi/todos/issue-211-task.md, .superpowers/single-writer/progress.md.
+```
+
+Format a mutating refusal as:
+
+```text
+Issue #45 recovery refused: ignored-worktree-content.
+Recovery action refresh-and-resume cannot prove ignored content will survive: .cache/generated.bin.
+```
+
+Do not use preservation wording on the refusal path. Retain existing active-run,
+dirty, commit-loss, and identity diagnostics.
+
+- [ ] **Step 7: Update existing typed fixtures and archived evidence coverage**
+
+Update `recovery.test.ts` assessment factories and any compile-time fixtures to
+use `ordinaryClean`. Preserve all legacy `BlockedRunRecoveryReport.worktree.clean`
+uses because that is a separate compatibility type.
+
+In `recovery-archive.test.ts`, include an assessment fixture with
+`ordinaryClean: true`, a non-empty `ignoredStatus`, and a non-empty
+`ignoredEntries`; assert the serialized `recovery-assessment.json` retains all
+three values under `worktree` while `recoveryClassification` remains intrinsic.
+
+- [ ] **Step 8: Run focused recovery tests**
+
+Run:
+
+```sh
+node --test \
+  src/cli/commands/run-once/recovery-ignored-content.test.ts \
+  src/cli/commands/run-once/recovery.test.ts \
+  src/cli/commands/run-once/recovery-archive.test.ts
+```
+
+Expected: PASS. Current and commit-bearing checkouts select `resume`; stale,
+recreate, and reset candidates with ignored inventory refuse with their blocked
+action; ordinary dirty and unique-commit reset precedence remain unchanged.
+
+- [ ] **Step 9: Commit the action-aware policy seam**
+
+```sh
+git add \
+  src/cli/commands/run-once/types.ts \
+  src/cli/commands/run-once/recovery-assessment.ts \
+  src/cli/commands/run-once/recovery-policy.ts \
+  src/cli/commands/run-once/recovery.ts \
+  src/cli/commands/run-once/recovery-ignored-content.test.ts \
+  src/cli/commands/run-once/recovery.test.ts \
+  src/cli/commands/run-once/recovery-archive.test.ts
+git commit -m "fix: make ignored recovery policy action-aware"
+```
+
+---
+
+### Task 2: Preserve ignored bytes through the blocked-retry pipeline
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/pipeline-recovery.ts:69-144`
+- Modify: `src/cli/commands/run-once/pipeline.ts:410-430`
+- Modify: `test-support/run-once/pipeline-fixtures.ts:307-463`
+- Create: `src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts`
+
+**Interfaces:**
+
+- Consumes: the non-refusal decision returned by `planRunRecovery()`, the
+  optional `RunRecoveryMutationResult`, `RunOneIssueOptions.progress`, and the
+  exact expected worktree path.
+- Produces:
+
+```ts
+export type BlockedWorkspaceRecoveryOutcome = {
+  decision: Exclude<RunRecoveryDecision, { action: "refuse" }>;
+  mutation?: RunRecoveryMutationResult;
+};
+
+export async function recoverBlockedWorkspace(
+  input: RecoverBlockedWorkspaceInput,
+): Promise<BlockedWorkspaceRecoveryOutcome | undefined>;
+```
+
+- The function returns `undefined` only when there is no blocked state or no
+  held lease. A `resume` returns its decision with no `mutation`; a refresh or
+  recreation returns the decision and mutation result. Refusals continue to
+  throw `AgentIssueSafetyError`.
+- The pipeline emits the preservation diagnostic only when the returned action
+  is `resume` and `ignoredEntries.length > 0`.
+
+- [ ] **Step 1: Extend the blocked-retry fixture without changing old callers**
+
+In `pipeline-fixtures.ts`, extend `blockedRecoveryRunner()` options as follows:
+
+```ts
+ordinaryStatus?: string;
+ignoredStatus?: string;
+onPi?: (
+  prompt: string,
+  call: Call,
+) => CommandResult | Promise<CommandResult>;
+```
+
+Import `Call` from `mock-runner.ts`. For worktree status, use
+`ignoredStatus` only when arguments contain `--ignored=matching`; otherwise use
+`ordinaryStatus`. Retain `dirtyStatus` as a backwards-compatible fallback for
+existing tests:
+
+```ts
+const status = call.args.includes("--ignored=matching")
+  ? (options.ignoredStatus ?? options.dirtyStatus ?? "")
+  : (options.ordinaryStatus ?? options.dirtyStatus ?? "");
+return { code: 0, stdout: status, stderr: "" };
+```
+
+Await `options.onPi(prompt, call)` so a test can inspect files at the exact Pi
+invocation boundary.
+
+- [ ] **Step 2: Write failing pipeline preservation tests**
+
+Create `pipeline-recovery-ignored-content.test.ts`. For each scenario below,
+write these sentinel paths beneath the expected worktree before retry:
+
+```ts
+const sentinels = new Map<string, Buffer>([
+  [".superpowers/single-writer/progress.md", Buffer.from("step=review\n")],
+  [
+    ".superpowers/single-writer/oracle-review-ledger.json",
+    Buffer.from('{"finding":"F-211"}\n'),
+  ],
+  [".pi/todos/issue-211-task.md", Buffer.from("# task\n")],
+  [".cache/generated.bin", Buffer.from([0, 1, 2, 255])],
+]);
+```
+
+Run one test with `{ revList: "0\t0\n", log: "" }` and one with
+`{ revList: "3\t2\n", log: "def456 verify\nabc123 implement\n" }`. In both,
+return these entries from the ignored status read and an empty ordinary status.
+
+Before the retry, record `stat()` values for the worktree and each sentinel. In
+the async Pi callback:
+
+```ts
+assert.equal(call.cwd, worktreeRoot);
+for (const [path, expectedBytes] of sentinels) {
+  assert.deepEqual(await readFile(join(worktreeRoot, path)), expectedBytes);
+  const before = stats.get(path)!;
+  const after = await stat(join(worktreeRoot, path));
+  assert.equal(after.dev, before.dev);
+  assert.equal(after.ino, before.ino);
+}
+timeline.push("pi");
+```
+
+Pass a progress reporter that records a `recovery` event in the same timeline.
+After `runOneIssue()`, assert:
+
+```ts
+assert.ok(
+  timeline[0]?.includes(
+    "resuming in place without workspace mutation; preserving ignored entries",
+  ),
+);
+assert.equal(timeline.at(-1), "pi");
+assert.deepEqual(
+  runner.calls.filter(isRecoveryMutationCommand),
+  [],
+);
+```
+
+Define `isRecoveryMutationCommand()` to reject `git worktree add`, `git worktree
+move`, `git update-ref`, `git reset`, and `git clean`. Also assert the worktree
+root keeps the same device/inode, the result reaches `pr-created`, and the
+commit-bearing-behind case does not refresh to the base.
+
+- [ ] **Step 3: Run the pipeline test and verify the missing outcome diagnostic**
+
+Run:
+
+```sh
+node --test \
+  src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts
+```
+
+Expected: FAIL because `recoverBlockedWorkspace()` discards its applied decision
+and the pipeline cannot emit the required preservation event before Pi.
+
+- [ ] **Step 4: Return the applied recovery outcome**
+
+In `pipeline-recovery.ts`, export the focused outcome type above. Store the
+mutation result instead of discarding it:
+
+```ts
+const decision = await reassess();
+if (decision.action === "refuse") {
+  throw new AgentIssueSafetyError(formatRunRecoveryDecision(decision));
+}
+if (decision.action === "resume") return { decision };
+const mutation = await executeRunRecoveryMutation({
+  decision,
+  runner: input.runner,
+  repoRoot: input.config.repoRoot,
+  reassess,
+});
+return { decision, mutation };
+```
+
+Keep all snapshot validation, lease checks, and reassessment behavior unchanged.
+Do not call `executeRunRecoveryMutation()` for `resume`.
+
+- [ ] **Step 5: Emit preservation progress before normal workspace handling**
+
+In `pipeline.ts`, capture the recovery outcome at the existing call site. When
+it is an ignored-content `resume`, call `formatRunRecoveryDecision()` and emit:
+
+```ts
+await progress(runOptions, "info", "recovery", message, {
+  issueNumber: issue.number,
+  consoleMessage: message,
+  data: {
+    action: "resume",
+    mutationApplied: false,
+    ignoredEntries: recovery.decision.assessment.worktree.ignoredEntries,
+  },
+});
+```
+
+Place this immediately after `recoverBlockedWorkspace()` and before artifact
+workspace inspection, claim-state writes, `ensureIssueWorkspace()`, or any Pi
+stage. Do not add recovery implementation to `pipeline.ts`.
+
+- [ ] **Step 6: Run focused pipeline and workspace tests**
+
+Run:
+
+```sh
+node --test \
+  src/cli/commands/run-once/pipeline-recovery.test.ts \
+  src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts \
+  src/cli/commands/run-once/pipeline-workspace-scenarios.test.ts
+```
+
+Expected: PASS. Both ignored-content scenarios invoke Pi in the exact existing
+worktree with byte-identical sentinels and no recovery mutation; unsafe snapshot
+and existing workspace scenarios remain green.
+
+- [ ] **Step 7: Commit the pipeline preservation boundary**
+
+```sh
+git add \
+  src/cli/commands/run-once/pipeline-recovery.ts \
+  src/cli/commands/run-once/pipeline.ts \
+  test-support/run-once/pipeline-fixtures.ts \
+  src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts
+git commit -m "fix: preserve ignored state on blocked retry"
+```
+
+---
+
+### Task 3: Prove destructive recovery remains fail-closed
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts`
+- Modify: `src/cli/commands/run/reset/reset.test.ts:1-405`
+- Verify unchanged: `src/cli/commands/run-once/recovery-mutation-helpers.ts`
+- Verify unchanged: `src/cli/commands/run-once/recovery-mutation-refresh.ts`
+- Verify unchanged: `src/cli/commands/run-once/recovery-mutation-reset.ts`
+- Verify unchanged: `src/cli/commands/run-once/recovery-mutation.test.ts:409-466`
+
+**Interfaces:**
+
+- Consumes: real Git repositories, the typed ignored-content refusal from Task
+  1, reset dependency injection, and the existing post-move
+  `assertRecoveryWorkspaceUnchanged()` guard.
+- Produces: regression evidence that pre-existing ignored content blocks reset
+  before archive/mutation and late ignored content blocks refresh before detach,
+  branch update, or publication.
+
+- [ ] **Step 1: Add a real-Git pre-existing ignored reset test**
+
+Use the existing `resetFixture()` in `run/reset/reset.test.ts`. Add
+`.env.local` to the repository's common `.git/info/exclude`, write a sentinel in
+the registered issue worktree, and record the issue branch OID. Inject archive
+and mutation spies:
+
+```ts
+let archiveCalled = false;
+let mutationCalled = false;
+await assert.rejects(
+  resetIssueRun(fixture.runner, fixture.runConfig, { now: NOW }, {
+    ...fixture.dependencies,
+    archiveRecovery: async () => {
+      archiveCalled = true;
+      return { path: "must-not-exist" };
+    },
+    executeMutation: async () => {
+      mutationCalled = true;
+      throw new Error("mutation must not run");
+    },
+  }),
+  (error: unknown) => {
+    assert.match(String(error), /ignored-worktree-content/);
+    assert.match(String(error), /archive-reset-and-start/);
+    assert.match(String(error), /.env.local/);
+    return true;
+  },
+);
+assert.equal(archiveCalled, false);
+assert.equal(mutationCalled, false);
+```
+
+Also assert the sentinel bytes and branch OID are unchanged and no quarantine
+path was created. This test should pass after Task 1 and proves the refusal is
+positioned before both destructive reset phases.
+
+- [ ] **Step 2: Add the missing late-ignored refresh race test**
+
+Create `recovery-mutation-ignored-content.test.ts` with a real repository whose
+initial commit includes `.gitignore` for `.cache/`, a stale issue branch/worktree,
+and a newer base commit. Construct the existing pinned
+`refresh-and-resume` decision. Wrap the real-Git runner so immediately after the
+first successful `git worktree move` it writes
+`quarantine/.cache/late.bin` and records all subsequent commands.
+
+Invoke `executeRunRecoveryMutation()` and assert a
+`RunRecoveryMutationError`. Then assert:
+
+```ts
+assert.deepEqual(
+  await readFile(join(quarantine, ".cache/late.bin")),
+  Buffer.from([0, 211, 255]),
+);
+assert.equal(git("rev-parse", branch), oldBranchOid);
+assert.equal(
+  calls.some(
+    (args) =>
+      args[0] === "update-ref" &&
+      (args[1] === "--no-deref" || args[1] === `refs/heads/${branch}`),
+  ),
+  false,
+);
+assert.equal(
+  calls.filter((args) => args[0] === "worktree" && args[1] === "move")
+    .length,
+  1,
+);
+```
+
+Assert the error reports the quarantine and staging paths. Do not alter the
+production helper to make this pass; it must detect the `!!` status after the
+move.
+
+- [ ] **Step 3: Run destructive-path regression tests**
+
+Run:
+
+```sh
+node --test \
+  src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts \
+  src/cli/commands/run-once/recovery-mutation.test.ts \
+  src/cli/commands/run/reset/reset.test.ts
+```
+
+Expected: PASS. The new refresh case and existing
+`late ignored quarantine content prevents reset ref deletion` case both retain
+the injected bytes and prevent later ref operations. The pre-existing reset case
+refuses before archive or mutation.
+
+- [ ] **Step 4: Review the mutation diff for accidental weakening**
+
+Run:
+
+```sh
+git diff HEAD~2 -- \
+  src/cli/commands/run-once/recovery-mutation-helpers.ts \
+  src/cli/commands/run-once/recovery-mutation-refresh.ts \
+  src/cli/commands/run-once/recovery-mutation-reset.ts
+```
+
+Expected: no production mutation diff. If a test exposes a genuine gap, make the
+smallest fail-closed change, rerun Step 3, and document the residual race in the
+commit body; do not filter ignored paths or permit publication/ref updates after
+a failed complete-status check.
+
+- [ ] **Step 5: Commit destructive-path regression coverage**
+
+```sh
+git add \
+  src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts \
+  src/cli/commands/run/reset/reset.test.ts
+git commit -m "test: protect ignored content during destructive recovery"
+```
+
+---
+
+### Task 4: Document the policy and run full verification
+
+**Files:**
+
+- Modify: `site/src/content/docs/using-patchmill/run-once.md:172-205`
+- Verify: all files changed by Tasks 1-3
+
+**Interfaces:**
+
+- Consumes: the final recovery decisions and diagnostics from Tasks 1-3.
+- Produces: operator documentation that explains when ignored content is
+  preserved versus refused, plus complete project verification evidence.
+
+- [ ] **Step 1: Update blocked-recovery operator guidance**
+
+Replace the statement that all ignored content refuses automatic recovery with
+three explicit rules:
+
+1. A verified ordinary-clean current or commit-bearing worktree resumes at the
+   same path without workspace mutation; every ignored entry remains in place
+   through Pi invocation.
+2. A zero-ahead branch behind the base still requires refresh, so ignored
+   content blocks that refresh rather than causing stale content to resume.
+3. Ignored content blocks every refresh, recreation, and reset because those
+   actions cannot prove preservation; the refusal names the blocked action,
+   while an allowed retry reports `resuming in place` and lists preserved
+   entries.
+
+State that `.pi/todos/`, `.superpowers/`, environment files, and generated
+content follow the same path-agnostic rule. Keep the existing late-content,
+quarantine, no-force, and lease-repair paragraphs.
+
+Do not add a documentation text assertion. The Testing Value Gate selects
+`npm run lint` and `npm run site:build` as direct verification.
+
+- [ ] **Step 2: Run focused issue verification**
+
+Run:
+
+```sh
+node --test \
+  src/cli/commands/run-once/recovery-ignored-content.test.ts \
+  src/cli/commands/run-once/recovery-archive.test.ts \
+  src/cli/commands/run-once/pipeline-recovery.test.ts \
+  src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts \
+  src/cli/commands/run-once/pipeline-workspace-scenarios.test.ts \
+  src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts \
+  src/cli/commands/run-once/recovery-mutation.test.ts \
+  src/cli/commands/run/reset/reset.test.ts
+```
+
+Expected: PASS with current and commit-bearing in-place preservation, ordinary
+dirty precedence, typed destructive refusals, and both refresh/reset late-race
+coverage.
+
+- [ ] **Step 3: Run the required project verification**
+
+Run each command separately and retain its exit status:
+
+```sh
+npm run test:run-once
+npm test
+npm run lint
+npm run build
+npm run site:build
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 4: Confirm dependency metadata did not change**
+
+Run:
+
+```sh
+base_commit=$(git merge-base HEAD origin/main)
+git diff --name-only "$base_commit"..HEAD -- \
+  package.json package-lock.json npm-shrinkwrap.json
+```
+
+Expected: no output. If any dependency file is listed unexpectedly, inspect and
+remove the out-of-scope change or, if it is truly required, run:
+
+```sh
+nix build .#patchmill --print-build-logs
+```
+
+Expected when required: exit 0, satisfying `AGENTS.md`.
+
+- [ ] **Step 5: Review acceptance evidence and scope**
+
+Run:
+
+```sh
+git status --short
+git diff --check
+git diff --stat "$base_commit"
+```
+
+Expected: only issue-scoped source, tests, fixture support, and run-once
+operator documentation are changed; `git diff --check` is silent. Confirm the
+pipeline tests observe exact paths and bytes at Pi invocation, mutation command
+lists are empty for in-place resume, destructive refusals name their blocked
+action, and late refresh/reset checks prevent ref updates.
+
+- [ ] **Step 6: Commit documentation**
+
+```sh
+git add site/src/content/docs/using-patchmill/run-once.md
+git commit -m "docs: explain ignored state recovery safety"
+```
+
+---
+
+## Acceptance Mapping
+
+| Acceptance criterion | Plan evidence |
+| --- | --- |
+| Clean commit-bearing retry resumes with ignored files | Task 1 selects `resume`; Task 2 exercises an ahead-and-behind branch through Pi. |
+| Ignored workflow bytes are identical at agent start | Task 2 reads four sentinel files and compares bytes/device/inode in the Pi callback. |
+| Retry does not refresh, reset, delete, or replace | Task 2 checks worktree identity and rejects every recovery mutation command. |
+| Current zero-ahead worktree resumes | Task 1 policy and Task 2 pipeline cases use `ahead = 0`, `behind = 0`. |
+| Destructive mutation remains fail-closed | Tasks 1 and 3 refuse stale refresh/recreate/reset and preserve reset's stronger commit refusal. |
+| Refresh/reset late races remain effective | Task 3 adds refresh race coverage and reruns the existing reset race. |
+| Diagnostics distinguish preserve from refuse | Task 1 formats separate messages; Task 2 proves preservation is emitted before Pi; Task 3 checks reset refusal action. |
+| Workflow and ordinary ignored paths are covered | Tasks 1 and 2 include `.pi/todos/`, `.superpowers/`, and `.cache/`. |

--- a/docs/specs/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state-design.md
+++ b/docs/specs/2026-09-06-issue-211-blocked-run-retry-refuses-clean-committed-worktrees-containing-required-ignored-agent-state-design.md
@@ -1,0 +1,350 @@
+# Preserve ignored agent state during in-place blocked-run retry
+
+- **Issue:** #211
+- **Status:** Proposed design
+
+## Summary
+
+An explicit retry of a blocked Issue run will preserve and reuse its existing
+worktree when Patchmill verifies that the worktree is registered at the expected
+path, is on the expected branch, has no blocking ordinary Git status, and needs
+no recovery mutation. Ignored content will remain inventoried, but it will no
+longer override the current or commit-bearing resume classification.
+
+The exception applies to all ignored content, not only recognized workflow
+paths. It therefore preserves coding-agent state such as `.pi/todos/` and
+`.superpowers/`, as well as ordinary local environment files and generated
+content. Patchmill will continue to refuse ignored content when the selected
+recovery action would refresh, recreate, reset, move, replace, or delete
+workspace state.
+
+## Context
+
+Issue #183 introduced a conservative recovery assessment and typed recovery
+actions. The assessment correctly inventories ignored content because Git cannot
+preserve it through a ref or worktree replacement. Its classification currently
+treats any ignored entry as `ignored-worktree-content` before it considers
+branch divergence or unique commits. The policy consequently refuses a retry
+even when its action would have been a no-op `resume` of the same worktree.
+
+This conflicts with the Run recovery state model. A blocked Run attempt may
+leave committed implementation work and ignored task, progress, review, repair,
+or environment state in the issue worktree. A later Run attempt must be able to
+continue the same Issue run with that state present.
+
+## Goals
+
+- Resume a blocked, acknowledged Issue run in the same verified worktree when
+  recovery requires no workspace mutation.
+- Support both a current zero-ahead branch and a branch with unique commits.
+- Preserve every pre-existing ignored path and its bytes until the recovered
+  coding-agent invocation starts.
+- Keep ordinary dirty status, workspace identity, branch state, and ignored
+  inventory as independent assessment facts.
+- Refuse ignored content before every recovery action that can move, recreate,
+  refresh, reset, overwrite, or delete workspace state.
+- Retain late ignored-content guards on refresh and reset paths.
+- Make operator diagnostics state whether ignored content is being preserved in
+  place or is blocking an unsafe destructive action.
+
+## Non-goals
+
+This issue will not:
+
+- allow tracked or untracked ordinary dirty changes during blocked retry;
+- add a force flag, cleanup command, automatic stash, or ignored-file backup;
+- introduce an allowlist of approved ignored paths;
+- refresh a stale zero-ahead branch in the presence of ignored content;
+- hash or persist the contents of ignored files;
+- provide snapshot isolation from unrelated processes modifying the worktree;
+- move Patchmill-owned durable state out of the worktree; or
+- change acknowledgment, lease, artifact, checkpoint, label, or reset-seed
+  semantics.
+
+## Approaches considered
+
+### Action-aware ignored-content policy (chosen)
+
+Assess ignored entries independently, derive the recovery action from workspace
+identity and branch state, and then apply an ignored-content gate based on
+whether that action mutates the workspace. A true in-place `resume` may proceed;
+all mutating actions remain fail-closed.
+
+This matches the actual data-loss boundary. It also preserves unknown ignored
+content without weakening refresh or reset safety.
+
+### Allow only recognized workflow paths
+
+Patchmill could allow `.pi/todos/` and selected `.superpowers/` paths while
+refusing caches or environment files. This is rejected because workflow state
+locations evolve, repository-local tools can have their own durable ignored
+state, and the safety property depends on the operation rather than the path
+name. The acceptance case also includes ordinary generated ignored content.
+
+### Copy or hash ignored content around recovery
+
+Patchmill could snapshot ignored files and restore them after refresh or reset.
+This is rejected because ignored trees can be large, sensitive, concurrently
+written, or contain special filesystem entries. Copying would create a second
+state-preservation protocol and still would not make destructive recovery
+provably safe. In-place reuse needs no such mechanism.
+
+## Proposed recovery model
+
+### Independent assessment facts
+
+`RunRecoveryAssessment` will represent these dimensions separately:
+
+- expected and saved workspace identity;
+- physical worktree existence and Git registration;
+- expected branch existence, checkout location, and pinned OID;
+- ordinary status after the existing configured status exclusions;
+- ignored status and normalized ignored entries;
+- divergence and actual unique commits;
+- saved commit-loss evidence; and
+- lease-protocol and legacy-fence evidence.
+
+The worktree's ordinary cleanliness must not include ignored entries. The
+assessment type should use an unambiguous ordinary-clean field, or derive it
+from `dirtyStatus`, while retaining `ignoredEntries` as a separate inventory. An
+ignored entry alone will no longer become the assessment's primary recovery
+classification.
+
+The existing unsafe classifications keep their precedence: unverifiable identity
+and ordinary dirty state still refuse recovery, and missing-branch commit-loss
+or lease-fence evidence remains unchanged. Branch/worktree shape then produces
+the existing current, stale-base, commit-bearing, or recreatable classification.
+
+### Action-aware decision
+
+The policy will first derive the candidate action without treating ignored
+content as branch state:
+
+- a verified current worktree produces `resume`;
+- a verified worktree with unique commits produces `resume` without rewriting
+  its branch, including when it is also behind the base;
+- a zero-ahead worktree behind the base produces `refresh-and-resume`;
+- an absent safe workspace produces `recreate-and-resume`; and
+- reset intent produces `archive-reset-and-start` only when existing reset
+  safety rules permit it.
+
+Ignored content may accompany `resume` only when the assessment also proves all
+of these in-place conditions:
+
+1. the expected physical worktree exists;
+2. it is registered at exactly the expected path;
+3. it has the expected branch checked out and that branch is not checked out
+   elsewhere;
+4. ordinary status is clean; and
+5. the chosen recovery action will not invoke the recovery mutation layer.
+
+A current branch means `ahead = 0` and `behind = 0`; it can resume under this
+rule. A zero-ahead branch with `behind > 0` remains stale and still requires a
+refresh. Patchmill will not silently choose stale content merely to avoid the
+ignored-content guard.
+
+After the candidate action is known, any non-empty ignored inventory will turn a
+mutating candidate into an `ignored-worktree-content` refusal. This gate covers
+refresh, recreation, and reset, including future actions added to the mutation
+layer. Reset of a commit-bearing branch retains its stronger unique-commit
+refusal.
+
+The refusal reason should be modeled separately from the intrinsic recovery
+classification so `ignored-worktree-content` describes why a candidate action
+cannot execute, not the branch/worktree shape.
+
+### In-place preservation contract
+
+For an allowed in-place resume, recovery will perform assessment reads only. It
+will not call `git worktree add`, `git worktree move`, `git update-ref`, reset,
+clean, removal, or filesystem copy/delete operations on the issue worktree. The
+normal pipeline may recheck identity and ordinary cleanliness, but it must reuse
+the same path and pass that path as the recovered coding agent's working
+directory.
+
+Preservation means Patchmill leaves the original files at their original paths
+with their original bytes until agent invocation. The product does not need to
+read, hash, interpret, copy, or persist ignored file contents. An independent
+process can still change those files; the guarantee is that recovery itself does
+not do so.
+
+All ignored paths receive the same rule. Recognized workflow paths may be used
+as representative tests and clearer examples, but they are not privileged by
+production policy.
+
+### Destructive recovery and race safety
+
+The existing destructive mutation checks remain strict. Refresh and reset will
+continue to reassess before movement and call
+`assertRecoveryWorkspaceUnchanged()` after worktree movement and before ref
+updates or publication. That helper must continue to treat any ordinary or
+ignored status as a change.
+
+Consequently:
+
+- pre-existing ignored content refuses before a destructive mutation;
+- ignored content appearing during refresh or reset either changes the
+  reassessed decision or stops the mutation after the complete checkout has
+  moved to quarantine;
+- no ref update, branch deletion, or publication follows a failed late-content
+  check; and
+- recreated target-path races retain their existing fail-closed behavior.
+
+The in-place exception must not be implemented by weakening
+`assertRecoveryWorkspaceUnchanged()` or by filtering workflow paths from its
+ignored-status check.
+
+## Data flow
+
+1. Explicit `run-once --issue N` eligibility and the Issue run lease establish
+   the existing blocked-retry boundary.
+2. Recovery assessment reads exact Run recovery state, workspace registration,
+   ordinary status, ignored inventory, branch OIDs, and divergence.
+3. Recovery policy derives a candidate action from the non-ignored facts.
+4. The policy allows ignored content only for a verified in-place `resume`; a
+   mutating candidate becomes a typed refusal.
+5. An allowed in-place resume emits a preservation diagnostic and returns to the
+   normal pipeline without invoking recovery mutation.
+6. The normal pipeline reuses the same worktree and starts the recovered coding
+   agent there, with ignored files still present.
+7. A permitted destructive action continues through existing reassessment,
+   quarantine, compare-and-swap, and late-content checks.
+
+No new persisted Run recovery status or state schema field is required.
+
+## Diagnostics
+
+The success diagnostic for a resume with ignored content will explicitly say
+that Patchmill is resuming in place without workspace mutation and preserving
+ignored entries. It may include the existing normalized path inventory or a
+count plus paths.
+
+An `ignored-worktree-content` refusal will identify the candidate destructive
+action, such as refresh or reset, and explain that recovery cannot prove the
+ignored content will survive that action. It must not use the in-place
+preservation wording.
+
+`recoverBlockedWorkspace()` should return the applied decision or a focused
+outcome so the pipeline can emit the successful preservation message before the
+coding-agent stage. Existing refusal formatting remains the error path.
+
+## Affected components
+
+### Assessment and types
+
+- `src/cli/commands/run-once/recovery-assessment.ts` will stop giving ignored
+  entries classification precedence and will expose ordinary cleanliness and
+  ignored inventory independently.
+- `src/cli/commands/run-once/types.ts` will separate intrinsic recovery
+  classification from policy refusal reasons and, if useful, represent the
+  verified in-place preservation condition or blocked candidate action.
+- `src/cli/commands/run-once/recovery-archive.ts` will continue to serialize
+  both ordinary and ignored assessment evidence using the clarified shape.
+
+### Policy and diagnostics
+
+- `src/cli/commands/run-once/recovery-policy.ts` will derive an action before
+  applying the ignored-content mutation gate.
+- `src/cli/commands/run-once/recovery.ts` will format distinct preserved-resume
+  and destructive-refusal diagnostics.
+- `src/cli/commands/run-once/pipeline-recovery.ts` and its narrow call site in
+  `pipeline.ts` will surface the successful decision while ensuring `resume`
+  bypasses recovery mutation.
+
+### Mutation safety
+
+- `recovery-mutation-refresh.ts`, `recovery-mutation-reset.ts`, and
+  `recovery-mutation-helpers.ts` should require no policy weakening. Their
+  reassessment and late ignored-content checks remain authoritative.
+
+### Tests and documentation
+
+- Add focused assessment/policy tests without further expanding the already
+  large general recovery test module where a dedicated ignored-content test file
+  is clearer.
+- Add a blocked-retry pipeline scenario that observes ignored file contents at
+  the Pi invocation boundary.
+- Keep or extend real-Git mutation tests for late ignored content during both
+  refresh and reset.
+- Update `site/src/content/docs/using-patchmill/run-once.md` so it distinguishes
+  ignored content preserved by in-place retry from ignored content that blocks
+  destructive recovery.
+
+No dependency change is planned.
+
+## Verification strategy
+
+These tests pass Patchmill's Testing Value Gate because they protect a data-loss
+boundary, a blocked-run regression, and operator-visible recovery behavior.
+
+### Assessment and policy tests
+
+Cover:
+
+- a registered, ordinary-clean current zero-ahead worktree with ignored entries
+  selecting `resume`;
+- the same decision for a branch with actual unique commits;
+- a commit-bearing branch that is also behind the base remaining an in-place
+  resume without branch rewrite;
+- ordinary dirty status still refusing even when ignored entries also exist;
+- a stale zero-ahead worktree with ignored entries refusing the required
+  refresh;
+- reset with ignored entries refusing before archive or mutation;
+- unknown generated ignored paths receiving the same in-place policy as known
+  workflow paths; and
+- intrinsic classification, ignored inventory, and refusal reason remaining
+  independently visible in the assessment/decision.
+
+### Pipeline preservation tests
+
+Create representative ignored files before retry, including:
+
+- `.superpowers/single-writer/progress.md`;
+- `.superpowers/single-writer/oracle-review-ledger.json`;
+- `.pi/todos/issue-211-task.md`; and
+- an ordinary ignored environment or generated file.
+
+For both a current zero-ahead branch and a commit-bearing branch, assert that:
+
+- retry reaches the recovered coding-agent invocation;
+- the Pi working directory is the exact registered worktree;
+- every sentinel file exists with byte-identical content when Pi is invoked;
+- no worktree add/move, ref update, reset, clean, removal, replacement, or
+  recovery filesystem mutation occurs beforehand; and
+- the success diagnostic states that ignored content is preserved in place.
+
+### Destructive-path regression tests
+
+Retain and strengthen race tests proving that ignored content arriving after
+initial assessment during refresh or reset remains in the original or
+quarantined checkout and prevents subsequent ref update, deletion, or
+publication. Add a refresh-specific late ignored-content case if one is not
+already covered. Assert destructive refusal diagnostics name the blocked action
+and list the ignored inventory.
+
+Implementation verification should run focused recovery and pipeline tests,
+then:
+
+```sh
+npm run test:run-once
+npm test
+npm run lint
+npm run build
+npm run site:build
+```
+
+No Nix build is required unless implementation unexpectedly changes
+`package.json`, `package-lock.json`, or `npm-shrinkwrap.json`.
+
+## Acceptance mapping
+
+| Acceptance criterion                               | Design response                                                                               |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Clean commit-bearing retry preserves ignored files | Candidate `resume` is derived before the ignored-content gate and bypasses mutation.          |
+| Ignored workflow bytes survive until agent start   | Pipeline tests inspect representative files at the Pi invocation boundary.                    |
+| Retry does not refresh, reset, delete, or replace  | In-place eligibility requires a `resume` action and the mutation layer is not invoked.        |
+| Current zero-ahead worktree can resume             | `ahead = 0`, `behind = 0` selects the same in-place preservation rule.                        |
+| Destructive paths remain fail-closed               | Any ignored inventory rejects refresh, recreation, or reset; late checks remain strict.       |
+| Refresh/reset race tests remain effective          | Reassessment and post-move ordinary-plus-ignored checks are retained and tested.              |
+| Diagnostics distinguish preserve from refuse       | Success says `resume in place`; refusal names the blocked destructive action.                 |
+| Workflow and ordinary ignored paths are covered    | Policy is path-agnostic and tests include `.superpowers/`, `.pi/todos/`, and generated state. |

--- a/site/src/content/docs/using-patchmill/run-once.md
+++ b/site/src/content/docs/using-patchmill/run-once.md
@@ -179,12 +179,19 @@ patchmill run reset --issue 123
 patchmill run lease repair --issue 123
 ```
 
-A clean current workspace, stale zero-ahead branch, clean branch with unique
-commits, or safely recreatable workspace can resume. Unique commits are
-preserved at their existing base without a merge or rewrite. Only an empty stale
-branch refreshes to a pinned current base. Dirty or ignored content,
-unmerged/lost commits, unverifiable paths, live leases, and unfenced legacy
-active state refuse automatic recovery.
+A verified ordinary-clean current workspace or clean branch with unique commits
+resumes at the same path without workspace mutation. Every ignored entry remains
+in place through the Pi invocation; `.pi/todos/`, `.superpowers/`, environment
+files, and generated content all follow the same path-agnostic rule. Unique
+commits are preserved at their existing base without a merge or rewrite.
+
+An empty zero-ahead branch behind the base still requires refresh to a pinned
+current base, so ignored content blocks that refresh instead of resuming stale
+content. Ignored content also blocks recreation and reset: those actions cannot
+prove it will survive and the refusal names the blocked action. An allowed
+in-place retry reports that it is resuming in place and lists the preserved
+entries. Dirty content, unmerged/lost commits, unverifiable paths, live leases,
+and unfenced legacy active state continue to refuse automatic recovery.
 
 `patchmill run reset --issue N` archives the exact state, moves the expected
 checkout to retained quarantine before ref updates, deletes only a

--- a/src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts
+++ b/src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts
@@ -52,6 +52,7 @@ for (const scenario of [
       await mkdir(join(worktreeRoot, path, ".."), { recursive: true });
       await writeFile(join(worktreeRoot, path), bytes);
     }
+    const worktreeStat = await stat(worktreeRoot);
     const stats = new Map(
       await Promise.all(
         [...sentinels.keys()].map(
@@ -70,6 +71,9 @@ for (const scenario of [
       ignoredStatus,
       async onPi(_prompt, call) {
         assert.equal(call.cwd, worktreeRoot);
+        const currentWorktreeStat = await stat(worktreeRoot);
+        assert.equal(currentWorktreeStat.dev, worktreeStat.dev);
+        assert.equal(currentWorktreeStat.ino, worktreeStat.ino);
         for (const [path, expected] of sentinels) {
           assert.deepEqual(await readFile(join(worktreeRoot, path)), expected);
           const before = stats.get(path)!;

--- a/src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts
+++ b/src/cli/commands/run-once/pipeline-recovery-ignored-content.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { readFile, stat, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+import { runOneIssue } from "./pipeline.ts";
+import {
+  blockedRecoveryRunner,
+  makeConfig,
+  writeBlockedRecoveryRunState,
+} from "../../../../test-support/run-once/pipeline-fixtures.ts";
+
+const NOW = new Date("2026-09-06T12:00:00.000Z");
+
+function isRecoveryMutationCommand(args: string[]): boolean {
+  return (
+    (args[0] === "worktree" && ["add", "move"].includes(args[1] ?? "")) ||
+    args[0] === "update-ref" ||
+    args[0] === "reset" ||
+    args[0] === "clean"
+  );
+}
+
+for (const scenario of [
+  { name: "current", revList: "0\t0\n", log: "" },
+  {
+    name: "commit-bearing",
+    revList: "3\t2\n",
+    log: "def456 verify\nabc123 implement\n",
+  },
+]) {
+  test(`blocked retry ${scenario.name} preserves ignored bytes through Pi`, async () => {
+    const config = await makeConfig({
+      dryRun: false,
+      execute: true,
+      issueNumber: 45,
+    });
+    await writeBlockedRecoveryRunState(config);
+    const worktreeRoot = join(
+      config.repoRoot,
+      ".worktrees/patchmill-issue-45-recover-blocked-run",
+    );
+    const sentinels = new Map<string, Buffer>([
+      [".superpowers/single-writer/progress.md", Buffer.from("step=review\n")],
+      [
+        ".superpowers/single-writer/oracle-review-ledger.json",
+        Buffer.from('{"finding":"F-211"}\n'),
+      ],
+      [".pi/todos/issue-211-task.md", Buffer.from("# task\n")],
+      [".cache/generated.bin", Buffer.from([0, 1, 2, 255])],
+    ]);
+    for (const [path, bytes] of sentinels) {
+      await mkdir(join(worktreeRoot, path, ".."), { recursive: true });
+      await writeFile(join(worktreeRoot, path), bytes);
+    }
+    const stats = new Map(
+      await Promise.all(
+        [...sentinels.keys()].map(
+          async (path) => [path, await stat(join(worktreeRoot, path))] as const,
+        ),
+      ),
+    );
+    const timeline: string[] = [];
+    const ignoredStatus = [...sentinels.keys()]
+      .map((path) => `!! ${path}\n`)
+      .join("");
+    const runner = blockedRecoveryRunner(config, {
+      revList: scenario.revList,
+      log: scenario.log,
+      ordinaryStatus: "",
+      ignoredStatus,
+      async onPi(_prompt, call) {
+        assert.equal(call.cwd, worktreeRoot);
+        for (const [path, expected] of sentinels) {
+          assert.deepEqual(await readFile(join(worktreeRoot, path)), expected);
+          const before = stats.get(path)!;
+          const after = await stat(join(worktreeRoot, path));
+          assert.equal(after.dev, before.dev);
+          assert.equal(after.ino, before.ino);
+        }
+        timeline.push("pi");
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            status: "pr-created",
+            prUrl: "https://forgejo/pr/45",
+            branch: "agent/issue-45-recover-blocked-run",
+            commits: ["abc123"],
+            validation: ["verification passed"],
+            reviewSummary: "reviewed",
+          }),
+          stderr: "",
+        };
+      },
+    });
+    const result = await runOneIssue(runner, config, {
+      now: NOW,
+      progress: {
+        event: async (event) => {
+          if (event.stage === "recovery") timeline.push(event.message);
+        },
+      },
+    });
+    assert.equal(result.status, "pr-created", JSON.stringify(result));
+    assert.ok(
+      timeline[0]?.includes(
+        "resuming in place without workspace mutation; preserving ignored entries",
+      ),
+    );
+    assert.equal(timeline.at(-1), "pi");
+    assert.deepEqual(
+      runner.calls
+        .filter((call) => call.command === "git")
+        .filter((call) => isRecoveryMutationCommand(call.args)),
+      [],
+    );
+  });
+}

--- a/src/cli/commands/run-once/pipeline-recovery.ts
+++ b/src/cli/commands/run-once/pipeline-recovery.ts
@@ -12,7 +12,10 @@ import {
   planRunRecovery,
 } from "./recovery.ts";
 import { readRunLegacyMigrationFence } from "./recovery-lease-repair.ts";
-import { executeRunRecoveryMutation } from "./recovery-mutation.ts";
+import {
+  executeRunRecoveryMutation,
+  type RunRecoveryMutationResult,
+} from "./recovery-mutation.ts";
 import {
   AgentIssueSafetyError,
   hasBlockedRunRecoveryState,
@@ -22,6 +25,7 @@ import type {
   AgentIssueRunState,
   CommandRunner,
   IssueRunLease,
+  RunRecoveryDecision,
 } from "./types.ts";
 
 /** Adopts a fenced legacy active state before the caller performs pipeline effects. */
@@ -65,6 +69,11 @@ export async function adoptLegacyRecoveryLease(input: {
   });
 }
 
+export type BlockedWorkspaceRecoveryOutcome = {
+  decision: Exclude<RunRecoveryDecision, { action: "refuse" }>;
+  mutation?: RunRecoveryMutationResult;
+};
+
 /** Reassesses and applies only a safe blocked-workspace recovery under the held lease. */
 export async function recoverBlockedWorkspace(input: {
   runner: CommandRunner;
@@ -75,8 +84,9 @@ export async function recoverBlockedWorkspace(input: {
   ignoredPaths: string[];
   resolvedArtifacts: ResolvedIssueArtifactSources;
   lease: IssueRunLease | undefined;
-}): Promise<void> {
-  if (!hasBlockedRunRecoveryState(input.existingState) || !input.lease) return;
+}): Promise<BlockedWorkspaceRecoveryOutcome | undefined> {
+  if (!hasBlockedRunRecoveryState(input.existingState) || !input.lease)
+    return undefined;
   const snapshot = await readRunStateSnapshot(
     input.config.runStateDir,
     input.issueNumber,
@@ -134,11 +144,12 @@ export async function recoverBlockedWorkspace(input: {
   const decision = await reassess();
   if (decision.action === "refuse")
     throw new AgentIssueSafetyError(formatRunRecoveryDecision(decision));
-  if (decision.action !== "resume")
-    await executeRunRecoveryMutation({
-      decision,
-      runner: input.runner,
-      repoRoot: input.config.repoRoot,
-      reassess,
-    });
+  if (decision.action === "resume") return { decision };
+  const mutation = await executeRunRecoveryMutation({
+    decision,
+    runner: input.runner,
+    repoRoot: input.config.repoRoot,
+    reassess,
+  });
+  return { decision, mutation };
 }

--- a/src/cli/commands/run-once/pipeline.ts
+++ b/src/cli/commands/run-once/pipeline.ts
@@ -67,6 +67,7 @@ import {
 } from "./pipeline-selection.ts";
 import { blockIssue, unexpectedFailure } from "./pipeline-failures.ts";
 import { withIssueRunLease } from "./recovery-lease.ts";
+import { formatRunRecoveryDecision } from "./recovery.ts";
 import {
   adoptLegacyRecoveryLease,
   recoverBlockedWorkspace,
@@ -416,7 +417,7 @@ async function runOneIssueInternal(
     issue.title,
     worktreeStrategy,
   );
-  await recoverBlockedWorkspace({
+  const blockedRecovery = await recoverBlockedWorkspace({
     runner,
     config,
     issueNumber: issue.number,
@@ -426,6 +427,22 @@ async function runOneIssueInternal(
     resolvedArtifacts,
     lease: options.lease,
   });
+  if (
+    blockedRecovery?.decision.action === "resume" &&
+    blockedRecovery.decision.assessment.worktree.ignoredEntries.length
+  ) {
+    const message = formatRunRecoveryDecision(blockedRecovery.decision);
+    await progress(runOptions, "info", "recovery", message, {
+      issueNumber: issue.number,
+      consoleMessage: message,
+      data: {
+        action: "resume",
+        mutationApplied: false,
+        ignoredEntries:
+          blockedRecovery.decision.assessment.worktree.ignoredEntries,
+      },
+    });
+  }
   const assertExpectedWorkspaceIdentity = (): void => {
     if (
       resumableState &&

--- a/src/cli/commands/run-once/recovery-archive.test.ts
+++ b/src/cli/commands/run-once/recovery-archive.test.ts
@@ -24,7 +24,13 @@ test("archives exact state bytes before reset mutation", async () => {
     savedWorkspace: {},
     baseOid: "0123456789abcdef0123456789abcdef01234567",
     branch: { exists: true, oid: "abcdefabcdefabcdefabcdefabcdefabcdefabcd" },
-    worktree: { exists: true, registered: true, ignoredEntries: [] },
+    worktree: {
+      exists: true,
+      registered: true,
+      ordinaryClean: true,
+      ignoredStatus: "!! .pi/todos/issue-211-task.md\n",
+      ignoredEntries: [".pi/todos/issue-211-task.md"],
+    },
     actualUniqueCommits: [],
     savedCommits: [],
     artifacts: { spec: { valid: false }, plan: { valid: false } },
@@ -55,6 +61,16 @@ test("archives exact state bytes before reset mutation", async () => {
     ).recoveryClassification,
     "resumable-current",
   );
+  const archivedAssessment = JSON.parse(
+    await readFile(join(archived.path, "recovery-assessment.json"), "utf8"),
+  );
+  assert.deepEqual(archivedAssessment.worktree, {
+    exists: true,
+    registered: true,
+    ordinaryClean: true,
+    ignoredStatus: "!! .pi/todos/issue-211-task.md\n",
+    ignoredEntries: [".pi/todos/issue-211-task.md"],
+  });
   assert.doesNotMatch(archived.path, /:/);
 });
 

--- a/src/cli/commands/run-once/recovery-assessment.ts
+++ b/src/cli/commands/run-once/recovery-assessment.ts
@@ -121,7 +121,6 @@ function classify(input: {
   expectedBranchElsewhere: boolean;
   expectedBranch: string;
   dirty?: string | undefined;
-  ignored: string[];
   savedCommits: string[];
   fenced: boolean;
   active: boolean;
@@ -148,13 +147,12 @@ function classify(input: {
   )
     return "workspace-unverifiable";
   if (input.dirty) return "dirty-worktree";
-  if (input.ignored.length) return "ignored-worktree-content";
   if (!input.branchExists && input.savedCommits.length)
     return "unmerged-commits";
-  if (input.commits.length || (input.divergence?.ahead ?? 0) > 0)
-    return "resumable-with-commits";
   if (input.active && !input.fenced) return "legacy-active-unfenced";
   if (!input.branchExists || !input.worktreeExists) return "recreatable-clean";
+  if (input.commits.length || (input.divergence?.ahead ?? 0) > 0)
+    return "resumable-with-commits";
   if ((input.divergence?.behind ?? 0) > 0) return "resumable-stale-base";
   return "resumable-current";
 }
@@ -279,7 +277,6 @@ export async function assessRunRecovery(
     expectedBranchElsewhere,
     expectedBranch: input.expectedWorkspace.branch,
     dirty: dirtyStatus,
-    ignored,
     savedCommits,
     fenced: legacyMigrationFenceValid,
     active,
@@ -324,7 +321,7 @@ export async function assessRunRecovery(
       ...(registered?.branch ? { registeredBranch: registered.branch } : {}),
       ...(registered && worktreeExists
         ? {
-            clean: !dirtyStatus && ignored.length === 0,
+            ordinaryClean: !dirtyStatus,
             dirtyStatus,
             ignoredStatus,
           }

--- a/src/cli/commands/run-once/recovery-ignored-content.test.ts
+++ b/src/cli/commands/run-once/recovery-ignored-content.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { formatRunRecoveryDecision, planRunRecovery } from "./recovery.ts";
+import { decideRunRecovery } from "./recovery-policy.ts";
+import type {
+  CommandResult,
+  CommandRunner,
+  RunRecoveryAssessment,
+} from "./types.ts";
+
+type Call = { command: string; args: string[]; cwd?: string };
+
+async function planRecovery(
+  overrides: Partial<{
+    ordinaryStatus: string;
+    ignoredStatus: string;
+    revList: string;
+    log: string;
+  }> = {},
+) {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-ignored-recovery-"));
+  const worktreePath = join(repoRoot, "work");
+  await mkdir(worktreePath);
+  const runner: CommandRunner = {
+    async run(command, args, options = {}): Promise<CommandResult> {
+      const call: Call = { command, args, cwd: options.cwd };
+      if (call.args[0] === "rev-parse")
+        return {
+          code: 0,
+          stdout: call.args.at(-1)?.includes("agent/recover")
+            ? "abcdefabcdefabcdefabcdefabcdefabcdefabcd\n"
+            : "0123456789abcdef0123456789abcdef01234567\n",
+          stderr: "",
+        };
+      if (call.args.join(" ") === "worktree list --porcelain")
+        return {
+          code: 0,
+          stdout: `worktree ${worktreePath}\nHEAD abcdefabcdefabcdefabcdefabcdefabcdefabcd\nbranch refs/heads/agent/recover\n\n`,
+          stderr: "",
+        };
+      if (call.args[0] === "-C" && call.args[2] === "status")
+        return {
+          code: 0,
+          stdout: call.args.includes("--ignored=matching")
+            ? (overrides.ignoredStatus ?? "")
+            : (overrides.ordinaryStatus ?? ""),
+          stderr: "",
+        };
+      if (call.args[0] === "rev-list")
+        return { code: 0, stdout: overrides.revList ?? "0\t0\n", stderr: "" };
+      if (call.args[0] === "log")
+        return { code: 0, stdout: overrides.log ?? "", stderr: "" };
+      if (call.args[0] === "cat-file")
+        return { code: 1, stdout: "", stderr: "" };
+      throw new Error(`unexpected git ${call.args.join(" ")}`);
+    },
+  };
+  return planRunRecovery({
+    intent: "retry",
+    runner,
+    repoRoot,
+    runStatePath: join(repoRoot, "state.json"),
+    state: {
+      issueNumber: 45,
+      title: "Recover",
+      status: "blocked",
+      branch: "agent/recover",
+      worktreePath,
+      createdAt: "x",
+      updatedAt: "x",
+    },
+    baseRef: "HEAD",
+    expectedWorkspace: { branch: "agent/recover", worktreePath },
+    leaseOwnerToken: "owner",
+    snapshotRaw: "state",
+    recoveryPaths: { quarantinePath: "quarantine", stagingPath: "staging" },
+  });
+}
+
+test("current blocked retry preserves ignored workflow state in place", async () => {
+  const decision = await planRecovery({
+    ignoredStatus:
+      "!! .pi/todos/issue-211-task.md\n" +
+      "!! .superpowers/single-writer/progress.md\n",
+  });
+  assert.equal(decision.action, "resume");
+  assert.equal(decision.assessment.classification, "resumable-current");
+  assert.equal(decision.assessment.worktree.ordinaryClean, true);
+  assert.deepEqual(decision.assessment.worktree.ignoredEntries, [
+    ".pi/todos/issue-211-task.md",
+    ".superpowers/single-writer/progress.md",
+  ]);
+  assert.match(
+    formatRunRecoveryDecision(decision),
+    /resuming in place without workspace mutation; preserving ignored entries/,
+  );
+});
+
+test("commit-bearing blocked retry preserves unknown ignored content in place", async () => {
+  const decision = await planRecovery({
+    revList: "3\t2\n",
+    log: "def456 verify recovery\nabc123 implement recovery\n",
+    ignoredStatus: "!! .cache/generated.bin\n",
+  });
+  assert.equal(decision.action, "resume");
+  assert.equal(decision.assessment.classification, "resumable-with-commits");
+  assert.deepEqual(decision.assessment.divergence, { behind: 3, ahead: 2 });
+});
+
+test("ordinary dirtiness still refuses before ignored preservation", async () => {
+  const decision = await planRecovery({
+    ordinaryStatus: " M src/index.ts\n",
+    ignoredStatus: "!! .cache/generated.bin\n",
+  });
+  assert.equal(decision.action, "refuse");
+  if (decision.action === "refuse")
+    assert.equal(decision.reason, "dirty-worktree");
+});
+
+test("ignored content blocks a stale refresh with its candidate action", async () => {
+  const decision = await planRecovery({
+    revList: "3\t0\n",
+    ignoredStatus: "!! .cache/generated.bin\n",
+  });
+  assert.equal(decision.action, "refuse");
+  if (decision.action === "refuse") {
+    assert.equal(decision.reason, "ignored-worktree-content");
+    assert.equal(decision.blockedAction, "refresh-and-resume");
+    const message = formatRunRecoveryDecision(decision);
+    assert.match(
+      message,
+      /refresh-and-resume cannot prove ignored content will survive/,
+    );
+    assert.match(message, /\.cache\/generated\.bin/);
+    assert.doesNotMatch(message, /resuming in place/);
+  }
+});
+
+test("ignored content blocks reset before mutation", async () => {
+  const retry = await planRecovery({
+    ignoredStatus: "!! .cache/generated.bin\n",
+  });
+  const decision = decideRunRecovery("reset", retry.assessment, {
+    quarantinePath: "quarantine",
+    stagingPath: "staging",
+  });
+  assert.equal(decision.action, "refuse");
+  if (decision.action === "refuse") {
+    assert.equal(decision.reason, "ignored-worktree-content");
+    assert.equal(decision.blockedAction, "archive-reset-and-start");
+  }
+});
+
+test("reset unique-commit refusal takes precedence over ignored content", async () => {
+  const retry = await planRecovery({
+    revList: "0\t1\n",
+    log: "abc123 implement\n",
+    ignoredStatus: "!! .cache/generated.bin\n",
+  });
+  const decision = decideRunRecovery("reset", retry.assessment, {
+    quarantinePath: "quarantine",
+    stagingPath: "staging",
+  });
+  assert.equal(decision.action, "refuse");
+  if (decision.action === "refuse")
+    assert.equal(decision.reason, "unmerged-commits");
+});
+
+test("ignored content blocks recreation regardless of path", () => {
+  const assessment = {
+    runStatePath: "state",
+    issueNumber: 45,
+    title: "Recover",
+    status: "blocked",
+    lease: { status: "owned", ownerToken: "owner" },
+    legacyMigrationFenceValid: true,
+    blocked: true,
+    expectedWorkspace: { branch: "agent/recover", worktreePath: "work" },
+    savedWorkspace: {},
+    baseOid: "0123456789abcdef0123456789abcdef01234567",
+    branch: { exists: false },
+    worktree: {
+      exists: false,
+      registered: false,
+      ignoredEntries: [".superpowers/state", ".cache/generated.bin"],
+    },
+    actualUniqueCommits: [],
+    savedCommits: [],
+    artifacts: { spec: { valid: false }, plan: { valid: false } },
+    classification: "recreatable-clean",
+  } satisfies RunRecoveryAssessment;
+  const decision = decideRunRecovery("retry", assessment, {
+    quarantinePath: "quarantine",
+    stagingPath: "staging",
+  });
+  assert.equal(decision.action, "refuse");
+  if (decision.action === "refuse") {
+    assert.equal(decision.reason, "ignored-worktree-content");
+    assert.equal(decision.blockedAction, "recreate-and-resume");
+  }
+});

--- a/src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts
+++ b/src/cli/commands/run-once/recovery-mutation-ignored-content.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  executeRunRecoveryMutation,
+  RunRecoveryMutationError,
+} from "./recovery-mutation.ts";
+import type { RunRecoveryDecision } from "./types.ts";
+
+test("late ignored quarantine content prevents refresh ref update", async () => {
+  const root = await mkdtemp(join(tmpdir(), "patchmill-refresh-late-"));
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+  git("init");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  await writeFile(join(root, ".gitignore"), ".cache/\n");
+  await writeFile(join(root, "file"), "old\n");
+  git("add", ".");
+  git("commit", "-m", "base");
+  const oldBranchOid = git("rev-parse", "HEAD");
+  const branch = "agent/refresh";
+  const expected = join(root, "expected");
+  const quarantine = join(root, "quarantine");
+  const staging = join(root, "staging");
+  git("worktree", "add", "-b", branch, expected, oldBranchOid);
+  await writeFile(join(root, "file"), "new\n");
+  git("add", "file");
+  git("commit", "-m", "new base");
+  const baseOid = git("rev-parse", "HEAD");
+  const assessment = {
+    runStatePath: "state",
+    issueNumber: 45,
+    title: "Recover",
+    status: "blocked",
+    lease: { status: "owned", ownerToken: "owner" },
+    legacyMigrationFenceValid: true,
+    blocked: true,
+    expectedWorkspace: { branch, worktreePath: expected },
+    savedWorkspace: { branch, worktreePath: expected },
+    baseOid,
+    branch: { exists: true, oid: oldBranchOid, checkedOutAt: expected },
+    worktree: {
+      exists: true,
+      registered: true,
+      registeredBranch: branch,
+      ordinaryClean: true,
+      ignoredEntries: [],
+    },
+    divergence: { behind: 1, ahead: 0 },
+    actualUniqueCommits: [],
+    savedCommits: [],
+    artifacts: { spec: { valid: false }, plan: { valid: false } },
+    classification: "resumable-stale-base" as const,
+  };
+  const decision: RunRecoveryDecision = {
+    action: "refresh-and-resume",
+    assessment,
+    refresh: {
+      branch,
+      expectedWorktreePath: expected,
+      expectedBranchOid: oldBranchOid,
+      baseOid,
+      quarantinePath: quarantine,
+      stagingPath: staging,
+    },
+  };
+  const calls: string[][] = [];
+  let injected = false;
+  const runner = {
+    async run(_command: string, args: string[], options?: { cwd?: string }) {
+      calls.push(args);
+      try {
+        const stdout = execFileSync("git", args, {
+          cwd: options?.cwd ?? root,
+          encoding: "utf8",
+        });
+        if (args[0] === "worktree" && args[1] === "move" && !injected) {
+          injected = true;
+          await (
+            await import("node:fs/promises")
+          ).mkdir(join(quarantine, ".cache"));
+          await writeFile(
+            join(quarantine, ".cache", "late.bin"),
+            Buffer.from([0, 211, 255]),
+          );
+        }
+        return { code: 0, stdout, stderr: "" };
+      } catch (error) {
+        const e = error as {
+          status?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          code: e.status ?? 1,
+          stdout: e.stdout ?? "",
+          stderr: e.stderr ?? "",
+        };
+      }
+    },
+  };
+  await assert.rejects(
+    executeRunRecoveryMutation({
+      decision,
+      repoRoot: root,
+      runner,
+      reassess: async () => decision,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof RunRecoveryMutationError);
+      assert.match(String(error), /quarantine/);
+      assert.match(String(error), /staging/);
+      return true;
+    },
+  );
+  assert.deepEqual(
+    await readFile(join(quarantine, ".cache", "late.bin")),
+    Buffer.from([0, 211, 255]),
+  );
+  assert.equal(git("rev-parse", branch), oldBranchOid);
+  assert.equal(
+    calls.some(
+      (args) =>
+        args[0] === "update-ref" &&
+        (args[1] === "--no-deref" || args[1] === `refs/heads/${branch}`),
+    ),
+    false,
+  );
+  assert.equal(
+    calls.filter((args) => args[0] === "worktree" && args[1] === "move").length,
+    1,
+  );
+});

--- a/src/cli/commands/run-once/recovery-policy.ts
+++ b/src/cli/commands/run-once/recovery-policy.ts
@@ -17,15 +17,17 @@ type IntrinsicRefusalReason = Exclude<
   "ignored-worktree-content"
 >;
 
+const unsafeClassifications = {
+  "dirty-worktree": true,
+  "unmerged-commits": true,
+  "workspace-unverifiable": true,
+  "legacy-active-unfenced": true,
+} satisfies Record<RunRecoveryUnsafeClassification, true>;
+
 function isUnsafeClassification(
   classification: RunRecoveryClassification,
 ): classification is RunRecoveryUnsafeClassification {
-  return (
-    classification === "workspace-unverifiable" ||
-    classification === "dirty-worktree" ||
-    classification === "unmerged-commits" ||
-    classification === "legacy-active-unfenced"
-  );
+  return Object.hasOwn(unsafeClassifications, classification);
 }
 
 function refusal(

--- a/src/cli/commands/run-once/recovery-policy.ts
+++ b/src/cli/commands/run-once/recovery-policy.ts
@@ -4,6 +4,7 @@ import type {
   RunRecoveryDecision,
   RunRecoveryIntent,
   RunRecoveryMutatingAction,
+  RunRecoveryUnsafeClassification,
   RunResetSeed,
 } from "./types.ts";
 
@@ -11,10 +12,25 @@ type AssessedRefusal = Extract<
   RunRecoveryDecision,
   { action: "refuse"; assessment: RunRecoveryAssessment }
 >;
+type IntrinsicRefusalReason = Exclude<
+  AssessedRefusal["reason"],
+  "ignored-worktree-content"
+>;
+
+function isUnsafeClassification(
+  classification: RunRecoveryClassification,
+): classification is RunRecoveryUnsafeClassification {
+  return (
+    classification === "workspace-unverifiable" ||
+    classification === "dirty-worktree" ||
+    classification === "unmerged-commits" ||
+    classification === "legacy-active-unfenced"
+  );
+}
 
 function refusal(
   assessment: RunRecoveryAssessment,
-  reason: Exclude<AssessedRefusal["reason"], "ignored-worktree-content">,
+  reason: IntrinsicRefusalReason,
 ): AssessedRefusal {
   const detail =
     reason === "dirty-worktree"
@@ -24,11 +40,9 @@ function refusal(
             .concat(assessment.savedCommits)
             .join(", ")
         : undefined;
-  const preserveGuidance: Partial<
-    Record<
-      RunRecoveryClassification | "not-blocked" | "active-run",
-      string | readonly string[]
-    >
+  const preserveGuidance: Record<
+    IntrinsicRefusalReason,
+    string | readonly string[]
   > = {
     "dirty-worktree":
       "Commit, stash, or clean local modifications before retrying recovery.",
@@ -43,9 +57,8 @@ function refusal(
       "Repair the legacy Run lease fence before retrying recovery.",
     "not-blocked":
       "Use normal run-once execution; this Run state is not blocked.",
-    "active-run": "Wait for the active Run attempt before retrying recovery.",
   } as const;
-  const guidance = preserveGuidance[reason] ?? `Recovery is unsafe: ${reason}.`;
+  const guidance = preserveGuidance[reason];
   return {
     action: "refuse",
     assessment,
@@ -199,14 +212,7 @@ export function decideRunRecovery(
 ): RunRecoveryDecision {
   if (intent === "retry" && !assessment.blocked)
     return refusal(assessment, "not-blocked");
-  if (
-    [
-      "workspace-unverifiable",
-      "dirty-worktree",
-      "unmerged-commits",
-      "legacy-active-unfenced",
-    ].includes(assessment.classification)
-  )
+  if (isUnsafeClassification(assessment.classification))
     return refusal(assessment, assessment.classification);
   if (
     intent === "reset" &&

--- a/src/cli/commands/run-once/recovery-policy.ts
+++ b/src/cli/commands/run-once/recovery-policy.ts
@@ -142,7 +142,8 @@ export function decideRunRecovery(
     return refusal(assessment, assessment.classification);
   if (
     intent === "reset" &&
-    assessment.classification === "resumable-with-commits"
+    (assessment.actualUniqueCommits.length > 0 ||
+      (assessment.divergence?.ahead ?? 0) > 0)
   )
     return refusal(assessment, "unmerged-commits");
 

--- a/src/cli/commands/run-once/recovery-policy.ts
+++ b/src/cli/commands/run-once/recovery-policy.ts
@@ -3,29 +3,27 @@ import type {
   RunRecoveryClassification,
   RunRecoveryDecision,
   RunRecoveryIntent,
+  RunRecoveryMutatingAction,
   RunResetSeed,
 } from "./types.ts";
 
-function refusal(
-  assessment: RunRecoveryAssessment,
-  reason: Extract<
-    RunRecoveryDecision,
-    { action: "refuse"; assessment: RunRecoveryAssessment }
-  >["reason"],
-): Extract<
+type AssessedRefusal = Extract<
   RunRecoveryDecision,
   { action: "refuse"; assessment: RunRecoveryAssessment }
-> {
+>;
+
+function refusal(
+  assessment: RunRecoveryAssessment,
+  reason: Exclude<AssessedRefusal["reason"], "ignored-worktree-content">,
+): AssessedRefusal {
   const detail =
     reason === "dirty-worktree"
       ? assessment.worktree.dirtyStatus
-      : reason === "ignored-worktree-content"
-        ? assessment.worktree.ignoredEntries.join(", ")
-        : reason === "unmerged-commits"
-          ? assessment.actualUniqueCommits
-              .concat(assessment.savedCommits)
-              .join(", ")
-          : undefined;
+      : reason === "unmerged-commits"
+        ? assessment.actualUniqueCommits
+            .concat(assessment.savedCommits)
+            .join(", ")
+        : undefined;
   const preserveGuidance: Partial<
     Record<
       RunRecoveryClassification | "not-blocked" | "active-run",
@@ -34,8 +32,6 @@ function refusal(
   > = {
     "dirty-worktree":
       "Commit, stash, or clean local modifications before retrying recovery.",
-    "ignored-worktree-content":
-      "Inspect and preserve ignored workspace content before retrying recovery.",
     "unmerged-commits":
       "Merge or preserve the unique branch commits before retrying recovery.",
     "workspace-unverifiable": [
@@ -62,6 +58,24 @@ function refusal(
     ],
   };
 }
+
+function ignoredRefusal(
+  assessment: RunRecoveryAssessment,
+  blockedAction: RunRecoveryMutatingAction,
+): Extract<AssessedRefusal, { reason: "ignored-worktree-content" }> {
+  const entries = assessment.worktree.ignoredEntries.join(", ");
+  return {
+    action: "refuse",
+    assessment,
+    reason: "ignored-worktree-content",
+    blockedAction,
+    guidance: [
+      `Recovery action ${blockedAction} cannot prove ignored content will survive: ${entries}.`,
+      `Inspect and preserve ignored workspace content before retrying ${blockedAction}.`,
+    ],
+  };
+}
+
 function seed(assessment: RunRecoveryAssessment): RunResetSeed {
   return {
     issueNumber: assessment.issueNumber,
@@ -83,6 +97,20 @@ function seed(assessment: RunRecoveryAssessment): RunResetSeed {
       : {}),
   };
 }
+
+function canResumeInPlace(assessment: RunRecoveryAssessment): boolean {
+  return (
+    assessment.worktree.exists &&
+    assessment.worktree.registered &&
+    assessment.worktree.ordinaryClean === true &&
+    assessment.worktree.registeredBranch ===
+      assessment.expectedWorkspace.branch &&
+    assessment.branch.checkedOutAt !== undefined &&
+    (assessment.classification === "resumable-current" ||
+      assessment.classification === "resumable-with-commits")
+  );
+}
+
 /** Allocate mutation paths once at the orchestration boundary. The policy is
  * deterministic: it only selects among evidence and these already-pinned paths. */
 export function createRunRecoveryPaths(input: {
@@ -95,6 +123,7 @@ export function createRunRecoveryPaths(input: {
     stagingPath: `${base}-staging`,
   };
 }
+
 export function decideRunRecovery(
   intent: RunRecoveryIntent,
   assessment: RunRecoveryAssessment,
@@ -106,7 +135,6 @@ export function decideRunRecovery(
     [
       "workspace-unverifiable",
       "dirty-worktree",
-      "ignored-worktree-content",
       "unmerged-commits",
       "legacy-active-unfenced",
     ].includes(assessment.classification)
@@ -117,60 +145,71 @@ export function decideRunRecovery(
     assessment.classification === "resumable-with-commits"
   )
     return refusal(assessment, "unmerged-commits");
+
   const { quarantinePath, stagingPath } = plannedPaths;
-  if (intent === "reset")
-    return {
-      action: "archive-reset-and-start",
-      assessment,
-      seed: seed(assessment),
-      cleanup: {
-        branch: assessment.branch.exists
-          ? assessment.expectedWorkspace.branch
-          : undefined,
-        expectedWorktreePath: assessment.worktree.registered
-          ? assessment.expectedWorkspace.worktreePath
-          : undefined,
-        expectedBranchOid: assessment.branch.oid,
-        quarantinePath: assessment.worktree.registered
-          ? quarantinePath
-          : undefined,
-      },
-    };
-  if (assessment.classification === "resumable-stale-base")
-    return {
-      action: "refresh-and-resume",
-      assessment,
-      refresh: {
-        branch: assessment.expectedWorkspace.branch,
-        expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
-        expectedBranchOid: assessment.branch.oid!,
-        baseOid: assessment.baseOid,
-        quarantinePath,
-        stagingPath,
-      },
-    };
-  if (assessment.classification === "recreatable-clean")
-    return {
-      action: "recreate-and-resume",
-      assessment,
-      recreation: {
-        branch: assessment.expectedWorkspace.branch,
-        expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
-        mode: !assessment.branch.exists
-          ? "create-from-base"
-          : assessment.divergence?.ahead === 0 &&
-              (assessment.divergence.behind ?? 0) > 0
-            ? "advance-to-base"
-            : "reuse-existing",
-        expectedBranchOid: assessment.branch.oid,
-        targetOid:
-          assessment.branch.exists &&
-          assessment.divergence?.ahead === 0 &&
-          (assessment.divergence.behind ?? 0) > 0
-            ? assessment.baseOid
-            : (assessment.branch.oid ?? assessment.baseOid),
-        stagingPath,
-      },
-    };
-  return { action: "resume", assessment };
+  const candidate: Exclude<RunRecoveryDecision, { action: "refuse" }> =
+    intent === "reset"
+      ? {
+          action: "archive-reset-and-start",
+          assessment,
+          seed: seed(assessment),
+          cleanup: {
+            branch: assessment.branch.exists
+              ? assessment.expectedWorkspace.branch
+              : undefined,
+            expectedWorktreePath: assessment.worktree.registered
+              ? assessment.expectedWorkspace.worktreePath
+              : undefined,
+            expectedBranchOid: assessment.branch.oid,
+            quarantinePath: assessment.worktree.registered
+              ? quarantinePath
+              : undefined,
+          },
+        }
+      : assessment.classification === "resumable-stale-base"
+        ? {
+            action: "refresh-and-resume",
+            assessment,
+            refresh: {
+              branch: assessment.expectedWorkspace.branch,
+              expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
+              expectedBranchOid: assessment.branch.oid!,
+              baseOid: assessment.baseOid,
+              quarantinePath,
+              stagingPath,
+            },
+          }
+        : assessment.classification === "recreatable-clean"
+          ? {
+              action: "recreate-and-resume",
+              assessment,
+              recreation: {
+                branch: assessment.expectedWorkspace.branch,
+                expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
+                mode: !assessment.branch.exists
+                  ? "create-from-base"
+                  : assessment.divergence?.ahead === 0 &&
+                      (assessment.divergence.behind ?? 0) > 0
+                    ? "advance-to-base"
+                    : "reuse-existing",
+                expectedBranchOid: assessment.branch.oid,
+                targetOid:
+                  assessment.branch.exists &&
+                  assessment.divergence?.ahead === 0 &&
+                  (assessment.divergence.behind ?? 0) > 0
+                    ? assessment.baseOid
+                    : (assessment.branch.oid ?? assessment.baseOid),
+                stagingPath,
+              },
+            }
+          : { action: "resume", assessment };
+
+  if (candidate.action === "resume" && !canResumeInPlace(assessment))
+    return refusal(assessment, "workspace-unverifiable");
+  if (
+    !assessment.worktree.ignoredEntries.length ||
+    candidate.action === "resume"
+  )
+    return candidate;
+  return ignoredRefusal(assessment, candidate.action);
 }

--- a/src/cli/commands/run-once/recovery-policy.ts
+++ b/src/cli/commands/run-once/recovery-policy.ts
@@ -111,6 +111,74 @@ function canResumeInPlace(assessment: RunRecoveryAssessment): boolean {
   );
 }
 
+type CandidateDecision = Exclude<RunRecoveryDecision, { action: "refuse" }>;
+
+function deriveCandidateDecision(
+  intent: RunRecoveryIntent,
+  assessment: RunRecoveryAssessment,
+  plannedPaths: { quarantinePath: string; stagingPath: string },
+): CandidateDecision {
+  const { quarantinePath, stagingPath } = plannedPaths;
+  if (intent === "reset") {
+    return {
+      action: "archive-reset-and-start",
+      assessment,
+      seed: seed(assessment),
+      cleanup: {
+        branch: assessment.branch.exists
+          ? assessment.expectedWorkspace.branch
+          : undefined,
+        expectedWorktreePath: assessment.worktree.registered
+          ? assessment.expectedWorkspace.worktreePath
+          : undefined,
+        expectedBranchOid: assessment.branch.oid,
+        quarantinePath: assessment.worktree.registered
+          ? quarantinePath
+          : undefined,
+      },
+    };
+  }
+  if (assessment.classification === "resumable-stale-base") {
+    return {
+      action: "refresh-and-resume",
+      assessment,
+      refresh: {
+        branch: assessment.expectedWorkspace.branch,
+        expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
+        expectedBranchOid: assessment.branch.oid!,
+        baseOid: assessment.baseOid,
+        quarantinePath,
+        stagingPath,
+      },
+    };
+  }
+  if (assessment.classification === "recreatable-clean") {
+    const branchBehindBase =
+      assessment.divergence?.ahead === 0 &&
+      (assessment.divergence.behind ?? 0) > 0;
+    let mode: "create-from-base" | "advance-to-base" | "reuse-existing" =
+      "reuse-existing";
+    if (!assessment.branch.exists) mode = "create-from-base";
+    else if (branchBehindBase) mode = "advance-to-base";
+    return {
+      action: "recreate-and-resume",
+      assessment,
+      recreation: {
+        branch: assessment.expectedWorkspace.branch,
+        expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
+        mode,
+        expectedBranchOid: assessment.branch.oid,
+        targetOid:
+          assessment.branch.exists && branchBehindBase
+            ? assessment.baseOid
+            : (assessment.branch.oid ?? assessment.baseOid),
+        stagingPath,
+      },
+    };
+  }
+  return { action: "resume", assessment };
+}
+
 /** Allocate mutation paths once at the orchestration boundary. The policy is
  * deterministic: it only selects among evidence and these already-pinned paths. */
 export function createRunRecoveryPaths(input: {
@@ -147,63 +215,7 @@ export function decideRunRecovery(
   )
     return refusal(assessment, "unmerged-commits");
 
-  const { quarantinePath, stagingPath } = plannedPaths;
-  const candidate: Exclude<RunRecoveryDecision, { action: "refuse" }> =
-    intent === "reset"
-      ? {
-          action: "archive-reset-and-start",
-          assessment,
-          seed: seed(assessment),
-          cleanup: {
-            branch: assessment.branch.exists
-              ? assessment.expectedWorkspace.branch
-              : undefined,
-            expectedWorktreePath: assessment.worktree.registered
-              ? assessment.expectedWorkspace.worktreePath
-              : undefined,
-            expectedBranchOid: assessment.branch.oid,
-            quarantinePath: assessment.worktree.registered
-              ? quarantinePath
-              : undefined,
-          },
-        }
-      : assessment.classification === "resumable-stale-base"
-        ? {
-            action: "refresh-and-resume",
-            assessment,
-            refresh: {
-              branch: assessment.expectedWorkspace.branch,
-              expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
-              expectedBranchOid: assessment.branch.oid!,
-              baseOid: assessment.baseOid,
-              quarantinePath,
-              stagingPath,
-            },
-          }
-        : assessment.classification === "recreatable-clean"
-          ? {
-              action: "recreate-and-resume",
-              assessment,
-              recreation: {
-                branch: assessment.expectedWorkspace.branch,
-                expectedWorktreePath: assessment.expectedWorkspace.worktreePath,
-                mode: !assessment.branch.exists
-                  ? "create-from-base"
-                  : assessment.divergence?.ahead === 0 &&
-                      (assessment.divergence.behind ?? 0) > 0
-                    ? "advance-to-base"
-                    : "reuse-existing",
-                expectedBranchOid: assessment.branch.oid,
-                targetOid:
-                  assessment.branch.exists &&
-                  assessment.divergence?.ahead === 0 &&
-                  (assessment.divergence.behind ?? 0) > 0
-                    ? assessment.baseOid
-                    : (assessment.branch.oid ?? assessment.baseOid),
-                stagingPath,
-              },
-            }
-          : { action: "resume", assessment };
+  const candidate = deriveCandidateDecision(intent, assessment, plannedPaths);
 
   if (candidate.action === "resume" && !canResumeInPlace(assessment))
     return refusal(assessment, "workspace-unverifiable");

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -408,8 +408,24 @@ test("typed recovery decision table selects only conservative actions", () => {
     expectedWorkspace: { branch: "agent/recover", worktreePath: "work" },
     savedWorkspace: {},
     baseOid: "0123456789abcdef0123456789abcdef01234567",
-    branch: { exists: false },
-    worktree: { exists: false, registered: false, ignoredEntries: [] },
+    branch: {
+      exists: classification !== "recreatable-clean",
+      ...(classification === "resumable-current" ||
+      classification === "resumable-with-commits"
+        ? { checkedOutAt: "work" }
+        : {}),
+    },
+    worktree:
+      classification === "resumable-current" ||
+      classification === "resumable-with-commits"
+        ? {
+            exists: true,
+            registered: true,
+            registeredBranch: "agent/recover",
+            ordinaryClean: true,
+            ignoredEntries: [],
+          }
+        : { exists: false, registered: false, ignoredEntries: [] },
     actualUniqueCommits: [],
     savedCommits: [],
     artifacts: { spec: { valid: false }, plan: { valid: false } },

--- a/src/cli/commands/run-once/recovery.test.ts
+++ b/src/cli/commands/run-once/recovery.test.ts
@@ -426,7 +426,8 @@ test("typed recovery decision table selects only conservative actions", () => {
             ignoredEntries: [],
           }
         : { exists: false, registered: false, ignoredEntries: [] },
-    actualUniqueCommits: [],
+    actualUniqueCommits:
+      classification === "resumable-with-commits" ? ["abc123 implement"] : [],
     savedCommits: [],
     artifacts: { spec: { valid: false }, plan: { valid: false } },
     classification,

--- a/src/cli/commands/run-once/recovery.ts
+++ b/src/cli/commands/run-once/recovery.ts
@@ -49,5 +49,7 @@ export function formatRunRecoveryDecision(
     return `Issue #${decision.assessment.issueNumber} will recreate its clean workspace before resuming.`;
   if (decision.action === "archive-reset-and-start")
     return `Issue #${decision.assessment.issueNumber} will archive recovery state and start a new Run attempt.`;
+  if (decision.assessment.worktree.ignoredEntries.length)
+    return `Issue #${decision.assessment.issueNumber} is resuming in place without workspace mutation; preserving ignored entries: ${decision.assessment.worktree.ignoredEntries.join(", ")}.`;
   return `Issue #${decision.assessment.issueNumber} will resume (${decision.assessment.classification}).`;
 }

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -341,6 +341,13 @@ export type RunRecoveryClassification =
   | "unmerged-commits"
   | "workspace-unverifiable"
   | "legacy-active-unfenced";
+export type RunRecoveryUnsafeClassification = Extract<
+  RunRecoveryClassification,
+  | "dirty-worktree"
+  | "unmerged-commits"
+  | "workspace-unverifiable"
+  | "legacy-active-unfenced"
+>;
 export type RunRecoveryAction =
   | "resume"
   | "refresh-and-resume"
@@ -348,7 +355,7 @@ export type RunRecoveryAction =
   | "archive-reset-and-start";
 export type RunRecoveryMutatingAction = Exclude<RunRecoveryAction, "resume">;
 export type RunRecoveryRefusalReason =
-  | RunRecoveryClassification
+  | RunRecoveryUnsafeClassification
   | "ignored-worktree-content"
   | "not-blocked";
 export type RunRecoveryLeaseOwner = {

--- a/src/cli/commands/run-once/types.ts
+++ b/src/cli/commands/run-once/types.ts
@@ -338,10 +338,19 @@ export type RunRecoveryClassification =
   | "resumable-with-commits"
   | "recreatable-clean"
   | "dirty-worktree"
-  | "ignored-worktree-content"
   | "unmerged-commits"
   | "workspace-unverifiable"
   | "legacy-active-unfenced";
+export type RunRecoveryAction =
+  | "resume"
+  | "refresh-and-resume"
+  | "recreate-and-resume"
+  | "archive-reset-and-start";
+export type RunRecoveryMutatingAction = Exclude<RunRecoveryAction, "resume">;
+export type RunRecoveryRefusalReason =
+  | RunRecoveryClassification
+  | "ignored-worktree-content"
+  | "not-blocked";
 export type RunRecoveryLeaseOwner = {
   version: 1;
   issueNumber: number;
@@ -399,7 +408,7 @@ export type RunRecoveryAssessment = {
     exists: boolean;
     registered: boolean;
     registeredBranch?: string | undefined;
-    clean?: boolean | undefined;
+    ordinaryClean?: boolean | undefined;
     dirtyStatus?: string | undefined;
     ignoredStatus?: string | undefined;
     ignoredEntries: string[];
@@ -456,7 +465,14 @@ export type RunRecoveryDecision =
   | {
       action: "refuse";
       assessment: RunRecoveryAssessment;
-      reason: RunRecoveryClassification | "not-blocked";
+      reason: "ignored-worktree-content";
+      blockedAction: RunRecoveryMutatingAction;
+      guidance: string[];
+    }
+  | {
+      action: "refuse";
+      assessment: RunRecoveryAssessment;
+      reason: Exclude<RunRecoveryRefusalReason, "ignored-worktree-content">;
       guidance: string[];
     }
   | {

--- a/src/cli/commands/run/reset/reset.test.ts
+++ b/src/cli/commands/run/reset/reset.test.ts
@@ -403,6 +403,53 @@ async function resetFixture(fail?: (args: string[]) => boolean) {
   };
 }
 
+test("ignored content refuses reset before archive or mutation", async () => {
+  const fixture = await resetFixture();
+  await writeFile(
+    join(fixture.runConfig.repoRoot, ".git", "info", "exclude"),
+    ".env.local\n",
+  );
+  const sentinel = join(fixture.worktreePath, ".env.local");
+  await writeFile(sentinel, "secret\n");
+  const branchOid = fixture.git("rev-parse", fixture.workspace.branch).trim();
+  let archiveCalled = false;
+  let mutationCalled = false;
+  await assert.rejects(
+    resetIssueRun(
+      fixture.runner,
+      fixture.runConfig,
+      { now: NOW },
+      {
+        ...fixture.dependencies,
+        archiveRecovery: async () => {
+          archiveCalled = true;
+          return { path: "must-not-exist" } as never;
+        },
+        executeMutation: async () => {
+          mutationCalled = true;
+          throw new Error("mutation must not run");
+        },
+      },
+    ),
+    (error: unknown) => {
+      assert.match(String(error), /ignored-worktree-content/);
+      assert.match(String(error), /archive-reset-and-start/);
+      assert.match(String(error), /\.env\.local/);
+      return true;
+    },
+  );
+  assert.equal(archiveCalled, false);
+  assert.equal(mutationCalled, false);
+  assert.equal(
+    await (await import("node:fs/promises")).readFile(sentinel, "utf8"),
+    "secret\n",
+  );
+  assert.equal(
+    fixture.git("rev-parse", fixture.workspace.branch).trim(),
+    branchOid,
+  );
+});
+
 test("archive failure leaves the active state and workspace untouched without pipeline entry", async () => {
   const fixture = await resetFixture();
   await assert.rejects(

--- a/src/cli/commands/run/reset/reset.test.ts
+++ b/src/cli/commands/run/reset/reset.test.ts
@@ -450,6 +450,51 @@ test("ignored content refuses reset before archive or mutation", async () => {
   );
 });
 
+test("missing worktree with unique commits refuses reset before archive or mutation", async () => {
+  const fixture = await resetFixture();
+  await writeFile(join(fixture.worktreePath, "partial"), "implementation\n");
+  fixture.git("-C", fixture.worktreePath, "add", "partial");
+  fixture.git(
+    "-C",
+    fixture.worktreePath,
+    "commit",
+    "-m",
+    "partial implementation",
+  );
+  const branchOid = fixture.git("rev-parse", fixture.workspace.branch).trim();
+  fixture.git("worktree", "remove", "--force", fixture.worktreePath);
+  let archiveCalled = false;
+  let mutationCalled = false;
+  await assert.rejects(
+    resetIssueRun(
+      fixture.runner,
+      fixture.runConfig,
+      { now: NOW },
+      {
+        ...fixture.dependencies,
+        archiveRecovery: async () => {
+          archiveCalled = true;
+          return { path: "must-not-exist" } as never;
+        },
+        executeMutation: async () => {
+          mutationCalled = true;
+          throw new Error("mutation must not run");
+        },
+      },
+    ),
+    (error: unknown) => {
+      assert.match(String(error), /unmerged-commits/);
+      return true;
+    },
+  );
+  assert.equal(archiveCalled, false);
+  assert.equal(mutationCalled, false);
+  assert.equal(
+    fixture.git("rev-parse", fixture.workspace.branch).trim(),
+    branchOid,
+  );
+});
+
 test("archive failure leaves the active state and workspace untouched without pipeline entry", async () => {
   const fixture = await resetFixture();
   await assert.rejects(

--- a/test-support/run-once/pipeline-fixtures.ts
+++ b/test-support/run-once/pipeline-fixtures.ts
@@ -311,10 +311,15 @@ export function blockedRecoveryRunner(
     branchExists?: boolean;
     worktreeRegistered?: boolean;
     dirtyStatus?: string;
+    ordinaryStatus?: string;
+    ignoredStatus?: string;
     merged?: boolean;
     revList?: string;
     log?: string;
-    onPi?: (prompt: string) => CommandResult;
+    onPi?: (
+      prompt: string,
+      call: Call,
+    ) => CommandResult | Promise<CommandResult>;
     selectedComments?: IssueSummary["comments"];
   } = {},
 ): MockRunner {
@@ -382,7 +387,10 @@ export function blockedRecoveryRunner(
       call.args[0] === "-C" &&
       call.args[2] === "status"
     ) {
-      return { code: 0, stdout: options.dirtyStatus ?? "", stderr: "" };
+      const status = call.args.includes("--ignored=matching")
+        ? (options.ignoredStatus ?? options.dirtyStatus ?? "")
+        : (options.ordinaryStatus ?? options.dirtyStatus ?? "");
+      return { code: 0, stdout: status, stderr: "" };
     }
     if (
       call.command === "git" &&
@@ -401,6 +409,12 @@ export function blockedRecoveryRunner(
     if (call.command === "git" && call.args[0] === "rev-list") {
       return { code: 0, stdout: options.revList ?? "0\t2\n", stderr: "" };
     }
+    if (
+      call.command === "git" &&
+      call.args[0] === "worktree" &&
+      call.args[1] === "move"
+    )
+      return { code: 0, stdout: "", stderr: "" };
     if (call.command === "git" && call.args[0] === "status") {
       return { code: 0, stdout: "", stderr: "" };
     }
@@ -434,7 +448,7 @@ export function blockedRecoveryRunner(
     if (call.command === "pi") {
       const prompt = await readFile(promptPath(call.args), "utf8");
       return options.onPi
-        ? options.onPi(prompt)
+        ? await options.onPi(prompt, call)
         : {
             code: 0,
             stdout: JSON.stringify({


### PR DESCRIPTION
## Summary

- classify ordinary worktree cleanliness and ignored inventory independently
- preserve all ignored state for verified in-place blocked-run resumes and report that preservation before Pi starts
- keep refresh, recreation, and reset fail-closed, including late ignored-content races and missing-worktree unique-commit reset protection
- document the path-agnostic preservation and destructive-refusal policy

## Validation

- focused recovery/pipeline/mutation/reset tests: 58 passed
- `npm run test:run-once`: 575 passed
- `npm test`: 1,532 passed
- `npm run lint`
- `npm run build`
- `npm run site:build`
- `git diff --check`
- dependency metadata unchanged; Nix build not required

## Reviews

- Final Codex full-worktree review passed after accepted test and reset-safety fixes.
- Final thermo-nuclear full-worktree review passed after focused policy-structure fixes.
- Final validation-readiness review passed against fresh exact-HEAD logs.

Closes #211

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Planning | gpt-5.6-sol | 3,571,786 | 28,419 | $3.3231 |
| Development environment | gpt-5.6-sol | 327,899 | 2,666 | $0.5450 |
| Implementation | gpt-5.6-sol | 17,590,288 | 126,071 | $19.1516 |
| Implementation | gpt-5.6-terra | 11,091,074 | 35,443 | $3.7681 |
| **Implementation subtotal** |  | **28,681,362** | **161,514** | **$22.9198** |
| **Total** |  | **32,581,047** | **192,599** | **$26.7879** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->