### PR TITLE
feat(host): implement Forgejo planning pull request adapter

### DIFF
--- a/docs/plans/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter.md
+++ b/docs/plans/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter.md
@@ -1,0 +1,1181 @@
+# Issue 186 Forgejo Planning Pull Request Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a provider-neutral `PullRequestHost` adapter for Forgejo
+through exact `git` and `tea api` command contracts without exposing it through
+the current factory or run-once workflow.
+
+**Architecture:** Add a small public `ForgejoTeaPullRequestHost` facade over a
+command client, pure Forgejo payload/remote parsers, and stable adapter errors.
+Resolve the target and configured push remote before every pull request
+operation, normalize complete nested identities, and let the command client own
+HTTP status extraction and exhaustive pagination.
+
+**Tech Stack:** TypeScript, Node.js 24, NodeNext modules, `node:test`, the
+existing `CommandRunner`, `tea api`, Git, ESLint, Prettier, strict TypeScript,
+and dependency-cruiser.
+
+**Spec:**
+`docs/specs/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter-design.md`
+
+## Global Constraints
+
+- Implement the unchanged `PullRequestHost` contract from
+  `src/host/pull-requests.ts`; do not extend `ForgejoTeaHostProvider`.
+- Keep the adapter unreachable from `src/host/factory.ts` and the run-once
+  workflow.
+- Do not change GitHub support, planning workspaces, phase publication,
+  recovery, merge behavior, branch cleanup, or the legacy URL-based Forgejo pull
+  request body adapter.
+- Use `CommandRunner`, `withTeaContext()`, and `withTeaRepositoryContext()`;
+  invoke commands with argument arrays and never pass a title, body, branch,
+  remote, or URL through a shell.
+- The constructor rejects a blank configured push remote. Public operations
+  reject invalid pull request numbers and invalid or owner-qualified Git branch
+  names before running provider commands.
+- Resolve both the live target and configured push-remote identity before each
+  create, find, get, read-body, or update-body operation. Start those two
+  resolutions independently with `Promise.all`.
+- Allow target and head owners or repository names to differ, but require the
+  provider and Forgejo host to match.
+- Treat Forgejo's repository response as authoritative for owner and repository
+  spelling, including renamed or transferred repositories.
+- Require mutually consistent `name`, `full_name`, `owner.login`, and `html_url`
+  repository fields. Never guess a missing nested repository.
+- Normalize only the three specified state/merge combinations: `open`, `merged`,
+  and `closed-unmerged`.
+- List `state=all` with a fixed page size of `50`, starting at page `1`, and
+  continue until the raw page has fewer than `50` entries. Never return a
+  partial result.
+- Convert only a nonzero exact get-endpoint result whose final complete HTTP
+  status line is `404` into `PullRequestNotFoundError`.
+- Keep command, authentication, rate-limit, transport, invalid-JSON, malformed
+  response, identity, incomplete-search, and not-found failures distinct.
+- Keep raw stdout and stderr available for explicit inspection but out of error
+  messages and default JSON serialization.
+- Keep each production module focused and target fewer than 200 meaningful
+  lines. Split by the parser/command/facade boundaries below rather than adding
+  generic helper modules.
+- Add no npm dependencies. If implementation unexpectedly changes
+  `package.json`, `package-lock.json`, or `npm-shrinkwrap.json`, run the
+  repository-required Nix build.
+
+---
+
+## File and Module Map
+
+### New production modules
+
+- `src/host/forgejo-tea-pull-request-errors.ts` owns stable Forgejo adapter
+  error categories, operation names, safe public fields, and non-enumerable raw
+  diagnostics.
+- `src/host/forgejo-tea-pull-request-parsing.ts` owns pure clone URL parsing,
+  public input validation, repository payload normalization, and pull request
+  payload normalization.
+- `src/host/forgejo-tea-pull-request-commands.ts` owns `git` and `tea api`
+  execution, target/explicit repository context, final HTTP status extraction,
+  JSON decoding, and page advancement.
+- `src/host/forgejo-tea-pull-requests.ts` owns the public
+  `ForgejoTeaPullRequestHost` and operation-level live-context validation.
+
+### New test modules
+
+- `src/host/forgejo-tea-pull-request-parsing.test.ts` protects remote URL,
+  repository payload, branch/number validation, and pull request normalization
+  behavior.
+- `src/host/forgejo-tea-pull-requests.test.ts` uses a recording runner to
+  protect repository resolution, exact command arguments, pagination, operation
+  orchestration, and failure classification.
+
+### Existing modules consumed but not modified
+
+- `src/host/pull-requests.ts:3-136` supplies `RepositoryIdentity`, normalized
+  pull request types, identity comparison, foundation errors, and
+  `PullRequestHost`.
+- `src/host/forgejo-tea-context.ts:72-88` supplies target and explicit
+  repository `tea` context argument insertion.
+- `src/cli/commands/triage/types.ts:45-65` supplies `CommandResult` and
+  `CommandRunner`.
+- `test-support/command-runner.ts:20-37` supplies a reusable recording static
+  command runner.
+
+Do not modify `src/host/factory.ts`, `src/host/forgejo-tea.ts`,
+`src/host/forgejo-pr-body.ts`, or files under `src/cli/commands/run-once/`.
+
+---
+
+### Task 1: Define safe Forgejo errors and pure normalization
+
+**Files:**
+
+- Create: `src/host/forgejo-tea-pull-request-errors.ts`
+- Create: `src/host/forgejo-tea-pull-request-parsing.ts`
+- Create: `src/host/forgejo-tea-pull-request-parsing.test.ts`
+
+**Interfaces:**
+
+- Consumes: `RepositoryIdentity`, `PullRequestSummary`,
+  `PullRequestIdentityError`, and `sameRepositoryIdentity` from
+  `src/host/pull-requests.ts`.
+- Produces: `ForgejoPullRequestErrorCategory`, `ForgejoPullRequestOperation`,
+  and `ForgejoTeaPullRequestError`.
+- Produces: `ForgejoRemoteRepositoryCoordinates` and
+  `parseForgejoRemoteUrl(remoteUrl)`.
+- Produces: `validateForgejoRemoteName(remote)`,
+  `validateForgejoBranchName(branch)`, and
+  `validateForgejoPullRequestNumber(number)`.
+- Produces: `normalizeForgejoRepository(payload, options)` and
+  `normalizeForgejoPullRequest(payload, options)`.
+
+- [ ] **Step 1: Write failing URL and public-input parsing tests**
+
+Create `src/host/forgejo-tea-pull-request-parsing.test.ts`. Use table-driven
+assertions for these exact successful clone URL cases:
+
+```ts
+const acceptedRemotes = [
+  [
+    "https://forge.example/acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+  [
+    "http://FORGE.EXAMPLE/acme/widgets",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+  [
+    "ssh://git@forge.example/acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+  [
+    "git@forge.example:acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+] as const;
+```
+
+Reject all of these without copying the raw URL into the thrown error message or
+`JSON.stringify(error)`:
+
+```ts
+const rejectedRemotes = [
+  "/srv/git/acme/widgets.git",
+  "file:///srv/git/acme/widgets.git",
+  "https://robot:secret@forge.example/acme/widgets.git",
+  "https://forge.example/widgets.git",
+  "https://forge.example/group/acme/widgets.git",
+  "https://forge.example/acme/widgets.git?token=secret",
+  "git@forge.example:widgets.git",
+  "git@forge.example:group/acme/widgets.git",
+];
+```
+
+Also assert that an empty/whitespace remote name, branch values `""`,
+`" owner:topic "`, `"owner:topic"`, `"topic..next"`, and `"-topic"`, and pull
+request numbers `0`, `-1`, `1.5`, `Number.MAX_SAFE_INTEGER + 1`, and `NaN`
+produce the adapter's `invalid-input` category. Assert that `"feature/topic"`
+and a leading-hyphen remote name such as `"-publish"` remain valid.
+
+- [ ] **Step 2: Write failing repository payload tests**
+
+Add fixtures with the exact Forgejo repository shape:
+
+```ts
+const targetPayload = {
+  name: "widgets-renamed",
+  full_name: "platform/widgets-renamed",
+  owner: { login: "platform" },
+  html_url: "https://FORGE.EXAMPLE/platform/widgets-renamed",
+};
+
+const targetIdentity = {
+  provider: "forgejo-tea",
+  host: "forge.example",
+  owner: "platform",
+  repository: "widgets-renamed",
+} as const;
+```
+
+Assert that `normalizeForgejoRepository` returns `targetIdentity`, proving that
+the response rather than the raw remote slug is authoritative. Add individual
+failure cases for:
+
+- a non-object payload;
+- missing or non-string `name`, `full_name`, `owner.login`, or `html_url`;
+- an empty owner or repository;
+- a non-HTTP(S), credential-bearing, query-bearing, or malformed web URL;
+- disagreement between `name`, `full_name`, `owner.login`, and the URL path;
+- an expected remote host that differs from the response host.
+
+Expect structural failures to be `ForgejoTeaPullRequestError` with category
+`malformed-response`. Expect complete but contradictory identity to be
+`PullRequestIdentityError`. No failure message may contain credentials or the
+raw response JSON.
+
+- [ ] **Step 3: Write failing pull request normalization tests**
+
+Use a complete nested fixture rather than replacing `base.repo` or `head.repo`
+with slugs:
+
+```ts
+const openPullPayload = {
+  number: 42,
+  html_url: "https://forge.example/platform/widgets-renamed/pulls/42",
+  body: "Refs #186",
+  state: "open",
+  merged: false,
+  merge_commit_sha: null,
+  base: { ref: "main", repo: targetPayload },
+  head: {
+    ref: "agent/issue-186-adapter",
+    sha: "abc123",
+    repo: {
+      name: "widgets",
+      full_name: "contributor/widgets",
+      owner: { login: "contributor" },
+      html_url: "https://forge.example/contributor/widgets",
+    },
+  },
+};
+```
+
+Assert exact normalized summaries for:
+
+- open with `merged: false` and no merge commit;
+- closed/merged with `merged: true` and a nonblank `merge_commit_sha`;
+- closed-unmerged with `merged: false` and no merge commit;
+- same-owner and cross-owner heads.
+
+Add rejection cases for an unsafe number, a URL with the wrong host, target,
+path kind, or number, a non-string body, blank base/head refs or head SHA,
+missing nested repositories, internally contradictory nested repositories,
+unknown state, and every inconsistent merged flag/merge commit combination. Pass
+`expectedNumber` for the number-mismatch test, `expectedTargetRepository` for
+every test, and `expectedHeadRepository` for create/get-style tests. Verify a
+structurally complete same-host head can be normalized without an
+`expectedHeadRepository`; Task 3 will use that form while examining list results
+and will filter it by exact query identity.
+
+- [ ] **Step 4: Run the parsing test to prove RED**
+
+Run:
+
+```sh
+node --test src/host/forgejo-tea-pull-request-parsing.test.ts
+```
+
+Expected: FAIL because the parsing and error modules do not exist.
+
+- [ ] **Step 5: Implement the stable error surface**
+
+Create `src/host/forgejo-tea-pull-request-errors.ts` with this public surface:
+
+```ts
+export type ForgejoPullRequestErrorCategory =
+  | "invalid-input"
+  | "command-failed"
+  | "invalid-json"
+  | "malformed-response";
+
+export type ForgejoPullRequestOperation =
+  | "validate-input"
+  | "resolve-target-repository"
+  | "resolve-remote-repository"
+  | "create-pull-request"
+  | "list-pull-requests"
+  | "get-pull-request"
+  | "update-pull-request";
+
+export type ForgejoCommandName = "git" | "tea";
+
+export type ForgejoCommandDiagnostics = Readonly<{
+  stdout: string;
+  stderr: string;
+}>;
+
+export class ForgejoTeaPullRequestError extends Error {
+  readonly category: ForgejoPullRequestErrorCategory;
+  readonly operation: ForgejoPullRequestOperation;
+  readonly command?: ForgejoCommandName;
+  readonly exitCode?: number;
+  readonly httpStatus?: number;
+  readonly rawDiagnostics?: ForgejoCommandDiagnostics;
+
+  constructor(input: {
+    category: ForgejoPullRequestErrorCategory;
+    operation: ForgejoPullRequestOperation;
+    command?: ForgejoCommandName;
+    exitCode?: number;
+    httpStatus?: number;
+    rawDiagnostics?: ForgejoCommandDiagnostics;
+    cause?: unknown;
+  });
+}
+```
+
+Set the public message only from `operation` and `category`, for example
+`Forgejo pull request get-pull-request failed: command-failed`. Assign optional
+safe fields only when present. Install `rawDiagnostics` with
+`Object.defineProperty(..., { enumerable: false })`; do not put stdout, stderr,
+command arguments, remote URLs, pull request titles, or bodies in the message.
+Set `name` to `ForgejoTeaPullRequestError` and pass `cause` to `Error` only when
+it is defined.
+
+- [ ] **Step 6: Implement strict pure parsers and validators**
+
+Create `src/host/forgejo-tea-pull-request-parsing.ts` with these exact exports:
+
+```ts
+export type ForgejoRemoteRepositoryCoordinates = {
+  host: string;
+  owner: string;
+  repository: string;
+  slug: string;
+};
+
+export function validateForgejoRemoteName(remote: string): void;
+export function validateForgejoBranchName(branch: string): void;
+export function validateForgejoPullRequestNumber(number: number): void;
+
+export function parseForgejoRemoteUrl(
+  remoteUrl: string,
+): ForgejoRemoteRepositoryCoordinates;
+
+export function normalizeForgejoRepository(
+  payload: unknown,
+  options: {
+    operation: ForgejoPullRequestOperation;
+    expectedHost?: string;
+  },
+): RepositoryIdentity;
+
+export function normalizeForgejoPullRequest(
+  payload: unknown,
+  options: {
+    operation: ForgejoPullRequestOperation;
+    expectedTargetRepository: RepositoryIdentity;
+    expectedHeadRepository?: RepositoryIdentity;
+    expectedNumber?: number;
+  },
+): PullRequestSummary;
+```
+
+Implement the following rules directly in the pure module:
+
+1. `parseForgejoRemoteUrl` accepts only HTTP, HTTPS, SSH URL, and scp-like
+   forms; permits an SSH user but rejects HTTP credentials; rejects query and
+   fragment data; requires exactly two nonempty path components; removes one
+   trailing `.git`; and returns the lowercased URL host plus provider spelling
+   for owner/repository. Throw `PullRequestIdentityError` with a fixed reason
+   that does not contain the input URL.
+2. Branch validation follows Git branch safety rules without running Git:
+   require the original value to be nonblank and trimmed; reject a leading
+   hyphen, exactly `@`, `..`, `@{`, control/space characters, `~ ^ : ? * [ \\`,
+   leading/trailing or doubled slash, a trailing dot, a dot-leading path
+   component, and a component ending in `.lock`. A slash inside a valid branch
+   remains allowed.
+3. Repository normalization requires exact agreement among `name`, `full_name`,
+   `owner.login`, and the two-component HTTP(S) `html_url` path. Use
+   `URL.host.toLowerCase()` for the normalized host. Reject URL credentials,
+   query, fragment, and extra path components.
+4. Pull request normalization parses both nested repositories with the same
+   strict repository parser, requires the nested base identity to match the
+   expected target, and requires the nested head identity to match the expected
+   head whenever that option is present. It validates an exact
+   `/owner/repository/pulls/<number>` HTTP(S) URL in the expected target.
+5. Map only `open/false/null`, `closed/true/nonblank-string`, and
+   `closed/false/null` to the three foundation statuses. Do not coerce strings,
+   numbers, booleans, states, or nullability.
+
+Use `PullRequestIdentityError` for complete identity disagreement. Use
+`ForgejoTeaPullRequestError` category `malformed-response` for missing,
+ill-typed, invalid URL, or inconsistent provider response fields.
+
+- [ ] **Step 7: Format, validate, and commit the parsing slice**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/host/forgejo-tea-pull-request-errors.ts \
+  src/host/forgejo-tea-pull-request-parsing.ts \
+  src/host/forgejo-tea-pull-request-parsing.test.ts
+node --test src/host/forgejo-tea-pull-request-parsing.test.ts
+npm run check:types
+```
+
+Expected: the focused test and strict type check PASS.
+
+Commit:
+
+```sh
+git add \
+  src/host/forgejo-tea-pull-request-errors.ts \
+  src/host/forgejo-tea-pull-request-parsing.ts \
+  src/host/forgejo-tea-pull-request-parsing.test.ts
+git commit -m "feat(host): parse Forgejo pull request payloads"
+```
+
+---
+
+### Task 2: Implement repository identity and command failure boundaries
+
+**Files:**
+
+- Create: `src/host/forgejo-tea-pull-request-commands.ts`
+- Create: `src/host/forgejo-tea-pull-requests.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CommandRunner`, `withTeaContext()`, `withTeaRepositoryContext()`,
+  Task 1 parsers/errors, and foundation identity comparison/errors.
+- Produces: `ForgejoTeaPullRequestCommandOptions` and the internal-facing
+  `ForgejoTeaPullRequestCommands` command client.
+- Produces now: `resolveTargetRepositoryIdentity(): Promise<RepositoryIdentity>`
+  and `resolveRemoteRepositoryIdentity(remote): Promise<RepositoryIdentity>`.
+- Produces private command primitives that Task 3 and Task 4 extend without
+  duplicating status, diagnostics, or JSON behavior.
+
+- [ ] **Step 1: Build recording-runner fixtures for exact commands**
+
+Create `src/host/forgejo-tea-pull-requests.test.ts`. Import
+`createStaticCommandRunner` from `../../test-support/command-runner.ts`, create
+a temporary Git repository config with an `origin` URL, and add fixture helpers
+with these signatures:
+
+```ts
+function repositoryPayload(input: {
+  host?: string;
+  owner: string;
+  repository: string;
+}): Record<string, unknown>;
+
+function jsonResult(value: unknown, stderr?: string): CommandResult;
+
+async function withForgejoRepository(
+  run: (repoRoot: string) => Promise<void>,
+): Promise<void>;
+```
+
+`withForgejoRepository` writes this target context and always removes its temp
+directory in `finally`:
+
+```ini
+[remote "origin"]
+    url = git@forge.example:legacy/widgets.git
+```
+
+- [ ] **Step 2: Write failing target and remote resolution tests**
+
+Test that target resolution returns provider-normalized renamed identity and
+records exactly:
+
+```ts
+{
+  command: "tea",
+  args: [
+    "api",
+    "/repos/{owner}/{repo}",
+    "--include",
+    "--repo",
+    "legacy/widgets",
+    "--login",
+    "robot",
+  ],
+  cwd: repoRoot,
+}
+```
+
+Test `resolveRemoteRepositoryIdentity("-publish")` with Git stdout containing
+two push URLs for the same repository. Assert this first call:
+
+```ts
+{
+  command: "git",
+  args: ["remote", "get-url", "--push", "--all", "--", "-publish"],
+  cwd: repoRoot,
+}
+```
+
+Then assert one `tea api /repos/{owner}/{repo} --include` call per nonempty URL,
+each with `--repo contributor/widgets --login robot`. Prove all results must
+normalize to the same identity. Add failures for:
+
+- a nonzero Git result;
+- successful Git output with no nonempty URL;
+- a rejected clone URL;
+- a Forgejo response host that disagrees with its source remote host;
+- two push URLs resolving to different owners or repositories.
+
+Expect remote/response disagreements to use `PullRequestIdentityError`, not a
+not-found error.
+
+- [ ] **Step 3: Write failing status, JSON, and diagnostics tests**
+
+For repository API calls, cover:
+
+```ts
+const statusCases = [
+  { stderr: "HTTP/2 401 Unauthorized\n", expectedStatus: 401 },
+  { stderr: "HTTP/1.1 429 Too Many Requests\n", expectedStatus: 429 },
+  {
+    stderr: "request failed with 404 in diagnostic text",
+    expectedStatus: undefined,
+  },
+  {
+    stderr: "HTTP/1.1 302 Found\nlocation: /next\n\nHTTP/2 403 Forbidden\n",
+    expectedStatus: 403,
+  },
+] as const;
+```
+
+Assert nonzero results produce `ForgejoTeaPullRequestError` category
+`command-failed` with exact operation, safe command name, exit code, and final
+well-formed status when present. Assert invalid JSON on a successful command
+produces category `invalid-json`. Assert a successful exit paired with a final
+4xx/5xx status remains `command-failed`. Verify `rawDiagnostics` is readable by
+explicit property access but absent from the public message, `Object.keys`, and
+`JSON.stringify`.
+
+- [ ] **Step 4: Run the command test to prove RED**
+
+Run:
+
+```sh
+node --test src/host/forgejo-tea-pull-requests.test.ts
+```
+
+Expected: FAIL because the command client does not exist.
+
+- [ ] **Step 5: Implement the command client core and identity methods**
+
+Create `src/host/forgejo-tea-pull-request-commands.ts` with this initial public
+surface:
+
+```ts
+export type ForgejoTeaPullRequestCommandOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  login?: string;
+};
+
+export class ForgejoTeaPullRequestCommands {
+  constructor(options: ForgejoTeaPullRequestCommandOptions);
+
+  resolveTargetRepositoryIdentity(): Promise<RepositoryIdentity>;
+
+  resolveRemoteRepositoryIdentity(remote: string): Promise<RepositoryIdentity>;
+}
+```
+
+Use one private raw API runner and one private JSON API runner. The raw runner
+must:
+
+- add `--include` to every `tea api` argument list;
+- apply `withTeaContext` for target calls and `withTeaRepositoryContext` for
+  parsed remote slugs;
+- execute with `{ cwd: repoRoot }`;
+- extract only complete lines matching
+  `/^HTTP\/\d(?:\.\d)?[ \t]+([1-5]\d{2})(?:[ \t]+[^\r\n]*)?$/u` after removing a
+  trailing carriage return, and retain the final match across redirect header
+  blocks;
+- treat nonzero exit or a final status of 400 or greater as `command-failed`;
+- never classify based on free-form diagnostic text.
+
+The JSON runner parses stdout only after command success and wraps JSON syntax
+failure as category `invalid-json` without embedding stdout. Target resolution
+normalizes the repository response. Remote resolution runs the exact Git
+command, keeps every nonempty stdout line in order, resolves every URL through
+Forgejo with explicit repository context, validates response-host agreement, and
+then requires all normalized identities to satisfy `sameRepositoryIdentity`.
+
+Do not deduplicate multiple push URLs: the spec requires every configured push
+URL to resolve through Forgejo.
+
+- [ ] **Step 6: Format, validate, and commit repository resolution**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+node --test src/host/forgejo-tea-pull-requests.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: focused tests, strict types, and architecture checks PASS.
+
+Commit:
+
+```sh
+git add \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+git commit -m "feat(host): resolve Forgejo repository identities"
+```
+
+---
+
+### Task 3: Add cross-owner creation and exhaustive exact discovery
+
+**Files:**
+
+- Modify: `src/host/forgejo-tea-pull-request-commands.ts`
+- Create: `src/host/forgejo-tea-pull-requests.ts`
+- Modify: `src/host/forgejo-tea-pull-requests.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 2 identity methods and Task 1 normalization/validators.
+- Produces command methods `createPullRequestPayload(input): Promise<unknown>`
+  and
+  `listPullRequests(query, normalize): Promise<readonly PullRequestSummary[]>`.
+- Produces public facade methods `resolveTargetRepositoryIdentity`,
+  `resolveRemoteRepositoryIdentity`, `createPullRequest`, and
+  `findPullRequests`.
+- The class becomes a complete `PullRequestHost` in Task 4; do not add temporary
+  methods that throw `not implemented`.
+
+- [ ] **Step 1: Write failing cross-owner creation tests**
+
+Extend `src/host/forgejo-tea-pull-requests.test.ts` with
+`ForgejoTeaPullRequestHost` construction using:
+
+```ts
+new ForgejoTeaPullRequestHost({
+  runner,
+  repoRoot,
+  pushRemote: "publish",
+  login: "robot",
+});
+```
+
+Script target resolution to return `platform/widgets` and push-remote resolution
+to return `contributor/widgets` on the same Forgejo host. Call:
+
+```ts
+await host.createPullRequest({
+  title: "Plan for #186",
+  body: "Refs #186\n\nDetails",
+  baseBranch: "main",
+  headBranch: "agent/issue-186-adapter",
+});
+```
+
+After the target `tea`, Git remote, and explicit remote `tea` calls, assert this
+exact creation call:
+
+```ts
+{
+  command: "tea",
+  args: [
+    "api",
+    "/repos/{owner}/{repo}/pulls",
+    "--method",
+    "POST",
+    "--field",
+    "base=main",
+    "--field",
+    "head=contributor:agent/issue-186-adapter",
+    "--field",
+    "title=Plan for #186",
+    "--field",
+    "body=Refs #186\n\nDetails",
+    "--include",
+    "--repo",
+    "legacy/widgets",
+    "--login",
+    "robot",
+  ],
+  cwd: repoRoot,
+}
+```
+
+Assert the returned payload is normalized and that mismatched nested base/head
+repositories or response branches fail closed. Add pre-command tests for a blank
+constructor `pushRemote`, invalid base branch, and owner-qualified head branch.
+Verify invalid input records no runner calls.
+
+- [ ] **Step 2: Write failing exact discovery and pagination tests**
+
+Add a `pullRequestPayload` fixture builder that always emits complete base and
+head repository objects. Cover these behaviors:
+
+1. Query target/head identities must match live target/configured push remote
+   before the first list call.
+2. The first list endpoint is exactly
+   `/repos/{owner}/{repo}/pulls?state=all&page=1&limit=50`.
+3. A raw page of exactly 50 entries causes page 2 to be fetched. A page of 49,
+   one, or zero entries stops pagination.
+4. Results are returned only after the short page succeeds and are filtered by
+   case-insensitive `sameRepositoryIdentity` plus case-sensitive base and head
+   branch equality.
+5. A structurally complete, same-host nonmatching head repository is excluded; a
+   missing or contradictory nested head repository is a malformed response.
+6. A page-2 command error, invalid JSON value, non-array JSON payload, or
+   malformed pull request rejects the whole call. Do not expose page-1 matches
+   as a successful partial result.
+7. A nonzero list response with an exact HTTP 404 remains an adapter
+   `command-failed` error rather than `PullRequestNotFoundError`.
+
+Use 50 generated complete payloads for the full page rather than weakening the
+page size in production for tests.
+
+- [ ] **Step 3: Run the create/discovery tests to prove RED**
+
+Run:
+
+```sh
+node --test src/host/forgejo-tea-pull-requests.test.ts
+```
+
+Expected: FAIL because the facade and create/list command methods do not exist.
+
+- [ ] **Step 4: Add create and paginated-list command methods**
+
+Extend `ForgejoTeaPullRequestCommands` with:
+
+```ts
+createPullRequestPayload(input: {
+  baseBranch: string;
+  headOwner: string;
+  headBranch: string;
+  title: string;
+  body: string;
+}): Promise<unknown>;
+
+listPullRequests<T>(input: {
+  query: FindPullRequestsQuery;
+  normalize: (payload: unknown) => T;
+}): Promise<readonly T[]>;
+```
+
+Creation uses the exact POST fields and target context shown in Step 1. Listing
+starts at page 1, validates that each decoded page is an array, normalizes every
+entry before advancing, and accumulates privately. Return only after
+`rawPage.length < 50`. Before incrementing a full-page number, prove the next
+page is a positive safe integer; if it is not, throw
+`IncompletePullRequestSearchError(input.query)` without returning the
+accumulator. Preserve a later page's existing command, invalid-JSON, or
+malformed-response error instead of replacing it with an incomplete-search
+error.
+
+- [ ] **Step 5: Implement the facade's shared live context and two operations**
+
+Create `src/host/forgejo-tea-pull-requests.ts` with this initial shape:
+
+```ts
+export type ForgejoTeaPullRequestHostOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  pushRemote: string;
+  login?: string;
+};
+
+export class ForgejoTeaPullRequestHost {
+  readonly id = "forgejo-tea" as const;
+
+  constructor(options: ForgejoTeaPullRequestHostOptions);
+
+  resolveTargetRepositoryIdentity(): Promise<RepositoryIdentity>;
+
+  resolveRemoteRepositoryIdentity(remote: string): Promise<RepositoryIdentity>;
+
+  createPullRequest(input: CreatePullRequestInput): Promise<PullRequestSummary>;
+
+  findPullRequests(
+    query: FindPullRequestsQuery,
+  ): Promise<readonly PullRequestSummary[]>;
+}
+```
+
+The private operation-context method evaluates these promises together:
+
+```ts
+const [targetRepository, headRepository] = await Promise.all([
+  this.commands.resolveTargetRepositoryIdentity(),
+  this.commands.resolveRemoteRepositoryIdentity(this.options.pushRemote),
+]);
+```
+
+Require matching provider and host while allowing different owner/repository.
+For creation, validate branches before resolving context, derive
+`<resolved-head-owner>:<head-branch>`, normalize with both expected identities,
+and require the response base/head branches to equal the requested branches.
+
+For discovery, validate branches, compare both query identities with live
+context, call the command client's exhaustive list method, and normalize every
+payload with the live target. Preserve each structurally complete nested head
+identity so valid unrelated heads can be excluded by the final exact query
+filter; require returned matches to equal the configured push identity. Perform
+filtering only after every page has succeeded.
+
+- [ ] **Step 6: Format, validate, and commit create/discovery**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+node --test \
+  src/host/forgejo-tea-pull-request-parsing.test.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: all focused tests, strict types, and architecture checks PASS.
+
+Commit:
+
+```sh
+git add \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+git commit -m "feat(host): create and find Forgejo pull requests"
+```
+
+---
+
+### Task 4: Complete get, body update, and exact 404 behavior
+
+**Files:**
+
+- Modify: `src/host/forgejo-tea-pull-request-commands.ts`
+- Modify: `src/host/forgejo-tea-pull-requests.ts`
+- Modify: `src/host/forgejo-tea-pull-requests.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PullRequestReference`, `PullRequestNotFoundError`, live operation
+  context, and Task 2's final-status command boundary.
+- Produces command methods `getPullRequestPayload(reference): Promise<unknown>`
+  and `updatePullRequestBody(reference, body): Promise<void>`.
+- Produces the complete `getPullRequest`, `readPullRequestBody`, and
+  `updatePullRequestBody` methods.
+- Produces `ForgejoTeaPullRequestHost implements PullRequestHost` with no
+  factory registration.
+
+- [ ] **Step 1: Write failing exact get and body method tests**
+
+Add tests that assert:
+
+- `getPullRequest` compares the caller's target to live target context before
+  calling `/repos/{owner}/{repo}/pulls/42`;
+- the exact get command contains `--include`, target `--repo`, optional
+  `--login`, and no high-level `tea pulls` command;
+- the normalized response number equals the requested number and both complete
+  nested identities equal the resolved live target/head;
+- `readPullRequestBody` delegates through the same validated get path and
+  returns the exact body string;
+- an invalid number or mismatched caller target fails before the exact get
+  command;
+- wrong response number/URL, missing nested identity, or nested target/head
+  mismatch fails closed.
+
+Add an update test with a multiline body. Assert the operation first performs
+the validated get and only then records this PATCH call:
+
+```ts
+{
+  command: "tea",
+  args: [
+    "api",
+    "/repos/{owner}/{repo}/pulls/42",
+    "--method",
+    "PATCH",
+    "--field",
+    "body=Summary\n\nDetails\n",
+    "--include",
+    "--repo",
+    "legacy/widgets",
+    "--login",
+    "robot",
+  ],
+  cwd: repoRoot,
+}
+```
+
+Assert no PATCH occurs when the validating get fails. Do not use or change
+`updateForgejoPullRequestBody` from the legacy URL adapter.
+
+- [ ] **Step 2: Write failing exact HTTP 404 classification tests**
+
+For the exact get endpoint, prove that only this combination becomes
+`PullRequestNotFoundError(reference)`:
+
+```ts
+{
+  code: 1,
+  stdout: "",
+  stderr: "HTTP/2 404 Not Found\n",
+}
+```
+
+Add separate tests proving these remain `ForgejoTeaPullRequestError` rather than
+not-found:
+
+- diagnostic prose containing `404` with no complete status line;
+- exact 401, 403, and 429 status lines;
+- a transport/CLI failure with no status;
+- other exact 4xx and 5xx statuses;
+- exit code 0 with an exact final 404 status;
+- exit code 0 with invalid JSON;
+- exit code 0 with structurally malformed JSON;
+- a successful validating get followed by a PATCH whose nonzero response has an
+  exact 404.
+
+Add a redirect case whose stderr contains a complete 302 status followed by a
+complete 404 status and assert the final status controls get classification. Add
+the inverse 404-then-200 case and assert the successful final status permits
+JSON normalization.
+
+- [ ] **Step 3: Run get/body tests to prove RED**
+
+Run:
+
+```sh
+node --test src/host/forgejo-tea-pull-requests.test.ts
+```
+
+Expected: FAIL because the exact get/PATCH command methods and public body
+methods do not exist.
+
+- [ ] **Step 4: Add exact get and PATCH command methods**
+
+Extend the command client with:
+
+```ts
+getPullRequestPayload(reference: PullRequestReference): Promise<unknown>;
+
+updatePullRequestBody(
+  reference: PullRequestReference,
+  body: string,
+): Promise<void>;
+```
+
+Teach the private JSON API runner to accept an optional `notFoundReference`.
+Only when that option is present, the process exit is nonzero, and the final
+complete status is exactly 404 may it throw `PullRequestNotFoundError`. A status
+404 paired with exit 0 follows the normal contradictory-status command error
+path. The PATCH method does not pass a not-found reference, parses its
+successful structured JSON response, and retains all ordinary adapter errors.
+
+Both methods use the target repository context. Build the endpoint from the
+already validated positive number and pass `body=<body>` as one argument after
+one `--field` token.
+
+- [ ] **Step 5: Complete the public `PullRequestHost` implementation**
+
+Change the declaration to:
+
+```ts
+export class ForgejoTeaPullRequestHost implements PullRequestHost
+```
+
+Add the three interface methods. Each method validates the number before
+starting commands. `getPullRequest` resolves target and configured head
+independently, compares the reference target to the live target, calls the exact
+get command, and normalizes with expected target, expected head, and expected
+number. `readPullRequestBody` returns
+`(await this.getPullRequest(reference)).body`. `updatePullRequestBody` awaits
+`this.getPullRequest(reference)` before calling the PATCH command, ensuring no
+caller-controlled URL reconstruction and no edit of an unvalidated pull request.
+
+Do not export this class from the existing host factory and do not add it to
+`RunOnceHostProvider`.
+
+- [ ] **Step 6: Format, validate, and commit the complete adapter**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+node --test \
+  src/host/forgejo-tea-pull-request-parsing.test.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: all focused tests, strict types, and architecture checks PASS.
+
+Commit:
+
+```sh
+git add \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+git commit -m "feat(host): get and update Forgejo pull requests"
+```
+
+---
+
+### Task 5: Verify the complete isolated adapter
+
+**Files:**
+
+- Verify only; no planned file changes.
+
+**Interfaces:**
+
+- Consumes: all Issue 186 implementation commits.
+- Produces: evidence that focused behavior, full repository checks, module
+  boundaries, non-wiring, and dependency policy all hold.
+
+- [ ] **Step 1: Run all focused Forgejo adapter tests together**
+
+Run:
+
+```sh
+node --test \
+  src/host/forgejo-tea-pull-request-parsing.test.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+```
+
+Expected: both test files PASS, including normalization, exact commands,
+pagination, and 404 classification.
+
+- [ ] **Step 2: Run the repository validation commands**
+
+Run exactly:
+
+```sh
+npm test
+npm run build
+npm run lint
+npm run check:types
+npm run check:architecture
+git diff --check
+```
+
+Expected: every command exits with status 0.
+
+- [ ] **Step 3: Apply the AGENTS.md dependency/Nix condition**
+
+Run:
+
+```sh
+if git diff --name-only main...HEAD -- \
+  package.json package-lock.json npm-shrinkwrap.json | grep -q .; then
+  nix build .#patchmill --print-build-logs
+else
+  echo "Nix build skipped: npm dependency metadata unchanged"
+fi
+```
+
+Expected for the planned implementation: print the skip message. If dependency
+metadata changed unexpectedly and is retained, the Nix build must run and
+exit 0.
+
+- [ ] **Step 4: Verify scope and non-wiring directly**
+
+Run:
+
+```sh
+git diff --name-only main...HEAD
+rg -n "ForgejoTeaPullRequestHost" \
+  src/host/factory.ts \
+  src/cli/commands/run-once || true
+```
+
+Expected branch files:
+
+```text
+docs/plans/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter.md
+docs/specs/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter-design.md
+src/host/forgejo-tea-pull-request-commands.ts
+src/host/forgejo-tea-pull-request-errors.ts
+src/host/forgejo-tea-pull-request-parsing.test.ts
+src/host/forgejo-tea-pull-request-parsing.ts
+src/host/forgejo-tea-pull-requests.test.ts
+src/host/forgejo-tea-pull-requests.ts
+```
+
+The `rg` command must print no factory or run-once reference. Investigate and
+remove any other production or dependency file change before completion.
+
+- [ ] **Step 5: Review module focus and report evidence**
+
+Run:
+
+```sh
+wc -l \
+  src/host/forgejo-tea-pull-request-errors.ts \
+  src/host/forgejo-tea-pull-request-parsing.ts \
+  src/host/forgejo-tea-pull-request-commands.ts \
+  src/host/forgejo-tea-pull-requests.ts
+git status --short
+```
+
+Review any production module substantially beyond 200 meaningful lines and split
+only along the error/parsing/command/facade responsibilities already specified.
+Expected final status is clean after the four implementation commits.
+
+---
+
+## Testing Value Gate
+
+The two new automated test modules pass Patchmill's Testing Value Gate:
+
+- They prove observable parsing, normalization, command arguments, pagination,
+  and error-classification behavior rather than restating configuration.
+- They fail for meaningful regressions such as accepting credential-bearing
+  URLs, truncating a full page, using the wrong remote, omitting nested
+  identity, shell-splitting a body, or converting a 403/429/transport failure to
+  absence.
+- Future provider-adapter maintainers benefit from rerunning deterministic
+  command-boundary tests without live Forgejo mutations.
+- The covered logic is reusable and safety-sensitive enough to justify test
+  maintenance.
+
+Do not add tests that merely assert factory source text, dependency file
+contents, or documentation. Task 5 uses direct `rg`, file-list, dependency-diff,
+build, lint, type, and architecture verification for those static constraints.
+
+## Implementation Completion Report
+
+The implementation worker reports:
+
+- The four implementation commit hashes.
+- Focused parsing and adapter test results.
+- Full test, build, lint, strict type, architecture, and `git diff --check`
+  results.
+- Whether the conditional Nix build was skipped or run, with the dependency diff
+  that justified the outcome.
+- The final branch file list and confirmation that factory/run-once wiring is
+  absent.
+- Any deviation from the six planned production/test files and any residual risk
+  in Forgejo CLI status formatting or provider payload compatibility.

--- a/docs/specs/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter-design.md
+++ b/docs/specs/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter-design.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-This written specification awaits manual approval. Planning and implementation
-must not continue until that approval is explicit.
+This specification is approved for implementation.
 
 Issue #184 supplied the provider-neutral `PullRequestHost` foundation. This
 issue adds only its Forgejo implementation.

--- a/docs/specs/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter-design.md
+++ b/docs/specs/2026-09-07-issue-186-implement-the-forgejo-planning-pull-request-adapter-design.md
@@ -1,0 +1,361 @@
+# Issue 186 Forgejo planning pull request adapter design
+
+## Status
+
+This written specification awaits manual approval. Planning and implementation
+must not continue until that approval is explicit.
+
+Issue #184 supplied the provider-neutral `PullRequestHost` foundation. This
+issue adds only its Forgejo implementation.
+
+## Summary
+
+Add a dedicated `ForgejoTeaPullRequestHost` that implements `PullRequestHost`
+through `tea api`. The adapter resolves the current target repository and the
+configured Git push remote through Forgejo before operating on pull requests.
+
+The target and head may have different owners or repository names, but they must
+resolve to the same Forgejo host. Pull request payloads must repeat those
+complete identities in their nested base and head repository objects.
+
+Discovery reads every API page and filters normalized results by the exact
+target repository, base branch, head repository, and head branch. Get maps only
+a machine-readable HTTP 404 for the requested pull request endpoint to
+`PullRequestNotFoundError`; all other failures retain a distinct adapter error.
+
+The adapter remains separate from the existing `ForgejoTeaHostProvider`, host
+factory, and run-once workflow.
+
+## Goals
+
+- Implement every `PullRequestHost` method for Forgejo.
+- Resolve provider-normalized target and push-remote repository identities.
+- Support any valid Git remote name and all of its configured push URLs.
+- Support same-host, cross-owner pull request heads.
+- Create, discover, and get pull requests through structured Forgejo API JSON.
+- Normalize open, merged, and closed-unmerged pull requests.
+- Fetch list pages until Forgejo returns a page shorter than the requested page
+  size.
+- Validate nested target and head repository identities without guessing.
+- Treat only an exact API 404 as a missing pull request.
+- Test pure normalization, pagination, and exact command contracts.
+
+## Non-goals
+
+- GitHub support.
+- Host-factory or `RunOnceHostProvider` changes.
+- Planning workspace, phase publisher, recovery, or pipeline integration.
+- Automatic pull request merge or remote branch cleanup.
+- Changes to the existing URL-based Forgejo pull request body adapter.
+- Live Forgejo mutations in the automated test suite.
+- New npm dependencies.
+
+## Recommended structure
+
+Use a dedicated adapter instead of extending `ForgejoTeaHostProvider`. The
+existing provider already combines issue, repository-setup, and legacy
+body-update responsibilities; adding identity resolution, pagination, and API
+error classification would give it another reason to change and would make the
+new interface reachable through the current factory.
+
+Split the new behavior by responsibility:
+
+- `src/host/forgejo-tea-pull-requests.ts` owns the public adapter and operation
+  orchestration.
+- `src/host/forgejo-tea-pull-request-commands.ts` owns `git` and `tea api`
+  execution, repository context, pagination, and HTTP status extraction.
+- `src/host/forgejo-tea-pull-request-parsing.ts` owns pure remote URL,
+  repository payload, and pull request normalization.
+- `src/host/forgejo-tea-pull-request-errors.ts` owns stable Forgejo adapter
+  error categories and fields.
+- Colocated parsing and adapter tests cover the pure and command boundaries.
+
+Reuse `CommandRunner`, `withTeaContext()`, and `withTeaRepositoryContext()`.
+This slice does not relocate command contracts or add a factory. Each production
+module should remain focused and target fewer than 200 meaningful lines; split
+parsing from execution before allowing a module to grow substantially beyond
+that target.
+
+### Alternatives considered
+
+1. **Extend `ForgejoTeaHostProvider`.** This minimizes constructor code, but it
+   grows an already broad class and risks accidental factory exposure. Reject.
+2. **Use high-level `tea pulls` commands.** Their list and display contracts do
+   not provide the required API pagination and exact HTTP-status boundary.
+   Reject.
+3. **Use a separate `tea api` adapter.** This keeps the foundation interface
+   isolated, consumes structured payloads, and makes command and failure
+   semantics testable. Choose this approach.
+
+## Adapter contract
+
+The public constructor accepts:
+
+```ts
+export type ForgejoTeaPullRequestHostOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  pushRemote: string;
+  login?: string;
+};
+```
+
+A blank `pushRemote` is invalid. The adapter has `id: "forgejo-tea"` and
+implements the unchanged `PullRequestHost` interface from
+`src/host/pull-requests.ts`.
+
+Public methods validate positive safe-integer pull request numbers and nonblank,
+unqualified Git branch names before executing provider operations. Commands use
+argument arrays; pull request bodies and branch names never pass through a
+shell.
+
+## Repository identity and context
+
+### Target repository
+
+`resolveTargetRepositoryIdentity()` calls the repository endpoint through the
+existing target context:
+
+```text
+tea api /repos/{owner}/{repo} --include --repo <target-slug> [--login <login>]
+```
+
+`withTeaContext()` supplies the target slug selected by the current repository.
+The Forgejo response, rather than the raw Git slug, is authoritative so renamed
+or transferred repositories normalize to their current identity.
+
+### Configured push remote
+
+`resolveRemoteRepositoryIdentity(remote)` first runs:
+
+```text
+git remote get-url --push --all -- <remote>
+```
+
+The `--` separator permits a valid remote name beginning with `-`. The command
+must return at least one nonempty URL. The parser accepts standard HTTP(S), SSH,
+and scp-like Forgejo clone URLs, removes one trailing `.git`, and rejects local,
+file, credential-bearing HTTP, incomplete, or ambiguous paths without exposing
+the raw URL in errors.
+
+For each returned push URL, the adapter calls the repository endpoint with an
+explicit repository context. The provider response must agree with the remote
+hostname. Every push URL must normalize through Forgejo to the same
+`RepositoryIdentity`; otherwise resolution fails with
+`PullRequestIdentityError`.
+
+### Provider-normalized repository payload
+
+A repository payload must contain mutually consistent `name`, `full_name`,
+`owner.login`, and `html_url` fields. The normalized identity is:
+
+```ts
+{
+  provider: "forgejo-tea";
+  host: string;
+  owner: string;
+  repository: string;
+}
+```
+
+The host is the lowercase host from Forgejo's returned web URL, without scheme
+or path. Owner and repository spelling comes from Forgejo. Missing fields,
+malformed URLs, or disagreement among the nested fields cause
+`PullRequestIdentityError` or a malformed-response error.
+
+Before each pull request operation, target resolution and configured push-remote
+resolution start independently. The two identities may differ in owner or
+repository, which enables fork heads, but must use the same provider and host.
+Each operation compares caller-supplied target and head identities with this
+live context before mutation or adoption.
+
+## Pull request normalization
+
+Forgejo pull request responses are normalized into `PullRequestSummary`. A valid
+payload requires:
+
+- a positive safe-integer number;
+- an HTTP(S) `html_url` identifying that number in the expected target
+  repository;
+- a string body;
+- nonblank `base.ref`, `head.ref`, and `head.sha` values;
+- complete `base.repo` and `head.repo` objects accepted by the repository
+  identity parser; and
+- a supported state with consistent merge fields.
+
+`base.repo` must equal the resolved target identity. `head.repo` must equal the
+resolved configured push-remote identity. Cross-owner heads are valid; missing
+or contradictory nested repositories fail closed.
+
+State mapping is exact:
+
+| Forgejo payload                                 | Patchmill status  |
+| ----------------------------------------------- | ----------------- |
+| `state: "open"`, not merged, no merge commit    | `open`            |
+| `state: "closed"`, merged, merge commit present | `merged`          |
+| `state: "closed"`, not merged, no merge commit  | `closed-unmerged` |
+
+Unknown states and inconsistent merge flags or commit data are malformed
+responses.
+
+## Operations
+
+### Create
+
+After validating input and resolving repository context, create sends a
+structured request to the target repository's pull endpoint:
+
+```text
+tea api /repos/{owner}/{repo}/pulls \
+  --method POST \
+  --field base=<base-branch> \
+  --field head=<resolved-head-owner>:<head-branch> \
+  --field title=<title> \
+  --field body=<body> \
+  --include --repo <target-slug> [--login <login>]
+```
+
+The adapter derives the owner-qualified head from the resolved push repository;
+the caller supplies only the branch. This supports cross-owner heads without
+accepting a caller-provided owner qualifier. The returned pull request payload
+must normalize against the resolved target and head identities before it is
+returned.
+
+### Exact discovery
+
+`findPullRequests(query)` first verifies that the query target and head match
+the resolved target and push identities. It then requests all states from the
+target endpoint with a fixed supported page size:
+
+```text
+tea api /repos/{owner}/{repo}/pulls?state=all&page=<page>&limit=50 \
+  --include --repo <target-slug> [--login <login>]
+```
+
+Pages start at one. The adapter validates each response as an array, normalizes
+its entries, and continues while the raw page length equals 50. It stops only
+when the raw page is shorter than 50, including an empty page.
+
+Only after all pages succeed does it return entries whose target repository,
+base branch, head repository, and head branch exactly match the query.
+Repository comparison uses `sameRepositoryIdentity`; branch comparison is
+case-sensitive. A later-page command, JSON, or payload failure throws its
+original adapter error and returns no partial results.
+
+### Get and body methods
+
+`getPullRequest(reference)` verifies the reference target against live context,
+then requests the exact target endpoint with `--include`. The payload must have
+the requested number and the resolved nested target and head identities.
+
+`readPullRequestBody(reference)` delegates to the same validated get path and
+returns its normalized body.
+
+`updatePullRequestBody(reference, body)` first uses the validated get path so it
+cannot edit an unrelated pull request. It then sends a structured PATCH to the
+validated target and number with `body` as one argument. It does not use the
+legacy URL-based helper or reconstruct identity from caller-owned URL text.
+
+## HTTP and error handling
+
+All `tea api` calls use `--include`, which writes HTTP status information to
+standard error while leaving JSON on standard output. Status parsing accepts
+only a complete HTTP status line and uses the final response status when a
+redirect produced more than one header block. Human-readable diagnostics never
+control classification.
+
+For the exact get endpoint, and only there, a nonzero `tea` result whose final
+well-formed API status is exactly `404` becomes
+`PullRequestNotFoundError(reference)`.
+
+These do **not** become not-found errors:
+
+- output text that merely contains `404`;
+- authentication or authorization responses such as 401 or 403;
+- rate-limit responses such as 429;
+- transport or CLI failures with no valid HTTP status;
+- other 4xx or 5xx responses;
+- a contradictory success exit with a 404 status; or
+- invalid JSON or structurally malformed success payloads.
+
+Forgejo-specific errors expose stable categories for invalid input, failed
+commands, invalid JSON, and malformed responses. Command errors retain the
+operation, command, exit code, and exact HTTP status when available. Raw command
+diagnostics remain available for explicit inspection but are not included in
+public messages or default serialization, preventing remote credentials and pull
+request bodies from leaking.
+
+Foundation errors remain authoritative:
+
+- `PullRequestIdentityError` for incomplete or mismatched repository identity;
+- `PullRequestNotFoundError` only for the exact get 404 rule; and
+- `IncompletePullRequestSearchError` if pagination cannot safely advance before
+  a short page, rather than returning accumulated results.
+
+## Verification strategy
+
+The Testing Value Gate supports automated tests because this adapter contains
+reusable parsing, pagination, external command contracts, and safety-sensitive
+error classification.
+
+Pure parsing and normalization tests cover:
+
+- HTTP(S), SSH, and scp-like remote URLs, `.git`, malformed paths, and safe
+  credential handling;
+- renamed or transferred repositories returned by Forgejo;
+- complete and inconsistent repository payloads;
+- same-repository and cross-owner head identities;
+- open, merged, and closed-unmerged normalization;
+- missing or mismatched nested base and head repositories; and
+- malformed JSON, URLs, branches, numbers, states, and merge data.
+
+Recording-runner command tests cover:
+
+- target and custom push-remote resolution, including a leading-hyphen remote;
+- every configured push URL and rejection of divergent destinations;
+- exact `tea api`, `git`, `--repo`, `--login`, method, field, and working
+  directory arguments;
+- owner-qualified cross-owner creation;
+- full pages followed by a short page and no partial result after a later-page
+  failure;
+- exact target, base, head repository, and head branch discovery;
+- get, body read, and body update;
+- exact API 404 conversion; and
+- preservation of authentication, rate-limit, transport, invalid-JSON, and
+  malformed-response failures.
+
+Focused validation will run the new parsing and adapter tests. Final validation
+will run:
+
+```sh
+npm test
+npm run build
+npm run lint
+npm run check:types
+npm run check:architecture
+git diff --check
+```
+
+No dependency changes are planned, so a Nix build is not required. If npm
+dependency metadata changes unexpectedly, the implementation must also run the
+repository-required Nix build.
+
+## Compatibility and acceptance
+
+The new class is unreachable from current production workflows. Existing Forgejo
+issue, setup, and URL-based pull request body behavior remains unchanged.
+
+The design is accepted when:
+
+- `ForgejoTeaPullRequestHost` satisfies the complete foundation interface;
+- target and every push destination resolve through Forgejo;
+- custom remotes and same-host cross-owner heads work;
+- normalized responses strictly validate nested target and head identities;
+- discovery requests all states and every page until a short page;
+- discovery returns only exact repository and branch matches and never partial
+  results;
+- only the exact get-endpoint API 404 becomes `PullRequestNotFoundError`;
+- command, authentication/rate-limit, transport, JSON, and malformed-response
+  failures remain distinguishable from absence;
+- command and normalization tests protect the external contract; and
+- neither the factory nor run-once is wired to the adapter.

--- a/src/host/forgejo-tea-pull-request-commands.ts
+++ b/src/host/forgejo-tea-pull-request-commands.ts
@@ -1,0 +1,240 @@
+import type {
+  CommandRunner,
+  CommandResult,
+} from "../cli/commands/triage/types.ts";
+import {
+  withTeaContext,
+  withTeaRepositoryContext,
+} from "./forgejo-tea-context.ts";
+import {
+  ForgejoTeaPullRequestError,
+  type ForgejoPullRequestOperation,
+} from "./forgejo-tea-pull-request-errors.ts";
+import {
+  normalizeForgejoRepository,
+  parseForgejoRemoteUrl,
+  validateForgejoRemoteName,
+} from "./forgejo-tea-pull-request-parsing.ts";
+import {
+  IncompletePullRequestSearchError,
+  PullRequestIdentityError,
+  PullRequestNotFoundError,
+  sameRepositoryIdentity,
+  type FindPullRequestsQuery,
+  type PullRequestReference,
+  type RepositoryIdentity,
+} from "./pull-requests.ts";
+
+export type ForgejoTeaPullRequestCommandOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  login?: string;
+};
+type ApiContext = { slug?: string };
+const statusLine = /^HTTP\/\d(?:\.\d)?[ \t]+([1-5]\d{2})(?:[ \t]+[^\r\n]*)?$/u;
+function status(stderr: string): number | undefined {
+  let value: number | undefined;
+  for (const line of stderr.split("\n")) {
+    const match = statusLine.exec(line.replace(/\r$/u, ""));
+    if (match?.[1] !== undefined) value = Number(match[1]);
+  }
+  return value;
+}
+
+export class ForgejoTeaPullRequestCommands {
+  readonly options: ForgejoTeaPullRequestCommandOptions;
+  constructor(options: ForgejoTeaPullRequestCommandOptions) {
+    this.options = options;
+  }
+
+  private async api(
+    operation: ForgejoPullRequestOperation,
+    args: string[],
+    context: ApiContext = {},
+    notFoundReference?: PullRequestReference,
+  ): Promise<CommandResult> {
+    const argsWithHeaders = [...args, "--include"];
+    const commandArgs =
+      context.slug === undefined
+        ? withTeaContext(
+            argsWithHeaders,
+            this.options.repoRoot,
+            this.options.login,
+          )
+        : withTeaRepositoryContext(
+            argsWithHeaders,
+            context.slug,
+            this.options.login,
+          );
+    const result = await this.options.runner.run("tea", commandArgs, {
+      cwd: this.options.repoRoot,
+    });
+    const httpStatus = status(result.stderr);
+    if (
+      result.code !== 0 &&
+      httpStatus === 404 &&
+      notFoundReference !== undefined
+    )
+      throw new PullRequestNotFoundError(notFoundReference);
+    if (result.code !== 0 || (httpStatus !== undefined && httpStatus >= 400))
+      throw new ForgejoTeaPullRequestError({
+        category: "command-failed",
+        operation,
+        command: "tea",
+        exitCode: result.code,
+        ...(httpStatus === undefined ? {} : { httpStatus }),
+        rawDiagnostics: result,
+      });
+    return result;
+  }
+  private async json(
+    operation: ForgejoPullRequestOperation,
+    args: string[],
+    context: ApiContext = {},
+    notFoundReference?: PullRequestReference,
+  ): Promise<unknown> {
+    const result = await this.api(operation, args, context, notFoundReference);
+    try {
+      return JSON.parse(result.stdout);
+    } catch (cause) {
+      throw new ForgejoTeaPullRequestError({
+        category: "invalid-json",
+        operation,
+        command: "tea",
+        rawDiagnostics: result,
+        cause,
+      });
+    }
+  }
+
+  async resolveTargetRepositoryIdentity(): Promise<RepositoryIdentity> {
+    return normalizeForgejoRepository(
+      await this.json("resolve-target-repository", [
+        "api",
+        "/repos/{owner}/{repo}",
+      ]),
+      { operation: "resolve-target-repository" },
+    );
+  }
+  async resolveRemoteRepositoryIdentity(
+    remote: string,
+  ): Promise<RepositoryIdentity> {
+    validateForgejoRemoteName(remote);
+    const result = await this.options.runner.run(
+      "git",
+      ["remote", "get-url", "--push", "--all", "--", remote],
+      { cwd: this.options.repoRoot },
+    );
+    if (result.code !== 0)
+      throw new ForgejoTeaPullRequestError({
+        category: "command-failed",
+        operation: "resolve-remote-repository",
+        command: "git",
+        exitCode: result.code,
+        rawDiagnostics: result,
+      });
+    const urls = result.stdout
+      .split(/\r?\n/u)
+      .filter((url) => url.trim() !== "");
+    if (!urls.length)
+      throw new ForgejoTeaPullRequestError({
+        category: "malformed-response",
+        operation: "resolve-remote-repository",
+        command: "git",
+        rawDiagnostics: result,
+      });
+    const identities = await Promise.all(
+      urls.map(async (url) => {
+        const source = parseForgejoRemoteUrl(url);
+        const identity = normalizeForgejoRepository(
+          await this.json(
+            "resolve-remote-repository",
+            ["api", "/repos/{owner}/{repo}"],
+            { slug: source.slug },
+          ),
+          { operation: "resolve-remote-repository", expectedHost: source.host },
+        );
+        return identity;
+      }),
+    );
+    const identity = identities[0];
+    if (!identity)
+      throw new ForgejoTeaPullRequestError({
+        category: "malformed-response",
+        operation: "resolve-remote-repository",
+      });
+    if (
+      identities.some(
+        (candidate) => !sameRepositoryIdentity(candidate, identity),
+      )
+    )
+      throw new PullRequestIdentityError("push remote URLs disagree");
+    return identity;
+  }
+  createPullRequestPayload(input: {
+    baseBranch: string;
+    headOwner: string;
+    headBranch: string;
+    title: string;
+    body: string;
+  }): Promise<unknown> {
+    return this.json("create-pull-request", [
+      "api",
+      "/repos/{owner}/{repo}/pulls",
+      "--method",
+      "POST",
+      "--field",
+      `base=${input.baseBranch}`,
+      "--field",
+      `head=${input.headOwner}:${input.headBranch}`,
+      "--field",
+      `title=${input.title}`,
+      "--field",
+      `body=${input.body}`,
+    ]);
+  }
+  async listPullRequests<T>(input: {
+    query: FindPullRequestsQuery;
+    normalize: (payload: unknown) => T;
+  }): Promise<readonly T[]> {
+    const found: T[] = [];
+    let page = 1;
+    while (true) {
+      const raw = await this.json("list-pull-requests", [
+        "api",
+        `/repos/{owner}/{repo}/pulls?state=all&page=${page}&limit=50`,
+      ]);
+      if (!Array.isArray(raw))
+        throw new ForgejoTeaPullRequestError({
+          category: "malformed-response",
+          operation: "list-pull-requests",
+        });
+      found.push(...raw.map(input.normalize));
+      if (raw.length < 50) return found;
+      if (!Number.isSafeInteger(page + 1) || page + 1 <= 0)
+        throw new IncompletePullRequestSearchError(input.query);
+      page += 1;
+    }
+  }
+  getPullRequestPayload(reference: PullRequestReference): Promise<unknown> {
+    return this.json(
+      "get-pull-request",
+      ["api", `/repos/{owner}/{repo}/pulls/${reference.number}`],
+      {},
+      reference,
+    );
+  }
+  async updatePullRequestBody(
+    reference: PullRequestReference,
+    body: string,
+  ): Promise<void> {
+    await this.json("update-pull-request", [
+      "api",
+      `/repos/{owner}/{repo}/pulls/${reference.number}`,
+      "--method",
+      "PATCH",
+      "--field",
+      `body=${body}`,
+    ]);
+  }
+}

--- a/src/host/forgejo-tea-pull-request-commands.ts
+++ b/src/host/forgejo-tea-pull-request-commands.ts
@@ -96,13 +96,12 @@ export class ForgejoTeaPullRequestCommands {
     const result = await this.api(operation, args, context, notFoundReference);
     try {
       return JSON.parse(result.stdout);
-    } catch (cause) {
+    } catch {
       throw new ForgejoTeaPullRequestError({
         category: "invalid-json",
         operation,
         command: "tea",
         rawDiagnostics: result,
-        cause,
       });
     }
   }

--- a/src/host/forgejo-tea-pull-request-commands.ts
+++ b/src/host/forgejo-tea-pull-request-commands.ts
@@ -47,6 +47,24 @@ export class ForgejoTeaPullRequestCommands {
     this.options = options;
   }
 
+  private async run(
+    operation: ForgejoPullRequestOperation,
+    command: "git" | "tea",
+    args: string[],
+  ): Promise<CommandResult> {
+    try {
+      return await this.options.runner.run(command, args, {
+        cwd: this.options.repoRoot,
+      });
+    } catch {
+      throw new ForgejoTeaPullRequestError({
+        category: "command-failed",
+        operation,
+        command,
+      });
+    }
+  }
+
   private async api(
     operation: ForgejoPullRequestOperation,
     args: string[],
@@ -66,9 +84,7 @@ export class ForgejoTeaPullRequestCommands {
             context.slug,
             this.options.login,
           );
-    const result = await this.options.runner.run("tea", commandArgs, {
-      cwd: this.options.repoRoot,
-    });
+    const result = await this.run(operation, "tea", commandArgs);
     const httpStatus = status(result.stderr);
     if (
       result.code !== 0 &&
@@ -119,11 +135,14 @@ export class ForgejoTeaPullRequestCommands {
     remote: string,
   ): Promise<RepositoryIdentity> {
     validateForgejoRemoteName(remote);
-    const result = await this.options.runner.run(
-      "git",
-      ["remote", "get-url", "--push", "--all", "--", remote],
-      { cwd: this.options.repoRoot },
-    );
+    const result = await this.run("resolve-remote-repository", "git", [
+      "remote",
+      "get-url",
+      "--push",
+      "--all",
+      "--",
+      remote,
+    ]);
     if (result.code !== 0)
       throw new ForgejoTeaPullRequestError({
         category: "command-failed",

--- a/src/host/forgejo-tea-pull-request-errors.ts
+++ b/src/host/forgejo-tea-pull-request-errors.ts
@@ -1,0 +1,55 @@
+export type ForgejoPullRequestErrorCategory =
+  | "invalid-input"
+  | "command-failed"
+  | "invalid-json"
+  | "malformed-response";
+
+export type ForgejoPullRequestOperation =
+  | "validate-input"
+  | "resolve-target-repository"
+  | "resolve-remote-repository"
+  | "create-pull-request"
+  | "list-pull-requests"
+  | "get-pull-request"
+  | "update-pull-request";
+
+export type ForgejoCommandName = "git" | "tea";
+export type ForgejoCommandDiagnostics = Readonly<{
+  stdout: string;
+  stderr: string;
+}>;
+
+export class ForgejoTeaPullRequestError extends Error {
+  readonly category: ForgejoPullRequestErrorCategory;
+  readonly operation: ForgejoPullRequestOperation;
+  readonly command?: ForgejoCommandName;
+  readonly exitCode?: number;
+  readonly httpStatus?: number;
+  declare readonly rawDiagnostics?: ForgejoCommandDiagnostics;
+
+  constructor(input: {
+    category: ForgejoPullRequestErrorCategory;
+    operation: ForgejoPullRequestOperation;
+    command?: ForgejoCommandName;
+    exitCode?: number;
+    httpStatus?: number;
+    rawDiagnostics?: ForgejoCommandDiagnostics;
+    cause?: unknown;
+  }) {
+    super(
+      `Forgejo pull request ${input.operation} failed: ${input.category}`,
+      input.cause === undefined ? undefined : { cause: input.cause },
+    );
+    this.name = "ForgejoTeaPullRequestError";
+    this.category = input.category;
+    this.operation = input.operation;
+    if (input.command !== undefined) this.command = input.command;
+    if (input.exitCode !== undefined) this.exitCode = input.exitCode;
+    if (input.httpStatus !== undefined) this.httpStatus = input.httpStatus;
+    if (input.rawDiagnostics !== undefined)
+      Object.defineProperty(this, "rawDiagnostics", {
+        value: input.rawDiagnostics,
+        enumerable: false,
+      });
+  }
+}

--- a/src/host/forgejo-tea-pull-request-parsing.test.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { ForgejoTeaPullRequestError } from "./forgejo-tea-pull-request-errors.ts";
 import { PullRequestIdentityError } from "./pull-requests.ts";
 import {
   normalizeForgejoPullRequest,
@@ -80,6 +81,10 @@ test("does not expose rejected clone URLs", () => {
     "https://forge.example/acme/widgets.git?token=secret",
     "git@forge.example:widgets.git",
     "git@forge.example:group/acme/widgets.git",
+    "git@forge.example:/acme/widgets.git",
+    "git@forge.example:acme/widgets.git/",
+    "https://forge.example/acme//widgets.git",
+    "https://forge.example/acme/widgets.git/",
   ]) {
     assert.throws(
       () => parseForgejoRemoteUrl(url),
@@ -101,6 +106,7 @@ test("validates public remote, branch, and number input", () => {
     "owner:topic",
     "topic..next",
     "-topic",
+    "topic\u007fnext",
   ])
     assert.throws(() => validateForgejoBranchName(value));
   for (const value of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, NaN])
@@ -170,7 +176,17 @@ const options = {
   expectedNumber: 42,
 };
 test("normalizes valid state combinations and rejects inconsistent pull payloads", () => {
-  assert.equal(normalizeForgejoPullRequest(pull(), options).status, "open");
+  assert.deepEqual(normalizeForgejoPullRequest(pull(), options), {
+    number: 42,
+    url: "https://forge.example/platform/widgets-renamed/pulls/42",
+    targetRepository: target,
+    baseBranch: "main",
+    headRepository: head,
+    headBranch: "agent/issue-186-adapter",
+    headSha: "abc123",
+    body: "Refs #186",
+    status: "open",
+  });
   assert.deepEqual(
     normalizeForgejoPullRequest(
       pull({ state: "closed", merged: true, merge_commit_sha: "abc" }),
@@ -191,3 +207,134 @@ test("normalizes valid state combinations and rejects inconsistent pull payloads
   ])
     assert.throws(() => normalizeForgejoPullRequest(payload, options));
 });
+
+test("rejects malformed repository and pull-request response fields by category", () => {
+  const malformedRepositoryPayloads = [
+    null,
+    {},
+    { ...targetPayload, name: null },
+    { ...targetPayload, name: "" },
+    { ...targetPayload, full_name: null },
+    { ...targetPayload, full_name: "platform//widgets-renamed" },
+    { ...targetPayload, owner: null },
+    { ...targetPayload, owner: { login: 1 } },
+    { ...targetPayload, owner: { login: "" } },
+    { ...targetPayload, html_url: null },
+    {
+      ...targetPayload,
+      html_url: "ssh://forge.example/platform/widgets-renamed",
+    },
+    {
+      ...targetPayload,
+      html_url: "https://robot:secret@forge.example/platform/widgets-renamed",
+    },
+    {
+      ...targetPayload,
+      html_url: "https://forge.example/platform/widgets-renamed?token=secret",
+    },
+    {
+      ...targetPayload,
+      html_url: "https://forge.example/platform//widgets-renamed",
+    },
+    {
+      ...targetPayload,
+      html_url: "https://forge.example/platform/widgets-renamed/",
+    },
+  ];
+  for (const payload of malformedRepositoryPayloads)
+    assert.throws(
+      () =>
+        normalizeForgejoRepository(payload, {
+          operation: "resolve-target-repository",
+        }),
+      (error: unknown) =>
+        error instanceof ForgejoTeaPullRequestError &&
+        error.category === "malformed-response",
+    );
+
+  for (const payload of [
+    pull({ number: Number.MAX_SAFE_INTEGER + 1 }),
+    pull({ body: null }),
+    pull({ base: null }),
+    pull({ base: { ref: "", repo: targetPayload } }),
+    pull({ head: null }),
+    pull({ head: { ref: "topic", sha: "", repo: targetPayload } }),
+    pull({
+      html_url: "https://forge.example/platform//widgets-renamed/pulls/42",
+    }),
+    pull({
+      html_url: "https://forge.example/platform/widgets-renamed/pulls/42/",
+    }),
+    pull({
+      html_url: "https://forge.example/platform/widgets-renamed/issues/42",
+    }),
+    pull({
+      html_url: "https://forge.example/platform/widgets-renamed/pulls/41",
+    }),
+    pull({ state: "open", merged: false, merge_commit_sha: "abc" }),
+    pull({ state: "open", merged: false, merge_commit_sha: undefined }),
+    pull({ state: "open", merged: true, merge_commit_sha: null }),
+    pull({ state: "open", merged: true, merge_commit_sha: "abc" }),
+    pull({ state: "closed", merged: true, merge_commit_sha: null }),
+    pull({ state: "closed", merged: true, merge_commit_sha: " " }),
+    pull({ state: "closed", merged: false, merge_commit_sha: "abc" }),
+    pull({ state: "closed", merged: false, merge_commit_sha: " " }),
+    pull({ state: "closed", merged: false, merge_commit_sha: undefined }),
+  ])
+    assert.throws(
+      () => normalizeForgejoPullRequest(payload, options),
+      (error: unknown) =>
+        error instanceof ForgejoTeaPullRequestError &&
+        error.category === "malformed-response",
+    );
+});
+
+test("uses identity errors only for complete identity disagreements", () => {
+  assert.throws(
+    () =>
+      normalizeForgejoRepository(
+        { ...targetPayload, name: "other" },
+        { operation: "resolve-target-repository" },
+      ),
+    PullRequestIdentityError,
+  );
+  for (const payload of [
+    pull({
+      html_url: "https://other.example/platform/widgets-renamed/pulls/42",
+    }),
+    pull({
+      head: {
+        ref: "agent/issue-186-adapter",
+        sha: "abc123",
+        repo: targetPayload,
+      },
+    }),
+  ])
+    assert.throws(
+      () => normalizeForgejoPullRequest(payload, options),
+      PullRequestIdentityError,
+    );
+  const sameOwner = pull({
+    head: {
+      ref: "topic",
+      sha: "abc",
+      repo: repositoryPayload(target),
+    },
+  });
+  assert.equal(
+    normalizeForgejoPullRequest(sameOwner, {
+      operation: "list-pull-requests",
+      expectedTargetRepository: target,
+    }).headRepository.owner,
+    "platform",
+  );
+});
+
+function repositoryPayload(identity: typeof target) {
+  return {
+    name: identity.repository,
+    full_name: `${identity.owner}/${identity.repository}`,
+    owner: { login: identity.owner },
+    html_url: `https://${identity.host}/${identity.owner}/${identity.repository}`,
+  };
+}

--- a/src/host/forgejo-tea-pull-request-parsing.test.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.test.ts
@@ -88,7 +88,11 @@ test("does not expose rejected clone URLs", () => {
     "https://forge.example/widgets.git",
     "https://forge.example/group/acme/widgets.git",
     "https://forge.example/acme/widgets.git?token=secret",
+    "https://forge.example/acme\\widgets.git",
+    "https://forge.example/acme/widgets%",
     "git@forge.example:acme/widgets.git?token=secret",
+    "git@forge.example:acme\\widgets.git",
+    "git@forge.example:acme/widgets%",
     "git@forge.example:acme/widgets.git#fragment",
     "git@forge.example:widgets.git",
     "git@forge.example:group/acme/widgets.git",
@@ -257,6 +261,14 @@ test("rejects malformed repository and pull-request response fields by category"
       ...targetPayload,
       html_url: "https://forge.example/ignored/../platform/widgets-renamed",
     },
+    {
+      ...targetPayload,
+      html_url: "https://forge.example/platform\\widgets-renamed",
+    },
+    {
+      ...targetPayload,
+      html_url: "https://forge.example/platform/widgets-renamed%",
+    },
   ];
   for (const payload of malformedRepositoryPayloads)
     assert.throws(
@@ -285,6 +297,12 @@ test("rejects malformed repository and pull-request response fields by category"
     pull({
       html_url:
         "https://forge.example/ignored/../platform/widgets-renamed/pulls/42",
+    }),
+    pull({
+      html_url: "https://forge.example/platform\\widgets-renamed/pulls/42",
+    }),
+    pull({
+      html_url: "https://forge.example/platform/widgets-renamed/pulls/42%",
     }),
     pull({
       html_url: "https://forge.example/platform/widgets-renamed/issues/42",

--- a/src/host/forgejo-tea-pull-request-parsing.test.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PullRequestIdentityError } from "./pull-requests.ts";
+import {
+  normalizeForgejoPullRequest,
+  normalizeForgejoRepository,
+  parseForgejoRemoteUrl,
+  validateForgejoBranchName,
+  validateForgejoPullRequestNumber,
+  validateForgejoRemoteName,
+} from "./forgejo-tea-pull-request-parsing.ts";
+
+const targetPayload = {
+  name: "widgets-renamed",
+  full_name: "platform/widgets-renamed",
+  owner: { login: "platform" },
+  html_url: "https://FORGE.EXAMPLE/platform/widgets-renamed",
+};
+const target = {
+  provider: "forgejo-tea" as const,
+  host: "forge.example",
+  owner: "platform",
+  repository: "widgets-renamed",
+};
+const head = {
+  provider: "forgejo-tea" as const,
+  host: "forge.example",
+  owner: "contributor",
+  repository: "widgets",
+};
+
+for (const [url, expected] of [
+  [
+    "https://forge.example/acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+  [
+    "http://FORGE.EXAMPLE/acme/widgets",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+  [
+    "ssh://git@forge.example/acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+  [
+    "git@forge.example:acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
+] as const)
+  test(`parses ${url}`, () =>
+    assert.deepEqual(parseForgejoRemoteUrl(url), expected));
+
+test("does not expose rejected clone URLs", () => {
+  for (const url of [
+    "/srv/git/acme/widgets.git",
+    "file:///srv/git/acme/widgets.git",
+    "https://robot:secret@forge.example/acme/widgets.git",
+    "https://forge.example/widgets.git",
+    "https://forge.example/group/acme/widgets.git",
+    "https://forge.example/acme/widgets.git?token=secret",
+    "git@forge.example:widgets.git",
+    "git@forge.example:group/acme/widgets.git",
+  ]) {
+    assert.throws(
+      () => parseForgejoRemoteUrl(url),
+      (error: Error) =>
+        !error.message.includes(url) && !JSON.stringify(error).includes(url),
+    );
+  }
+});
+
+test("validates public remote, branch, and number input", () => {
+  validateForgejoRemoteName("-publish");
+  validateForgejoBranchName("feature/topic");
+  validateForgejoPullRequestNumber(1);
+  for (const value of ["", " "])
+    assert.throws(() => validateForgejoRemoteName(value));
+  for (const value of [
+    "",
+    " owner:topic ",
+    "owner:topic",
+    "topic..next",
+    "-topic",
+  ])
+    assert.throws(() => validateForgejoBranchName(value));
+  for (const value of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, NaN])
+    assert.throws(() => validateForgejoPullRequestNumber(value));
+});
+
+test("normalizes an authoritative repository payload", () => {
+  assert.deepEqual(
+    normalizeForgejoRepository(targetPayload, {
+      operation: "resolve-target-repository",
+      expectedHost: "forge.example",
+    }),
+    target,
+  );
+  for (const payload of [
+    null,
+    {},
+    { ...targetPayload, name: "other" },
+    {
+      ...targetPayload,
+      html_url: "https://robot:secret@forge.example/platform/widgets-renamed",
+    },
+  ]) {
+    assert.throws(() =>
+      normalizeForgejoRepository(payload, {
+        operation: "resolve-target-repository",
+        expectedHost: "forge.example",
+      }),
+    );
+  }
+  assert.throws(
+    () =>
+      normalizeForgejoRepository(targetPayload, {
+        operation: "resolve-target-repository",
+        expectedHost: "other.example",
+      }),
+    PullRequestIdentityError,
+  );
+});
+
+function pull(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 42,
+    html_url: "https://forge.example/platform/widgets-renamed/pulls/42",
+    body: "Refs #186",
+    state: "open",
+    merged: false,
+    merge_commit_sha: null,
+    base: { ref: "main", repo: targetPayload },
+    head: {
+      ref: "agent/issue-186-adapter",
+      sha: "abc123",
+      repo: {
+        name: "widgets",
+        full_name: "contributor/widgets",
+        owner: { login: "contributor" },
+        html_url: "https://forge.example/contributor/widgets",
+      },
+    },
+    ...overrides,
+  };
+}
+const options = {
+  operation: "get-pull-request" as const,
+  expectedTargetRepository: target,
+  expectedHeadRepository: head,
+  expectedNumber: 42,
+};
+test("normalizes valid state combinations and rejects inconsistent pull payloads", () => {
+  assert.equal(normalizeForgejoPullRequest(pull(), options).status, "open");
+  assert.deepEqual(
+    normalizeForgejoPullRequest(
+      pull({ state: "closed", merged: true, merge_commit_sha: "abc" }),
+      options,
+    ).status,
+    "merged",
+  );
+  assert.equal(
+    normalizeForgejoPullRequest(pull({ state: "closed" }), options).status,
+    "closed-unmerged",
+  );
+  for (const payload of [
+    pull({ number: 0 }),
+    pull({ state: "unknown" }),
+    pull({ merged: true }),
+    pull({ head: { ref: "", sha: "abc", repo: targetPayload } }),
+    pull({ base: { ref: "main" } }),
+  ])
+    assert.throws(() => normalizeForgejoPullRequest(payload, options));
+});

--- a/src/host/forgejo-tea-pull-request-parsing.test.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.test.ts
@@ -67,6 +67,15 @@ for (const [url, expected] of [
       slug: "acme/widgets",
     },
   ],
+  [
+    "forge.example:acme/widgets.git",
+    {
+      host: "forge.example",
+      owner: "acme",
+      repository: "widgets",
+      slug: "acme/widgets",
+    },
+  ],
 ] as const)
   test(`parses ${url}`, () =>
     assert.deepEqual(parseForgejoRemoteUrl(url), expected));

--- a/src/host/forgejo-tea-pull-request-parsing.test.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.test.ts
@@ -85,6 +85,8 @@ test("does not expose rejected clone URLs", () => {
     "git@forge.example:acme/widgets.git/",
     "https://forge.example/acme//widgets.git",
     "https://forge.example/acme/widgets.git/",
+    "ssh:///acme/widgets.git",
+    "https://forge.example/ignored/../acme/widgets.git",
   ]) {
     assert.throws(
       () => parseForgejoRemoteUrl(url),
@@ -240,6 +242,10 @@ test("rejects malformed repository and pull-request response fields by category"
       ...targetPayload,
       html_url: "https://forge.example/platform/widgets-renamed/",
     },
+    {
+      ...targetPayload,
+      html_url: "https://forge.example/ignored/../platform/widgets-renamed",
+    },
   ];
   for (const payload of malformedRepositoryPayloads)
     assert.throws(
@@ -264,6 +270,10 @@ test("rejects malformed repository and pull-request response fields by category"
     }),
     pull({
       html_url: "https://forge.example/platform/widgets-renamed/pulls/42/",
+    }),
+    pull({
+      html_url:
+        "https://forge.example/ignored/../platform/widgets-renamed/pulls/42",
     }),
     pull({
       html_url: "https://forge.example/platform/widgets-renamed/issues/42",

--- a/src/host/forgejo-tea-pull-request-parsing.test.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.test.ts
@@ -79,6 +79,8 @@ test("does not expose rejected clone URLs", () => {
     "https://forge.example/widgets.git",
     "https://forge.example/group/acme/widgets.git",
     "https://forge.example/acme/widgets.git?token=secret",
+    "git@forge.example:acme/widgets.git?token=secret",
+    "git@forge.example:acme/widgets.git#fragment",
     "git@forge.example:widgets.git",
     "git@forge.example:group/acme/widgets.git",
     "git@forge.example:/acme/widgets.git",

--- a/src/host/forgejo-tea-pull-request-parsing.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.ts
@@ -63,10 +63,16 @@ function urlCoordinates(
     url.hash
   )
     return malformed(operation);
-  const parts = url.pathname.split("/").filter(Boolean);
-  if (parts.length !== 2 || parts.some((part) => part === ""))
+  const parts = url.pathname.split("/");
+  if (
+    parts.length !== 3 ||
+    parts[0] !== "" ||
+    parts[1] === "" ||
+    parts[2] === ""
+  )
     return malformed(operation);
-  const [owner, repository] = parts;
+  const owner = parts[1];
+  const repository = parts[2];
   if (owner === undefined || repository === undefined)
     return malformed(operation);
   return {
@@ -89,7 +95,7 @@ export function validateForgejoBranchName(branch: string): void {
     branch === "@" ||
     branch.includes("..") ||
     branch.includes("@{") ||
-    /[\x00-\x20~^:?*[\\]/u.test(branch) ||
+    /[\x00-\x20\x7f~^:?*[\\]/u.test(branch) ||
     branch.startsWith("/") ||
     branch.endsWith("/") ||
     branch.includes("//") ||
@@ -112,6 +118,7 @@ export function parseForgejoRemoteUrl(
   };
   let host: string;
   let path: string;
+  let scpLike = false;
   if (/^[^@\s/:]+@[^\s/:]+:[^\s]+$/u.test(remoteUrl)) {
     const match = /^[^@\s/:]+@([^\s/:]+):([^\s]+)$/u.exec(remoteUrl);
     const matchHost = match?.[1];
@@ -119,6 +126,7 @@ export function parseForgejoRemoteUrl(
     if (matchHost === undefined || matchPath === undefined) return fail();
     host = matchHost;
     path = matchPath;
+    scpLike = true;
   } else {
     let url: URL;
     try {
@@ -136,10 +144,14 @@ export function parseForgejoRemoteUrl(
     host = url.host;
     path = url.pathname;
   }
-  const parts = path.replace(/^\/+|\/+$/gu, "").split("/");
-  if (parts.length !== 2 || parts.some((part) => !part)) return fail();
-  const owner = parts[0];
-  const last = parts[1];
+  const parts = path.split("/");
+  const owner = scpLike ? parts[0] : parts[1];
+  const last = scpLike ? parts[1] : parts[2];
+  if (
+    (scpLike && (parts.length !== 2 || !owner || !last)) ||
+    (!scpLike && (parts.length !== 3 || parts[0] !== "" || !owner || !last))
+  )
+    return fail();
   if (owner === undefined || last === undefined) return fail();
   const repository = last.endsWith(".git") ? last.slice(0, -4) : last;
   if (!repository) return fail();
@@ -255,10 +267,16 @@ export function normalizeForgejoPullRequest(
     parsed.hash
   )
     return malformed(options.operation);
-  const parts = parsed.pathname.split("/").filter(Boolean);
-  const [urlOwner, urlRepository, pathKind, urlNumber] = parts;
+  const parts = parsed.pathname.split("/");
+  const urlOwner = parts[1];
+  const urlRepository = parts[2];
+  const pathKind = parts[3];
+  const urlNumber = parts[4];
   if (
-    parts.length !== 4 ||
+    parts.length !== 5 ||
+    parts[0] !== "" ||
+    urlOwner === "" ||
+    urlRepository === "" ||
     pathKind !== "pulls" ||
     urlNumber !== String(number)
   )

--- a/src/host/forgejo-tea-pull-request-parsing.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.ts
@@ -48,13 +48,16 @@ function nonblank(
 function rawUrlPath(value: string): string {
   return /^[a-z][a-z\d+.-]*:\/\/[^/?#]*(\/[^?#]*)?/iu.exec(value)?.[1] ?? "";
 }
-function hasDotSegment(path: string): boolean {
+function hasUnsafeUrlText(value: string): boolean {
+  return /[\\\x00-\x20\x7f]/u.test(value);
+}
+function hasInvalidOrDotSegment(path: string): boolean {
   return path.split("/").some((part) => {
     try {
       const decoded = decodeURIComponent(part);
       return decoded === "." || decoded === "..";
     } catch {
-      return false;
+      return true;
     }
   });
 }
@@ -75,7 +78,8 @@ function urlCoordinates(
     url.password ||
     url.search ||
     url.hash ||
-    hasDotSegment(rawUrlPath(value))
+    hasUnsafeUrlText(value) ||
+    hasInvalidOrDotSegment(rawUrlPath(value))
   )
     return malformed(operation);
   const parts = url.pathname.split("/");
@@ -164,7 +168,8 @@ export function parseForgejoRemoteUrl(
   const owner = scpLike ? parts[0] : parts[1];
   const last = scpLike ? parts[1] : parts[2];
   if (
-    hasDotSegment(path) ||
+    hasUnsafeUrlText(remoteUrl) ||
+    hasInvalidOrDotSegment(path) ||
     (scpLike &&
       (path.includes("?") ||
         path.includes("#") ||
@@ -288,7 +293,8 @@ export function normalizeForgejoPullRequest(
     parsed.password ||
     parsed.search ||
     parsed.hash ||
-    hasDotSegment(rawUrlPath(html))
+    hasUnsafeUrlText(html) ||
+    hasInvalidOrDotSegment(rawUrlPath(html))
   )
     return malformed(options.operation);
   const parts = parsed.pathname.split("/");

--- a/src/host/forgejo-tea-pull-request-parsing.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.ts
@@ -45,6 +45,19 @@ function nonblank(
     return malformed(operation);
   return value;
 }
+function rawUrlPath(value: string): string {
+  return /^[a-z][a-z\d+.-]*:\/\/[^/?#]*(\/[^?#]*)?/iu.exec(value)?.[1] ?? "";
+}
+function hasDotSegment(path: string): boolean {
+  return path.split("/").some((part) => {
+    try {
+      const decoded = decodeURIComponent(part);
+      return decoded === "." || decoded === "..";
+    } catch {
+      return false;
+    }
+  });
+}
 function urlCoordinates(
   value: string,
   operation: ForgejoPullRequestOperation,
@@ -57,10 +70,12 @@ function urlCoordinates(
   }
   if (
     !/^https?:$/u.test(url.protocol) ||
+    !url.host ||
     url.username ||
     url.password ||
     url.search ||
-    url.hash
+    url.hash ||
+    hasDotSegment(rawUrlPath(value))
   )
     return malformed(operation);
   const parts = url.pathname.split("/");
@@ -141,13 +156,15 @@ export function parseForgejoRemoteUrl(
       (url.protocol !== "ssh:" && (url.username || url.password))
     )
       return fail();
+    if (!url.host) return fail();
     host = url.host;
-    path = url.pathname;
+    path = rawUrlPath(remoteUrl);
   }
   const parts = path.split("/");
   const owner = scpLike ? parts[0] : parts[1];
   const last = scpLike ? parts[1] : parts[2];
   if (
+    hasDotSegment(path) ||
     (scpLike && (parts.length !== 2 || !owner || !last)) ||
     (!scpLike && (parts.length !== 3 || parts[0] !== "" || !owner || !last))
   )
@@ -261,10 +278,12 @@ export function normalizeForgejoPullRequest(
   }
   if (
     !/^https?:$/u.test(parsed.protocol) ||
+    !parsed.host ||
     parsed.username ||
     parsed.password ||
     parsed.search ||
-    parsed.hash
+    parsed.hash ||
+    hasDotSegment(rawUrlPath(html))
   )
     return malformed(options.operation);
   const parts = parsed.pathname.split("/");

--- a/src/host/forgejo-tea-pull-request-parsing.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.ts
@@ -134,8 +134,8 @@ export function parseForgejoRemoteUrl(
   let host: string;
   let path: string;
   let scpLike = false;
-  if (/^[^@\s/:]+@[^\s/:]+:[^\s]+$/u.test(remoteUrl)) {
-    const match = /^[^@\s/:]+@([^\s/:]+):([^\s]+)$/u.exec(remoteUrl);
+  if (/^(?:[^@\s/:]+@)?[^\s/:]+:(?!\/)[^\s]+$/u.test(remoteUrl)) {
+    const match = /^(?:[^@\s/:]+@)?([^\s/:]+):(?!\/)([^\s]+)$/u.exec(remoteUrl);
     const matchHost = match?.[1];
     const matchPath = match?.[2];
     if (matchHost === undefined || matchPath === undefined) return fail();

--- a/src/host/forgejo-tea-pull-request-parsing.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.ts
@@ -165,7 +165,12 @@ export function parseForgejoRemoteUrl(
   const last = scpLike ? parts[1] : parts[2];
   if (
     hasDotSegment(path) ||
-    (scpLike && (parts.length !== 2 || !owner || !last)) ||
+    (scpLike &&
+      (path.includes("?") ||
+        path.includes("#") ||
+        parts.length !== 2 ||
+        !owner ||
+        !last)) ||
     (!scpLike && (parts.length !== 3 || parts[0] !== "" || !owner || !last))
   )
     return fail();

--- a/src/host/forgejo-tea-pull-request-parsing.ts
+++ b/src/host/forgejo-tea-pull-request-parsing.ts
@@ -1,0 +1,323 @@
+import {
+  PullRequestIdentityError,
+  sameRepositoryIdentity,
+  type PullRequestSummary,
+  type RepositoryIdentity,
+} from "./pull-requests.ts";
+import {
+  ForgejoTeaPullRequestError,
+  type ForgejoPullRequestOperation,
+} from "./forgejo-tea-pull-request-errors.ts";
+
+export type ForgejoRemoteRepositoryCoordinates = {
+  host: string;
+  owner: string;
+  repository: string;
+  slug: string;
+};
+
+type ObjectValue = Record<string, unknown>;
+function invalidInput(): never {
+  throw new ForgejoTeaPullRequestError({
+    category: "invalid-input",
+    operation: "validate-input",
+  });
+}
+function malformed(operation: ForgejoPullRequestOperation): never {
+  throw new ForgejoTeaPullRequestError({
+    category: "malformed-response",
+    operation,
+  });
+}
+function object(
+  value: unknown,
+  operation: ForgejoPullRequestOperation,
+): ObjectValue {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return malformed(operation);
+  return value as ObjectValue;
+}
+function nonblank(
+  value: unknown,
+  operation: ForgejoPullRequestOperation,
+): string {
+  if (typeof value !== "string" || value.trim() === "")
+    return malformed(operation);
+  return value;
+}
+function urlCoordinates(
+  value: string,
+  operation: ForgejoPullRequestOperation,
+): ForgejoRemoteRepositoryCoordinates {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return malformed(operation);
+  }
+  if (
+    !/^https?:$/u.test(url.protocol) ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  )
+    return malformed(operation);
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length !== 2 || parts.some((part) => part === ""))
+    return malformed(operation);
+  const [owner, repository] = parts;
+  if (owner === undefined || repository === undefined)
+    return malformed(operation);
+  return {
+    host: url.host.toLowerCase(),
+    owner,
+    repository,
+    slug: `${owner}/${repository}`,
+  };
+}
+
+export function validateForgejoRemoteName(remote: string): void {
+  if (typeof remote !== "string" || remote.trim() === "") invalidInput();
+}
+export function validateForgejoBranchName(branch: string): void {
+  if (
+    typeof branch !== "string" ||
+    branch.trim() !== branch ||
+    !branch ||
+    branch.startsWith("-") ||
+    branch === "@" ||
+    branch.includes("..") ||
+    branch.includes("@{") ||
+    /[\x00-\x20~^:?*[\\]/u.test(branch) ||
+    branch.startsWith("/") ||
+    branch.endsWith("/") ||
+    branch.includes("//") ||
+    branch.endsWith(".") ||
+    branch
+      .split("/")
+      .some((part) => part.startsWith(".") || part.endsWith(".lock"))
+  )
+    invalidInput();
+}
+export function validateForgejoPullRequestNumber(number: number): void {
+  if (!Number.isSafeInteger(number) || number <= 0) invalidInput();
+}
+
+export function parseForgejoRemoteUrl(
+  remoteUrl: string,
+): ForgejoRemoteRepositoryCoordinates {
+  const fail = (): never => {
+    throw new PullRequestIdentityError("unsupported Forgejo remote URL");
+  };
+  let host: string;
+  let path: string;
+  if (/^[^@\s/:]+@[^\s/:]+:[^\s]+$/u.test(remoteUrl)) {
+    const match = /^[^@\s/:]+@([^\s/:]+):([^\s]+)$/u.exec(remoteUrl);
+    const matchHost = match?.[1];
+    const matchPath = match?.[2];
+    if (matchHost === undefined || matchPath === undefined) return fail();
+    host = matchHost;
+    path = matchPath;
+  } else {
+    let url: URL;
+    try {
+      url = new URL(remoteUrl);
+    } catch {
+      return fail();
+    }
+    if (
+      !/^https?:$|^ssh:$/u.test(url.protocol) ||
+      url.search ||
+      url.hash ||
+      (url.protocol !== "ssh:" && (url.username || url.password))
+    )
+      return fail();
+    host = url.host;
+    path = url.pathname;
+  }
+  const parts = path.replace(/^\/+|\/+$/gu, "").split("/");
+  if (parts.length !== 2 || parts.some((part) => !part)) return fail();
+  const owner = parts[0];
+  const last = parts[1];
+  if (owner === undefined || last === undefined) return fail();
+  const repository = last.endsWith(".git") ? last.slice(0, -4) : last;
+  if (!repository) return fail();
+  return {
+    host: host.toLowerCase(),
+    owner,
+    repository,
+    slug: `${owner}/${repository}`,
+  };
+}
+
+export function normalizeForgejoRepository(
+  payload: unknown,
+  options: { operation: ForgejoPullRequestOperation; expectedHost?: string },
+): RepositoryIdentity {
+  const value = object(payload, options.operation);
+  const name = nonblank(value.name, options.operation);
+  const fullName = nonblank(value.full_name, options.operation);
+  const owner = nonblank(
+    object(value.owner, options.operation).login,
+    options.operation,
+  );
+  const html = nonblank(value.html_url, options.operation);
+  const coordinates = urlCoordinates(html, options.operation);
+  const fullNameParts = fullName.split("/");
+  if (fullNameParts.length !== 2 || fullNameParts.some((part) => !part))
+    return malformed(options.operation);
+  const identity = {
+    provider: "forgejo-tea" as const,
+    host: coordinates.host,
+    owner,
+    repository: name,
+  };
+  if (
+    fullNameParts[0] !== owner ||
+    fullNameParts[1] !== name ||
+    coordinates.owner !== owner ||
+    coordinates.repository !== name
+  )
+    throw new PullRequestIdentityError("repository fields disagree", {
+      actual: identity,
+    });
+  if (
+    options.expectedHost !== undefined &&
+    coordinates.host.toLowerCase() !== options.expectedHost.toLowerCase()
+  )
+    throw new PullRequestIdentityError("repository host disagrees", {
+      actual: identity,
+    });
+  return identity;
+}
+
+export function normalizeForgejoPullRequest(
+  payload: unknown,
+  options: {
+    operation: ForgejoPullRequestOperation;
+    expectedTargetRepository: RepositoryIdentity;
+    expectedHeadRepository?: RepositoryIdentity;
+    expectedNumber?: number;
+  },
+): PullRequestSummary {
+  const value = object(payload, options.operation);
+  const number = value.number;
+  if (
+    typeof number !== "number" ||
+    !Number.isSafeInteger(number) ||
+    number <= 0 ||
+    (options.expectedNumber !== undefined && number !== options.expectedNumber)
+  )
+    return malformed(options.operation);
+  const body = value.body;
+  if (typeof body !== "string") return malformed(options.operation);
+  const base = object(value.base, options.operation);
+  const head = object(value.head, options.operation);
+  const baseBranch = nonblank(base.ref, options.operation);
+  const headBranch = nonblank(head.ref, options.operation);
+  const headSha = nonblank(head.sha, options.operation);
+  const targetRepository = normalizeForgejoRepository(base.repo, {
+    operation: options.operation,
+    expectedHost: options.expectedTargetRepository.host,
+  });
+  const headRepository = normalizeForgejoRepository(head.repo, {
+    operation: options.operation,
+    expectedHost: options.expectedTargetRepository.host,
+  });
+  if (
+    !sameRepositoryIdentity(targetRepository, options.expectedTargetRepository)
+  )
+    throw new PullRequestIdentityError("pull request target disagrees", {
+      expected: options.expectedTargetRepository,
+      actual: targetRepository,
+    });
+  if (
+    options.expectedHeadRepository &&
+    !sameRepositoryIdentity(headRepository, options.expectedHeadRepository)
+  )
+    throw new PullRequestIdentityError("pull request head disagrees", {
+      expected: options.expectedHeadRepository,
+      actual: headRepository,
+    });
+  const html = nonblank(value.html_url, options.operation);
+  let parsed: URL;
+  try {
+    parsed = new URL(html);
+  } catch {
+    return malformed(options.operation);
+  }
+  if (
+    !/^https?:$/u.test(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  )
+    return malformed(options.operation);
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  const [urlOwner, urlRepository, pathKind, urlNumber] = parts;
+  if (
+    parts.length !== 4 ||
+    pathKind !== "pulls" ||
+    urlNumber !== String(number)
+  )
+    return malformed(options.operation);
+  if (
+    parsed.host.toLowerCase() !== targetRepository.host ||
+    urlOwner !== targetRepository.owner ||
+    urlRepository !== targetRepository.repository
+  )
+    throw new PullRequestIdentityError("pull request URL target disagrees");
+  if (
+    value.state === "open" &&
+    value.merged === false &&
+    value.merge_commit_sha === null
+  )
+    return {
+      number,
+      url: html,
+      targetRepository,
+      baseBranch,
+      headRepository,
+      headBranch,
+      headSha,
+      body,
+      status: "open",
+    };
+  if (
+    value.state === "closed" &&
+    value.merged === true &&
+    typeof value.merge_commit_sha === "string" &&
+    value.merge_commit_sha.trim()
+  )
+    return {
+      number,
+      url: html,
+      targetRepository,
+      baseBranch,
+      headRepository,
+      headBranch,
+      headSha,
+      body,
+      status: "merged",
+      mergeCommit: value.merge_commit_sha,
+    };
+  if (
+    value.state === "closed" &&
+    value.merged === false &&
+    value.merge_commit_sha === null
+  )
+    return {
+      number,
+      url: html,
+      targetRepository,
+      baseBranch,
+      headRepository,
+      headBranch,
+      headSha,
+      body,
+      status: "closed-unmerged",
+    };
+  return malformed(options.operation);
+}

--- a/src/host/forgejo-tea-pull-requests.test.ts
+++ b/src/host/forgejo-tea-pull-requests.test.ts
@@ -314,3 +314,26 @@ test("command failures retain safe status diagnostics", async () =>
       },
     );
   }));
+
+test("a contradictory successful 404 remains a command failure", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner([
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      { code: 0, stdout: "{}", stderr: "HTTP/2 404 Not Found\n" },
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.getPullRequest({ targetRepository: target, number: 42 }),
+      ForgejoTeaPullRequestError,
+    );
+  }));

--- a/src/host/forgejo-tea-pull-requests.test.ts
+++ b/src/host/forgejo-tea-pull-requests.test.ts
@@ -251,6 +251,19 @@ test("create, find, get, read, and update use exhaustive validated API operation
       ],
       cwd: repoRoot,
     });
+    assert.deepEqual(runner.calls[12], {
+      command: "tea",
+      args: [
+        "api",
+        "/repos/{owner}/{repo}/pulls/42",
+        "--include",
+        "--repo",
+        "legacy/widgets",
+        "--login",
+        "robot",
+      ],
+      cwd: repoRoot,
+    });
     assert.deepEqual(runner.calls.at(-1), {
       command: "tea",
       args: [

--- a/src/host/forgejo-tea-pull-requests.test.ts
+++ b/src/host/forgejo-tea-pull-requests.test.ts
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { CommandResult } from "../cli/commands/triage/types.ts";
+import { createStaticCommandRunner } from "../../test-support/command-runner.ts";
+import { ForgejoTeaPullRequestError } from "./forgejo-tea-pull-request-errors.ts";
+import { ForgejoTeaPullRequestHost } from "./forgejo-tea-pull-requests.ts";
+
+function repositoryPayload({
+  host = "forge.example",
+  owner,
+  repository,
+}: {
+  host?: string;
+  owner: string;
+  repository: string;
+}): Record<string, unknown> {
+  return {
+    name: repository,
+    full_name: `${owner}/${repository}`,
+    owner: { login: owner },
+    html_url: `https://${host}/${owner}/${repository}`,
+  };
+}
+function jsonResult(value: unknown, stderr = ""): CommandResult {
+  return { code: 0, stdout: JSON.stringify(value), stderr };
+}
+async function withForgejoRepository(
+  run: (repoRoot: string) => Promise<void>,
+): Promise<void> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "patchmill-forgejo-"));
+  try {
+    await mkdir(join(repoRoot, ".git"));
+    await writeFile(
+      join(repoRoot, ".git", "config"),
+      '[remote "origin"]\n    url = git@forge.example:legacy/widgets.git\n',
+    );
+    await run(repoRoot);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+}
+const target = {
+  provider: "forgejo-tea" as const,
+  host: "forge.example",
+  owner: "platform",
+  repository: "widgets",
+};
+const head = {
+  provider: "forgejo-tea" as const,
+  host: "forge.example",
+  owner: "contributor",
+  repository: "widgets",
+};
+function pull(number = 42, overrides: Record<string, unknown> = {}) {
+  return {
+    number,
+    html_url: `https://forge.example/platform/widgets/pulls/${number}`,
+    body: "body",
+    state: "open",
+    merged: false,
+    merge_commit_sha: null,
+    base: { ref: "main", repo: repositoryPayload(target) },
+    head: { ref: "topic", sha: "abc", repo: repositoryPayload(head) },
+    ...overrides,
+  };
+}
+
+test("resolves target and each configured push URL with exact safe commands", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner([
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout:
+          "git@forge.example:contributor/widgets.git\nhttps://forge.example/contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      jsonResult(repositoryPayload(head)),
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "-publish",
+      login: "robot",
+    });
+    assert.deepEqual(await host.resolveTargetRepositoryIdentity(), target);
+    assert.deepEqual(
+      await host.resolveRemoteRepositoryIdentity("-publish"),
+      head,
+    );
+    assert.deepEqual(runner.calls, [
+      {
+        command: "tea",
+        args: [
+          "api",
+          "/repos/{owner}/{repo}",
+          "--include",
+          "--repo",
+          "legacy/widgets",
+          "--login",
+          "robot",
+        ],
+        cwd: repoRoot,
+      },
+      {
+        command: "git",
+        args: ["remote", "get-url", "--push", "--all", "--", "-publish"],
+        cwd: repoRoot,
+      },
+      {
+        command: "tea",
+        args: [
+          "api",
+          "/repos/{owner}/{repo}",
+          "--include",
+          "--repo",
+          "contributor/widgets",
+          "--login",
+          "robot",
+        ],
+        cwd: repoRoot,
+      },
+      {
+        command: "tea",
+        args: [
+          "api",
+          "/repos/{owner}/{repo}",
+          "--include",
+          "--repo",
+          "contributor/widgets",
+          "--login",
+          "robot",
+        ],
+        cwd: repoRoot,
+      },
+    ]);
+  }));
+
+test("create, find, get, read, and update use exhaustive validated API operations", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const full = Array.from({ length: 50 }, (_, i) => pull(i + 1));
+    const runner = createStaticCommandRunner([
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      jsonResult(pull()),
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      jsonResult(full),
+      jsonResult([]),
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      jsonResult(pull()),
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      jsonResult(pull()),
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      jsonResult(pull()),
+      jsonResult({}),
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+      login: "robot",
+    });
+    const created = await host.createPullRequest({
+      title: "Plan",
+      body: "Details",
+      baseBranch: "main",
+      headBranch: "topic",
+    });
+    assert.equal(created.number, 42);
+    const query = {
+      targetRepository: target,
+      baseBranch: "main",
+      headRepository: head,
+      headBranch: "topic",
+    };
+    assert.equal((await host.findPullRequests(query)).length, 50);
+    const reference = { targetRepository: target, number: 42 };
+    assert.equal((await host.getPullRequest(reference)).number, 42);
+    assert.equal(await host.readPullRequestBody(reference), "body");
+    await host.updatePullRequestBody(reference, "Summary\n\nDetails\n");
+    assert.deepEqual(runner.calls[3], {
+      command: "tea",
+      args: [
+        "api",
+        "/repos/{owner}/{repo}/pulls",
+        "--method",
+        "POST",
+        "--field",
+        "base=main",
+        "--field",
+        "head=contributor:topic",
+        "--field",
+        "title=Plan",
+        "--field",
+        "body=Details",
+        "--include",
+        "--repo",
+        "legacy/widgets",
+        "--login",
+        "robot",
+      ],
+      cwd: repoRoot,
+    });
+    assert.deepEqual(runner.calls[7], {
+      command: "tea",
+      args: [
+        "api",
+        "/repos/{owner}/{repo}/pulls?state=all&page=1&limit=50",
+        "--include",
+        "--repo",
+        "legacy/widgets",
+        "--login",
+        "robot",
+      ],
+      cwd: repoRoot,
+    });
+    assert.deepEqual(runner.calls.at(-1), {
+      command: "tea",
+      args: [
+        "api",
+        "/repos/{owner}/{repo}/pulls/42",
+        "--method",
+        "PATCH",
+        "--field",
+        "body=Summary\n\nDetails\n",
+        "--include",
+        "--repo",
+        "legacy/widgets",
+        "--login",
+        "robot",
+      ],
+      cwd: repoRoot,
+    });
+  }));
+
+test("only a nonzero exact get 404 is not found", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner([
+      jsonResult(repositoryPayload(target)),
+      {
+        code: 0,
+        stdout: "git@forge.example:contributor/widgets.git\n",
+        stderr: "",
+      },
+      jsonResult(repositoryPayload(head)),
+      { code: 1, stdout: "", stderr: "HTTP/2 404 Not Found\n" },
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.getPullRequest({ targetRepository: target, number: 42 }),
+      { name: "PullRequestNotFoundError" },
+    );
+  }));
+
+test("command failures retain safe status diagnostics", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner([
+      {
+        code: 1,
+        stdout: "secret",
+        stderr: "HTTP/1.1 302 Found\nHTTP/2 403 Forbidden\n",
+      },
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.resolveTargetRepositoryIdentity(),
+      (error: unknown) => {
+        assert.ok(error instanceof ForgejoTeaPullRequestError);
+        assert.equal(error.httpStatus, 403);
+        assert.equal(error.rawDiagnostics?.stdout, "secret");
+        assert.ok(!JSON.stringify(error).includes("secret"));
+        return true;
+      },
+    );
+  }));

--- a/src/host/forgejo-tea-pull-requests.test.ts
+++ b/src/host/forgejo-tea-pull-requests.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import type { CommandResult } from "../cli/commands/triage/types.ts";
 import { createStaticCommandRunner } from "../../test-support/command-runner.ts";
 import { ForgejoTeaPullRequestError } from "./forgejo-tea-pull-request-errors.ts";
+import { PullRequestIdentityError } from "./pull-requests.ts";
 import { ForgejoTeaPullRequestHost } from "./forgejo-tea-pull-requests.ts";
 
 function repositoryPayload({
@@ -336,4 +337,373 @@ test("a contradictory successful 404 remains a command failure", async () =>
       host.getPullRequest({ targetRepository: target, number: 42 }),
       ForgejoTeaPullRequestError,
     );
+  }));
+
+function contextResults(): CommandResult[] {
+  return [
+    jsonResult(repositoryPayload(target)),
+    {
+      code: 0,
+      stdout: "git@forge.example:contributor/widgets.git\n",
+      stderr: "",
+    },
+    jsonResult(repositoryPayload(head)),
+  ];
+}
+function query() {
+  return {
+    targetRepository: target,
+    baseBranch: "main",
+    headRepository: head,
+    headBranch: "topic",
+  };
+}
+function hostFor(repoRoot: string, results: CommandResult[]) {
+  return new ForgejoTeaPullRequestHost({
+    runner: createStaticCommandRunner(results),
+    repoRoot,
+    pushRemote: "publish",
+    login: "robot",
+  });
+}
+
+test("repository commands retain complete HTTP status diagnostics", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    for (const { stderr, expectedStatus } of [
+      { stderr: "HTTP/2 401 Unauthorized\n", expectedStatus: 401 },
+      { stderr: "HTTP/1.1 429 Too Many Requests\n", expectedStatus: 429 },
+      {
+        stderr: "request failed with 404 in diagnostic text",
+        expectedStatus: undefined,
+      },
+      {
+        stderr: "HTTP/1.1 302 Found\nlocation: /next\n\nHTTP/2 403 Forbidden\n",
+        expectedStatus: 403,
+      },
+    ]) {
+      const host = hostFor(repoRoot, [{ code: 1, stdout: "secret", stderr }]);
+      await assert.rejects(
+        host.resolveTargetRepositoryIdentity(),
+        (error: unknown) => {
+          assert.ok(error instanceof ForgejoTeaPullRequestError);
+          assert.equal(error.category, "command-failed");
+          assert.equal(error.operation, "resolve-target-repository");
+          assert.equal(error.exitCode, 1);
+          assert.equal(error.httpStatus, expectedStatus);
+          assert.equal(error.rawDiagnostics?.stdout, "secret");
+          assert.equal(Object.keys(error).includes("rawDiagnostics"), false);
+          return true;
+        },
+      );
+    }
+  }));
+
+test("remote resolution rejects failed, empty, malformed, and disagreeing remotes", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const cases = [
+      {
+        results: [{ code: 1, stdout: "", stderr: "failed" }],
+        error: ForgejoTeaPullRequestError,
+      },
+      {
+        results: [{ code: 0, stdout: "\n\r\n", stderr: "" }],
+        error: ForgejoTeaPullRequestError,
+      },
+      {
+        results: [
+          {
+            code: 0,
+            stdout: "git@forge.example:/contributor/widgets.git\n",
+            stderr: "",
+          },
+        ],
+        error: PullRequestIdentityError,
+      },
+      {
+        results: [
+          {
+            code: 0,
+            stdout: "git@forge.example:contributor/widgets.git\n",
+            stderr: "",
+          },
+          jsonResult(repositoryPayload({ ...head, host: "other.example" })),
+        ],
+        error: PullRequestIdentityError,
+      },
+      {
+        results: [
+          {
+            code: 0,
+            stdout:
+              "git@forge.example:contributor/widgets.git\ngit@forge.example:other/widgets.git\n",
+            stderr: "",
+          },
+          jsonResult(repositoryPayload(head)),
+          jsonResult(repositoryPayload({ ...head, owner: "other" })),
+        ],
+        error: PullRequestIdentityError,
+      },
+    ];
+    for (const { results, error } of cases) {
+      const host = hostFor(repoRoot, results);
+      await assert.rejects(
+        host.resolveRemoteRepositoryIdentity("publish"),
+        error,
+      );
+    }
+  }));
+
+test("input validation prevents any live command", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner([]);
+    assert.throws(
+      () =>
+        new ForgejoTeaPullRequestHost({
+          runner,
+          repoRoot,
+          pushRemote: " ",
+        }),
+      ForgejoTeaPullRequestError,
+    );
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.createPullRequest({
+        title: "title",
+        body: "body",
+        baseBranch: "main",
+        headBranch: "topic\u007fnext",
+      }),
+      ForgejoTeaPullRequestError,
+    );
+    await assert.rejects(
+      host.getPullRequest({ targetRepository: target, number: 0 }),
+      ForgejoTeaPullRequestError,
+    );
+    assert.deepEqual(runner.calls, []);
+  }));
+
+test("find fetches page two before filtering and never returns a partial result", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const fullPage = Array.from({ length: 50 }, (_, index) => pull(index + 1));
+    const runner = createStaticCommandRunner([
+      ...contextResults(),
+      jsonResult(fullPage),
+      { code: 1, stdout: "", stderr: "HTTP/2 500 Server Error\n" },
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+      login: "robot",
+    });
+    await assert.rejects(host.findPullRequests(query()), (error: unknown) => {
+      assert.ok(error instanceof ForgejoTeaPullRequestError);
+      assert.equal(error.operation, "list-pull-requests");
+      return true;
+    });
+    assert.deepEqual(runner.calls[4], {
+      command: "tea",
+      args: [
+        "api",
+        "/repos/{owner}/{repo}/pulls?state=all&page=2&limit=50",
+        "--include",
+        "--repo",
+        "legacy/widgets",
+        "--login",
+        "robot",
+      ],
+      cwd: repoRoot,
+    });
+  }));
+
+test("find stops on a short raw page and excludes nonmatching heads", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const unrelatedHead = {
+      provider: "forgejo-tea" as const,
+      host: "forge.example",
+      owner: "other",
+      repository: "widgets",
+    };
+    const runner = createStaticCommandRunner([
+      ...contextResults(),
+      jsonResult([
+        pull(1),
+        pull(2, {
+          head: {
+            ref: "topic",
+            sha: "abc",
+            repo: repositoryPayload(unrelatedHead),
+          },
+        }),
+      ]),
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    assert.deepEqual(
+      (await host.findPullRequests(query())).map((entry) => entry.number),
+      [1],
+    );
+    assert.equal(runner.calls.length, 4);
+  }));
+
+test("get status classification, malformed payloads, and failed validation suppress PATCH", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const reference = { targetRepository: target, number: 42 };
+    const statusCases = [
+      { code: 1, stderr: "request failed with 404 in diagnostic text\n" },
+      { code: 1, stderr: "HTTP/2 401 Unauthorized\n" },
+      { code: 1, stderr: "HTTP/1.1 429 Too Many Requests\n" },
+      { code: 1, stderr: "HTTP/2 500 Server Error\n" },
+      { code: 0, stderr: "HTTP/2 404 Not Found\n" },
+    ];
+    for (const result of statusCases) {
+      const host = hostFor(repoRoot, [
+        ...contextResults(),
+        { stdout: "{}", ...result },
+      ]);
+      await assert.rejects(
+        host.getPullRequest(reference),
+        ForgejoTeaPullRequestError,
+      );
+    }
+    for (const result of [
+      { code: 0, stdout: "not json", stderr: "" },
+      { code: 0, stdout: "{}", stderr: "" },
+    ]) {
+      const host = hostFor(repoRoot, [...contextResults(), result]);
+      await assert.rejects(
+        host.getPullRequest(reference),
+        ForgejoTeaPullRequestError,
+      );
+    }
+    const runner = createStaticCommandRunner([
+      ...contextResults(),
+      { code: 1, stdout: "", stderr: "HTTP/2 403 Forbidden\n" },
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.updatePullRequestBody(reference, "Summary\n\nDetails\n"),
+      ForgejoTeaPullRequestError,
+    );
+    assert.equal(
+      runner.calls.some((call) => call.args.includes("PATCH")),
+      false,
+    );
+  }));
+
+test("the final HTTP status controls exact get classification", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const reference = { targetRepository: target, number: 42 };
+    const notFound = hostFor(repoRoot, [
+      ...contextResults(),
+      {
+        code: 1,
+        stdout: "",
+        stderr: "HTTP/1.1 302 Found\nlocation: /next\n\nHTTP/2 404 Not Found\n",
+      },
+    ]);
+    await assert.rejects(notFound.getPullRequest(reference), {
+      name: "PullRequestNotFoundError",
+    });
+    const found = hostFor(repoRoot, [
+      ...contextResults(),
+      jsonResult(pull(), "HTTP/2 404 Not Found\nHTTP/2 200 OK\n"),
+    ]);
+    assert.equal((await found.getPullRequest(reference)).number, 42);
+  }));
+
+test("find rejects malformed later list results without exposing partial matches", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    for (const result of [
+      { code: 0, stdout: "not json", stderr: "" },
+      jsonResult({}),
+      jsonResult([pull(1, { head: { ref: "topic" } })]),
+    ]) {
+      const host = hostFor(repoRoot, [...contextResults(), result]);
+      await assert.rejects(
+        host.findPullRequests(query()),
+        ForgejoTeaPullRequestError,
+      );
+    }
+  }));
+
+test("find validates live query identities before issuing a list request", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner(contextResults());
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.findPullRequests({ ...query(), targetRepository: head }),
+      PullRequestIdentityError,
+    );
+    assert.equal(runner.calls.length, 3);
+  }));
+
+test("get validates caller and response identities before accepting a payload", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const reference = { targetRepository: target, number: 42 };
+    const callerMismatchRunner = createStaticCommandRunner(contextResults());
+    const callerMismatch = new ForgejoTeaPullRequestHost({
+      runner: callerMismatchRunner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      callerMismatch.getPullRequest({ targetRepository: head, number: 42 }),
+      PullRequestIdentityError,
+    );
+    assert.equal(callerMismatchRunner.calls.length, 3);
+
+    for (const payload of [
+      pull(41),
+      pull(42, {
+        html_url: "https://forge.example/platform/widgets/issues/42",
+      }),
+      pull(42, { base: { ref: "main" } }),
+      pull(42, {
+        head: { ref: "topic", sha: "abc", repo: repositoryPayload(target) },
+      }),
+    ]) {
+      const host = hostFor(repoRoot, [
+        ...contextResults(),
+        jsonResult(payload),
+      ]);
+      await assert.rejects(host.getPullRequest(reference));
+    }
+  }));
+
+test("a PATCH 404 remains a command failure after a validated get", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const runner = createStaticCommandRunner([
+      ...contextResults(),
+      jsonResult(pull()),
+      { code: 1, stdout: "", stderr: "HTTP/2 404 Not Found\n" },
+    ]);
+    const host = new ForgejoTeaPullRequestHost({
+      runner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.updatePullRequestBody(
+        { targetRepository: target, number: 42 },
+        "Summary\n\nDetails\n",
+      ),
+      ForgejoTeaPullRequestError,
+    );
+    assert.equal(runner.calls.at(-1)?.args.includes("PATCH"), true);
   }));

--- a/src/host/forgejo-tea-pull-requests.test.ts
+++ b/src/host/forgejo-tea-pull-requests.test.ts
@@ -316,6 +316,25 @@ test("command failures retain safe status diagnostics", async () =>
     );
   }));
 
+test("invalid JSON does not retain a secret-bearing parser cause", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const secret = "credential-that-must-not-leak";
+    const host = hostFor(repoRoot, [
+      { code: 0, stdout: `{"token":"${secret}"`, stderr: "" },
+    ]);
+    await assert.rejects(
+      host.resolveTargetRepositoryIdentity(),
+      (error: unknown) => {
+        assert.ok(error instanceof ForgejoTeaPullRequestError);
+        assert.equal(error.category, "invalid-json");
+        assert.equal(error.cause, undefined);
+        assert.ok(!error.message.includes(secret));
+        assert.ok(!JSON.stringify(error).includes(secret));
+        return true;
+      },
+    );
+  }));
+
 test("a contradictory successful 404 remains a command failure", async () =>
   withForgejoRepository(async (repoRoot) => {
     const runner = createStaticCommandRunner([

--- a/src/host/forgejo-tea-pull-requests.test.ts
+++ b/src/host/forgejo-tea-pull-requests.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import type { CommandResult } from "../cli/commands/triage/types.ts";
+import type {
+  CommandResult,
+  CommandRunner,
+} from "../cli/commands/triage/types.ts";
 import { createStaticCommandRunner } from "../../test-support/command-runner.ts";
 import { ForgejoTeaPullRequestError } from "./forgejo-tea-pull-request-errors.ts";
 import { PullRequestIdentityError } from "./pull-requests.ts";
@@ -311,6 +314,77 @@ test("command failures retain safe status diagnostics", async () =>
         assert.equal(error.httpStatus, 403);
         assert.equal(error.rawDiagnostics?.stdout, "secret");
         assert.ok(!JSON.stringify(error).includes("secret"));
+        return true;
+      },
+    );
+  }));
+
+test("runner rejections retain neither caller input nor rejection diagnostics", async () =>
+  withForgejoRepository(async (repoRoot) => {
+    const secret = "body-that-must-not-leak";
+    const teaRunner: CommandRunner = {
+      async run(command, args) {
+        if (command === "git")
+          return {
+            code: 0,
+            stdout: "git@forge.example:contributor/widgets.git\n",
+            stderr: "",
+          };
+        if (args.includes("POST"))
+          throw new TypeError(`runner rejected ${args.join(" ")} ${secret}`);
+        return jsonResult(
+          repositoryPayload(
+            args.includes("contributor/widgets") ? head : target,
+          ),
+        );
+      },
+    };
+    const host = new ForgejoTeaPullRequestHost({
+      runner: teaRunner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      host.createPullRequest({
+        title: secret,
+        body: secret,
+        baseBranch: "main",
+        headBranch: "topic",
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof ForgejoTeaPullRequestError);
+        assert.equal(error.category, "command-failed");
+        assert.equal(error.operation, "create-pull-request");
+        assert.equal(error.command, "tea");
+        assert.equal(error.cause, undefined);
+        assert.equal(error.rawDiagnostics, undefined);
+        assert.ok(!error.message.includes(secret));
+        assert.ok(!JSON.stringify(error).includes(secret));
+        return true;
+      },
+    );
+
+    const gitRunner: CommandRunner = {
+      async run(_command, args) {
+        throw new TypeError(`runner rejected ${args.join(" ")} ${secret}`);
+      },
+    };
+    const gitHost = new ForgejoTeaPullRequestHost({
+      runner: gitRunner,
+      repoRoot,
+      pushRemote: "publish",
+    });
+    await assert.rejects(
+      gitHost.resolveRemoteRepositoryIdentity("publish"),
+      (error: unknown) => {
+        assert.ok(error instanceof ForgejoTeaPullRequestError);
+        assert.equal(error.category, "command-failed");
+        assert.equal(error.operation, "resolve-remote-repository");
+        assert.equal(error.command, "git");
+        assert.equal(error.cause, undefined);
+        assert.equal(error.rawDiagnostics, undefined);
+        assert.ok(!error.message.includes(secret));
+        assert.ok(!JSON.stringify(error).includes(secret));
         return true;
       },
     );

--- a/src/host/forgejo-tea-pull-requests.ts
+++ b/src/host/forgejo-tea-pull-requests.ts
@@ -1,0 +1,151 @@
+import type { CommandRunner } from "../cli/commands/triage/types.ts";
+import { ForgejoTeaPullRequestCommands } from "./forgejo-tea-pull-request-commands.ts";
+import {
+  validateForgejoBranchName,
+  validateForgejoPullRequestNumber,
+  validateForgejoRemoteName,
+  normalizeForgejoPullRequest,
+} from "./forgejo-tea-pull-request-parsing.ts";
+import {
+  PullRequestIdentityError,
+  sameRepositoryIdentity,
+  type CreatePullRequestInput,
+  type FindPullRequestsQuery,
+  type PullRequestHost,
+  type PullRequestReference,
+  type PullRequestSummary,
+  type RepositoryIdentity,
+} from "./pull-requests.ts";
+
+export type ForgejoTeaPullRequestHostOptions = {
+  runner: CommandRunner;
+  repoRoot: string;
+  pushRemote: string;
+  login?: string;
+};
+export class ForgejoTeaPullRequestHost implements PullRequestHost {
+  readonly id = "forgejo-tea" as const;
+  readonly options: ForgejoTeaPullRequestHostOptions;
+  readonly commands: ForgejoTeaPullRequestCommands;
+  constructor(options: ForgejoTeaPullRequestHostOptions) {
+    validateForgejoRemoteName(options.pushRemote);
+    this.options = options;
+    this.commands = new ForgejoTeaPullRequestCommands(options);
+  }
+  resolveTargetRepositoryIdentity(): Promise<RepositoryIdentity> {
+    return this.commands.resolveTargetRepositoryIdentity();
+  }
+  resolveRemoteRepositoryIdentity(remote: string): Promise<RepositoryIdentity> {
+    return this.commands.resolveRemoteRepositoryIdentity(remote);
+  }
+  private async context(): Promise<{
+    targetRepository: RepositoryIdentity;
+    headRepository: RepositoryIdentity;
+  }> {
+    const [targetRepository, headRepository] = await Promise.all([
+      this.commands.resolveTargetRepositoryIdentity(),
+      this.commands.resolveRemoteRepositoryIdentity(this.options.pushRemote),
+    ]);
+    if (
+      targetRepository.provider !== headRepository.provider ||
+      targetRepository.host.toLowerCase() !== headRepository.host.toLowerCase()
+    )
+      throw new PullRequestIdentityError(
+        "target and push remote hosts disagree",
+        { expected: targetRepository, actual: headRepository },
+      );
+    return { targetRepository, headRepository };
+  }
+  async createPullRequest(
+    input: CreatePullRequestInput,
+  ): Promise<PullRequestSummary> {
+    validateForgejoBranchName(input.baseBranch);
+    validateForgejoBranchName(input.headBranch);
+    const { targetRepository, headRepository } = await this.context();
+    const result = normalizeForgejoPullRequest(
+      await this.commands.createPullRequestPayload({
+        ...input,
+        headOwner: headRepository.owner,
+      }),
+      {
+        operation: "create-pull-request",
+        expectedTargetRepository: targetRepository,
+        expectedHeadRepository: headRepository,
+      },
+    );
+    if (
+      result.baseBranch !== input.baseBranch ||
+      result.headBranch !== input.headBranch
+    )
+      throw new PullRequestIdentityError(
+        "created pull request branches disagree",
+      );
+    return result;
+  }
+  async findPullRequests(
+    query: FindPullRequestsQuery,
+  ): Promise<readonly PullRequestSummary[]> {
+    validateForgejoBranchName(query.baseBranch);
+    validateForgejoBranchName(query.headBranch);
+    const { targetRepository, headRepository } = await this.context();
+    if (!sameRepositoryIdentity(query.targetRepository, targetRepository))
+      throw new PullRequestIdentityError("search target disagrees", {
+        expected: targetRepository,
+        actual: query.targetRepository,
+      });
+    if (!sameRepositoryIdentity(query.headRepository, headRepository))
+      throw new PullRequestIdentityError("search head disagrees", {
+        expected: headRepository,
+        actual: query.headRepository,
+      });
+    const all = await this.commands.listPullRequests({
+      query,
+      normalize: (payload) =>
+        normalizeForgejoPullRequest(payload, {
+          operation: "list-pull-requests",
+          expectedTargetRepository: targetRepository,
+        }),
+    });
+    return all.filter(
+      (entry) =>
+        sameRepositoryIdentity(
+          entry.targetRepository,
+          query.targetRepository,
+        ) &&
+        entry.baseBranch === query.baseBranch &&
+        sameRepositoryIdentity(entry.headRepository, query.headRepository) &&
+        entry.headBranch === query.headBranch,
+    );
+  }
+  async getPullRequest(
+    reference: PullRequestReference,
+  ): Promise<PullRequestSummary> {
+    validateForgejoPullRequestNumber(reference.number);
+    const { targetRepository, headRepository } = await this.context();
+    if (!sameRepositoryIdentity(reference.targetRepository, targetRepository))
+      throw new PullRequestIdentityError("pull request target disagrees", {
+        expected: targetRepository,
+        actual: reference.targetRepository,
+      });
+    return normalizeForgejoPullRequest(
+      await this.commands.getPullRequestPayload(reference),
+      {
+        operation: "get-pull-request",
+        expectedTargetRepository: targetRepository,
+        expectedHeadRepository: headRepository,
+        expectedNumber: reference.number,
+      },
+    );
+  }
+  async readPullRequestBody(reference: PullRequestReference): Promise<string> {
+    return (await this.getPullRequest(reference)).body;
+  }
+  async updatePullRequestBody(
+    reference: PullRequestReference,
+    body: string,
+  ): Promise<void> {
+    validateForgejoPullRequestNumber(reference.number);
+    await this.getPullRequest(reference);
+    await this.commands.updatePullRequestBody(reference, body);
+  }
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral `ForgejoTeaPullRequestHost` backed by exact `git` and `tea api` command contracts
- resolve provider-normalized target and push-remote identities, including custom remotes, multiple push URLs, and same-host cross-owner heads
- normalize nested repository and pull request payloads with exhaustive pagination, exact discovery, safe diagnostics, and exact get-only HTTP 404 handling
- keep the adapter isolated from the host factory and run-once pipeline

## Validation

- `node --test src/host/forgejo-tea-pull-request-parsing.test.ts src/host/forgejo-tea-pull-requests.test.ts` — 29 passed
- `npm test` — 1,549 passed
- `npm run build`
- `npm run lint` — 0 errors
- `npm run check:types`
- `npm run check:architecture` — 0 dependency violations
- `git diff --check`
- Nix build skipped because npm dependency metadata is unchanged
- confirmed no `ForgejoTeaPullRequestHost` wiring in `src/host/factory.ts` or `src/cli/commands/run-once`

## Reviews

- Final Codex full-worktree review passed; its one non-blocking exact-GET test gap was fixed before handoff
- Final thermo-nuclear full-worktree re-review passed with no findings after accepted URL and command-contract fixes
- Final validation-readiness review and attached host gate passed

Closes #186

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Development environment | gpt-5.6-sol | 429,892 | 2,994 | $0.6155 |
| Implementation | gpt-5.6-sol | 7,983,204 | 162,685 | $12.0262 |
| Implementation | gpt-5.6-terra | 3,773,626 | 15,631 | $1.6707 |
| **Implementation subtotal** |  | **11,756,830** | **178,316** | **$13.6969** |
| **Total** |  | **12,186,722** | **181,310** | **$14.3124** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->