### PR TITLE
Add durable planning state and pull request workspaces

### DIFF
--- a/docs/plans/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces.md
+++ b/docs/plans/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces.md
@@ -1,0 +1,1607 @@
+# Durable Planning State and Pull Request Workspaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add strict durable recovery state, ownership-ID locking, fetched
+remote-base evidence, and a Git-backed lifecycle for safely creating, resuming,
+and cleaning up planning phase workspaces.
+
+**Architecture:** Keep pure state parsing and transition invariants under
+`src/workflow/`, with filesystem durability and lock ownership in separate
+modules. Refine the provider-neutral workspace contract in `src/git/`, then put
+remote-base discovery, strict Git response parsing, and worktree effects behind
+small adapters that consume complete saved ownership evidence. These modules
+remain unwired from the current run-once workflow.
+
+**Tech Stack:** TypeScript, Node.js 22.19+ filesystem APIs, Node's `node:test`
+runner, Git CLI through `CommandRunner`, SHA-256 diagnostics, Prettier, ESLint,
+strict TypeScript, and dependency-cruiser.
+
+**Spec:**
+`docs/specs/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces-design.md`
+
+## Global Constraints
+
+- Keep the durable namespace exactly
+  `<runStateDir>/planning-pr-v1/{issues,locks}`; do not reuse current run state
+  or Issue run leases.
+- Keep state `version` equal to `1` and `workflowVersion` equal to
+  `planning-pr-v1`.
+- Create one UUID `runId` for an Issue run and retain it across Run attempts;
+  create a new unguessable `ownershipId` for every lock acquisition.
+- Reject unknown keys at every state and lock object level. Never coerce,
+  repair, or partially merge persisted documents.
+- Require complete-document state replacement under the matching live issue
+  lock, immutable Issue run identity, and an exact one-step revision increment.
+- Use exclusive mode-`0600` creation for lock and temporary state files, flush
+  file contents before close, replace state by same-directory rename, and sync
+  the parent directory where supported.
+- Never take over, archive, replace, or repair an existing planning lock.
+- Classify an existing lock as `active`, `stale`, `unverifiable`, or
+  `malformed`; age is diagnostic only and never authorizes mutation.
+- Fetch the configured remote branch with an explicit refspec before each phase
+  snapshot; use the resolved full object ID for artifact inspection and fresh
+  workspace creation.
+- Inspect planning artifacts from the pinned commit tree, not the working tree,
+  and preserve zero, one, or multiple deterministic candidates.
+- Fresh preparation never adopts an existing branch, path, or registration.
+- Resume performs no fetch, reset, creation, or cleanup and accepts only the
+  exact saved Run, phase, identity, base, and head.
+- Cleanup consumes complete durable ownership evidence, refuses tracked,
+  untracked, and ignored content, and never uses force, recursive filesystem
+  deletion, `git clean`, `git reset`, name-pattern sweeps, merge, or rebase.
+- Delete a local branch only after proving the exact configured remote branch
+  equals the saved pushed head, and use expected-old-object compare-and-swap.
+- Keep production modules focused. Use a public facade plus private validation
+  modules for state, and extract strict worktree response parsing rather than
+  growing an effect module beyond roughly 200 meaningful lines.
+- Do not add dependencies or configuration keys.
+- Do not run planning agents, create or reconcile pull requests, select phases,
+  push branches, or wire these modules into `run-once`.
+- Existing state, leases, workspaces, host factories, labels, publication, and
+  CLI behavior must remain unchanged.
+
+---
+
+## File and Module Map
+
+### Workflow state and locking
+
+- Create `src/workflow/planning-state-types.ts` for the exact version-1 state
+  and discriminator types used by the public state facade.
+- Create `src/workflow/planning-state-validation.ts` for strict object readers,
+  bounded scalar validation, cross-field invariants, and stable validation
+  errors.
+- Create `src/workflow/planning-state.ts` as the public owner of state creation,
+  parsing, canonical serialization, and replacement-transition validation; it
+  re-exports the public version-1 types and validation error.
+- Create `src/workflow/planning-state.test.ts` for round trips, strict schema
+  rejection, cross-field contradictions, and replacement rules.
+- Create `src/workflow/planning-issue-lock.ts` for planning lock paths, exact
+  record parsing, exclusive acquisition, diagnostics, ownership verification,
+  and idempotent release.
+- Create `src/workflow/planning-issue-lock.test.ts` for acquisition races,
+  ownership checks, release retries, and all conflict classifications.
+- Create `src/workflow/planning-state-store.ts` for planning state paths, reads,
+  initialization, and atomic complete-document replacement.
+- Create `src/workflow/planning-state-store.test.ts` for lock-fenced writes,
+  optimistic revision conflicts, file mode, canonical bytes, crash safety, and
+  directory isolation.
+
+### Git infrastructure
+
+- Modify `src/git/planning-workspaces.ts` to make pinned remote-base snapshots
+  and complete saved workspace ownership first-class contract values, and add
+  stable command/response error types.
+- Modify `src/git/planning-workspaces.test.ts` to exercise the refined contract
+  through a command-free fake adapter.
+- Create `src/git/planning-remote-base.ts` for fetch, pinned-ref resolution,
+  configured artifact-directory normalization, and commit-tree discovery.
+- Create `src/git/planning-remote-base.test.ts` for recording-runner command
+  contracts and real-Git artifact discovery.
+- Create `src/git/planning-worktree-porcelain.ts` for strict parsing of
+  `git worktree list --porcelain -z` output.
+- Create `src/git/planning-worktree-porcelain.test.ts` for attached, detached,
+  malformed, duplicate-path, and duplicate-branch records.
+- Create `src/git/planning-workspace-git.ts` for inspection, fresh creation,
+  exact resume, and the two idempotent cleanup operations.
+- Create `src/git/planning-workspace-git.test.ts` for recording-runner command
+  behavior and real repositories with local bare remotes.
+
+No current `src/cli/`, `src/config/`, provider, package, or lockfile module is
+modified.
+
+## Public Data Shapes
+
+The implementation tasks use these names consistently:
+
+```ts
+// src/git/planning-workspaces.ts
+export type PlanningArtifactCandidates = Readonly<{
+  spec: readonly string[];
+  plan: readonly string[];
+}>;
+
+export type PlanningRemoteBaseSnapshot = Readonly<{
+  remote: string;
+  baseBranch: string;
+  baseOid: string;
+  artifactCandidates: PlanningArtifactCandidates;
+}>;
+
+export type PlanningWorkspaceCleanup =
+  | Readonly<{ state: "ready" }>
+  | Readonly<{ state: "worktree-removed"; pushedHeadOid: string }>
+  | Readonly<{ state: "removed"; pushedHeadOid: string }>;
+
+export type PlanningWorkspaceOwnership<
+  Cleanup extends PlanningWorkspaceCleanup = PlanningWorkspaceCleanup,
+> = Readonly<{
+  runId: string;
+  phase: PlanningPhaseKind;
+  identity: PlanningWorkspaceIdentity;
+  remote: string;
+  baseBranch: string;
+  baseOid: string;
+  headOid: string;
+  cleanup: Cleanup;
+}>;
+```
+
+```ts
+// src/workflow/planning-state-types.ts
+export type PlanningStateV1 = Readonly<{
+  version: 1;
+  workflowVersion: "planning-pr-v1";
+  runId: string;
+  issueNumber: number;
+  issueTitle: string;
+  gates: PlanningGateSnapshot;
+  phases: readonly PlanningPhaseStateV1[];
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type PlanningPhaseStateV1 =
+  | Readonly<{ kind: PlanningPhaseKind; status: "pending" }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "workspace-ready";
+      base: PlanningBaseEvidence;
+      workspace: PlanningWorkspaceEvidence;
+    }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "pull-request-open";
+      base: PlanningBaseEvidence;
+      workspace: PlanningWorkspaceEvidence;
+      artifacts: readonly PlanningArtifactEvidence[];
+      pullRequest: PlanningPullRequestEvidence;
+    }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "complete";
+      base: PlanningBaseEvidence;
+      artifacts: readonly PlanningArtifactEvidence[];
+      completion: Readonly<{ kind: "remote-base" }>;
+    }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "complete";
+      base: PlanningBaseEvidence;
+      workspace: PlanningWorkspaceEvidence;
+      artifacts: readonly PlanningArtifactEvidence[];
+      pullRequest: PlanningPullRequestEvidence;
+      completion: Readonly<{
+        kind: "merged-pull-request";
+        mergeOid: string;
+      }>;
+    }>;
+```
+
+`PlanningBaseEvidence` aliases `PlanningRemoteBaseSnapshot`, and
+`PlanningWorkspaceEvidence` aliases `PlanningWorkspaceOwnership`.
+`PlanningArtifactEvidence` and `PlanningPullRequestEvidence` retain the exact
+fields from the approved spec.
+
+## Testing Value Gate
+
+The planned automated tests pass Patchmill's Testing Value Gate:
+
+- Strict state and lock tests prove reusable parsing, authorization,
+  concurrency, and crash-safety behavior that can fail under meaningful
+  regressions.
+- Recording-runner tests prove command ordering, working directories, immutable
+  object-ID use, safe arguments, and typed error classification without testing
+  private implementation structure.
+- Real-Git tests prove stale-clone fetching, commit-tree discovery, collision
+  refusal, mutation-free resume, and destructive-cleanup boundaries against
+  actual Git behavior.
+- No new test asserts static documentation, configuration text, dependency
+  versions, lockfile contents, or module import spelling. Runtime wiring and
+  dependency absence are checked directly in final diff inspection.
+
+---
+
+### Task 1: Refine the planning workspace evidence contract
+
+**Files:**
+
+- Modify: `src/git/planning-workspaces.ts`
+- Modify: `src/git/planning-workspaces.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlanningPhaseKind` from
+  `src/workflow/planning-pull-request-markers.ts`.
+- Produces: `PlanningArtifactCandidates`, `PlanningRemoteBaseSnapshot`,
+  `PlanningWorkspaceCleanup`, and generic `PlanningWorkspaceOwnership`.
+- Preserves: `PlanningWorkspaceIdentity`, `PlanningWorkspaceSnapshot`,
+  `PreparedPlanningWorkspace`, and `PlanningWorkspaceLifecycle`, with `Sha`
+  property names replaced by `Oid` and exact ownership inputs added.
+- Produces: stable `PlanningWorkspaceConflictError`,
+  `PlanningWorkspaceCommandError`, and `PlanningWorkspaceResponseError`.
+- Later tasks consume only these high-level types; command arrays remain private
+  to concrete Git adapters.
+
+- [ ] **Step 1: Rewrite the fake-adapter test for pinned and owned inputs**
+
+Update the fake in `src/git/planning-workspaces.test.ts` so the contract is used
+through these calls:
+
+```ts
+const base: PlanningRemoteBaseSnapshot = {
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: "a".repeat(40),
+  artifactCandidates: { spec: [], plan: [] },
+};
+
+const prepared = await workspace.prepare({
+  runId: "123e4567-e89b-42d3-a456-426614174000",
+  phase: "spec",
+  identity,
+  base,
+});
+assert.equal(prepared.workspace.baseOid, base.baseOid);
+
+const resumed = await workspace.resume({
+  runId: prepared.workspace.runId,
+  phase: "spec",
+  identity,
+  base,
+  saved: prepared.workspace,
+});
+assert.deepEqual(resumed, prepared.snapshot);
+
+const branchOnly = await workspace.removeWorktree({
+  runId: prepared.workspace.runId,
+  phase: "spec",
+  workspace: prepared.workspace,
+});
+assert.equal(branchOnly.state, "branch-only");
+```
+
+Have the fake's `removeBranch` accept a workspace whose cleanup discriminator is
+`worktree-removed`; have `removeWorktree` permit `branch-only | missing` and
+`removeBranch` return `missing`. Assert the fake receives saved ownership rather
+than reconstructed branch and SHA strings.
+
+- [ ] **Step 2: Run the contract test to prove RED**
+
+Run:
+
+```sh
+node --test src/git/planning-workspaces.test.ts
+```
+
+Expected: FAIL with TypeScript/runtime export mismatches because the existing
+contract has no pinned-base, ownership, or separate resume types.
+
+- [ ] **Step 3: Implement the refined public contract**
+
+Replace the lifecycle surface with this exact shape:
+
+```ts
+export interface PlanningWorkspaceLifecycle {
+  prepare(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+  }): Promise<PreparedPlanningWorkspace>;
+
+  resume(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+    saved: PlanningWorkspaceOwnership;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "ready" }>>;
+
+  inspect(
+    identity: PlanningWorkspaceIdentity,
+  ): Promise<PlanningWorkspaceSnapshot>;
+
+  removeWorktree(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  }): Promise<
+    Extract<PlanningWorkspaceSnapshot, { state: "branch-only" | "missing" }>
+  >;
+
+  removeBranch(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{
+      state: "worktree-removed";
+      pushedHeadOid: string;
+    }>;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "missing" }>>;
+}
+```
+
+Use `headOid` and `baseOid` throughout. `PreparedPlanningWorkspace` has
+`created: true`, `base`, `workspace` with `cleanup.state === "ready"`, and a
+ready `snapshot`.
+
+Expand conflict reasons to cover invalid saved identity, branch/path collision,
+unsafe registration, base/head mismatch, dirty content, remote-head mismatch,
+and configured-root containment. Define operation unions for fetch,
+ref-resolution, tree inspection, worktree inspection/add/remove, status,
+remote-head inspection, and branch deletion.
+
+`PlanningWorkspaceCommandError` exposes only stable `operation` and `exitCode`
+as enumerable fields; retain a frozen `CommandResult` as non-enumerable
+`diagnostics`. `PlanningWorkspaceResponseError` exposes stable `operation` and
+`reason`. No error message or enumerable field contains command arguments,
+remote credentials, stdout, or stderr.
+
+- [ ] **Step 4: Format and validate the refined seam**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/git/planning-workspaces.ts \
+  src/git/planning-workspaces.test.ts
+node --test src/git/planning-workspaces.test.ts
+npm run check:contract-tests
+npm run check:types
+npm run check:architecture
+```
+
+Expected: the fake-adapter contract test and all static checks PASS.
+
+- [ ] **Step 5: Commit the contract refinement**
+
+```sh
+git add src/git/planning-workspaces.ts src/git/planning-workspaces.test.ts
+git commit -m "refactor(git): refine planning workspace evidence"
+```
+
+---
+
+### Task 2: Add strict versioned planning state
+
+**Files:**
+
+- Create: `src/workflow/planning-state-types.ts`
+- Create: `src/workflow/planning-state-validation.ts`
+- Create: `src/workflow/planning-state.ts`
+- Create: `src/workflow/planning-state.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PullRequestReference` from `src/host/pull-requests.ts`.
+- Consumes: `PlanningGateSnapshot`, `PlanningArtifactKind`, and
+  `planningPhasePlan` from `src/workflow/planning-pull-requests.ts`.
+- Consumes: remote-base and workspace evidence from
+  `src/git/planning-workspaces.ts`.
+- Produces: every version-1 evidence and phase discriminator shown in the spec.
+- Produces: `createPlanningState`, `parsePlanningState`,
+  `validatePlanningState`, `serializePlanningState`, and
+  `assertPlanningStateReplacement`.
+- Produces: `PlanningStateValidationError` with stable `reason`, JSON `path`,
+  and an optional safe `statePath` when filesystem reads supply document
+  context.
+
+- [ ] **Step 1: Write valid-state fixtures and round-trip tests**
+
+Start `src/workflow/planning-state.test.ts` with one initial state for each gate
+matrix row and fixture builders for all phase states. Use canonical UUIDs,
+40-character lowercase object IDs, and ISO timestamps. Assert round trips for:
+
+```ts
+for (const phase of [
+  pendingPhase,
+  workspaceReadyPhase,
+  pullRequestOpenPhase,
+  remoteBaseCompletePhase,
+  mergedPullRequestCompleteReady,
+  mergedPullRequestCompleteWorktreeRemoved,
+  mergedPullRequestCompleteRemoved,
+]) {
+  const state = validStateWithPhase(phase);
+  assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
+}
+```
+
+Also assert `createPlanningState` emits revision `0`, identical creation/update
+timestamps, a phase record for every `planningPhasePlan(gates)` item in order,
+and only `pending` phase records.
+
+- [ ] **Step 2: Run the state test to prove RED**
+
+Run:
+
+```sh
+node --test src/workflow/planning-state.test.ts
+```
+
+Expected: FAIL because the planning state modules do not exist.
+
+- [ ] **Step 3: Define the exact state type graph and bounded scalar rules**
+
+Put declarations only in `planning-state-types.ts`. Use `readonly` fields and
+the exact discriminator shapes in this plan and the spec. Define:
+
+```ts
+export type PlanningArtifactEvidence = Readonly<{
+  kind: PlanningArtifactKind;
+  path: string;
+  commitOid: string;
+  source: "remote-base" | "workspace";
+}>;
+
+export type PlanningPullRequestEvidence = Readonly<{
+  reference: PullRequestReference;
+  baseBranch: string;
+  headBranch: string;
+  headOid: string;
+}>;
+```
+
+In `planning-state-validation.ts`, apply these exact scalar predicates before
+constructing typed output:
+
+```ts
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const FULL_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+```
+
+- IDs must be canonical UUID strings.
+- Issue and pull request numbers must be positive safe integers.
+- Revisions must be non-negative safe integers.
+- `issueTitle` is non-empty, contains no NUL/CR/LF, and is at most 1,024 code
+  units.
+- Remote and repository identity fields are non-empty single-line strings of at
+  most 1,024 code units; provider is exactly `github-gh` or `forgejo-tea`.
+- Branches are at most 1,024 code units and reject leading `-`, controls,
+  spaces, `..`, `@{`, backslash, `~^:?*[`, empty components, a trailing dot or
+  slash, and a leading slash.
+- Artifact paths are slash-normalized, repository-relative, at most 4,096 code
+  units, and have no empty, `.` or `..` segment, NUL, CR, or LF.
+- Worktree paths use the same 4,096-code-unit and control-character bounds, but
+  may contain leading `..` segments because the configured worktree root may be
+  outside the repository; the Git adapter later proves configured-root
+  containment.
+- Timestamps must match the regular expression, parse successfully, and equal
+  `new Date(value).toISOString()`.
+
+- [ ] **Step 4: Implement strict structural parsing and canonical output**
+
+Use an `exactObject(value, allowedKeys, path)` helper that rejects arrays,
+missing required keys, and every unknown own key. Parse every discriminator with
+its own exact key set:
+
+```text
+pending:             kind,status
+workspace-ready:     kind,status,base,workspace
+pull-request-open:   kind,status,base,workspace,artifacts,pullRequest
+complete/remote:     kind,status,base,artifacts,completion
+complete/merged PR:  kind,status,base,workspace,artifacts,pullRequest,completion
+```
+
+Apply exact-key checks recursively to `gates`, `artifactCandidates`, artifact
+evidence, workspace `identity`, each cleanup variant, pull request evidence,
+`reference`, and nested repository identity.
+
+Expose these exact signatures from `planning-state.ts`:
+
+```ts
+export function createPlanningState(input: {
+  issueNumber: number;
+  issueTitle: string;
+  gates: PlanningGateSnapshot;
+  runId?: string;
+  now?: string;
+}): PlanningStateV1;
+
+export function validatePlanningState(value: unknown): PlanningStateV1;
+export function parsePlanningState(raw: string): PlanningStateV1;
+export function serializePlanningState(state: PlanningStateV1): string;
+export function assertPlanningStateReplacement(
+  current: PlanningStateV1,
+  next: PlanningStateV1,
+): void;
+```
+
+`PlanningStateValidationError` accepts `reason`, JSON `path`, and optional
+`statePath`; its message includes only those safe values. `parsePlanningState`
+maps `JSON.parse` failures to
+`PlanningStateValidationError("invalid-json", "$")` without including raw bytes.
+`validatePlanningState` reconstructs objects in the documented key order.
+`serializePlanningState` validates again and returns two-space JSON plus exactly
+one trailing newline.
+
+- [ ] **Step 5: Add strict-schema and malformed-value tests**
+
+Add table-driven copies of a valid state with one mutation per case. Cover
+unknown top-level and nested keys, missing keys, unsupported versions, malformed
+UUID/OID/timestamp/branch/path, invalid issue/revision/PR numbers, repeated
+artifact kinds, and every forbidden field on each discriminator. Assert the
+stable path as well as the reason:
+
+```ts
+assert.throws(
+  () => validatePlanningState(candidate),
+  (error: unknown) =>
+    error instanceof PlanningStateValidationError &&
+    error.reason === "unknown-key" &&
+    error.path === "$.phases[0].workspace.cleanup.extra",
+);
+```
+
+The named production mutation that makes these tests fail is accepting an
+unrecognized or unbounded persisted value into recovery decisions.
+
+- [ ] **Step 6: Implement document-level cross-field invariants**
+
+After structural parsing, enforce all of these checks with stable reason/path
+pairs:
+
+1. Phase kinds are unique and exactly equal to
+   `planningPhasePlan(gates).map(({ kind }) => kind)` in order.
+2. Complete records form a prefix; pending records form a suffix; no more than
+   one `workspace-ready` or `pull-request-open` record exists.
+3. `artifacts` has exactly the phase's assigned artifact kinds in planner order
+   (including an empty array for implementation where applicable).
+4. Remote-base completion artifacts all have `source: "remote-base"`, use
+   `base.baseOid`, and name a path in the matching
+   `base.artifactCandidates[kind]` array.
+5. Workspace-source artifacts use `workspace.headOid`; pull request evidence
+   uses the workspace branch/head and the base branch.
+6. Every workspace run/phase/remote/base tuple agrees with the containing state,
+   phase, and base evidence. Ready and open phase records require
+   `cleanup.state === "ready"`.
+7. A `worktree-removed` or `removed` cleanup record has
+   `pushedHeadOid === headOid` and can appear only in merged completion.
+8. No two phase records share a branch or normalized worktree path.
+9. Candidate arrays and artifact arrays contain no duplicates.
+10. `updatedAt` is not earlier than `createdAt`.
+
+- [ ] **Step 7: Add replacement-transition tests**
+
+Test one valid transition for each allowed edge and one rejection for each
+immutable or backward edge. The allowed graph is:
+
+```text
+pending -> workspace-ready | complete(remote-base)
+workspace-ready -> workspace-ready | pull-request-open
+pull-request-open -> pull-request-open | complete(merged-pull-request)
+complete(merged, ready) -> complete(merged, worktree-removed)
+complete(merged, worktree-removed) -> complete(merged, removed)
+complete(remote-base) -> same complete(remote-base)
+complete(merged, removed) -> same complete(merged, removed)
+```
+
+Same-status replacements preserve evidence except that `workspace.headOid` may
+advance while `cleanup.state === "ready"`. When pull request or workspace-source
+artifact evidence already exists, its `headOid`/`commitOid` must advance in the
+same replacement; the pull request reference, base branch, and head branch stay
+immutable. Once cleanup reaches `worktree-removed`, the saved head cannot
+change. Assert that replacement rejects changes to version, workflow version,
+run ID, issue number, issue title, gates, phase sequence, created timestamp,
+workspace run/phase/identity/remote/base tuple, pull request identity, or
+completion. Require `next.revision === current.revision + 1` and
+`next.updatedAt >= current.updatedAt`.
+
+- [ ] **Step 8: Implement replacement validation**
+
+Have `assertPlanningStateReplacement` first strictly validate and normalize both
+documents, then compare immutable fields and each phase transition. Use
+`PlanningStateValidationError` for invalid next-document structure and a
+transition reason/path for illegal state movement; reserve store-level conflict
+errors for a changed file, lock, Run ID, or expected revision observed during
+I/O.
+
+- [ ] **Step 9: Format and run focused state validation**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/workflow/planning-state-types.ts \
+  src/workflow/planning-state-validation.ts \
+  src/workflow/planning-state.ts \
+  src/workflow/planning-state.test.ts
+node --test src/workflow/planning-state.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: every phase/cleanup round trip and rejection test passes, and the
+state facade does not create an architecture cycle.
+
+- [ ] **Step 10: Commit strict planning state**
+
+```sh
+git add \
+  src/workflow/planning-state-types.ts \
+  src/workflow/planning-state-validation.ts \
+  src/workflow/planning-state.ts \
+  src/workflow/planning-state.test.ts
+git commit -m "feat(workflow): add strict planning state"
+```
+
+---
+
+### Task 3: Add the ownership-ID planning issue lock
+
+**Files:**
+
+- Create: `src/workflow/planning-issue-lock.ts`
+- Create: `src/workflow/planning-issue-lock.test.ts`
+
+**Interfaces:**
+
+- Consumes: UUID and timestamp semantics established by planning state; keep
+  lock parsing independent from state bytes.
+- Produces: `planningIssueLockPath`, `PlanningIssueLockRecord`,
+  `PlanningIssueLock`, `PlanningIssueLockDiagnostic`,
+  `parsePlanningIssueLockRecord`, `acquirePlanningIssueLock`,
+  `assertPlanningIssueLockOwned`, and `releasePlanningIssueLock`.
+- Produces: `PlanningIssueLockConflictError` whose diagnostic classification is
+  `active | stale | unverifiable | malformed`.
+- The state store in Task 4 calls `assertPlanningIssueLockOwned` immediately
+  before every mutation.
+
+- [ ] **Step 1: Write exact record and idempotent owner tests**
+
+Create tests that acquire into a temporary run-state directory and assert:
+
+```ts
+const lock = await acquirePlanningIssueLock(
+  runStateDir,
+  {
+    issueNumber: 187,
+    runId,
+  },
+  {
+    ownershipId,
+    pid: 1234,
+    hostname: "local.test",
+    now: () => new Date("2026-09-07T12:00:00.000Z"),
+  },
+);
+
+assert.equal(
+  lock.path,
+  join(runStateDir, "planning-pr-v1", "locks", "issue-187.lock"),
+);
+assert.equal((await stat(lock.path)).mode & 0o777, 0o600);
+await assertPlanningIssueLockOwned(lock, { issueNumber: 187, runId });
+await releasePlanningIssueLock(lock);
+await releasePlanningIssueLock(lock);
+```
+
+Also parse the persisted bytes and assert the exact seven keys: `version`,
+`issueNumber`, `runId`, `ownershipId`, `pid`, `hostname`, and `acquiredAt`.
+
+- [ ] **Step 2: Add acquisition-race and non-owner release tests**
+
+Start two acquisitions with distinct ownership IDs via `Promise.allSettled` and
+assert exactly one fulfills. Replace the winning lock bytes with a valid record
+that changes only `ownershipId`; assert owner verification and release reject,
+the file still exists, and the other owner can release its own record. Add the
+same preservation assertion for malformed current bytes.
+
+- [ ] **Step 3: Add all existing-lock diagnostic tests**
+
+Inject `hostname`, `processState`, and `now` options and cover:
+
+- same host + `alive` => `active`;
+- same host + `dead` => `stale`;
+- same host + `unverifiable` => `unverifiable`;
+- different host => `unverifiable` without invoking `processState`;
+- invalid JSON, unknown keys, or invalid values => `malformed`.
+
+For every case, compute the expected
+`createHash("sha256").update(exactBytes).digest("hex")` and assert it equals the
+diagnostic fingerprint. Assert safe owner fields include issue number, Run ID,
+PID, host, and acquisition timestamp but not `ownershipId`. Assert elapsed time
+does not change the classification.
+
+- [ ] **Step 4: Run lock tests to prove RED**
+
+Run:
+
+```sh
+node --test src/workflow/planning-issue-lock.test.ts
+```
+
+Expected: FAIL because the planning lock module does not exist.
+
+- [ ] **Step 5: Implement exact lock parsing and exclusive acquisition**
+
+Use this record shape and options seam:
+
+```ts
+export type PlanningIssueLockRecord = Readonly<{
+  version: 1;
+  issueNumber: number;
+  runId: string;
+  ownershipId: string;
+  pid: number;
+  hostname: string;
+  acquiredAt: string;
+}>;
+
+export type PlanningIssueLockOptions = Readonly<{
+  ownershipId?: string;
+  pid?: number;
+  hostname?: string;
+  now?: () => Date;
+  processState?: (pid: number) => "alive" | "dead" | "unverifiable";
+}>;
+```
+
+Validate exact keys, positive safe issue/PID values, canonical UUIDs, canonical
+ISO timestamp, and host names matching `^[A-Za-z0-9_][A-Za-z0-9._-]{0,252}$`.
+Build the path only from the trusted requested issue number.
+
+Create the lock directory, then perform one `open(path, "wx", 0o600)`. Write
+canonical compact JSON plus newline, call `handle.sync()`, and close. If writing
+or syncing fails after this process created the file, close and unlink that
+owned incomplete file before rethrowing. Never rename, archive, or retry over an
+existing canonical lock.
+
+- [ ] **Step 6: Implement conflict inspection, ownership verification, and
+      release**
+
+On `EEXIST`, read the exact bytes once, hash those bytes, parse them strictly,
+and classify with same-host process liveness only. The default liveness check
+uses `process.kill(pid, 0)`: success is alive, `ESRCH` is dead, and every other
+failure is unverifiable.
+
+Use this verification signature:
+
+```ts
+export async function assertPlanningIssueLockOwned(
+  lock: PlanningIssueLock,
+  expected: { issueNumber: number; runId: string; lockPath?: string },
+): Promise<void>;
+```
+
+It rereads and strictly parses the canonical file and requires exact issue, Run,
+ownership ID, and optional canonical path equality. Release calls the same logic
+and unlinks only after it succeeds. An `ENOENT` during release is success; all
+malformed or mismatched files remain untouched.
+
+- [ ] **Step 7: Format and validate locking behavior**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/workflow/planning-issue-lock.ts \
+  src/workflow/planning-issue-lock.test.ts
+node --test src/workflow/planning-issue-lock.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: race, diagnostics, ownership, file-mode, and idempotent release tests
+PASS.
+
+- [ ] **Step 8: Commit the planning issue lock**
+
+```sh
+git add \
+  src/workflow/planning-issue-lock.ts \
+  src/workflow/planning-issue-lock.test.ts
+git commit -m "feat(workflow): add planning issue lock"
+```
+
+---
+
+### Task 4: Add the atomic planning state store
+
+**Files:**
+
+- Create: `src/workflow/planning-state-store.ts`
+- Create: `src/workflow/planning-state-store.test.ts`
+
+**Interfaces:**
+
+- Consumes: strict parsing, serialization, and replacement validation from
+  `src/workflow/planning-state.ts`.
+- Consumes: `PlanningIssueLock` and `assertPlanningIssueLockOwned` from
+  `src/workflow/planning-issue-lock.ts`.
+- Produces: `planningStatePath`, `PlanningStateStore`, and
+  `PlanningStateConflictError`.
+- `PlanningStateStore` binds to one configured run-state directory and does not
+  expose arbitrary output paths.
+
+- [ ] **Step 1: Write initialization, read, and canonical-byte tests**
+
+Create a temporary store and matching issue lock. Initialize revision zero and
+assert the returned state, exact path, mode `0600`, trailing newline, and
+`parsePlanningState(raw)` equality. Assert a second initialization reports
+`state-exists` and preserves the original bytes. Assert a missing read returns
+`undefined`, while malformed existing bytes throw `PlanningStateValidationError`
+with its JSON `path`, canonical `statePath`, and a default message that omits
+raw contents.
+
+- [ ] **Step 2: Write replacement conflict tests**
+
+For a valid revision-zero state, create a revision-one replacement. Assert
+success only with matching `expectedRunId`, `expectedRevision`, issue, and live
+lock. Add separate tests for changed Run ID, stale revision, wrong-issue lock,
+wrong-Run lock, changed ownership ID, missing lock, malformed lock, malformed
+state, and an invalid next transition. In each case assert the previous state
+bytes remain unchanged.
+
+- [ ] **Step 3: Write the pre-rename interruption test**
+
+Construct the store with an injected `beforeRename` test hook that throws after
+the temporary file has been flushed and closed. Assert:
+
+```ts
+await assert.rejects(store.replace(replacementInput), /injected interruption/);
+assert.deepEqual(await store.read(187), revisionZero);
+assert.deepEqual(
+  (await readdir(dirname(store.path(187)))).filter((name) =>
+    name.endsWith(".tmp"),
+  ),
+  [],
+);
+```
+
+The production mutation caught by this test is writing the canonical file in
+place or leaving a partial temporary file after a pre-rename failure.
+
+- [ ] **Step 4: Run store tests to prove RED**
+
+Run:
+
+```sh
+node --test src/workflow/planning-state-store.test.ts
+```
+
+Expected: FAIL because the planning state store does not exist.
+
+- [ ] **Step 5: Implement path ownership and stable conflicts**
+
+Use the exact path:
+
+```ts
+join(runStateDir, "planning-pr-v1", "issues", `issue-${issueNumber}.json`);
+```
+
+Expose:
+
+```ts
+export class PlanningStateStore {
+  constructor(
+    runStateDir: string,
+    options?: {
+      beforeRename?: (temporary: string, target: string) => Promise<void>;
+    },
+  );
+  path(issueNumber: number): string;
+  read(issueNumber: number): Promise<PlanningStateV1 | undefined>;
+  initialize(input: {
+    state: PlanningStateV1;
+    lock: PlanningIssueLock;
+  }): Promise<PlanningStateV1>;
+  replace(input: {
+    issueNumber: number;
+    expectedRunId: string;
+    expectedRevision: number;
+    next: PlanningStateV1;
+    lock: PlanningIssueLock;
+  }): Promise<PlanningStateV1>;
+}
+```
+
+`PlanningStateConflictError.reason` is one of `state-exists`, `state-missing`,
+`run-id-mismatch`, `revision-mismatch`, `lock-path-mismatch`, or
+`lock-ownership-mismatch`. Expose safe expected issue/Run/revision fields and
+state path; never expose lock ownership ID or document bytes. When a state read
+fails strict parsing, rethrow the same validation reason/JSON path with the
+canonical file path in `statePath`. Map lock path/identity changes observed by
+`assertPlanningIssueLockOwned` to the corresponding store conflict reason.
+
+- [ ] **Step 6: Implement atomic complete-document replacement**
+
+For initialize and replace:
+
+1. Strictly validate the complete candidate before filesystem mutation.
+2. Create the controlled issue directory recursively.
+3. Reread and strictly parse the current state as required by the operation.
+4. Verify expected Run/revision and call
+   `assertPlanningStateReplacement(current, next)` for replacement.
+5. Reread the canonical planning lock and verify issue, Run, ownership, and
+   expected lock path immediately before writing.
+6. Create `<target>.<randomUUID()>.tmp` with `open("wx", 0o600)` in the same
+   directory.
+7. Write `serializePlanningState(next)`, call file `sync()`, and close.
+8. Invoke the test hook, then `rename(temporary, target)`.
+9. Open and sync the parent directory. Ignore only documented unsupported
+   directory-sync error codes (`EINVAL`, `ENOTSUP`, and Windows `EPERM`).
+10. In `finally`, unlink a temporary file remaining after any pre-rename
+    failure; ignore only `ENOENT`.
+
+Initialization checks for an existing destination under the issue lock and
+refuses to rename over it. Reads never rewrite, normalize, or repair bytes.
+
+- [ ] **Step 7: Format and validate store behavior**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/workflow/planning-state-store.ts \
+  src/workflow/planning-state-store.test.ts
+node --test \
+  src/workflow/planning-state.test.ts \
+  src/workflow/planning-issue-lock.test.ts \
+  src/workflow/planning-state-store.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: state, lock, store, crash-boundary, and conflict tests PASS.
+
+- [ ] **Step 8: Commit the atomic planning state store**
+
+```sh
+git add \
+  src/workflow/planning-state-store.ts \
+  src/workflow/planning-state-store.test.ts
+git commit -m "feat(workflow): add atomic planning state store"
+```
+
+---
+
+### Task 5: Fetch and pin remote-base artifact evidence
+
+**Files:**
+
+- Create: `src/git/planning-remote-base.ts`
+- Create: `src/git/planning-remote-base.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CommandRunner` from `src/process/command.ts`.
+- Consumes: `PlanningRemoteBaseSnapshot`, `PlanningWorkspaceCommandError`, and
+  `PlanningWorkspaceResponseError` from `src/git/planning-workspaces.ts`.
+- Produces: `PlanningRemoteBaseGit`, bound to one repository root and configured
+  specs/plans directories.
+- Produces: a fetched immutable snapshot consumed by workspace preparation and
+  persisted as planning base evidence.
+
+- [ ] **Step 1: Write recording-runner fetch and parse tests**
+
+Use `createStaticCommandRunner` to return a fetch success, a full OID, and a
+NUL-delimited tree. Assert exact commands and `cwd`:
+
+```ts
+assert.deepEqual(runner.calls, [
+  {
+    command: "git",
+    args: [
+      "fetch",
+      "--no-tags",
+      "--",
+      "origin",
+      "+refs/heads/main:refs/remotes/origin/main",
+    ],
+    cwd: repoRoot,
+  },
+  {
+    command: "git",
+    args: ["rev-parse", "--verify", "refs/remotes/origin/main^{commit}"],
+    cwd: repoRoot,
+  },
+  {
+    command: "git",
+    args: [
+      "ls-tree",
+      "-r",
+      "-z",
+      "--full-tree",
+      baseOid,
+      "--",
+      "docs/specs",
+      "docs/plans",
+    ],
+    cwd: repoRoot,
+  },
+]);
+```
+
+Include tree entries with modes `100644`, `100755`, `120000`, and `160000`.
+Assert only regular files whose basename contains `-issue-187-` are returned,
+with repository-relative slash paths sorted separately under `spec` and `plan`.
+Assert multiple candidates remain present rather than selecting one.
+
+- [ ] **Step 2: Add path, output, and command failure tests**
+
+Cover configured directories expressed as repository-relative and absolute
+paths. Reject a directory that resolves outside `repoRoot` before any command.
+Return empty arrays for absent tree prefixes and no matches. Reject truncated
+NUL records, malformed mode/type/OID/path fields, unexpected duplicate entries,
+and a non-full `rev-parse` OID as response errors. For each nonzero command
+result, assert the correct command operation and that enumerable error fields
+and default messages contain no stdout, stderr, refspec, or remote URL.
+
+- [ ] **Step 3: Run remote-base tests to prove RED**
+
+Run:
+
+```sh
+node --test src/git/planning-remote-base.test.ts
+```
+
+Expected: FAIL because the remote-base adapter does not exist.
+
+- [ ] **Step 4: Implement configured path normalization and strict tree
+      parsing**
+
+Use `resolve(repoRoot, configured)` for relative inputs and
+`resolve(configured)` for absolute inputs. Compute
+`relative(repoRoot, absolute)`, reject an absolute result or a result beginning
+with `..`, convert separators to `/`, and pass the repository-relative paths to
+Git.
+
+Parse each default `ls-tree -z` record as:
+
+```text
+<mode> SP <type> SP <full-object-id> TAB <repository-relative-path> NUL
+```
+
+Accept only mode `100644` or `100755` with type `blob`; ignore valid symlink and
+gitlink records; reject malformed records globally. Apply the current local
+artifact filename rule exactly to `basename(path)`:
+
+```ts
+basename(path).includes(`-issue-${issueNumber}-`);
+```
+
+Do not read or materialize a working-tree file.
+
+- [ ] **Step 5: Implement fetched snapshot orchestration**
+
+Expose:
+
+```ts
+export class PlanningRemoteBaseGit {
+  constructor(input: {
+    runner: CommandRunner;
+    repoRoot: string;
+    specsDir: string;
+    plansDir: string;
+  });
+
+  fetch(input: {
+    issueNumber: number;
+    remote: string;
+    baseBranch: string;
+  }): Promise<PlanningRemoteBaseSnapshot>;
+}
+```
+
+Validate issue, remote, and branch before commands. Use argument arrays and the
+explicit branch refspec shown in Step 1. Resolve the remote-tracking commit
+once, require a 40- or 64-character lowercase full object ID, and pass only that
+OID to tree inspection. Return frozen/copied candidate arrays so moving refs
+cannot change the snapshot.
+
+- [ ] **Step 6: Add the stale-clone real-Git test**
+
+Create a temporary bare remote, a seed repository, and a stale clone using
+`execFileSync("git", ...)` only inside the test. Commit and push an old base,
+clone it, then commit a newer base containing zero, one, and multiple issue
+artifact cases in the seed and push again. Run `PlanningRemoteBaseGit.fetch`
+from the stale clone and assert:
+
+```ts
+assert.equal(snapshot.baseOid, seedGit("rev-parse", "HEAD"));
+assert.notEqual(snapshot.baseOid, staleOid);
+assert.deepEqual(snapshot.artifactCandidates.spec, expectedSpecs);
+assert.deepEqual(snapshot.artifactCandidates.plan, expectedPlans);
+```
+
+Delete or modify a corresponding file in the stale checkout before fetch and
+assert the candidates still come from the pinned remote tree.
+
+- [ ] **Step 7: Format and validate remote-base behavior**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/git/planning-remote-base.ts \
+  src/git/planning-remote-base.test.ts
+node --test src/git/planning-remote-base.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: recording-runner and real-Git fetch/discovery tests PASS.
+
+- [ ] **Step 8: Commit remote-base evidence**
+
+```sh
+git add src/git/planning-remote-base.ts src/git/planning-remote-base.test.ts
+git commit -m "feat(git): pin planning remote base"
+```
+
+---
+
+### Task 6: Implement strict workspace creation and resume
+
+**Files:**
+
+- Create: `src/git/planning-worktree-porcelain.ts`
+- Create: `src/git/planning-worktree-porcelain.test.ts`
+- Create: `src/git/planning-workspace-git.ts`
+- Create: `src/git/planning-workspace-git.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CommandRunner` and the refined lifecycle/evidence types.
+- Produces: `parsePlanningWorktreePorcelain` with complete attached worktree
+  path, branch, and head evidence.
+- Produces: `PlanningWorkspaceGit`, bound to one repository root and one
+  configured worktree root, implementing `inspect`, fresh `prepare`, and exact
+  mutation-free `resume` in this task.
+- Task 7 adds cleanup to the same adapter without changing these signatures.
+
+- [ ] **Step 1: Write strict `worktree --porcelain -z` parser tests**
+
+Use actual NUL-delimited records and assert normalized absolute paths, full head
+OIDs, and `refs/heads/` stripping. Cover multiple valid records plus each unsafe
+response: relative/empty path, missing or duplicate field, abbreviated OID,
+invalid branch, detached expected path, bare record, unknown field, duplicate
+path, duplicate branch, and an unterminated record. The parser returns all valid
+records plus a global malformed flag only if the entire response is safe to
+inspect; the adapter maps any malformed flag to a response error before
+mutation.
+
+- [ ] **Step 2: Implement the focused porcelain parser**
+
+Expose:
+
+```ts
+export type PlanningWorktreeRegistration = Readonly<{
+  path: string;
+  headOid: string;
+  branch?: string;
+  detached: boolean;
+  locked: boolean;
+  prunable: boolean;
+}>;
+
+export function parsePlanningWorktreePorcelain(output: string): Readonly<{
+  entries: readonly PlanningWorktreeRegistration[];
+  malformed: boolean;
+}>;
+```
+
+Recognize the documented linked-worktree fields `worktree`, `HEAD`, `branch`,
+`detached`, `locked`, and `prunable`; tolerate one optional value for locked and
+prunable. Treat locked/prunable expected resources as unsafe later. Reject
+unknown or duplicate fields and duplicate identities globally.
+
+- [ ] **Step 3: Write fresh-prepare command and collision tests**
+
+With a recording runner, start from no registration, no branch, and no path.
+Assert `prepare` runs inspection, then exactly:
+
+```ts
+[
+  "worktree",
+  "add",
+  "-b",
+  identity.branch,
+  "--",
+  absoluteWorktreePath,
+  base.baseOid,
+];
+```
+
+and then reinspects. Assert returned ownership includes the input Run, phase,
+identity, remote/base branch/OID, identical initial head OID, and
+`cleanup: { state: "ready" }`.
+
+Add separate refusal tests for branch-only collision, existing unregistered
+path, expected path registered to another branch, expected branch registered at
+another path, detached expected path, locked/prunable registration, malformed
+porcelain, and a branch or worktree head different from the pinned base. Assert
+none invokes `worktree add`.
+
+- [ ] **Step 4: Write exact mutation-free resume tests**
+
+Create matching saved ownership and assert repeated `resume` returns the same
+ready snapshot. Record calls and assert there is no `fetch`, `worktree add`,
+`worktree remove`, `update-ref`, `reset`, or filesystem write.
+
+Table-test one mismatch at a time: requested Run, phase, expected identity,
+saved remote, base branch, base OID, live registration mapping, live branch
+head, live worktree head, or missing saved base commit. Also test branch-only,
+missing, unregistered, and detached resources. Every case fails closed with a
+specific conflict/response reason.
+
+- [ ] **Step 5: Run workspace tests to prove RED**
+
+Run:
+
+```sh
+node --test \
+  src/git/planning-worktree-porcelain.test.ts \
+  src/git/planning-workspace-git.test.ts
+```
+
+Expected: parser tests may pass after Step 2, while adapter tests FAIL because
+`PlanningWorkspaceGit` does not exist.
+
+- [ ] **Step 6: Implement safe inspection primitives**
+
+Construct the adapter as:
+
+```ts
+export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
+  constructor(input: {
+    runner: CommandRunner;
+    repoRoot: string;
+    worktreeRoot: string;
+  });
+  // interface methods from Task 1
+}
+```
+
+Normalize `repoRoot` and configured `worktreeRoot` once. Resolve each identity
+path against `repoRoot`, then require it to be equal to or below `worktreeRoot`
+via `relative(worktreeRoot, absolutePath)`. Validate branch and saved scalar
+forms before commands.
+
+Use these evidence sources:
+
+- `git worktree list --porcelain -z` from `repoRoot` for path/branch/head
+  registration;
+- `git show-ref --verify --quiet refs/heads/<branch>` for local branch
+  existence, where exit `1` means absent and other nonzero exits are command
+  failures;
+- `git rev-parse --verify refs/heads/<branch>^{commit}` for full branch head;
+- `git rev-parse --verify <saved-base-oid>^{commit}` to prove saved base exists;
+- `git -C <absolute-path> rev-parse --verify HEAD^{commit}` for checkout head;
+- `git -C <absolute-path> status --porcelain=v1 -z --untracked-files=all --ignored=matching`
+  for current cleanliness.
+
+Use `lstat` only to distinguish absent paths from existing unregistered content;
+do not enumerate or modify unregistered directories.
+
+- [ ] **Step 7: Implement fresh prepare and exact resume**
+
+Fresh `prepare` requires a fully validated `PlanningRemoteBaseSnapshot` and
+refuses any pre-existing branch, path, or registration. After `worktree add`,
+rerun all inspection and require expected branch/path mapping, branch head,
+worktree head, and pinned base OID equality before returning evidence.
+
+`resume` first compares requested values to every saved ownership field and base
+evidence. It then performs read-only inspection and returns only if the live
+path, branch, branch head, worktree head, and saved base commit all match.
+Return the status-derived `clean` boolean for later coordination; do not treat a
+dirty matching workspace as an identity mismatch during resume.
+
+- [ ] **Step 8: Add real-Git create-at-pinned-base and no-op resume tests**
+
+Use a repository plus local bare remote. Fetch snapshot A, advance the remote to
+B without refetching, and call `prepare` with A. Assert branch and worktree HEAD
+are A, proving creation does not dereference the moving remote. Then commit in
+the phase worktree, update saved `headOid` to that commit, and call resume
+twice; assert both return the saved head and leave repository refs and status
+unchanged.
+
+Create real branch/path/worktree collisions and assert fresh preparation never
+adopts them. Add one real detached checkout case and one saved-head mismatch.
+
+- [ ] **Step 9: Format and validate creation/resume behavior**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/git/planning-worktree-porcelain.ts \
+  src/git/planning-worktree-porcelain.test.ts \
+  src/git/planning-workspace-git.ts \
+  src/git/planning-workspace-git.test.ts
+node --test \
+  src/git/planning-workspaces.test.ts \
+  src/git/planning-remote-base.test.ts \
+  src/git/planning-worktree-porcelain.test.ts \
+  src/git/planning-workspace-git.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: contract, parser, recording-runner, and real-Git creation/resume tests
+PASS.
+
+- [ ] **Step 10: Commit creation and resume**
+
+```sh
+git add \
+  src/git/planning-worktree-porcelain.ts \
+  src/git/planning-worktree-porcelain.test.ts \
+  src/git/planning-workspace-git.ts \
+  src/git/planning-workspace-git.test.ts
+git commit -m "feat(git): prepare and resume planning workspaces"
+```
+
+---
+
+### Task 7: Add owned and idempotent workspace cleanup
+
+**Files:**
+
+- Modify: `src/git/planning-workspace-git.ts`
+- Modify: `src/git/planning-workspace-git.test.ts`
+
+**Interfaces:**
+
+- Consumes: ready ownership for `removeWorktree` and `worktree-removed`
+  ownership with `pushedHeadOid` for `removeBranch`.
+- Preserves: prepare, resume, and inspect behavior from Task 6.
+- Produces: idempotent `branch-only`/`missing` cleanup snapshots without
+  mutating durable state; later workflow coordination persists the cleanup
+  discriminator between calls.
+
+- [ ] **Step 1: Write clean, dirty, and retry worktree-removal tests**
+
+For matching ready ownership, assert `removeWorktree` checks registration,
+branch/worktree heads, and status before invoking:
+
+```ts
+["worktree", "remove", "--", absoluteWorktreePath];
+```
+
+Assert no `--force`. Test tracked modifications, staged changes, untracked
+files, and ignored files independently; every nonempty `-z` status blocks
+removal and leaves both resources intact.
+
+Assert the first successful call returns `branch-only`; a retry with the exact
+branch/head and absent checkout also returns `branch-only`; and a retry after
+both resources are absent returns `missing`. Refuse an unexpected existing path,
+changed head, changed branch mapping, branch checked out elsewhere, detached or
+malformed registration, and wrong Run/phase/identity.
+
+- [ ] **Step 2: Write remote proof and compare-and-swap branch tests**
+
+For worktree-removed ownership, assert `removeBranch` first proves the branch is
+not checked out, then invokes:
+
+```ts
+[
+  "ls-remote",
+  "--exit-code",
+  "--heads",
+  "--",
+  workspace.remote,
+  `refs/heads/${workspace.identity.branch}`,
+];
+```
+
+Parse exactly one `<full-oid> TAB <exact-ref>` line and require it to equal
+`cleanup.pushedHeadOid`. Only then invoke:
+
+```ts
+[
+  "update-ref",
+  "-d",
+  `refs/heads/${workspace.identity.branch}`,
+  workspace.headOid,
+];
+```
+
+Assert changed/missing/multiple/malformed remote output, a checked-out branch,
+changed local head, and compare-and-swap failure all block or report the
+specific typed error. Assert no `git branch -D` or name sweep is used.
+
+- [ ] **Step 3: Write branch-removal retry tests**
+
+After a successful deletion, call `removeBranch` again with the same ownership.
+Require remote proof to remain exact, permit the local branch to be absent, and
+return the same `missing` snapshot without a second `update-ref`. Assert both
+first and repeated results are identical. If the remote head changed between
+attempts, fail closed even though the local branch is already absent.
+
+- [ ] **Step 4: Run focused cleanup tests to prove RED**
+
+Run:
+
+```sh
+node --test \
+  --test-name-pattern="remove|cleanup|dirty|remote" \
+  src/git/planning-workspace-git.test.ts
+```
+
+Expected: FAIL because cleanup methods do not yet implement the owned and
+idempotent behavior.
+
+- [ ] **Step 5: Implement `removeWorktree` ownership checks and idempotency**
+
+Before mutation, validate requested Run/phase against the saved record, prove
+configured-root containment, inspect all registrations, and compare exact saved
+head. A registered clean matching checkout is removed without force and then
+reinspected. An absent checkout with exact branch/head returns `branch-only`; an
+absent checkout and absent branch returns `missing`. Any existing unregistered
+path or uncertain Git response is a conflict.
+
+Do not alter the caller's ownership object. The coordinator in a later issue
+creates the `worktree-removed` state only after this method succeeds.
+
+- [ ] **Step 6: Implement `removeBranch` remote proof and CAS deletion**
+
+Accept only the compile-time `worktree-removed` cleanup input. Revalidate the
+saved tuple, path absence, branch registration absence, and local branch head.
+Query the configured remote with `ls-remote` and strictly parse exact ref/OID
+evidence. Delete only with `git update-ref -d <ref> <expected-old-oid>`.
+Reinspect and require the local branch to be absent before returning `missing`.
+
+For an earlier identical successful attempt, still validate the saved tuple and
+remote head, observe both local resources absent, skip `update-ref`, and return
+`missing`.
+
+- [ ] **Step 7: Add real-Git owned-cleanup tests**
+
+With a local bare remote, create and push a phase branch, remove the worktree,
+and delete the local branch through the adapter. Repeat both operations and
+assert idempotent snapshots. Recreate fixtures to prove each of these leaves the
+workspace/branch untouched:
+
+- tracked, untracked, or ignored content;
+- another branch at the saved path;
+- the saved branch at another worktree;
+- local head advancement after state was saved;
+- remote branch advancement after `pushedHeadOid` was saved.
+
+Capture every command and assert no force worktree removal, recursive delete,
+clean, reset, merge, rebase, or branch-name sweep occurs.
+
+- [ ] **Step 8: Format and validate the complete Git adapter**
+
+Run:
+
+```sh
+npx --no-install prettier --write \
+  src/git/planning-workspace-git.ts \
+  src/git/planning-workspace-git.test.ts
+node --test \
+  src/git/planning-workspaces.test.ts \
+  src/git/planning-remote-base.test.ts \
+  src/git/planning-worktree-porcelain.test.ts \
+  src/git/planning-workspace-git.test.ts
+npm run check:types
+npm run check:architecture
+```
+
+Expected: all Git contract, remote-base, parser, creation, resume, and cleanup
+tests PASS.
+
+- [ ] **Step 9: Commit owned cleanup**
+
+```sh
+git add \
+  src/git/planning-workspace-git.ts \
+  src/git/planning-workspace-git.test.ts
+git commit -m "feat(git): clean up owned planning workspaces"
+```
+
+---
+
+### Task 8: Run full validation and audit scope
+
+**Files:**
+
+- Verify only; no production or test file is created in this task.
+
+**Interfaces:**
+
+- Verifies: all issue #187 acceptance criteria across the state, lock,
+  remote-base, and workspace seams.
+- Verifies: no current run-once, provider, configuration, or dependency wiring
+  changed.
+
+- [ ] **Step 1: Run all issue-focused tests together**
+
+```sh
+node --test \
+  src/workflow/planning-state.test.ts \
+  src/workflow/planning-issue-lock.test.ts \
+  src/workflow/planning-state-store.test.ts \
+  src/git/planning-workspaces.test.ts \
+  src/git/planning-remote-base.test.ts \
+  src/git/planning-worktree-porcelain.test.ts \
+  src/git/planning-workspace-git.test.ts
+```
+
+Expected: all focused tests PASS with no warning or skipped destructive-safety
+case.
+
+- [ ] **Step 2: Run the repository validation commands from the approved spec**
+
+Run in this exact order:
+
+```sh
+npm test
+npm run build
+npm run lint
+npm run check:types
+npm run check:architecture
+git diff --check
+```
+
+Expected: every command exits with status `0`.
+
+- [ ] **Step 3: Verify compatibility and dependency scope directly**
+
+```sh
+git diff --exit-code main...HEAD -- \
+  package.json package-lock.json npm-shrinkwrap.json \
+  src/config src/cli src/host
+git diff --name-only main...HEAD
+```
+
+Expected: the first command has no diff. The file list contains only the
+approved spec and plan plus the workflow/Git modules and tests named in this
+plan. No Nix build is required because npm dependencies do not change; if any
+package or lockfile unexpectedly changed, stop, remove the change or run the Nix
+build required by `AGENTS.md` before completion.
+
+- [ ] **Step 4: Review error confidentiality and forbidden Git operations**
+
+```sh
+rg -n -- "--force|git clean|git reset|rm\(|rmSync|recursive" \
+  src/git/planning-*.ts src/workflow/planning-*.ts
+rg -n "stdout|stderr|ownershipId|command arguments" \
+  src/git/planning-*.ts src/workflow/planning-*.ts
+```
+
+Inspect every match. Expected: force/recursive mutation does not occur;
+`ownershipId` appears only in lock records and equality checks; raw command
+output exists only in non-enumerable diagnostics or private parsing paths, not
+in default error messages or enumerable error fields.
+
+- [ ] **Step 5: Record implementation completion evidence**
+
+The implementation worker reports:
+
+- the seven implementation commit hashes;
+- focused and full validation command results;
+- the changed-file list and confirmation that dependencies/config/runtime wiring
+  stayed unchanged;
+- confirmation that tests were observed failing before implementation;
+- any residual platform risk around directory syncing or Git SHA-256
+  repositories.

--- a/docs/specs/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces-design.md
+++ b/docs/specs/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces-design.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-This specification awaits manual review. Implementation planning must not begin
-until the specification is approved.
+This specification was approved for implementation for issue #187.
 
 ## Summary
 

--- a/docs/specs/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces-design.md
+++ b/docs/specs/2026-09-07-issue-187-add-durable-planning-state-and-pull-request-workspaces-design.md
@@ -1,0 +1,553 @@
+# Issue 187 durable planning state and pull request workspaces design
+
+## Status
+
+This specification awaits manual review. Implementation planning must not begin
+until the specification is approved.
+
+## Summary
+
+Patchmill will add the local durability and Git infrastructure required by the
+`planning-pr-v1` workflow defined in issue #184:
+
+- a strict, versioned state document for one Issue run;
+- an atomic state store guarded by an ownership-ID issue lock;
+- a Git-backed implementation of `PlanningWorkspaceLifecycle`;
+- a fetched, immutable remote-base snapshot with planning-artifact discovery;
+- exact resume checks; and
+- idempotent cleanup limited to workspaces recorded as Patchmill-owned.
+
+This slice supplies reusable infrastructure only. It does not select phases, run
+agents, create or reconcile pull requests, or connect the new components to the
+current run-once pipeline.
+
+## Goals
+
+- Reject unsupported, unknown, malformed, or internally contradictory state.
+- Preserve one immutable Run identity across every resumed Run attempt.
+- Replace state atomically and durably while the caller owns the issue lock.
+- Acquire issue locks through one exclusive filesystem operation.
+- Authorize release and state mutation by an unguessable ownership ID.
+- Diagnose active, stale, unverifiable, and malformed existing locks without
+  taking them over automatically.
+- Fetch and pin the configured remote base before deciding whether a phase needs
+  a workspace.
+- Inspect planning artifacts from the pinned base tree, not the current
+  checkout.
+- Create each new phase branch and worktree at that exact base commit.
+- Resume only the workspace identity and commits saved for the same Run and
+  phase.
+- Make cleanup retries safe after either cleanup step has already succeeded.
+- Refuse deletion unless durable ownership and current Git identity agree.
+
+## Non-goals
+
+- Run planning or implementation agents.
+- Select the next planning phase or approval policy.
+- Create, find, update, merge, or reconcile pull requests.
+- Push phase branches.
+- Connect the new state, lock, or workspace adapter to `run-once`.
+- Replace or migrate the existing `AgentIssueRunState` and Issue run lease.
+- Add automatic stale-lock takeover, a lock-repair CLI, or force cleanup.
+- Clean, stash, reset, merge, or rebase a phase workspace.
+- Remove an unregistered directory or a workspace not proven to be owned.
+- Add dependencies or configuration keys.
+
+## Approaches considered
+
+### Focused planning store, lock, and Git adapter (chosen)
+
+Keep the new workflow under its own versioned state namespace. A strict state
+module owns domain invariants, a small store owns filesystem atomicity, an
+ownership-ID lock serializes issue mutations, and a Git adapter implements the
+workspace contract.
+
+This keeps pure validation separate from filesystem and Git effects. It also
+allows later phase coordination to consume stable interfaces without changing
+the current pipeline in this slice.
+
+### Extend legacy run state and recovery leases
+
+The existing run state is incrementally merged, accepts fields that its recovery
+parser does not reject, and has compatibility rules for the current pipeline.
+Its lease also performs same-host stale takeover. Retrofitting the stricter
+planning contract there would couple the new workflow to legacy checkpoints and
+expand issue #187 into a migration. This approach is rejected.
+
+### Reconstruct state and ownership from Git
+
+Deterministic branch and worktree names could be rediscovered after a restart,
+but names do not prove which Run created a workspace or which base and head were
+saved. This cannot meet immutable Run identity, exact resume, or owned cleanup
+requirements and is rejected.
+
+## Architecture and module boundaries
+
+### Planning state
+
+Add focused modules under `src/workflow/`:
+
+- `planning-state.ts` owns the versioned types, strict parser, serializer, and
+  cross-field invariants.
+- `planning-state-store.ts` owns state paths, initialization, reads, and atomic
+  replacement.
+- `planning-issue-lock.ts` owns lock records, acquisition, inspection, release,
+  and conflict diagnostics.
+
+The files live below the configured run-state directory without adding a new
+configuration key:
+
+```text
+<runStateDir>/planning-pr-v1/issues/issue-N.json
+<runStateDir>/planning-pr-v1/locks/issue-N.lock
+```
+
+This namespace avoids collisions with current `issue-N.json` state and locks. It
+is already covered by the configured run-state cleanliness exclusion.
+
+### Git infrastructure
+
+Keep the provider-neutral types in `src/git/planning-workspaces.ts`. Refine that
+contract so a fetched remote-base snapshot and saved ownership record are
+first-class inputs rather than loose SHA strings.
+
+Add focused Git implementation modules under `src/git/`:
+
+- `planning-workspace-git.ts` implements inspection, creation, resume, and
+  cleanup through `CommandRunner`.
+- `planning-remote-base.ts` fetches and pins the target base and inspects
+  artifact candidates in that commit tree.
+- A parsing helper may be extracted if robust `git worktree --porcelain` or
+  `git ls-tree -z` parsing would push either effect module beyond roughly 200
+  meaningful lines.
+
+The adapter binds to one repository root and one configured worktree root.
+Callers use lifecycle methods and typed snapshots; they do not assemble Git
+command sequences.
+
+## Durable planning state
+
+### Top-level identity
+
+The version `1` document has this structural shape:
+
+```ts
+type PlanningStateV1 = {
+  version: 1;
+  workflowVersion: "planning-pr-v1";
+  runId: string;
+  issueNumber: number;
+  issueTitle: string;
+  gates: PlanningGateSnapshot;
+  phases: PlanningPhaseStateV1[];
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+`runId` is an immutable UUID for the Issue run. `revision` starts at zero. The
+ordered `phases` array has one record for every phase returned by
+`planningPhasePlan(gates)`.
+
+A retry starts a new Run attempt but retains `runId`. A new state file receives
+a new `runId`. No update API accepts a replacement Run ID, issue identity, gate
+snapshot, workflow version, or phase sequence.
+
+The store does not merge arbitrary partial objects. A caller constructs the next
+complete typed state from the current parsed state. Replacement requires the
+current `runId` and `revision`; the next document must preserve the immutable
+fields and increment `revision` by exactly one.
+
+### Phase records
+
+Reusable phase evidence has these shapes:
+
+```ts
+type PlanningBaseEvidence = {
+  remote: string;
+  baseBranch: string;
+  baseOid: string;
+  artifactCandidates: { spec: string[]; plan: string[] };
+};
+
+type PlanningArtifactEvidence = {
+  kind: "spec" | "plan";
+  path: string;
+  commitOid: string;
+  source: "remote-base" | "workspace";
+};
+
+type PlanningPullRequestEvidence = {
+  reference: PullRequestReference;
+  baseBranch: string;
+  headBranch: string;
+  headOid: string;
+};
+
+type PlanningWorkspaceEvidence = {
+  runId: string;
+  phase: PlanningPhaseKind;
+  identity: PlanningWorkspaceIdentity;
+  remote: string;
+  baseBranch: string;
+  baseOid: string;
+  headOid: string;
+  cleanup:
+    | { state: "ready" }
+    | { state: "worktree-removed"; pushedHeadOid: string }
+    | { state: "removed"; pushedHeadOid: string };
+};
+```
+
+`PlanningPhaseStateV1` is the following exact discriminator family:
+
+- `pending`: `kind` and `status` only.
+- `workspace-ready`: `kind`, `status`, base evidence, and workspace evidence.
+- `pull-request-open`: `kind`, `status`, base, workspace, artifact, and pull
+  request evidence.
+- `complete` with `completion.kind = "remote-base"`: `kind`, `status`, base,
+  artifact evidence, and the completion discriminator; it has no workspace or
+  pull request.
+- `complete` with `completion.kind = "merged-pull-request"`: `kind`, `status`,
+  base, workspace, artifact evidence, pull request evidence, and the merge
+  object ID in its completion value.
+
+Artifact arrays contain exactly the planning artifact kinds assigned to the
+phase and may be empty for implementation. Workspace cleanup retains immutable
+identity evidence while moving from `ready` through `worktree-removed` to
+`removed`.
+
+This slice defines and tests these state shapes but does not perform pull
+request transitions. Later coordination code will supply neutral pull request
+references from `PullRequestHost`.
+
+### State invariants
+
+The parser and every write enforce all of these rules:
+
+- Objects at every level contain exactly the documented keys for their
+  discriminator. Unknown keys and missing required keys fail.
+- Only state version `1` and workflow version `planning-pr-v1` are accepted.
+- IDs, timestamps, Git object IDs, branch names, repository-relative paths, and
+  artifact kinds have bounded validated forms.
+- The stored phase sequence exactly matches `planningPhasePlan(gates)`; phases
+  are unique and in order.
+- Completed phases form a prefix, pending phases form a suffix, and at most one
+  phase is active or waiting for a pull request merge.
+- A phase discriminator requires its evidence and forbids evidence belonging to
+  another state. For example, `pending` cannot contain a workspace, and a
+  pull-request completion requires a merged summary and merge commit.
+- A remote-base completion refers only to artifact kinds assigned to that phase
+  and paths found in its pinned base snapshot. It has no workspace or pull
+  request.
+- Workspace ownership always agrees with the containing `runId` and phase.
+  Branches and worktree paths cannot be shared by two phase records.
+- A workspace base, identity, and ownership tuple never changes. Its saved head
+  may advance only before cleanup starts. Cleanup can move only
+  `ready -> worktree-removed -> removed`.
+- `updatedAt` cannot precede `createdAt`, and revisions cannot move backward or
+  skip.
+
+Invalid JSON, unsupported versions, unknown keys, and invariant violations use a
+stable `PlanningStateValidationError` with a reason and JSON path. Raw document
+contents are not included in the default error message.
+
+## Atomic state store
+
+All mutating store methods require a live `PlanningIssueLock` for the same issue
+and Run. Immediately before replacement, the store rereads and strictly parses
+both state and lock, verifies the ownership ID, `runId`, and expected revision,
+and validates the complete next document.
+
+A write uses this sequence in the destination directory:
+
+1. Create a unique temporary file with exclusive creation and mode `0600`.
+2. Write one canonical JSON document plus a trailing newline.
+3. Flush and close the temporary file.
+4. Rename it over the destination in the same directory.
+5. Flush the parent directory where the platform supports directory syncing.
+6. Remove a remaining temporary file after a pre-rename failure.
+
+The old or new complete document is therefore visible after interruption; a
+partially written canonical file is not. Initialization uses the same sequence
+while holding the issue lock and refuses to replace an existing state file.
+
+Read methods never coerce or repair malformed state. A parse failure blocks the
+operation with the exact state path for operator inspection.
+
+## Ownership-ID issue lock
+
+### Lock record and acquisition
+
+Each Run attempt receives a fresh random `ownershipId`; this differs from the
+stable state `runId`. The version `1` lock record contains:
+
+- issue number and Run ID;
+- ownership ID;
+- process ID and host name for diagnostics only; and
+- an acquisition timestamp.
+
+Acquisition creates the canonical lock file with `open(..., "wx", 0o600)`,
+writes and flushes the validated record, and keeps the resulting lock value in
+memory. File existence is the atomic exclusion primitive. Process ID, host, and
+age never authorize mutation.
+
+Release rereads the lock and removes it only when issue number, Run ID, and
+ownership ID all match. A missing lock is an idempotent successful release. A
+mismatched or malformed lock is never removed.
+
+### Existing-lock diagnostics
+
+When exclusive creation reports `EEXIST`, Patchmill reads the exact existing
+bytes and returns a stable conflict classification:
+
+- `active`: a valid same-host record whose process is alive;
+- `stale`: a valid same-host record whose process is proven dead;
+- `unverifiable`: a valid remote-host record or a local liveness check that is
+  not permitted;
+- `malformed`: bytes do not parse as the exact supported lock schema.
+
+Diagnostics contain the lock path, safe parsed owner fields when available, and
+a SHA-256 fingerprint of the exact bytes. Elapsed time may be reported but does
+not classify or invalidate a lock. This slice never archives, replaces, or
+repairs an existing lock; stale and malformed locks require later explicit
+operator tooling or manual inspection.
+
+## Remote-base snapshot and artifact discovery
+
+For each phase, the adapter first fetches the configured remote branch using
+argument arrays and an explicit branch refspec. It does not rely on a possibly
+stale local checkout or `HEAD`. After a successful fetch it resolves the
+remote-tracking ref to one full Git object ID and returns an immutable snapshot:
+
+```text
+remote + base branch + base object ID + artifact candidates
+```
+
+All subsequent artifact inspection and workspace creation for that phase use the
+object ID, never the moving ref name.
+
+Artifact discovery normalizes the configured specs and plans directories against
+the repository root, requires them to remain inside that root, and uses the
+resulting repository-relative tree paths. It runs `git ls-tree -r -z` against
+the pinned commit, accepts regular files only, and applies the same issue-number
+filename rule used by current local artifact discovery. It returns deterministic
+sorted candidate arrays for spec and plan rather than silently choosing the
+first match. No file is materialized and the current checkout is not read.
+
+Missing directories and no matching files produce empty candidate arrays.
+Multiple candidates remain explicit so later phase coordination can fail closed
+or apply its approved resolution policy. Invalid configured paths, malformed Git
+output, missing commits, and command failures fail without creating a workspace.
+
+## Workspace creation and resume
+
+### New workspace
+
+A new prepare call requires the remote-base snapshot for the current phase. The
+adapter revalidates the snapshot inputs, proves the expected branch is absent,
+proves the expected path is absent and unregistered, then runs
+`git worktree add` with a new phase branch at the exact pinned base object ID.
+
+After creation it inspects Git again and returns a ready snapshot only when:
+
+- the expected absolute path is a registered worktree;
+- that worktree is attached to the exact expected branch;
+- the branch is not attached elsewhere;
+- branch and worktree `HEAD` equal the pinned base object ID; and
+- Git status can be read.
+
+A branch-only collision, unregistered directory, detached checkout, path owned
+by another branch, or branch owned by another worktree is a conflict. Fresh
+prepare never adopts pre-existing state.
+
+### Resume
+
+Resume accepts the saved workspace record from strictly parsed state, not newly
+derived names plus loose commit strings. It verifies all of these values before
+returning the existing checkout:
+
+- state Run ID and phase equal the requested Run and phase;
+- saved and expected branch and worktree path are identical;
+- saved remote and base branch equal current inputs;
+- the live registered path and branch map to each other;
+- live branch and worktree `HEAD` equal the saved head object ID; and
+- the saved pinned base object exists and equals the phase base evidence.
+
+Resume performs no fetch, reset, branch creation, worktree creation, or cleanup.
+It reports current cleanliness for the later coordinator to interpret. Missing,
+branch-only, mismatched, detached, or unregistered state fails closed. Repeating
+a matching resume produces the same snapshot and no mutation.
+
+## Owned and idempotent cleanup
+
+Cleanup methods require the complete saved ownership record from strict state. A
+deterministic phase suffix alone is never ownership proof. Before each mutation,
+the adapter validates the Run, phase, configured worktree containment, exact
+branch/path registration, and expected head object ID.
+
+`removeWorktree`:
+
+- refuses tracked, untracked, or ignored content;
+- uses `git worktree remove` without `--force`;
+- returns `branch-only` after successful removal;
+- returns the same `branch-only` result when the checkout is already absent but
+  the exact branch and head remain; and
+- returns `missing` when both exact resources were already removed.
+
+`removeBranch`:
+
+- accepts only a `worktree-removed` ownership record;
+- proves the branch is not checked out anywhere;
+- queries the configured remote and proves that its exact branch ref equals the
+  saved pushed head object ID;
+- deletes only `refs/heads/<saved-branch>` using an expected-old-object
+  compare-and-swap; and
+- returns `missing` both after deletion and when an earlier identical attempt
+  already removed it.
+
+Unexpected path contents, a differently attached branch, a changed local head, a
+changed remote head, or unverifiable Git state blocks cleanup. Cleanup never
+uses recursive filesystem deletion, `git clean`, `git reset`, force worktree
+removal, or name-pattern sweeps. State persists `worktree-removed` before branch
+removal so a crash between steps resumes at the safe boundary.
+
+## Error handling
+
+Use stable typed errors rather than message parsing:
+
+- `PlanningStateValidationError` for schema and invariant failures;
+- `PlanningStateConflictError` for Run ID, revision, or lock-ownership changes;
+- `PlanningIssueLockConflictError` with active/stale/unverifiable/malformed
+  diagnostics;
+- `PlanningWorkspaceConflictError` for unsafe live Git identity or cleanup;
+- `PlanningWorkspaceCommandError` for failed Git commands; and
+- `PlanningWorkspaceResponseError` for malformed Git output.
+
+Errors include safe operation, reason, and expected identity fields. Command
+arguments, remote credentials, state bytes, and raw output are not present in
+default messages or enumerable fields.
+
+## Data flows
+
+### Start a phase
+
+1. Acquire the issue lock with the stable Run ID and a fresh ownership ID.
+2. Reread and strictly parse planning state under the lock.
+3. Fetch and pin the configured remote base.
+4. Inspect that exact tree for issue planning artifacts.
+5. If remote-base artifacts satisfy the phase, persist a remote-base completion
+   without creating a branch or worktree.
+6. Otherwise create the phase workspace at the pinned object ID.
+7. Persist the owned ready workspace by atomic state replacement.
+8. Release the lock when the surrounding Run attempt ends.
+
+Steps 5 and later phase decisions are consumers of this infrastructure and are
+not wired into production by issue #187.
+
+### Resume or cleanup
+
+1. Read planning state to learn the Run ID, then acquire the issue lock.
+2. Reread state under the lock and verify its expected revision.
+3. Pass the saved phase ownership record to resume or cleanup.
+4. Persist each successful cleanup boundary atomically.
+5. Repeating the operation either returns the same verified snapshot or reports
+   a focused conflict; it does not adopt or delete different state.
+
+## Verification strategy
+
+The Testing Value Gate supports automated tests here because parsing,
+concurrency, crash safety, Git command contracts, and destructive cleanup are
+reusable and high-risk behavior.
+
+### State and lock tests
+
+Focused tests will cover:
+
+- round-trip parsing of every phase and cleanup discriminator;
+- rejection of unknown top-level and nested keys, unsupported versions,
+  malformed values, wrong phase sequences, forbidden fields, duplicate
+  identities, invalid progress ordering, and incomplete merge evidence;
+- immutable Run identity and monotonic revision enforcement;
+- a simulated failure before rename leaving the previous complete document;
+- exact-lock ownership required for replacement and release;
+- concurrent lock acquisition allowing exactly one owner;
+- idempotent release by the owner; and
+- active, stale, remote/unverifiable, and malformed lock diagnostics with stable
+  reasons and fingerprints.
+
+### Git adapter tests
+
+Recording-runner tests will verify command arguments, working directories,
+ordering, exact object-ID use, and error classification.
+
+Real-Git tests with temporary repositories and a local bare remote will prove:
+
+- advancing the remote after the local clone is stale still creates a phase
+  workspace at the newly fetched remote base;
+- spec and plan candidates are read from the pinned remote tree, including empty
+  and multiple-candidate results;
+- fresh creation refuses every branch/path collision;
+- matching saved resume is a no-op;
+- Run, phase, identity, base, or head mismatches refuse resume;
+- dirty, untracked, and ignored content blocks worktree removal;
+- a different workspace or changed head is never removed;
+- repeated worktree and branch cleanup returns the expected idempotent state;
+- branch cleanup requires the exact remote head; and
+- no cleanup path uses force or recursive deletion.
+
+### Validation commands
+
+Focused implementation validation will use the new state, lock, remote-base, and
+Git workspace test files plus the existing workspace contract tests. Final
+validation will use:
+
+```sh
+npm test
+npm run build
+npm run lint
+npm run check:types
+npm run check:architecture
+```
+
+No dependency change is planned, so a Nix build is not required. No new test
+will assert static documentation or configuration text; the final diff will
+verify that runtime wiring and configuration remain unchanged.
+
+## Compatibility
+
+The new modules remain unreachable from the current run-once workflow. Existing
+run state, recovery leases, issue workspaces, labels, artifact publication, host
+factories, and CLI behavior do not change.
+
+The `PlanningWorkspaceLifecycle` refinement is limited to the unused foundation
+introduced by issue #184 and its contract tests. It makes fetched-base and
+ownership evidence explicit before a production consumer exists.
+
+No glossary change is required. This design uses the established Issue run, Run
+attempt, and Run recovery state distinction; the new planning state is the
+strict Run recovery state for `planning-pr-v1`, not an Event ledger or Pi
+session log.
+
+## Acceptance criteria
+
+- State parsing rejects unknown keys, unsupported versions, malformed values,
+  and contradictory phase, artifact, pull request, workspace, and cleanup data.
+- State initialization and replacement use same-directory atomic rename and
+  preserve an immutable Run ID.
+- Every state mutation requires the matching ownership-ID issue lock.
+- Lock acquisition is exclusive and existing locks produce safe stale-lock
+  diagnostics without automatic takeover.
+- Each phase uses one fetched, pinned remote-base object ID for artifact
+  inspection and new workspace creation.
+- Remote-base artifact discovery does not depend on the current checkout and
+  does not silently choose among multiple candidates.
+- Fresh preparation never adopts an existing branch, path, or worktree.
+- Resume is mutation-free and succeeds only for the saved Run, phase, workspace
+  identity, base, and head.
+- Cleanup retries are idempotent at worktree-removed and branch-removed
+  boundaries.
+- Cleanup removes only the exact clean phase workspace and branch proven by
+  durable Patchmill ownership and live Git evidence.
+- Existing production workflow behavior remains unchanged.

--- a/src/git/planning-git-validation.ts
+++ b/src/git/planning-git-validation.ts
@@ -1,0 +1,38 @@
+export const planningOid = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+
+export function isPlanningSingleLine(
+  value: unknown,
+  maximumLength = 1024,
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maximumLength &&
+    !/[\0\r\n]/u.test(value)
+  );
+}
+
+export function isPlanningBranch(value: unknown): value is string {
+  return (
+    isPlanningSingleLine(value) &&
+    !value.startsWith("-") &&
+    !value.startsWith("/") &&
+    !value.endsWith("/") &&
+    !value.endsWith(".") &&
+    !/[\x00-\x20\\~^:?*[]/u.test(value) &&
+    !value.includes("..") &&
+    !value.includes("@{") &&
+    !value.split("/").some((part) => part.length === 0)
+  );
+}
+
+export function isPlanningArtifactPath(value: unknown): value is string {
+  return (
+    isPlanningSingleLine(value, 4096) &&
+    !value.includes("\\") &&
+    !value.startsWith("/") &&
+    !value
+      .split("/")
+      .some((part) => part === "" || part === "." || part === "..")
+  );
+}

--- a/src/git/planning-git-validation.ts
+++ b/src/git/planning-git-validation.ts
@@ -19,7 +19,7 @@ export function isPlanningBranch(value: unknown): value is string {
     !value.startsWith("/") &&
     !value.endsWith("/") &&
     !value.endsWith(".") &&
-    !/[\x00-\x20\\~^:?*[]/u.test(value) &&
+    !/[\s\x00-\x1f\x7f\\~^:?*[]/u.test(value) &&
     !value.includes("..") &&
     !value.includes("@{") &&
     !value.split("/").some((part) => part.length === 0)

--- a/src/git/planning-remote-base.test.ts
+++ b/src/git/planning-remote-base.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import { PlanningRemoteBaseGit } from "./planning-remote-base.ts";
 import type { CommandRunner } from "../process/command.ts";
+import { PlanningRemoteBaseGit } from "./planning-remote-base.ts";
 const oid = "a".repeat(40);
 function runner(tree: string): CommandRunner {
   return {
@@ -74,6 +78,130 @@ test("fetches a pinned remote ref and discovers regular issue artifacts", async 
     },
   ]);
 });
+test("fetch reads multiple candidates from a newly advanced remote tree", async () => {
+  const root = await mkdtemp(join(tmpdir(), "planning-remote-base-"));
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  const stale = join(root, "stale");
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+  const realRunner: CommandRunner = {
+    run: async (command, args, options) => {
+      try {
+        return {
+          code: 0,
+          stdout: execFileSync(command, args, {
+            cwd: options?.cwd,
+            encoding: "utf8",
+          }),
+          stderr: "",
+        };
+      } catch (error) {
+        const failure = error as {
+          status?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          code: failure.status ?? 1,
+          stdout: failure.stdout ?? "",
+          stderr: failure.stderr ?? "",
+        };
+      }
+    },
+  };
+  try {
+    execFileSync("git", ["init", "--bare", "--initial-branch=main", remote]);
+    execFileSync("git", ["init", "-b", "main", seed]);
+    git(seed, "config", "user.name", "Patchmill Test");
+    git(seed, "config", "user.email", "patchmill@example.test");
+    await writeFile(join(seed, "README.md"), "old\n");
+    git(seed, "add", ".");
+    git(seed, "commit", "-m", "old base");
+    git(seed, "remote", "add", "origin", remote);
+    git(seed, "push", "-u", "origin", "main");
+    execFileSync("git", ["clone", remote, stale]);
+    const staleOid = git(stale, "rev-parse", "HEAD");
+
+    await mkdir(join(seed, "docs/specs"), { recursive: true });
+    await mkdir(join(seed, "docs/plans"), { recursive: true });
+    await writeFile(join(seed, "docs/specs/a-issue-187-one.md"), "a\n");
+    await writeFile(join(seed, "docs/specs/b-issue-187-two.md"), "b\n");
+    await writeFile(join(seed, "docs/plans/c-issue-187-plan.md"), "c\n");
+    await writeFile(join(seed, "docs/plans/other-issue-999-plan.md"), "x\n");
+    git(seed, "add", ".");
+    git(seed, "commit", "-m", "new planning artifacts");
+    git(seed, "push", "origin", "main");
+    const remoteOid = git(seed, "rev-parse", "HEAD");
+    await writeFile(join(stale, "README.md"), "working tree differs\n");
+
+    const adapter = new PlanningRemoteBaseGit({
+      runner: realRunner,
+      repoRoot: stale,
+      specsDir: "docs/specs",
+      plansDir: "docs/plans",
+    });
+    const snapshot = await adapter.fetch({
+      issueNumber: 187,
+      remote: "origin",
+      baseBranch: "main",
+    });
+    assert.equal(snapshot.baseOid, remoteOid);
+    assert.notEqual(snapshot.baseOid, staleOid);
+    assert.deepEqual(snapshot.artifactCandidates, {
+      spec: ["docs/specs/a-issue-187-one.md", "docs/specs/b-issue-187-two.md"],
+      plan: ["docs/plans/c-issue-187-plan.md"],
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects invalid remote inputs before invoking Git", async () => {
+  const calls: string[][] = [];
+  const adapter = new PlanningRemoteBaseGit({
+    runner: {
+      run: async (_command, args) => {
+        calls.push(args);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+    repoRoot: "/repo",
+    specsDir: "docs/specs",
+    plansDir: "docs/plans",
+  });
+  for (const input of [
+    { issueNumber: 0, remote: "origin", baseBranch: "main" },
+    { issueNumber: 187, remote: "origin\nother", baseBranch: "main" },
+    { issueNumber: 187, remote: "origin", baseBranch: "bad branch" },
+    { issueNumber: 187, remote: "origin", baseBranch: `x${"a".repeat(1024)}` },
+    { issueNumber: 187, remote: "origin", baseBranch: "bad\u0001branch" },
+  ]) {
+    await assert.rejects(adapter.fetch(input), /Invalid planning remote-base/);
+  }
+  assert.deepEqual(calls, []);
+});
+
+test("rejects invalid tree mode and type pairings", async () => {
+  for (const record of [
+    `100644 commit ${oid}\tdocs/specs/a-issue-187.md\0`,
+    `100755 commit ${oid}\tdocs/specs/a-issue-187.md\0`,
+    `120000 commit ${oid}\tdocs/specs/a-issue-187.md\0`,
+    `160000 blob ${oid}\tdocs/specs/a-issue-187.md\0`,
+  ]) {
+    const adapter = new PlanningRemoteBaseGit({
+      runner: runner(record),
+      repoRoot: "/repo",
+      specsDir: "docs/specs",
+      plansDir: "docs/plans",
+    });
+    await assert.rejects(
+      adapter.fetch({ issueNumber: 187, remote: "origin", baseBranch: "main" }),
+      /invalid-mode-type/,
+    );
+  }
+});
+
 test("rejects malformed symlink entries and duplicate tree paths", async () => {
   const malformed = new PlanningRemoteBaseGit({
     runner: runner(`120000 blob not-an-oid\tdocs/specs/link-issue-187.md\0`),

--- a/src/git/planning-remote-base.test.ts
+++ b/src/git/planning-remote-base.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PlanningRemoteBaseGit } from "./planning-remote-base.ts";
+import type { CommandRunner } from "../process/command.ts";
+const oid = "a".repeat(40);
+test("fetches a pinned remote ref and discovers regular issue artifacts", async () => {
+  const calls: unknown[] = [];
+  const runner: CommandRunner = {
+    run: async (command, args, options) => {
+      calls.push({ command, args, cwd: options?.cwd });
+      if (args[0] === "rev-parse")
+        return { code: 0, stdout: `${oid}\n`, stderr: "" };
+      if (args[0] === "ls-tree")
+        return {
+          code: 0,
+          stdout:
+            `100644 blob ${oid}\tdocs/specs/a-issue-187-x.md\0` +
+            `120000 blob ${oid}\tdocs/plans/link-issue-187-x.md\0` +
+            `100755 blob ${oid}\tdocs/plans/b-issue-187-x.md\0`,
+          stderr: "",
+        };
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  };
+  const git = new PlanningRemoteBaseGit({
+    runner,
+    repoRoot: "/repo",
+    specsDir: "docs/specs",
+    plansDir: "docs/plans",
+  });
+  const snapshot = await git.fetch({
+    issueNumber: 187,
+    remote: "origin",
+    baseBranch: "main",
+  });
+  assert.equal(snapshot.baseOid, oid);
+  assert.deepEqual(snapshot.artifactCandidates, {
+    spec: ["docs/specs/a-issue-187-x.md"],
+    plan: ["docs/plans/b-issue-187-x.md"],
+  });
+  assert.deepEqual(calls, [
+    {
+      command: "git",
+      args: [
+        "fetch",
+        "--no-tags",
+        "--",
+        "origin",
+        "+refs/heads/main:refs/remotes/origin/main",
+      ],
+      cwd: "/repo",
+    },
+    {
+      command: "git",
+      args: ["rev-parse", "--verify", "refs/remotes/origin/main^{commit}"],
+      cwd: "/repo",
+    },
+    {
+      command: "git",
+      args: [
+        "ls-tree",
+        "-r",
+        "-z",
+        "--full-tree",
+        oid,
+        "--",
+        "docs/specs",
+        "docs/plans",
+      ],
+      cwd: "/repo",
+    },
+  ]);
+});

--- a/src/git/planning-remote-base.test.ts
+++ b/src/git/planning-remote-base.test.ts
@@ -3,27 +3,30 @@ import test from "node:test";
 import { PlanningRemoteBaseGit } from "./planning-remote-base.ts";
 import type { CommandRunner } from "../process/command.ts";
 const oid = "a".repeat(40);
+function runner(tree: string): CommandRunner {
+  return {
+    run: async (_command, args) =>
+      args[0] === "rev-parse"
+        ? { code: 0, stdout: `${oid}\n`, stderr: "" }
+        : args[0] === "ls-tree"
+          ? { code: 0, stdout: tree, stderr: "" }
+          : { code: 0, stdout: "", stderr: "" },
+  };
+}
 test("fetches a pinned remote ref and discovers regular issue artifacts", async () => {
   const calls: unknown[] = [];
-  const runner: CommandRunner = {
+  const recording: CommandRunner = {
     run: async (command, args, options) => {
       calls.push({ command, args, cwd: options?.cwd });
-      if (args[0] === "rev-parse")
-        return { code: 0, stdout: `${oid}\n`, stderr: "" };
-      if (args[0] === "ls-tree")
-        return {
-          code: 0,
-          stdout:
-            `100644 blob ${oid}\tdocs/specs/a-issue-187-x.md\0` +
-            `120000 blob ${oid}\tdocs/plans/link-issue-187-x.md\0` +
-            `100755 blob ${oid}\tdocs/plans/b-issue-187-x.md\0`,
-          stderr: "",
-        };
-      return { code: 0, stdout: "", stderr: "" };
+      return runner(
+        `100644 blob ${oid}\tdocs/specs/a-issue-187-x.md\0` +
+          `120000 blob ${oid}\tdocs/plans/link-issue-187-x.md\0` +
+          `100755 blob ${oid}\tdocs/plans/b-issue-187-x.md\0`,
+      ).run(command, args, options);
     },
   };
   const git = new PlanningRemoteBaseGit({
-    runner,
+    runner: recording,
     repoRoot: "/repo",
     specsDir: "docs/specs",
     plansDir: "docs/plans",
@@ -70,4 +73,29 @@ test("fetches a pinned remote ref and discovers regular issue artifacts", async 
       cwd: "/repo",
     },
   ]);
+});
+test("rejects malformed symlink entries and duplicate tree paths", async () => {
+  const malformed = new PlanningRemoteBaseGit({
+    runner: runner(`120000 blob not-an-oid\tdocs/specs/link-issue-187.md\0`),
+    repoRoot: "/repo",
+    specsDir: "docs/specs",
+    plansDir: "docs/plans",
+  });
+  await assert.rejects(
+    malformed.fetch({ issueNumber: 187, remote: "origin", baseBranch: "main" }),
+    /malformed-record/,
+  );
+  const duplicate = new PlanningRemoteBaseGit({
+    runner: runner(
+      `100644 blob ${oid}\tdocs/specs/a-issue-187.md\0` +
+        `100644 blob ${oid}\tdocs/specs/a-issue-187.md\0`,
+    ),
+    repoRoot: "/repo",
+    specsDir: "docs/specs",
+    plansDir: "docs/plans",
+  });
+  await assert.rejects(
+    duplicate.fetch({ issueNumber: 187, remote: "origin", baseBranch: "main" }),
+    /duplicate-entry/,
+  );
 });

--- a/src/git/planning-remote-base.test.ts
+++ b/src/git/planning-remote-base.test.ts
@@ -174,6 +174,7 @@ test("rejects invalid remote inputs before invoking Git", async () => {
     { issueNumber: 0, remote: "origin", baseBranch: "main" },
     { issueNumber: 187, remote: "origin\nother", baseBranch: "main" },
     { issueNumber: 187, remote: "origin", baseBranch: "bad branch" },
+    { issueNumber: 187, remote: "origin", baseBranch: "bad\u00a0branch" },
     { issueNumber: 187, remote: "origin", baseBranch: `x${"a".repeat(1024)}` },
     { issueNumber: 187, remote: "origin", baseBranch: "bad\u0001branch" },
   ]) {
@@ -212,6 +213,20 @@ test("rejects malformed symlink entries and duplicate tree paths", async () => {
   await assert.rejects(
     malformed.fetch({ issueNumber: 187, remote: "origin", baseBranch: "main" }),
     /malformed-record/,
+  );
+  const invalidPath = new PlanningRemoteBaseGit({
+    runner: runner(`100644 blob ${oid}\tdocs/specs/bad\\name-issue-187.md\0`),
+    repoRoot: "/repo",
+    specsDir: "docs/specs",
+    plansDir: "docs/plans",
+  });
+  await assert.rejects(
+    invalidPath.fetch({
+      issueNumber: 187,
+      remote: "origin",
+      baseBranch: "main",
+    }),
+    /invalid-path/,
   );
   const duplicate = new PlanningRemoteBaseGit({
     runner: runner(

--- a/src/git/planning-remote-base.ts
+++ b/src/git/planning-remote-base.ts
@@ -100,6 +100,7 @@ export class PlanningRemoteBaseGit {
     check(result, "tree-inspection");
     const spec: string[] = [];
     const plan: string[] = [];
+    const seen = new Set<string>();
     if (result.stdout !== "" && !result.stdout.endsWith("\0"))
       throw new PlanningWorkspaceResponseError(
         "tree-inspection",
@@ -107,25 +108,27 @@ export class PlanningRemoteBaseGit {
       );
     for (const record of result.stdout.split("\0").filter(Boolean)) {
       const match =
-        /^(100644|100755) (blob) ([0-9a-f]{40}|[0-9a-f]{64})\t(.+)$/u.exec(
+        /^(100644|100755|120000|160000) (blob|commit) ([0-9a-f]{40}|[0-9a-f]{64})\t([^\0\r\n]+)$/u.exec(
           record,
         );
-      if (match === null) {
-        if (/^(120000|160000) /u.test(record)) continue;
+      if (match === null)
         throw new PlanningWorkspaceResponseError(
           "tree-inspection",
           "malformed-record",
         );
-      }
-      const path = match[4]!;
-      if (
-        !path.includes("\0") &&
-        basename(path).includes(`-issue-${input.issueNumber}-`)
-      ) {
-        if (path === this.specsDir || path.startsWith(`${this.specsDir}/`))
-          spec.push(path);
-        if (path === this.plansDir || path.startsWith(`${this.plansDir}/`))
-          plan.push(path);
+      const [mode, type, objectId, path] = match.slice(1);
+      if (!OID.test(objectId!) || seen.has(path!))
+        throw new PlanningWorkspaceResponseError(
+          "tree-inspection",
+          seen.has(path!) ? "duplicate-entry" : "malformed-record",
+        );
+      seen.add(path!);
+      if ((mode !== "100644" && mode !== "100755") || type !== "blob") continue;
+      if (basename(path!).includes(`-issue-${input.issueNumber}-`)) {
+        if (path === this.specsDir || path!.startsWith(`${this.specsDir}/`))
+          spec.push(path!);
+        if (path === this.plansDir || path!.startsWith(`${this.plansDir}/`))
+          plan.push(path!);
       }
     }
     return Object.freeze({
@@ -133,8 +136,8 @@ export class PlanningRemoteBaseGit {
       baseBranch: input.baseBranch,
       baseOid,
       artifactCandidates: Object.freeze({
-        spec: Object.freeze([...new Set(spec)].sort()),
-        plan: Object.freeze([...new Set(plan)].sort()),
+        spec: Object.freeze(spec.sort()),
+        plan: Object.freeze(plan.sort()),
       }),
     });
   }

--- a/src/git/planning-remote-base.ts
+++ b/src/git/planning-remote-base.ts
@@ -1,6 +1,7 @@
 import { basename, isAbsolute, relative, resolve } from "node:path";
 import type { CommandRunner } from "../process/command.ts";
 import {
+  isPlanningArtifactPath,
   isPlanningBranch,
   isPlanningSingleLine,
   planningOid,
@@ -121,11 +122,20 @@ export class PlanningRemoteBaseGit {
           "malformed-record",
         );
       const [mode, type, objectId, path] = match.slice(1);
-      if (!planningOid.test(objectId!) || seen.has(path!))
+      if (
+        !planningOid.test(objectId!) ||
+        !isPlanningArtifactPath(path!) ||
+        seen.has(path!)
+      ) {
         throw new PlanningWorkspaceResponseError(
           "tree-inspection",
-          seen.has(path!) ? "duplicate-entry" : "malformed-record",
+          seen.has(path!)
+            ? "duplicate-entry"
+            : !isPlanningArtifactPath(path!)
+              ? "invalid-path"
+              : "malformed-record",
         );
+      }
       if (
         (mode === "160000" && type !== "commit") ||
         (mode !== "160000" && type !== "blob")

--- a/src/git/planning-remote-base.ts
+++ b/src/git/planning-remote-base.ts
@@ -1,0 +1,141 @@
+import { basename, isAbsolute, relative, resolve } from "node:path";
+import type { CommandRunner } from "../process/command.ts";
+import {
+  PlanningWorkspaceCommandError,
+  PlanningWorkspaceResponseError,
+} from "./planning-workspaces.ts";
+import type { PlanningRemoteBaseSnapshot } from "./planning-workspaces.ts";
+const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+function directory(root: string, value: string): string {
+  const absolute = isAbsolute(value) ? resolve(value) : resolve(root, value);
+  const path = relative(root, absolute).replaceAll("\\", "/");
+  if (
+    path === "" ||
+    isAbsolute(path) ||
+    path === ".." ||
+    path.startsWith("../")
+  )
+    throw new RangeError(
+      "Planning artifact directory must be inside repository root",
+    );
+  return path;
+}
+function check(
+  result: { code: number },
+  operation: "fetch" | "ref-resolution" | "tree-inspection",
+): void {
+  if (result.code !== 0)
+    throw new PlanningWorkspaceCommandError(
+      operation,
+      result as { code: number; stdout: string; stderr: string },
+    );
+}
+export class PlanningRemoteBaseGit {
+  readonly runner: CommandRunner;
+  readonly repoRoot: string;
+  readonly specsDir: string;
+  readonly plansDir: string;
+  constructor(input: {
+    runner: CommandRunner;
+    repoRoot: string;
+    specsDir: string;
+    plansDir: string;
+  }) {
+    this.runner = input.runner;
+    this.repoRoot = resolve(input.repoRoot);
+    this.specsDir = directory(this.repoRoot, input.specsDir);
+    this.plansDir = directory(this.repoRoot, input.plansDir);
+  }
+  async fetch(input: {
+    issueNumber: number;
+    remote: string;
+    baseBranch: string;
+  }): Promise<PlanningRemoteBaseSnapshot> {
+    if (
+      !Number.isSafeInteger(input.issueNumber) ||
+      input.issueNumber < 1 ||
+      !input.remote ||
+      !input.baseBranch
+    )
+      throw new RangeError("Invalid planning remote-base input");
+    const ref = `refs/remotes/${input.remote}/${input.baseBranch}`;
+    let result = await this.runner.run(
+      "git",
+      [
+        "fetch",
+        "--no-tags",
+        "--",
+        input.remote,
+        `+refs/heads/${input.baseBranch}:${ref}`,
+      ],
+      { cwd: this.repoRoot },
+    );
+    check(result, "fetch");
+    result = await this.runner.run(
+      "git",
+      ["rev-parse", "--verify", `${ref}^{commit}`],
+      { cwd: this.repoRoot },
+    );
+    check(result, "ref-resolution");
+    const baseOid = result.stdout.trim();
+    if (!OID.test(baseOid))
+      throw new PlanningWorkspaceResponseError(
+        "ref-resolution",
+        "invalid-object-id",
+      );
+    result = await this.runner.run(
+      "git",
+      [
+        "ls-tree",
+        "-r",
+        "-z",
+        "--full-tree",
+        baseOid,
+        "--",
+        this.specsDir,
+        this.plansDir,
+      ],
+      { cwd: this.repoRoot },
+    );
+    check(result, "tree-inspection");
+    const spec: string[] = [];
+    const plan: string[] = [];
+    if (result.stdout !== "" && !result.stdout.endsWith("\0"))
+      throw new PlanningWorkspaceResponseError(
+        "tree-inspection",
+        "unterminated-record",
+      );
+    for (const record of result.stdout.split("\0").filter(Boolean)) {
+      const match =
+        /^(100644|100755) (blob) ([0-9a-f]{40}|[0-9a-f]{64})\t(.+)$/u.exec(
+          record,
+        );
+      if (match === null) {
+        if (/^(120000|160000) /u.test(record)) continue;
+        throw new PlanningWorkspaceResponseError(
+          "tree-inspection",
+          "malformed-record",
+        );
+      }
+      const path = match[4]!;
+      if (
+        !path.includes("\0") &&
+        basename(path).includes(`-issue-${input.issueNumber}-`)
+      ) {
+        if (path === this.specsDir || path.startsWith(`${this.specsDir}/`))
+          spec.push(path);
+        if (path === this.plansDir || path.startsWith(`${this.plansDir}/`))
+          plan.push(path);
+      }
+    }
+    return Object.freeze({
+      remote: input.remote,
+      baseBranch: input.baseBranch,
+      baseOid,
+      artifactCandidates: Object.freeze({
+        spec: Object.freeze([...new Set(spec)].sort()),
+        plan: Object.freeze([...new Set(plan)].sort()),
+      }),
+    });
+  }
+}

--- a/src/git/planning-remote-base.ts
+++ b/src/git/planning-remote-base.ts
@@ -1,16 +1,15 @@
 import { basename, isAbsolute, relative, resolve } from "node:path";
 import type { CommandRunner } from "../process/command.ts";
 import {
+  isPlanningBranch,
+  isPlanningSingleLine,
+  planningOid,
+} from "./planning-git-validation.ts";
+import {
   PlanningWorkspaceCommandError,
   PlanningWorkspaceResponseError,
 } from "./planning-workspaces.ts";
 import type { PlanningRemoteBaseSnapshot } from "./planning-workspaces.ts";
-const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
-const BRANCH =
-  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
-function remote(value: string): boolean {
-  return value.length > 0 && value.length <= 1024 && !/[\0\r\n]/u.test(value);
-}
 function directory(root: string, value: string): string {
   const absolute = isAbsolute(value) ? resolve(value) : resolve(root, value);
   const path = relative(root, absolute).replaceAll("\\", "/");
@@ -59,8 +58,8 @@ export class PlanningRemoteBaseGit {
     if (
       !Number.isSafeInteger(input.issueNumber) ||
       input.issueNumber < 1 ||
-      !remote(input.remote) ||
-      !BRANCH.test(input.baseBranch)
+      !isPlanningSingleLine(input.remote) ||
+      !isPlanningBranch(input.baseBranch)
     )
       throw new RangeError("Invalid planning remote-base input");
     const ref = `refs/remotes/${input.remote}/${input.baseBranch}`;
@@ -83,7 +82,7 @@ export class PlanningRemoteBaseGit {
     );
     check(result, "ref-resolution");
     const baseOid = result.stdout.trim();
-    if (!OID.test(baseOid))
+    if (!planningOid.test(baseOid))
       throw new PlanningWorkspaceResponseError(
         "ref-resolution",
         "invalid-object-id",
@@ -122,7 +121,7 @@ export class PlanningRemoteBaseGit {
           "malformed-record",
         );
       const [mode, type, objectId, path] = match.slice(1);
-      if (!OID.test(objectId!) || seen.has(path!))
+      if (!planningOid.test(objectId!) || seen.has(path!))
         throw new PlanningWorkspaceResponseError(
           "tree-inspection",
           seen.has(path!) ? "duplicate-entry" : "malformed-record",

--- a/src/git/planning-remote-base.ts
+++ b/src/git/planning-remote-base.ts
@@ -6,6 +6,11 @@ import {
 } from "./planning-workspaces.ts";
 import type { PlanningRemoteBaseSnapshot } from "./planning-workspaces.ts";
 const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const BRANCH =
+  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
+function remote(value: string): boolean {
+  return value.length > 0 && value.length <= 1024 && !/[\0\r\n]/u.test(value);
+}
 function directory(root: string, value: string): string {
   const absolute = isAbsolute(value) ? resolve(value) : resolve(root, value);
   const path = relative(root, absolute).replaceAll("\\", "/");
@@ -54,8 +59,8 @@ export class PlanningRemoteBaseGit {
     if (
       !Number.isSafeInteger(input.issueNumber) ||
       input.issueNumber < 1 ||
-      !input.remote ||
-      !input.baseBranch
+      !remote(input.remote) ||
+      !BRANCH.test(input.baseBranch)
     )
       throw new RangeError("Invalid planning remote-base input");
     const ref = `refs/remotes/${input.remote}/${input.baseBranch}`;
@@ -122,8 +127,16 @@ export class PlanningRemoteBaseGit {
           "tree-inspection",
           seen.has(path!) ? "duplicate-entry" : "malformed-record",
         );
+      if (
+        (mode === "160000" && type !== "commit") ||
+        (mode !== "160000" && type !== "blob")
+      )
+        throw new PlanningWorkspaceResponseError(
+          "tree-inspection",
+          "invalid-mode-type",
+        );
       seen.add(path!);
-      if ((mode !== "100644" && mode !== "100755") || type !== "blob") continue;
+      if (mode === "120000" || mode === "160000") continue;
       if (basename(path!).includes(`-issue-${input.issueNumber}-`)) {
         if (path === this.specsDir || path!.startsWith(`${this.specsDir}/`))
           spec.push(path!);

--- a/src/git/planning-workspace-cleanup.ts
+++ b/src/git/planning-workspace-cleanup.ts
@@ -153,8 +153,8 @@ export class PlanningWorkspaceCleanupGit {
       ],
       "remote-head-inspection",
     );
-    const expected = `${workspace.cleanup.pushedHeadOid}\trefs/heads/${workspace.identity.branch}`;
-    if (remote.stdout.trim() !== expected) {
+    const expected = `${workspace.cleanup.pushedHeadOid}\trefs/heads/${workspace.identity.branch}\n`;
+    if (remote.stdout !== expected) {
       throw new PlanningWorkspaceConflictError(
         "remote-head-mismatch",
         workspace.identity,

--- a/src/git/planning-workspace-cleanup.ts
+++ b/src/git/planning-workspace-cleanup.ts
@@ -1,0 +1,164 @@
+import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
+import { PlanningWorkspaceRepositoryGit } from "./planning-workspace-inspection.ts";
+import {
+  PlanningWorkspaceConflictError,
+  type PlanningWorkspaceOwnership,
+  type PlanningWorkspaceSnapshot,
+} from "./planning-workspaces.ts";
+
+export class PlanningWorkspaceCleanupGit {
+  private readonly repository: PlanningWorkspaceRepositoryGit;
+
+  constructor(repository: PlanningWorkspaceRepositoryGit) {
+    this.repository = repository;
+  }
+
+  async removeWorktree(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  }): Promise<
+    Extract<PlanningWorkspaceSnapshot, { state: "branch-only" | "missing" }>
+  > {
+    const { workspace } = input;
+    this.assertOwner(input.runId, input.phase, workspace);
+    const snapshot = await this.repository.inspect(workspace.identity);
+    const path = this.repository.path(workspace.identity);
+    if (snapshot.state === "missing") {
+      await this.assertPathAbsent(path, workspace);
+      return snapshot;
+    }
+    if (snapshot.state === "branch-only") {
+      await this.assertPathAbsent(path, workspace);
+      this.assertHead(snapshot.headOid, workspace);
+      return snapshot;
+    }
+    this.assertHead(snapshot.headOid, workspace);
+    if (!snapshot.clean) {
+      throw new PlanningWorkspaceConflictError(
+        "dirty-worktree",
+        workspace.identity,
+      );
+    }
+    await this.repository.run(
+      ["worktree", "remove", "--", path],
+      "worktree-remove",
+    );
+    const after = await this.repository.inspect(workspace.identity);
+    if (after.state === "ready") {
+      throw new PlanningWorkspaceConflictError(
+        "unsafe-registration",
+        workspace.identity,
+      );
+    }
+    return after;
+  }
+
+  async removeBranch(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{
+      state: "worktree-removed";
+      pushedHeadOid: string;
+    }>;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "missing" }>> {
+    const { workspace } = input;
+    this.assertOwner(input.runId, input.phase, workspace);
+    this.assertHead(workspace.cleanup.pushedHeadOid, workspace);
+    const current = await this.repository.inspect(workspace.identity);
+    if (current.state === "ready") {
+      throw new PlanningWorkspaceConflictError(
+        "branch-owned-by-other-worktree",
+        workspace.identity,
+      );
+    }
+    await this.assertPathAbsent(
+      this.repository.path(workspace.identity),
+      workspace,
+    );
+    await this.assertRemoteHead(workspace);
+    if (current.state === "branch-only") {
+      this.assertHead(current.headOid, workspace);
+      await this.repository.run(
+        [
+          "update-ref",
+          "-d",
+          `refs/heads/${workspace.identity.branch}`,
+          workspace.headOid,
+        ],
+        "branch-deletion",
+      );
+    }
+    const after = await this.repository.inspect(workspace.identity);
+    if (after.state !== "missing") {
+      throw new PlanningWorkspaceConflictError(
+        "unsafe-registration",
+        workspace.identity,
+      );
+    }
+    return after;
+  }
+
+  private assertOwner(
+    runId: string,
+    phase: PlanningPhaseKind,
+    workspace: PlanningWorkspaceOwnership,
+  ): void {
+    if (runId !== workspace.runId || phase !== workspace.phase) {
+      throw new PlanningWorkspaceConflictError(
+        "invalid-saved-identity",
+        workspace.identity,
+      );
+    }
+  }
+
+  private assertHead(
+    actual: string,
+    workspace: PlanningWorkspaceOwnership,
+  ): void {
+    if (actual !== workspace.headOid) {
+      throw new PlanningWorkspaceConflictError(
+        "head-oid-mismatch",
+        workspace.identity,
+      );
+    }
+  }
+
+  private async assertPathAbsent(
+    path: string,
+    workspace: PlanningWorkspaceOwnership,
+  ): Promise<void> {
+    if (await this.repository.existing(path)) {
+      throw new PlanningWorkspaceConflictError(
+        "unregistered-path",
+        workspace.identity,
+      );
+    }
+  }
+
+  private async assertRemoteHead(
+    workspace: PlanningWorkspaceOwnership<{
+      state: "worktree-removed";
+      pushedHeadOid: string;
+    }>,
+  ): Promise<void> {
+    const remote = await this.repository.run(
+      [
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        "--",
+        workspace.remote,
+        `refs/heads/${workspace.identity.branch}`,
+      ],
+      "remote-head-inspection",
+    );
+    const expected = `${workspace.cleanup.pushedHeadOid}\trefs/heads/${workspace.identity.branch}`;
+    if (remote.stdout.trim() !== expected) {
+      throw new PlanningWorkspaceConflictError(
+        "remote-head-mismatch",
+        workspace.identity,
+      );
+    }
+  }
+}

--- a/src/git/planning-workspace-git.test.ts
+++ b/src/git/planning-workspace-git.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type { CommandRunner } from "../process/command.ts";
+import { PlanningRemoteBaseGit } from "./planning-remote-base.ts";
 import { PlanningWorkspaceGit } from "./planning-workspace-git.ts";
+import type { PlanningWorkspaceOwnership } from "./planning-workspaces.ts";
 const oid = "a".repeat(40);
 const identity = { branch: "topic", worktreePath: ".worktrees/topic" };
 const base = {
@@ -68,6 +74,163 @@ test("prepares at exact pinned OID and resumes saved ownership without mutation"
       ),
   );
 });
+test("invalid prepare evidence is rejected before any Git command", async () => {
+  const calls: string[][] = [];
+  const git = new PlanningWorkspaceGit({
+    runner: {
+      run: async (_command, args) => {
+        calls.push(args);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+    repoRoot: "/repo",
+    worktreeRoot: "/repo/.worktrees",
+  });
+  const valid = {
+    runId: "123e4567-e89b-42d3-a456-426614174000",
+    phase: "spec" as const,
+    identity,
+    base,
+  };
+  for (const candidate of [
+    { ...valid, runId: "not-a-uuid" },
+    { ...valid, phase: "unknown" },
+    { ...valid, identity: { ...identity, branch: "bad branch" } },
+    { ...valid, base: { ...base, remote: "bad\nremote" } },
+    { ...valid, base: { ...base, baseBranch: "bad branch" } },
+    {
+      ...valid,
+      base: {
+        ...base,
+        artifactCandidates: { spec: ["../outside.md"], plan: [] },
+      },
+    },
+  ]) {
+    await assert.rejects(
+      git.prepare(candidate as Parameters<PlanningWorkspaceGit["prepare"]>[0]),
+      /invalid-saved-identity/,
+    );
+  }
+  assert.deepEqual(calls, []);
+});
+
+test("fresh prepare refuses every branch and worktree registration collision", async () => {
+  const registrations = [
+    { label: "branch-only collision", output: "", branchExists: true },
+    {
+      label: "path owned by another branch",
+      output: `worktree /repo/.worktrees/topic\0HEAD ${oid}\0branch refs/heads/other\0\0`,
+      branchExists: false,
+    },
+    {
+      label: "branch owned by another worktree",
+      output: `worktree /repo/.worktrees/other\0HEAD ${oid}\0branch refs/heads/topic\0\0`,
+      branchExists: true,
+    },
+    {
+      label: "detached expected path",
+      output: `worktree /repo/.worktrees/topic\0HEAD ${oid}\0detached\0\0`,
+      branchExists: false,
+    },
+    {
+      label: "locked expected path",
+      output: `worktree /repo/.worktrees/topic\0HEAD ${oid}\0branch refs/heads/topic\0locked reason\0\0`,
+      branchExists: true,
+    },
+    {
+      label: "prunable expected path",
+      output: `worktree /repo/.worktrees/topic\0HEAD ${oid}\0branch refs/heads/topic\0prunable reason\0\0`,
+      branchExists: true,
+    },
+    {
+      label: "malformed response",
+      output: `worktree relative\0HEAD ${oid}\0branch refs/heads/topic\0\0`,
+      branchExists: true,
+    },
+  ];
+  for (const item of registrations) {
+    const calls: string[][] = [];
+    const git = new PlanningWorkspaceGit({
+      runner: {
+        run: async (_command, args) => {
+          calls.push(args);
+          if (args[0] === "worktree" && args[1] === "list") {
+            return { code: 0, stdout: item.output, stderr: "" };
+          }
+          if (args[0] === "show-ref") {
+            return {
+              code: item.branchExists ? 0 : 1,
+              stdout: "",
+              stderr: "",
+            };
+          }
+          if (args[0] === "rev-parse") {
+            return { code: 0, stdout: `${oid}\n`, stderr: "" };
+          }
+          throw new Error(`unexpected command ${args.join(" ")}`);
+        },
+      },
+      repoRoot: "/repo",
+      worktreeRoot: "/repo/.worktrees",
+    });
+    await assert.rejects(
+      git.prepare({
+        runId: "123e4567-e89b-42d3-a456-426614174000",
+        phase: "spec",
+        identity,
+        base,
+      }),
+      undefined,
+      item.label,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "worktree" && args[1] === "add"),
+      false,
+      item.label,
+    );
+  }
+});
+
+test("fresh prepare refuses an existing unregistered path", async () => {
+  const root = await mkdtemp(join(tmpdir(), "planning-collision-"));
+  const repo = join(root, "repo");
+  const worktreeRoot = join(root, "worktrees");
+  await mkdir(repo);
+  await mkdir(join(worktreeRoot, "topic"), { recursive: true });
+  const calls: string[][] = [];
+  try {
+    const git = new PlanningWorkspaceGit({
+      runner: {
+        run: async (_command, args) => {
+          calls.push(args);
+          if (args[0] === "worktree")
+            return { code: 0, stdout: "", stderr: "" };
+          if (args[0] === "show-ref")
+            return { code: 1, stdout: "", stderr: "" };
+          throw new Error(`unexpected command ${args.join(" ")}`);
+        },
+      },
+      repoRoot: repo,
+      worktreeRoot,
+    });
+    await assert.rejects(
+      git.prepare({
+        runId: "123e4567-e89b-42d3-a456-426614174000",
+        phase: "spec",
+        identity: { branch: "topic", worktreePath: "../worktrees/topic" },
+        base,
+      }),
+      /path-collision/,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "worktree" && args[1] === "add"),
+      false,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("cleanup rejects dirty owned worktrees before destructive command", async () => {
   const runner: CommandRunner = {
     run: async (_command, args) => {
@@ -108,3 +271,288 @@ test("cleanup rejects dirty owned worktrees before destructive command", async (
     /dirty-worktree/,
   );
 });
+
+test("branch cleanup requires exact remote proof and expected-old CAS", async () => {
+  const runId = "123e4567-e89b-42d3-a456-426614174000";
+  const workspace: PlanningWorkspaceOwnership<{
+    state: "worktree-removed";
+    pushedHeadOid: string;
+  }> = {
+    runId,
+    phase: "spec",
+    identity,
+    remote: "origin",
+    baseBranch: "main",
+    baseOid: oid,
+    headOid: oid,
+    cleanup: { state: "worktree-removed", pushedHeadOid: oid },
+  };
+  const exact = `${oid}\trefs/heads/topic\n`;
+  for (const stdout of [
+    `${"b".repeat(40)}\trefs/heads/topic\n`,
+    `${oid}\trefs/heads/other\n`,
+    `${exact}${exact}`,
+    "malformed\n",
+  ]) {
+    const calls: string[][] = [];
+    const adapter = new PlanningWorkspaceGit({
+      runner: {
+        run: async (_command, args) => {
+          calls.push(args);
+          if (args[0] === "worktree")
+            return { code: 0, stdout: "", stderr: "" };
+          if (args[0] === "show-ref")
+            return { code: 0, stdout: "", stderr: "" };
+          if (args[0] === "rev-parse")
+            return { code: 0, stdout: `${oid}\n`, stderr: "" };
+          if (args[0] === "ls-remote") return { code: 0, stdout, stderr: "" };
+          throw new Error(`unexpected command ${args.join(" ")}`);
+        },
+      },
+      repoRoot: "/repo",
+      worktreeRoot: "/repo/.worktrees",
+    });
+    await assert.rejects(
+      adapter.removeBranch({ runId, phase: "spec", workspace }),
+      /remote-head-mismatch/,
+    );
+    assert.equal(
+      calls.some((args) => args[0] === "update-ref"),
+      false,
+    );
+  }
+
+  const calls: string[][] = [];
+  const adapter = new PlanningWorkspaceGit({
+    runner: {
+      run: async (_command, args) => {
+        calls.push(args);
+        if (args[0] === "worktree") return { code: 0, stdout: "", stderr: "" };
+        if (args[0] === "show-ref") return { code: 0, stdout: "", stderr: "" };
+        if (args[0] === "rev-parse")
+          return { code: 0, stdout: `${oid}\n`, stderr: "" };
+        if (args[0] === "ls-remote")
+          return { code: 0, stdout: exact, stderr: "" };
+        if (args[0] === "update-ref")
+          return { code: 1, stdout: "", stderr: "changed" };
+        throw new Error(`unexpected command ${args.join(" ")}`);
+      },
+    },
+    repoRoot: "/repo",
+    worktreeRoot: "/repo/.worktrees",
+  });
+  await assert.rejects(
+    adapter.removeBranch({ runId, phase: "spec", workspace }),
+    /branch-deletion/,
+  );
+  assert.deepEqual(
+    calls.find((args) => args[0] === "update-ref"),
+    ["update-ref", "-d", "refs/heads/topic", oid],
+  );
+  assert.equal(
+    calls.some((args) => args.includes("-D")),
+    false,
+  );
+});
+
+test(
+  "real Git creates at the pinned OID, resumes without index mutation, and cleans up idempotently",
+  { timeout: 30_000 },
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), "planning-workspace-"));
+    const remote = join(root, "remote.git");
+    const seed = join(root, "seed");
+    const repo = join(root, "repo");
+    const worktreeRoot = join(root, "worktrees");
+    const git = (cwd: string, ...args: string[]) =>
+      execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+    const runner: CommandRunner = {
+      run: async (command, args, options) => {
+        try {
+          return {
+            code: 0,
+            stdout: execFileSync(command, args, {
+              cwd: options?.cwd,
+              encoding: "utf8",
+              env: { ...process.env, ...options?.env },
+            }),
+            stderr: "",
+          };
+        } catch (error) {
+          const failure = error as {
+            status?: number;
+            stdout?: string;
+            stderr?: string;
+          };
+          return {
+            code: failure.status ?? 1,
+            stdout: failure.stdout ?? "",
+            stderr: failure.stderr ?? "",
+          };
+        }
+      },
+    };
+    try {
+      execFileSync("git", ["init", "--bare", "--initial-branch=main", remote]);
+      execFileSync("git", ["init", "-b", "main", seed]);
+      git(seed, "config", "user.name", "Patchmill Test");
+      git(seed, "config", "user.email", "patchmill@example.test");
+      await writeFile(join(seed, "tracked.txt"), "base\n");
+      await writeFile(join(seed, ".gitignore"), "ignored.txt\n");
+      git(seed, "add", ".");
+      git(seed, "commit", "-m", "base");
+      git(seed, "remote", "add", "origin", remote);
+      git(seed, "push", "-u", "origin", "main");
+      execFileSync("git", ["clone", remote, repo]);
+      await mkdir(worktreeRoot);
+
+      const remoteBase = new PlanningRemoteBaseGit({
+        runner,
+        repoRoot: repo,
+        specsDir: "docs/specs",
+        plansDir: "docs/plans",
+      });
+      const snapshot = await remoteBase.fetch({
+        issueNumber: 187,
+        remote: "origin",
+        baseBranch: "main",
+      });
+      await writeFile(join(seed, "tracked.txt"), "remote advanced\n");
+      git(seed, "add", "tracked.txt");
+      git(seed, "commit", "-m", "advance remote");
+      git(seed, "push", "origin", "main");
+      assert.notEqual(snapshot.baseOid, git(seed, "rev-parse", "HEAD"));
+
+      const workspace = new PlanningWorkspaceGit({
+        runner,
+        repoRoot: repo,
+        worktreeRoot,
+      });
+      const ownedIdentity = {
+        branch: "planning/spec",
+        worktreePath: "../worktrees/spec",
+      };
+      const prepared = await workspace.prepare({
+        runId: "123e4567-e89b-42d3-a456-426614174000",
+        phase: "spec",
+        identity: ownedIdentity,
+        base: snapshot,
+      });
+      const worktreePath = join(worktreeRoot, "spec");
+      assert.equal(git(worktreePath, "rev-parse", "HEAD"), snapshot.baseOid);
+      const indexPath = git(worktreePath, "rev-parse", "--git-path", "index");
+      const indexBefore = await readFile(indexPath);
+      const refsBefore = git(repo, "show-ref");
+      await workspace.resume({
+        runId: prepared.workspace.runId,
+        phase: "spec",
+        identity: ownedIdentity,
+        base: snapshot,
+        saved: prepared.workspace,
+      });
+      await workspace.resume({
+        runId: prepared.workspace.runId,
+        phase: "spec",
+        identity: ownedIdentity,
+        base: snapshot,
+        saved: prepared.workspace,
+      });
+      assert.deepEqual(await readFile(indexPath), indexBefore);
+      assert.equal(git(repo, "show-ref"), refsBefore);
+
+      git(worktreePath, "push", "-u", "origin", ownedIdentity.branch);
+      const branchOnly = await workspace.removeWorktree({
+        runId: prepared.workspace.runId,
+        phase: "spec",
+        workspace: prepared.workspace,
+      });
+      assert.equal(branchOnly.state, "branch-only");
+      assert.equal(
+        (
+          await workspace.removeWorktree({
+            runId: prepared.workspace.runId,
+            phase: "spec",
+            workspace: prepared.workspace,
+          })
+        ).state,
+        "branch-only",
+      );
+      const pushed: PlanningWorkspaceOwnership<{
+        state: "worktree-removed";
+        pushedHeadOid: string;
+      }> = {
+        ...prepared.workspace,
+        cleanup: {
+          state: "worktree-removed",
+          pushedHeadOid: prepared.workspace.headOid,
+        },
+      };
+      assert.equal(
+        (
+          await workspace.removeBranch({
+            runId: pushed.runId,
+            phase: "spec",
+            workspace: pushed,
+          })
+        ).state,
+        "missing",
+      );
+      assert.equal(
+        (
+          await workspace.removeBranch({
+            runId: pushed.runId,
+            phase: "spec",
+            workspace: pushed,
+          })
+        ).state,
+        "missing",
+      );
+
+      for (const dirty of [
+        "tracked",
+        "staged",
+        "untracked",
+        "ignored",
+      ] as const) {
+        const dirtyIdentity = {
+          branch: `planning/${dirty}`,
+          worktreePath: `../worktrees/${dirty}`,
+        };
+        const dirtyPrepared = await workspace.prepare({
+          runId: "123e4567-e89b-42d3-a456-426614174000",
+          phase: "spec",
+          identity: dirtyIdentity,
+          base: snapshot,
+        });
+        const dirtyPath = join(worktreeRoot, dirty);
+        if (dirty === "tracked" || dirty === "staged") {
+          await writeFile(join(dirtyPath, "tracked.txt"), `${dirty}\n`);
+          if (dirty === "staged") git(dirtyPath, "add", "tracked.txt");
+        } else {
+          await writeFile(join(dirtyPath, `${dirty}.txt`), `${dirty}\n`);
+        }
+        await assert.rejects(
+          workspace.removeWorktree({
+            runId: dirtyPrepared.workspace.runId,
+            phase: "spec",
+            workspace: dirtyPrepared.workspace,
+          }),
+          /dirty-worktree/,
+          dirty,
+        );
+        git(dirtyPath, "reset", "--hard", "HEAD");
+        if (dirty === "untracked" || dirty === "ignored") {
+          await rm(join(dirtyPath, `${dirty}.txt`), { force: true });
+        }
+        await workspace.removeWorktree({
+          runId: dirtyPrepared.workspace.runId,
+          phase: "spec",
+          workspace: dirtyPrepared.workspace,
+        });
+        git(repo, "branch", "-D", dirtyIdentity.branch);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/src/git/planning-workspace-git.test.ts
+++ b/src/git/planning-workspace-git.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { CommandRunner } from "../process/command.ts";
+import { PlanningWorkspaceGit } from "./planning-workspace-git.ts";
+const oid = "a".repeat(40);
+const identity = { branch: "topic", worktreePath: ".worktrees/topic" };
+const base = {
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid,
+  artifactCandidates: { spec: [], plan: [] },
+};
+test("prepares at exact pinned OID and resumes saved ownership without mutation", async () => {
+  let added = false;
+  const calls: string[][] = [];
+  const runner: CommandRunner = {
+    run: async (_command, args) => {
+      calls.push(args);
+      if (args[0] === "worktree" && args[1] === "list")
+        return {
+          code: 0,
+          stdout: added
+            ? `worktree /repo/.worktrees/topic\0HEAD ${oid}\0branch refs/heads/topic\0\0`
+            : "",
+          stderr: "",
+        };
+      if (args[0] === "show-ref")
+        return { code: added ? 0 : 1, stdout: "", stderr: "" };
+      if (args[0] === "worktree" && args[1] === "add") {
+        added = true;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "rev-parse")
+        return { code: 0, stdout: `${oid}\n`, stderr: "" };
+      if (args.includes("status")) return { code: 0, stdout: "", stderr: "" };
+      return { code: 0, stdout: "", stderr: "" };
+    },
+  };
+  const git = new PlanningWorkspaceGit({
+    runner,
+    repoRoot: "/repo",
+    worktreeRoot: "/repo/.worktrees",
+  });
+  const prepared = await git.prepare({
+    runId: "123e4567-e89b-42d3-a456-426614174000",
+    phase: "spec",
+    identity,
+    base,
+  });
+  assert.equal(prepared.workspace.headOid, oid);
+  const before = calls.length;
+  assert.deepEqual(
+    await git.resume({
+      runId: prepared.workspace.runId,
+      phase: "spec",
+      identity,
+      base,
+      saved: prepared.workspace,
+    }),
+    prepared.snapshot,
+  );
+  assert.ok(
+    calls
+      .slice(before)
+      .every(
+        (args) =>
+          args[0] !== "fetch" && !(args[0] === "worktree" && args[1] === "add"),
+      ),
+  );
+});

--- a/src/git/planning-workspace-git.test.ts
+++ b/src/git/planning-workspace-git.test.ts
@@ -68,3 +68,43 @@ test("prepares at exact pinned OID and resumes saved ownership without mutation"
       ),
   );
 });
+test("cleanup rejects dirty owned worktrees before destructive command", async () => {
+  const runner: CommandRunner = {
+    run: async (_command, args) => {
+      if (args[0] === "worktree" && args[1] === "list")
+        return {
+          code: 0,
+          stdout: `worktree /repo/.worktrees/topic\0HEAD ${oid}\0branch refs/heads/topic\0\0`,
+          stderr: "",
+        };
+      if (args[0] === "show-ref") return { code: 0, stdout: "", stderr: "" };
+      if (args[0] === "rev-parse")
+        return { code: 0, stdout: `${oid}\n`, stderr: "" };
+      if (args.includes("status"))
+        return { code: 0, stdout: " M changed\0", stderr: "" };
+      throw new Error(`unexpected command ${args.join(" ")}`);
+    },
+  };
+  const git = new PlanningWorkspaceGit({
+    runner,
+    repoRoot: "/repo",
+    worktreeRoot: "/repo/.worktrees",
+  });
+  await assert.rejects(
+    git.removeWorktree({
+      runId: "123e4567-e89b-42d3-a456-426614174000",
+      phase: "spec",
+      workspace: {
+        runId: "123e4567-e89b-42d3-a456-426614174000",
+        phase: "spec",
+        identity,
+        remote: "origin",
+        baseBranch: "main",
+        baseOid: oid,
+        headOid: oid,
+        cleanup: { state: "ready" },
+      },
+    }),
+    /dirty-worktree/,
+  );
+});

--- a/src/git/planning-workspace-git.test.ts
+++ b/src/git/planning-workspace-git.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import type { CommandRunner } from "../process/command.ts";
 import { PlanningRemoteBaseGit } from "./planning-remote-base.ts";
 import { PlanningWorkspaceGit } from "./planning-workspace-git.ts";
+import { isPlanningRelativeWithinRoot } from "./planning-workspace-input.ts";
 import type { PlanningWorkspaceOwnership } from "./planning-workspaces.ts";
 const oid = "a".repeat(40);
 const identity = { branch: "topic", worktreePath: ".worktrees/topic" };
@@ -96,6 +97,7 @@ test("invalid prepare evidence is rejected before any Git command", async () => 
     { ...valid, runId: "not-a-uuid" },
     { ...valid, phase: "unknown" },
     { ...valid, identity: { ...identity, branch: "bad branch" } },
+    { ...valid, identity: { ...identity, branch: "bad\u00a0branch" } },
     { ...valid, base: { ...base, remote: "bad\nremote" } },
     { ...valid, base: { ...base, baseBranch: "bad branch" } },
     {
@@ -112,6 +114,9 @@ test("invalid prepare evidence is rejected before any Git command", async () => 
     );
   }
   assert.deepEqual(calls, []);
+  assert.equal(isPlanningRelativeWithinRoot("D:\\owned"), false);
+  assert.equal(isPlanningRelativeWithinRoot("../owned"), false);
+  assert.equal(isPlanningRelativeWithinRoot("phase/spec"), true);
 });
 
 test("fresh prepare refuses every branch and worktree registration collision", async () => {
@@ -293,6 +298,9 @@ test("branch cleanup requires exact remote proof and expected-old CAS", async ()
     `${oid}\trefs/heads/other\n`,
     `${exact}${exact}`,
     "malformed\n",
+    `\n${exact}`,
+    `${exact}\n`,
+    ` ${exact}`,
   ]) {
     const calls: string[][] = [];
     const adapter = new PlanningWorkspaceGit({

--- a/src/git/planning-workspace-git.ts
+++ b/src/git/planning-workspace-git.ts
@@ -34,7 +34,8 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
   private path(identity: PlanningWorkspaceIdentity): string {
     const path = resolve(this.repoRoot, identity.worktreePath);
     const rel = relative(this.worktreeRoot, path);
-    if (rel === ".." || rel.startsWith("../") || !rel)
+    const portable = rel.replaceAll("\\", "/");
+    if (portable === ".." || portable.startsWith("../"))
       throw new PlanningWorkspaceConflictError(
         "outside-worktree-root",
         identity,
@@ -94,6 +95,7 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
   private async clean(path: string): Promise<boolean> {
     const result = await this.run(
       [
+        "--no-optional-locks",
         "-C",
         path,
         "status",
@@ -121,6 +123,14 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
     const path = this.path(identity);
     const entries = await this.entries();
     const entry = entries.find((item) => item.path === path);
+    const branchElsewhere = entries.find(
+      (item) => item.branch === identity.branch && item.path !== path,
+    );
+    if (branchElsewhere !== undefined)
+      throw new PlanningWorkspaceConflictError(
+        "branch-owned-by-other-worktree",
+        identity,
+      );
     const head = await this.branchHead(identity.branch);
     if (entry === undefined)
       return head === undefined
@@ -247,8 +257,20 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
         workspace.identity,
       );
     const snapshot = await this.inspect(workspace.identity);
-    if (snapshot.state === "missing") return snapshot;
+    if (snapshot.state === "missing") {
+      if (await this.existing(this.path(workspace.identity)))
+        throw new PlanningWorkspaceConflictError(
+          "unregistered-path",
+          workspace.identity,
+        );
+      return snapshot;
+    }
     if (snapshot.state === "branch-only") {
+      if (await this.existing(this.path(workspace.identity)))
+        throw new PlanningWorkspaceConflictError(
+          "unregistered-path",
+          workspace.identity,
+        );
       if (snapshot.headOid !== workspace.headOid)
         throw new PlanningWorkspaceConflictError(
           "head-oid-mismatch",
@@ -292,10 +314,20 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
         "invalid-saved-identity",
         workspace.identity,
       );
+    if (workspace.cleanup.pushedHeadOid !== workspace.headOid)
+      throw new PlanningWorkspaceConflictError(
+        "head-oid-mismatch",
+        workspace.identity,
+      );
     const current = await this.inspect(workspace.identity);
     if (current.state === "ready")
       throw new PlanningWorkspaceConflictError(
         "branch-owned-by-other-worktree",
+        workspace.identity,
+      );
+    if (await this.existing(this.path(workspace.identity)))
+      throw new PlanningWorkspaceConflictError(
+        "unregistered-path",
         workspace.identity,
       );
     const remote = await this.runner.run(

--- a/src/git/planning-workspace-git.ts
+++ b/src/git/planning-workspace-git.ts
@@ -18,6 +18,34 @@ import {
   type PreparedPlanningWorkspace,
 } from "./planning-workspaces.ts";
 const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const BRANCH =
+  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
+function validPath(path: unknown): path is string {
+  return (
+    typeof path === "string" &&
+    path.length > 0 &&
+    path.length <= 4096 &&
+    !/[\\\0\r\n]/u.test(path) &&
+    !path.startsWith("/") &&
+    !path
+      .split("/")
+      .some((part) => part === "" || part === "." || part === "..")
+  );
+}
+function exact(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === keys.length &&
+    keys.every((key) => key in (value as Record<string, unknown>))
+  );
+}
 export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
   readonly runner: CommandRunner;
   readonly repoRoot: string;
@@ -158,6 +186,7 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
     identity: PlanningWorkspaceIdentity;
     base: PlanningRemoteBaseSnapshot;
   }): Promise<PreparedPlanningWorkspace> {
+    this.validatePrepare(input);
     const path = this.path(input.identity);
     if (!OID.test(input.base.baseOid))
       throw new PlanningWorkspaceConflictError(
@@ -203,6 +232,55 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
       },
       snapshot,
     };
+  }
+  private validatePrepare(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+  }): void {
+    const raw = input as unknown;
+    if (
+      !exact(raw, ["runId", "phase", "identity", "base"]) ||
+      !UUID.test(input.runId) ||
+      !["spec", "plan", "implementation"].includes(input.phase) ||
+      !exact(input.identity, ["branch", "worktreePath"]) ||
+      !BRANCH.test(input.identity.branch) ||
+      typeof input.identity.worktreePath !== "string" ||
+      input.identity.worktreePath.length === 0 ||
+      /[\0\r\n]/u.test(input.identity.worktreePath) ||
+      !exact(input.base, [
+        "remote",
+        "baseBranch",
+        "baseOid",
+        "artifactCandidates",
+      ]) ||
+      typeof input.base.remote !== "string" ||
+      input.base.remote.length === 0 ||
+      input.base.remote.length > 1024 ||
+      /[\0\r\n]/u.test(input.base.remote) ||
+      !BRANCH.test(input.base.baseBranch) ||
+      !OID.test(input.base.baseOid) ||
+      !exact(input.base.artifactCandidates, ["spec", "plan"])
+    )
+      throw new PlanningWorkspaceConflictError(
+        "invalid-saved-identity",
+        input.identity,
+      );
+    for (const values of [
+      input.base.artifactCandidates.spec,
+      input.base.artifactCandidates.plan,
+    ]) {
+      if (
+        !Array.isArray(values) ||
+        values.some((value) => !validPath(value)) ||
+        new Set(values).size !== values.length
+      )
+        throw new PlanningWorkspaceConflictError(
+          "invalid-saved-identity",
+          input.identity,
+        );
+    }
   }
   async resume(input: {
     runId: string;

--- a/src/git/planning-workspace-git.ts
+++ b/src/git/planning-workspace-git.ts
@@ -1,7 +1,12 @@
 import { lstat } from "node:fs/promises";
-import { relative, resolve } from "node:path";
+import { resolve } from "node:path";
 import type { CommandRunner } from "../process/command.ts";
 import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
+import {
+  assertPlanningWorkspacePrepareInput,
+  planningOid,
+  planningWorkspacePath,
+} from "./planning-workspace-input.ts";
 import {
   parsePlanningWorktreePorcelain,
   type PlanningWorktreeRegistration,
@@ -17,35 +22,7 @@ import {
   type PlanningWorkspaceSnapshot,
   type PreparedPlanningWorkspace,
 } from "./planning-workspaces.ts";
-const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
-const UUID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
-const BRANCH =
-  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
-function validPath(path: unknown): path is string {
-  return (
-    typeof path === "string" &&
-    path.length > 0 &&
-    path.length <= 4096 &&
-    !/[\\\0\r\n]/u.test(path) &&
-    !path.startsWith("/") &&
-    !path
-      .split("/")
-      .some((part) => part === "" || part === "." || part === "..")
-  );
-}
-function exact(
-  value: unknown,
-  keys: readonly string[],
-): value is Record<string, unknown> {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    Object.keys(value as Record<string, unknown>).length === keys.length &&
-    keys.every((key) => key in (value as Record<string, unknown>))
-  );
-}
+const OID = planningOid;
 export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
   readonly runner: CommandRunner;
   readonly repoRoot: string;
@@ -60,15 +37,7 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
     this.worktreeRoot = resolve(input.worktreeRoot);
   }
   private path(identity: PlanningWorkspaceIdentity): string {
-    const path = resolve(this.repoRoot, identity.worktreePath);
-    const rel = relative(this.worktreeRoot, path);
-    const portable = rel.replaceAll("\\", "/");
-    if (portable === ".." || portable.startsWith("../"))
-      throw new PlanningWorkspaceConflictError(
-        "outside-worktree-root",
-        identity,
-      );
-    return path;
+    return planningWorkspacePath(this.repoRoot, this.worktreeRoot, identity);
   }
   private async run(
     args: string[],
@@ -186,7 +155,7 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
     identity: PlanningWorkspaceIdentity;
     base: PlanningRemoteBaseSnapshot;
   }): Promise<PreparedPlanningWorkspace> {
-    this.validatePrepare(input);
+    assertPlanningWorkspacePrepareInput(input);
     const path = this.path(input.identity);
     if (!OID.test(input.base.baseOid))
       throw new PlanningWorkspaceConflictError(
@@ -232,55 +201,6 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
       },
       snapshot,
     };
-  }
-  private validatePrepare(input: {
-    runId: string;
-    phase: PlanningPhaseKind;
-    identity: PlanningWorkspaceIdentity;
-    base: PlanningRemoteBaseSnapshot;
-  }): void {
-    const raw = input as unknown;
-    if (
-      !exact(raw, ["runId", "phase", "identity", "base"]) ||
-      !UUID.test(input.runId) ||
-      !["spec", "plan", "implementation"].includes(input.phase) ||
-      !exact(input.identity, ["branch", "worktreePath"]) ||
-      !BRANCH.test(input.identity.branch) ||
-      typeof input.identity.worktreePath !== "string" ||
-      input.identity.worktreePath.length === 0 ||
-      /[\0\r\n]/u.test(input.identity.worktreePath) ||
-      !exact(input.base, [
-        "remote",
-        "baseBranch",
-        "baseOid",
-        "artifactCandidates",
-      ]) ||
-      typeof input.base.remote !== "string" ||
-      input.base.remote.length === 0 ||
-      input.base.remote.length > 1024 ||
-      /[\0\r\n]/u.test(input.base.remote) ||
-      !BRANCH.test(input.base.baseBranch) ||
-      !OID.test(input.base.baseOid) ||
-      !exact(input.base.artifactCandidates, ["spec", "plan"])
-    )
-      throw new PlanningWorkspaceConflictError(
-        "invalid-saved-identity",
-        input.identity,
-      );
-    for (const values of [
-      input.base.artifactCandidates.spec,
-      input.base.artifactCandidates.plan,
-    ]) {
-      if (
-        !Array.isArray(values) ||
-        values.some((value) => !validPath(value)) ||
-        new Set(values).size !== values.length
-      )
-        throw new PlanningWorkspaceConflictError(
-          "invalid-saved-identity",
-          input.identity,
-        );
-    }
   }
   async resume(input: {
     runId: string;

--- a/src/git/planning-workspace-git.ts
+++ b/src/git/planning-workspace-git.ts
@@ -1,20 +1,10 @@
-import { lstat } from "node:fs/promises";
-import { resolve } from "node:path";
 import type { CommandRunner } from "../process/command.ts";
 import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
+import { PlanningWorkspaceCleanupGit } from "./planning-workspace-cleanup.ts";
+import { PlanningWorkspaceRepositoryGit } from "./planning-workspace-inspection.ts";
+import { assertPlanningWorkspacePrepareInput } from "./planning-workspace-input.ts";
 import {
-  assertPlanningWorkspacePrepareInput,
-  planningOid,
-  planningWorkspacePath,
-} from "./planning-workspace-input.ts";
-import {
-  parsePlanningWorktreePorcelain,
-  type PlanningWorktreeRegistration,
-} from "./planning-worktree-porcelain.ts";
-import {
-  PlanningWorkspaceCommandError,
   PlanningWorkspaceConflictError,
-  PlanningWorkspaceResponseError,
   type PlanningRemoteBaseSnapshot,
   type PlanningWorkspaceIdentity,
   type PlanningWorkspaceLifecycle,
@@ -22,133 +12,32 @@ import {
   type PlanningWorkspaceSnapshot,
   type PreparedPlanningWorkspace,
 } from "./planning-workspaces.ts";
-const OID = planningOid;
+
 export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
   readonly runner: CommandRunner;
   readonly repoRoot: string;
   readonly worktreeRoot: string;
+  private readonly repository: PlanningWorkspaceRepositoryGit;
+  private readonly cleanup: PlanningWorkspaceCleanupGit;
+
   constructor(input: {
     runner: CommandRunner;
     repoRoot: string;
     worktreeRoot: string;
   }) {
-    this.runner = input.runner;
-    this.repoRoot = resolve(input.repoRoot);
-    this.worktreeRoot = resolve(input.worktreeRoot);
+    this.repository = new PlanningWorkspaceRepositoryGit(input);
+    this.cleanup = new PlanningWorkspaceCleanupGit(this.repository);
+    this.runner = this.repository.runner;
+    this.repoRoot = this.repository.repoRoot;
+    this.worktreeRoot = this.repository.worktreeRoot;
   }
-  private path(identity: PlanningWorkspaceIdentity): string {
-    return planningWorkspacePath(this.repoRoot, this.worktreeRoot, identity);
-  }
-  private async run(
-    args: string[],
-    operation:
-      | "worktree-inspection"
-      | "worktree-add"
-      | "worktree-remove"
-      | "status"
-      | "ref-resolution"
-      | "remote-head-inspection"
-      | "branch-deletion",
-  ) {
-    const result = await this.runner.run("git", args, { cwd: this.repoRoot });
-    if (result.code !== 0)
-      throw new PlanningWorkspaceCommandError(operation, result);
-    return result;
-  }
-  private async entries(): Promise<readonly PlanningWorktreeRegistration[]> {
-    const result = await this.run(
-      ["worktree", "list", "--porcelain", "-z"],
-      "worktree-inspection",
-    );
-    const parsed = parsePlanningWorktreePorcelain(result.stdout);
-    if (parsed.malformed)
-      throw new PlanningWorkspaceResponseError(
-        "worktree-inspection",
-        "malformed-porcelain",
-      );
-    return parsed.entries;
-  }
-  private async branchHead(branch: string): Promise<string | undefined> {
-    const exists = await this.runner.run(
-      "git",
-      ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
-      { cwd: this.repoRoot },
-    );
-    if (exists.code === 1) return undefined;
-    if (exists.code !== 0)
-      throw new PlanningWorkspaceCommandError("ref-resolution", exists);
-    const result = await this.run(
-      ["rev-parse", "--verify", `refs/heads/${branch}^{commit}`],
-      "ref-resolution",
-    );
-    const oid = result.stdout.trim();
-    if (!OID.test(oid))
-      throw new PlanningWorkspaceResponseError(
-        "ref-resolution",
-        "invalid-object-id",
-      );
-    return oid;
-  }
-  private async clean(path: string): Promise<boolean> {
-    const result = await this.run(
-      [
-        "--no-optional-locks",
-        "-C",
-        path,
-        "status",
-        "--porcelain=v1",
-        "-z",
-        "--untracked-files=all",
-        "--ignored=matching",
-      ],
-      "status",
-    );
-    return result.stdout === "";
-  }
-  private async existing(path: string): Promise<boolean> {
-    try {
-      await lstat(path);
-      return true;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
-      throw error;
-    }
-  }
-  async inspect(
+
+  inspect(
     identity: PlanningWorkspaceIdentity,
   ): Promise<PlanningWorkspaceSnapshot> {
-    const path = this.path(identity);
-    const entries = await this.entries();
-    const entry = entries.find((item) => item.path === path);
-    const branchElsewhere = entries.find(
-      (item) => item.branch === identity.branch && item.path !== path,
-    );
-    if (branchElsewhere !== undefined)
-      throw new PlanningWorkspaceConflictError(
-        "branch-owned-by-other-worktree",
-        identity,
-      );
-    const head = await this.branchHead(identity.branch);
-    if (entry === undefined)
-      return head === undefined
-        ? { state: "missing", identity }
-        : { state: "branch-only", identity, headOid: head };
-    if (
-      entry.branch !== identity.branch ||
-      entry.detached ||
-      entry.locked ||
-      entry.prunable
-    )
-      throw new PlanningWorkspaceConflictError("unsafe-registration", identity);
-    if (head === undefined || head !== entry.headOid)
-      throw new PlanningWorkspaceConflictError("head-oid-mismatch", identity);
-    return {
-      state: "ready",
-      identity,
-      headOid: head,
-      clean: await this.clean(path),
-    };
+    return this.repository.inspect(identity);
   }
+
   async prepare(input: {
     runId: string;
     phase: PlanningPhaseKind;
@@ -156,19 +45,15 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
     base: PlanningRemoteBaseSnapshot;
   }): Promise<PreparedPlanningWorkspace> {
     assertPlanningWorkspacePrepareInput(input);
-    const path = this.path(input.identity);
-    if (!OID.test(input.base.baseOid))
-      throw new PlanningWorkspaceConflictError(
-        "base-oid-mismatch",
-        input.identity,
-      );
-    const before = await this.inspect(input.identity);
-    if (before.state !== "missing" || (await this.existing(path)))
+    const path = this.repository.path(input.identity);
+    const before = await this.repository.inspect(input.identity);
+    if (before.state !== "missing" || (await this.repository.existing(path))) {
       throw new PlanningWorkspaceConflictError(
         before.state === "branch-only" ? "branch-collision" : "path-collision",
         input.identity,
       );
-    await this.run(
+    }
+    await this.repository.run(
       [
         "worktree",
         "add",
@@ -180,12 +65,13 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
       ],
       "worktree-add",
     );
-    const snapshot = await this.inspect(input.identity);
-    if (snapshot.state !== "ready" || snapshot.headOid !== input.base.baseOid)
+    const snapshot = await this.repository.inspect(input.identity);
+    if (snapshot.state !== "ready" || snapshot.headOid !== input.base.baseOid) {
       throw new PlanningWorkspaceConflictError(
         "base-oid-mismatch",
         input.identity,
       );
+    }
     return {
       created: true,
       base: input.base,
@@ -202,6 +88,7 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
       snapshot,
     };
   }
+
   async resume(input: {
     runId: string;
     phase: PlanningPhaseKind;
@@ -219,86 +106,43 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
       saved.baseBranch !== input.base.baseBranch ||
       saved.baseOid !== input.base.baseOid ||
       saved.cleanup.state !== "ready"
-    )
+    ) {
       throw new PlanningWorkspaceConflictError(
         "invalid-saved-identity",
         input.identity,
       );
-    const proof = await this.run(
+    }
+    const proof = await this.repository.run(
       ["rev-parse", "--verify", `${saved.baseOid}^{commit}`],
       "ref-resolution",
     );
-    if (proof.stdout.trim() !== saved.baseOid)
+    if (proof.stdout.trim() !== saved.baseOid) {
       throw new PlanningWorkspaceConflictError(
         "base-oid-mismatch",
         input.identity,
       );
-    const snapshot = await this.inspect(input.identity);
-    if (snapshot.state !== "ready" || snapshot.headOid !== saved.headOid)
+    }
+    const snapshot = await this.repository.inspect(input.identity);
+    if (snapshot.state !== "ready" || snapshot.headOid !== saved.headOid) {
       throw new PlanningWorkspaceConflictError(
         "head-oid-mismatch",
         input.identity,
       );
+    }
     return snapshot;
   }
-  async removeWorktree(input: {
+
+  removeWorktree(input: {
     runId: string;
     phase: PlanningPhaseKind;
     workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
   }): Promise<
     Extract<PlanningWorkspaceSnapshot, { state: "branch-only" | "missing" }>
   > {
-    const { workspace } = input;
-    if (input.runId !== workspace.runId || input.phase !== workspace.phase)
-      throw new PlanningWorkspaceConflictError(
-        "invalid-saved-identity",
-        workspace.identity,
-      );
-    const snapshot = await this.inspect(workspace.identity);
-    if (snapshot.state === "missing") {
-      if (await this.existing(this.path(workspace.identity)))
-        throw new PlanningWorkspaceConflictError(
-          "unregistered-path",
-          workspace.identity,
-        );
-      return snapshot;
-    }
-    if (snapshot.state === "branch-only") {
-      if (await this.existing(this.path(workspace.identity)))
-        throw new PlanningWorkspaceConflictError(
-          "unregistered-path",
-          workspace.identity,
-        );
-      if (snapshot.headOid !== workspace.headOid)
-        throw new PlanningWorkspaceConflictError(
-          "head-oid-mismatch",
-          workspace.identity,
-        );
-      return snapshot;
-    }
-    if (snapshot.headOid !== workspace.headOid)
-      throw new PlanningWorkspaceConflictError(
-        "head-oid-mismatch",
-        workspace.identity,
-      );
-    if (!snapshot.clean)
-      throw new PlanningWorkspaceConflictError(
-        "dirty-worktree",
-        workspace.identity,
-      );
-    await this.run(
-      ["worktree", "remove", "--", this.path(workspace.identity)],
-      "worktree-remove",
-    );
-    const after = await this.inspect(workspace.identity);
-    if (after.state === "ready")
-      throw new PlanningWorkspaceConflictError(
-        "unsafe-registration",
-        workspace.identity,
-      );
-    return after;
+    return this.cleanup.removeWorktree(input);
   }
-  async removeBranch(input: {
+
+  removeBranch(input: {
     runId: string;
     phase: PlanningPhaseKind;
     workspace: PlanningWorkspaceOwnership<{
@@ -306,70 +150,6 @@ export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
       pushedHeadOid: string;
     }>;
   }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "missing" }>> {
-    const { workspace } = input;
-    if (input.runId !== workspace.runId || input.phase !== workspace.phase)
-      throw new PlanningWorkspaceConflictError(
-        "invalid-saved-identity",
-        workspace.identity,
-      );
-    if (workspace.cleanup.pushedHeadOid !== workspace.headOid)
-      throw new PlanningWorkspaceConflictError(
-        "head-oid-mismatch",
-        workspace.identity,
-      );
-    const current = await this.inspect(workspace.identity);
-    if (current.state === "ready")
-      throw new PlanningWorkspaceConflictError(
-        "branch-owned-by-other-worktree",
-        workspace.identity,
-      );
-    if (await this.existing(this.path(workspace.identity)))
-      throw new PlanningWorkspaceConflictError(
-        "unregistered-path",
-        workspace.identity,
-      );
-    const remote = await this.runner.run(
-      "git",
-      [
-        "ls-remote",
-        "--exit-code",
-        "--heads",
-        "--",
-        workspace.remote,
-        `refs/heads/${workspace.identity.branch}`,
-      ],
-      { cwd: this.repoRoot },
-    );
-    if (remote.code !== 0)
-      throw new PlanningWorkspaceCommandError("remote-head-inspection", remote);
-    const expected = `${workspace.cleanup.pushedHeadOid}\trefs/heads/${workspace.identity.branch}`;
-    if (remote.stdout.trim() !== expected)
-      throw new PlanningWorkspaceConflictError(
-        "remote-head-mismatch",
-        workspace.identity,
-      );
-    if (current.state === "branch-only") {
-      if (current.headOid !== workspace.headOid)
-        throw new PlanningWorkspaceConflictError(
-          "head-oid-mismatch",
-          workspace.identity,
-        );
-      await this.run(
-        [
-          "update-ref",
-          "-d",
-          `refs/heads/${workspace.identity.branch}`,
-          workspace.headOid,
-        ],
-        "branch-deletion",
-      );
-    }
-    const after = await this.inspect(workspace.identity);
-    if (after.state !== "missing")
-      throw new PlanningWorkspaceConflictError(
-        "unsafe-registration",
-        workspace.identity,
-      );
-    return after;
+    return this.cleanup.removeBranch(input);
   }
 }

--- a/src/git/planning-workspace-git.ts
+++ b/src/git/planning-workspace-git.ts
@@ -1,0 +1,345 @@
+import { lstat } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import type { CommandRunner } from "../process/command.ts";
+import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
+import {
+  parsePlanningWorktreePorcelain,
+  type PlanningWorktreeRegistration,
+} from "./planning-worktree-porcelain.ts";
+import {
+  PlanningWorkspaceCommandError,
+  PlanningWorkspaceConflictError,
+  PlanningWorkspaceResponseError,
+  type PlanningRemoteBaseSnapshot,
+  type PlanningWorkspaceIdentity,
+  type PlanningWorkspaceLifecycle,
+  type PlanningWorkspaceOwnership,
+  type PlanningWorkspaceSnapshot,
+  type PreparedPlanningWorkspace,
+} from "./planning-workspaces.ts";
+const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+export class PlanningWorkspaceGit implements PlanningWorkspaceLifecycle {
+  readonly runner: CommandRunner;
+  readonly repoRoot: string;
+  readonly worktreeRoot: string;
+  constructor(input: {
+    runner: CommandRunner;
+    repoRoot: string;
+    worktreeRoot: string;
+  }) {
+    this.runner = input.runner;
+    this.repoRoot = resolve(input.repoRoot);
+    this.worktreeRoot = resolve(input.worktreeRoot);
+  }
+  private path(identity: PlanningWorkspaceIdentity): string {
+    const path = resolve(this.repoRoot, identity.worktreePath);
+    const rel = relative(this.worktreeRoot, path);
+    if (rel === ".." || rel.startsWith("../") || !rel)
+      throw new PlanningWorkspaceConflictError(
+        "outside-worktree-root",
+        identity,
+      );
+    return path;
+  }
+  private async run(
+    args: string[],
+    operation:
+      | "worktree-inspection"
+      | "worktree-add"
+      | "worktree-remove"
+      | "status"
+      | "ref-resolution"
+      | "remote-head-inspection"
+      | "branch-deletion",
+  ) {
+    const result = await this.runner.run("git", args, { cwd: this.repoRoot });
+    if (result.code !== 0)
+      throw new PlanningWorkspaceCommandError(operation, result);
+    return result;
+  }
+  private async entries(): Promise<readonly PlanningWorktreeRegistration[]> {
+    const result = await this.run(
+      ["worktree", "list", "--porcelain", "-z"],
+      "worktree-inspection",
+    );
+    const parsed = parsePlanningWorktreePorcelain(result.stdout);
+    if (parsed.malformed)
+      throw new PlanningWorkspaceResponseError(
+        "worktree-inspection",
+        "malformed-porcelain",
+      );
+    return parsed.entries;
+  }
+  private async branchHead(branch: string): Promise<string | undefined> {
+    const exists = await this.runner.run(
+      "git",
+      ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+      { cwd: this.repoRoot },
+    );
+    if (exists.code === 1) return undefined;
+    if (exists.code !== 0)
+      throw new PlanningWorkspaceCommandError("ref-resolution", exists);
+    const result = await this.run(
+      ["rev-parse", "--verify", `refs/heads/${branch}^{commit}`],
+      "ref-resolution",
+    );
+    const oid = result.stdout.trim();
+    if (!OID.test(oid))
+      throw new PlanningWorkspaceResponseError(
+        "ref-resolution",
+        "invalid-object-id",
+      );
+    return oid;
+  }
+  private async clean(path: string): Promise<boolean> {
+    const result = await this.run(
+      [
+        "-C",
+        path,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=matching",
+      ],
+      "status",
+    );
+    return result.stdout === "";
+  }
+  private async existing(path: string): Promise<boolean> {
+    try {
+      await lstat(path);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+  }
+  async inspect(
+    identity: PlanningWorkspaceIdentity,
+  ): Promise<PlanningWorkspaceSnapshot> {
+    const path = this.path(identity);
+    const entries = await this.entries();
+    const entry = entries.find((item) => item.path === path);
+    const head = await this.branchHead(identity.branch);
+    if (entry === undefined)
+      return head === undefined
+        ? { state: "missing", identity }
+        : { state: "branch-only", identity, headOid: head };
+    if (
+      entry.branch !== identity.branch ||
+      entry.detached ||
+      entry.locked ||
+      entry.prunable
+    )
+      throw new PlanningWorkspaceConflictError("unsafe-registration", identity);
+    if (head === undefined || head !== entry.headOid)
+      throw new PlanningWorkspaceConflictError("head-oid-mismatch", identity);
+    return {
+      state: "ready",
+      identity,
+      headOid: head,
+      clean: await this.clean(path),
+    };
+  }
+  async prepare(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+  }): Promise<PreparedPlanningWorkspace> {
+    const path = this.path(input.identity);
+    if (!OID.test(input.base.baseOid))
+      throw new PlanningWorkspaceConflictError(
+        "base-oid-mismatch",
+        input.identity,
+      );
+    const before = await this.inspect(input.identity);
+    if (before.state !== "missing" || (await this.existing(path)))
+      throw new PlanningWorkspaceConflictError(
+        before.state === "branch-only" ? "branch-collision" : "path-collision",
+        input.identity,
+      );
+    await this.run(
+      [
+        "worktree",
+        "add",
+        "-b",
+        input.identity.branch,
+        "--",
+        path,
+        input.base.baseOid,
+      ],
+      "worktree-add",
+    );
+    const snapshot = await this.inspect(input.identity);
+    if (snapshot.state !== "ready" || snapshot.headOid !== input.base.baseOid)
+      throw new PlanningWorkspaceConflictError(
+        "base-oid-mismatch",
+        input.identity,
+      );
+    return {
+      created: true,
+      base: input.base,
+      workspace: {
+        runId: input.runId,
+        phase: input.phase,
+        identity: input.identity,
+        remote: input.base.remote,
+        baseBranch: input.base.baseBranch,
+        baseOid: input.base.baseOid,
+        headOid: snapshot.headOid,
+        cleanup: { state: "ready" },
+      },
+      snapshot,
+    };
+  }
+  async resume(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+    saved: PlanningWorkspaceOwnership;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "ready" }>> {
+    const saved = input.saved;
+    if (
+      saved.runId !== input.runId ||
+      saved.phase !== input.phase ||
+      saved.identity.branch !== input.identity.branch ||
+      saved.identity.worktreePath !== input.identity.worktreePath ||
+      saved.remote !== input.base.remote ||
+      saved.baseBranch !== input.base.baseBranch ||
+      saved.baseOid !== input.base.baseOid ||
+      saved.cleanup.state !== "ready"
+    )
+      throw new PlanningWorkspaceConflictError(
+        "invalid-saved-identity",
+        input.identity,
+      );
+    const proof = await this.run(
+      ["rev-parse", "--verify", `${saved.baseOid}^{commit}`],
+      "ref-resolution",
+    );
+    if (proof.stdout.trim() !== saved.baseOid)
+      throw new PlanningWorkspaceConflictError(
+        "base-oid-mismatch",
+        input.identity,
+      );
+    const snapshot = await this.inspect(input.identity);
+    if (snapshot.state !== "ready" || snapshot.headOid !== saved.headOid)
+      throw new PlanningWorkspaceConflictError(
+        "head-oid-mismatch",
+        input.identity,
+      );
+    return snapshot;
+  }
+  async removeWorktree(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  }): Promise<
+    Extract<PlanningWorkspaceSnapshot, { state: "branch-only" | "missing" }>
+  > {
+    const { workspace } = input;
+    if (input.runId !== workspace.runId || input.phase !== workspace.phase)
+      throw new PlanningWorkspaceConflictError(
+        "invalid-saved-identity",
+        workspace.identity,
+      );
+    const snapshot = await this.inspect(workspace.identity);
+    if (snapshot.state === "missing") return snapshot;
+    if (snapshot.state === "branch-only") {
+      if (snapshot.headOid !== workspace.headOid)
+        throw new PlanningWorkspaceConflictError(
+          "head-oid-mismatch",
+          workspace.identity,
+        );
+      return snapshot;
+    }
+    if (snapshot.headOid !== workspace.headOid)
+      throw new PlanningWorkspaceConflictError(
+        "head-oid-mismatch",
+        workspace.identity,
+      );
+    if (!snapshot.clean)
+      throw new PlanningWorkspaceConflictError(
+        "dirty-worktree",
+        workspace.identity,
+      );
+    await this.run(
+      ["worktree", "remove", "--", this.path(workspace.identity)],
+      "worktree-remove",
+    );
+    const after = await this.inspect(workspace.identity);
+    if (after.state === "ready")
+      throw new PlanningWorkspaceConflictError(
+        "unsafe-registration",
+        workspace.identity,
+      );
+    return after;
+  }
+  async removeBranch(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{
+      state: "worktree-removed";
+      pushedHeadOid: string;
+    }>;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "missing" }>> {
+    const { workspace } = input;
+    if (input.runId !== workspace.runId || input.phase !== workspace.phase)
+      throw new PlanningWorkspaceConflictError(
+        "invalid-saved-identity",
+        workspace.identity,
+      );
+    const current = await this.inspect(workspace.identity);
+    if (current.state === "ready")
+      throw new PlanningWorkspaceConflictError(
+        "branch-owned-by-other-worktree",
+        workspace.identity,
+      );
+    const remote = await this.runner.run(
+      "git",
+      [
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        "--",
+        workspace.remote,
+        `refs/heads/${workspace.identity.branch}`,
+      ],
+      { cwd: this.repoRoot },
+    );
+    if (remote.code !== 0)
+      throw new PlanningWorkspaceCommandError("remote-head-inspection", remote);
+    const expected = `${workspace.cleanup.pushedHeadOid}\trefs/heads/${workspace.identity.branch}`;
+    if (remote.stdout.trim() !== expected)
+      throw new PlanningWorkspaceConflictError(
+        "remote-head-mismatch",
+        workspace.identity,
+      );
+    if (current.state === "branch-only") {
+      if (current.headOid !== workspace.headOid)
+        throw new PlanningWorkspaceConflictError(
+          "head-oid-mismatch",
+          workspace.identity,
+        );
+      await this.run(
+        [
+          "update-ref",
+          "-d",
+          `refs/heads/${workspace.identity.branch}`,
+          workspace.headOid,
+        ],
+        "branch-deletion",
+      );
+    }
+    const after = await this.inspect(workspace.identity);
+    if (after.state !== "missing")
+      throw new PlanningWorkspaceConflictError(
+        "unsafe-registration",
+        workspace.identity,
+      );
+    return after;
+  }
+}

--- a/src/git/planning-workspace-input.ts
+++ b/src/git/planning-workspace-input.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve, win32 } from "node:path";
 import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
 import {
   isPlanningArtifactPath,
@@ -26,15 +26,26 @@ function exact(
     keys.every((key) => key in (value as Record<string, unknown>))
   );
 }
+export function isPlanningRelativeWithinRoot(relativePath: string): boolean {
+  const portable = relativePath.replaceAll("\\", "/");
+  return (
+    !isAbsolute(relativePath) &&
+    !win32.isAbsolute(relativePath) &&
+    portable !== ".." &&
+    !portable.startsWith("../")
+  );
+}
+
 export function planningWorkspacePath(
   repoRoot: string,
   worktreeRoot: string,
   identity: PlanningWorkspaceIdentity,
 ): string {
   const path = resolve(repoRoot, identity.worktreePath);
-  const relativePath = relative(worktreeRoot, path).replaceAll("\\", "/");
-  if (relativePath === ".." || relativePath.startsWith("../"))
+  const relativePath = relative(worktreeRoot, path);
+  if (!isPlanningRelativeWithinRoot(relativePath)) {
     throw new PlanningWorkspaceConflictError("outside-worktree-root", identity);
+  }
   return path;
 }
 export function assertPlanningWorkspacePrepareInput(input: {

--- a/src/git/planning-workspace-input.ts
+++ b/src/git/planning-workspace-input.ts
@@ -1,16 +1,19 @@
 import { relative, resolve } from "node:path";
 import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
 import {
+  isPlanningArtifactPath,
+  isPlanningBranch,
+  isPlanningSingleLine,
+  planningOid,
+} from "./planning-git-validation.ts";
+import {
   PlanningWorkspaceConflictError,
   type PlanningRemoteBaseSnapshot,
   type PlanningWorkspaceIdentity,
 } from "./planning-workspaces.ts";
 
-export const planningOid = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
 const uuid =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
-const branch =
-  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
 function exact(
   value: unknown,
   keys: readonly string[],
@@ -21,18 +24,6 @@ function exact(
     !Array.isArray(value) &&
     Object.keys(value as Record<string, unknown>).length === keys.length &&
     keys.every((key) => key in (value as Record<string, unknown>))
-  );
-}
-function artifactPath(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    value.length > 0 &&
-    value.length <= 4096 &&
-    !/[\\\0\r\n]/u.test(value) &&
-    !value.startsWith("/") &&
-    !value
-      .split("/")
-      .some((part) => part === "" || part === "." || part === "..")
   );
 }
 export function planningWorkspacePath(
@@ -57,21 +48,16 @@ export function assertPlanningWorkspacePrepareInput(input: {
     !uuid.test(input.runId) ||
     !["spec", "plan", "implementation"].includes(input.phase) ||
     !exact(input.identity, ["branch", "worktreePath"]) ||
-    !branch.test(input.identity.branch) ||
-    typeof input.identity.worktreePath !== "string" ||
-    input.identity.worktreePath.length === 0 ||
-    /[\0\r\n]/u.test(input.identity.worktreePath) ||
+    !isPlanningBranch(input.identity.branch) ||
+    !isPlanningSingleLine(input.identity.worktreePath, 4096) ||
     !exact(input.base, [
       "remote",
       "baseBranch",
       "baseOid",
       "artifactCandidates",
     ]) ||
-    typeof input.base.remote !== "string" ||
-    input.base.remote.length === 0 ||
-    input.base.remote.length > 1024 ||
-    /[\0\r\n]/u.test(input.base.remote) ||
-    !branch.test(input.base.baseBranch) ||
+    !isPlanningSingleLine(input.base.remote) ||
+    !isPlanningBranch(input.base.baseBranch) ||
     !planningOid.test(input.base.baseOid) ||
     !exact(input.base.artifactCandidates, ["spec", "plan"])
   )
@@ -85,7 +71,7 @@ export function assertPlanningWorkspacePrepareInput(input: {
   ])
     if (
       !Array.isArray(values) ||
-      values.some((value) => !artifactPath(value)) ||
+      values.some((value) => !isPlanningArtifactPath(value)) ||
       new Set(values).size !== values.length
     )
       throw new PlanningWorkspaceConflictError(

--- a/src/git/planning-workspace-input.ts
+++ b/src/git/planning-workspace-input.ts
@@ -1,0 +1,95 @@
+import { relative, resolve } from "node:path";
+import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
+import {
+  PlanningWorkspaceConflictError,
+  type PlanningRemoteBaseSnapshot,
+  type PlanningWorkspaceIdentity,
+} from "./planning-workspaces.ts";
+
+export const planningOid = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const uuid =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const branch =
+  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
+function exact(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === keys.length &&
+    keys.every((key) => key in (value as Record<string, unknown>))
+  );
+}
+function artifactPath(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 4096 &&
+    !/[\\\0\r\n]/u.test(value) &&
+    !value.startsWith("/") &&
+    !value
+      .split("/")
+      .some((part) => part === "" || part === "." || part === "..")
+  );
+}
+export function planningWorkspacePath(
+  repoRoot: string,
+  worktreeRoot: string,
+  identity: PlanningWorkspaceIdentity,
+): string {
+  const path = resolve(repoRoot, identity.worktreePath);
+  const relativePath = relative(worktreeRoot, path).replaceAll("\\", "/");
+  if (relativePath === ".." || relativePath.startsWith("../"))
+    throw new PlanningWorkspaceConflictError("outside-worktree-root", identity);
+  return path;
+}
+export function assertPlanningWorkspacePrepareInput(input: {
+  runId: string;
+  phase: PlanningPhaseKind;
+  identity: PlanningWorkspaceIdentity;
+  base: PlanningRemoteBaseSnapshot;
+}): void {
+  if (
+    !exact(input, ["runId", "phase", "identity", "base"]) ||
+    !uuid.test(input.runId) ||
+    !["spec", "plan", "implementation"].includes(input.phase) ||
+    !exact(input.identity, ["branch", "worktreePath"]) ||
+    !branch.test(input.identity.branch) ||
+    typeof input.identity.worktreePath !== "string" ||
+    input.identity.worktreePath.length === 0 ||
+    /[\0\r\n]/u.test(input.identity.worktreePath) ||
+    !exact(input.base, [
+      "remote",
+      "baseBranch",
+      "baseOid",
+      "artifactCandidates",
+    ]) ||
+    typeof input.base.remote !== "string" ||
+    input.base.remote.length === 0 ||
+    input.base.remote.length > 1024 ||
+    /[\0\r\n]/u.test(input.base.remote) ||
+    !branch.test(input.base.baseBranch) ||
+    !planningOid.test(input.base.baseOid) ||
+    !exact(input.base.artifactCandidates, ["spec", "plan"])
+  )
+    throw new PlanningWorkspaceConflictError(
+      "invalid-saved-identity",
+      input.identity,
+    );
+  for (const values of [
+    input.base.artifactCandidates.spec,
+    input.base.artifactCandidates.plan,
+  ])
+    if (
+      !Array.isArray(values) ||
+      values.some((value) => !artifactPath(value)) ||
+      new Set(values).size !== values.length
+    )
+      throw new PlanningWorkspaceConflictError(
+        "invalid-saved-identity",
+        input.identity,
+      );
+}

--- a/src/git/planning-workspace-inspection.ts
+++ b/src/git/planning-workspace-inspection.ts
@@ -1,10 +1,8 @@
 import { lstat } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { CommandRunner } from "../process/command.ts";
-import {
-  planningOid,
-  planningWorkspacePath,
-} from "./planning-workspace-input.ts";
+import { planningOid } from "./planning-git-validation.ts";
+import { planningWorkspacePath } from "./planning-workspace-input.ts";
 import {
   parsePlanningWorktreePorcelain,
   type PlanningWorktreeRegistration,

--- a/src/git/planning-workspace-inspection.ts
+++ b/src/git/planning-workspace-inspection.ts
@@ -1,0 +1,153 @@
+import { lstat } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { CommandRunner } from "../process/command.ts";
+import {
+  planningOid,
+  planningWorkspacePath,
+} from "./planning-workspace-input.ts";
+import {
+  parsePlanningWorktreePorcelain,
+  type PlanningWorktreeRegistration,
+} from "./planning-worktree-porcelain.ts";
+import {
+  PlanningWorkspaceCommandError,
+  PlanningWorkspaceConflictError,
+  PlanningWorkspaceResponseError,
+  type PlanningWorkspaceIdentity,
+  type PlanningWorkspaceOperation,
+  type PlanningWorkspaceSnapshot,
+} from "./planning-workspaces.ts";
+
+export class PlanningWorkspaceRepositoryGit {
+  readonly runner: CommandRunner;
+  readonly repoRoot: string;
+  readonly worktreeRoot: string;
+
+  constructor(input: {
+    runner: CommandRunner;
+    repoRoot: string;
+    worktreeRoot: string;
+  }) {
+    this.runner = input.runner;
+    this.repoRoot = resolve(input.repoRoot);
+    this.worktreeRoot = resolve(input.worktreeRoot);
+  }
+
+  path(identity: PlanningWorkspaceIdentity): string {
+    return planningWorkspacePath(this.repoRoot, this.worktreeRoot, identity);
+  }
+
+  async run(args: string[], operation: PlanningWorkspaceOperation) {
+    const result = await this.runner.run("git", args, { cwd: this.repoRoot });
+    if (result.code !== 0) {
+      throw new PlanningWorkspaceCommandError(operation, result);
+    }
+    return result;
+  }
+
+  async existing(path: string): Promise<boolean> {
+    try {
+      await lstat(path);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+  }
+
+  async inspect(
+    identity: PlanningWorkspaceIdentity,
+  ): Promise<PlanningWorkspaceSnapshot> {
+    const path = this.path(identity);
+    const entries = await this.entries();
+    const entry = entries.find((item) => item.path === path);
+    const branchElsewhere = entries.find(
+      (item) => item.branch === identity.branch && item.path !== path,
+    );
+    if (branchElsewhere !== undefined) {
+      throw new PlanningWorkspaceConflictError(
+        "branch-owned-by-other-worktree",
+        identity,
+      );
+    }
+    const head = await this.branchHead(identity.branch);
+    if (entry === undefined) {
+      return head === undefined
+        ? { state: "missing", identity }
+        : { state: "branch-only", identity, headOid: head };
+    }
+    if (
+      entry.branch !== identity.branch ||
+      entry.detached ||
+      entry.locked ||
+      entry.prunable
+    ) {
+      throw new PlanningWorkspaceConflictError("unsafe-registration", identity);
+    }
+    if (head === undefined || head !== entry.headOid) {
+      throw new PlanningWorkspaceConflictError("head-oid-mismatch", identity);
+    }
+    return {
+      state: "ready",
+      identity,
+      headOid: head,
+      clean: await this.clean(path),
+    };
+  }
+
+  private async entries(): Promise<readonly PlanningWorktreeRegistration[]> {
+    const result = await this.run(
+      ["worktree", "list", "--porcelain", "-z"],
+      "worktree-inspection",
+    );
+    const parsed = parsePlanningWorktreePorcelain(result.stdout);
+    if (parsed.malformed) {
+      throw new PlanningWorkspaceResponseError(
+        "worktree-inspection",
+        "malformed-porcelain",
+      );
+    }
+    return parsed.entries;
+  }
+
+  private async branchHead(branch: string): Promise<string | undefined> {
+    const exists = await this.runner.run(
+      "git",
+      ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+      { cwd: this.repoRoot },
+    );
+    if (exists.code === 1) return undefined;
+    if (exists.code !== 0) {
+      throw new PlanningWorkspaceCommandError("ref-resolution", exists);
+    }
+    const result = await this.run(
+      ["rev-parse", "--verify", `refs/heads/${branch}^{commit}`],
+      "ref-resolution",
+    );
+    const oid = result.stdout.trim();
+    if (!planningOid.test(oid)) {
+      throw new PlanningWorkspaceResponseError(
+        "ref-resolution",
+        "invalid-object-id",
+      );
+    }
+    return oid;
+  }
+
+  private async clean(path: string): Promise<boolean> {
+    const result = await this.run(
+      [
+        "--no-optional-locks",
+        "-C",
+        path,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=matching",
+      ],
+      "status",
+    );
+    return result.stdout === "";
+  }
+}

--- a/src/git/planning-workspaces.test.ts
+++ b/src/git/planning-workspaces.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   PlanningWorkspaceConflictError,
+  type PlanningRemoteBaseSnapshot,
   type PlanningWorkspaceIdentity,
   type PlanningWorkspaceLifecycle,
+  type PlanningWorkspaceOwnership,
   type PlanningWorkspaceSnapshot,
   type PreparedPlanningWorkspace,
 } from "./planning-workspaces.ts";
@@ -12,105 +14,146 @@ const identity: PlanningWorkspaceIdentity = {
   branch: "agent/issue-184-foundations-spec",
   worktreePath: ".worktrees/patchmill-issue-184-foundations-spec",
 };
+const base: PlanningRemoteBaseSnapshot = {
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: "a".repeat(40),
+  artifactCandidates: { spec: [], plan: [] },
+};
 
 class FakePlanningWorkspace implements PlanningWorkspaceLifecycle {
   readonly events: string[] = [];
-  private snapshot: PlanningWorkspaceSnapshot = {
-    state: "missing",
-    identity,
-  };
+  private snapshot: PlanningWorkspaceSnapshot = { state: "missing", identity };
 
   async prepare(input: {
+    runId: string;
+    phase: "spec" | "plan" | "implementation";
     identity: PlanningWorkspaceIdentity;
-    remote: string;
-    baseBranch: string;
-    resume?: { baseSha: string; headSha: string };
+    base: PlanningRemoteBaseSnapshot;
   }): Promise<PreparedPlanningWorkspace> {
     this.events.push("prepare");
-    const headSha = input.resume?.headSha ?? "head-1";
-    const snapshot: Extract<PlanningWorkspaceSnapshot, { state: "ready" }> = {
-      state: "ready",
+    const snapshot = {
+      state: "ready" as const,
       identity: input.identity,
-      headSha,
+      headOid: input.base.baseOid,
       clean: true,
     };
     this.snapshot = snapshot;
     return {
-      created: input.resume === undefined,
-      remote: input.remote,
-      baseBranch: input.baseBranch,
-      baseSha: input.resume?.baseSha ?? "base-1",
+      created: true,
+      base: input.base,
+      workspace: {
+        runId: input.runId,
+        phase: input.phase,
+        identity: input.identity,
+        remote: input.base.remote,
+        baseBranch: input.base.baseBranch,
+        baseOid: input.base.baseOid,
+        headOid: input.base.baseOid,
+        cleanup: { state: "ready" },
+      },
       snapshot,
     };
   }
 
-  async inspect(
-    _identity: PlanningWorkspaceIdentity,
-  ): Promise<PlanningWorkspaceSnapshot> {
-    this.events.push("inspect");
+  async resume(input: {
+    runId: string;
+    phase: "spec" | "plan" | "implementation";
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+    saved: PlanningWorkspaceOwnership;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "ready" }>> {
+    this.events.push("resume");
+    assert.equal(input.saved.runId, input.runId);
+    assert.equal(input.saved.phase, input.phase);
+    assert.deepEqual(input.saved.identity, input.identity);
+    assert.deepEqual(input.base, base);
+    if (this.snapshot.state !== "ready") throw new Error("not ready");
     return this.snapshot;
   }
 
-  async removeWorktree(
-    _identity: PlanningWorkspaceIdentity,
-  ): Promise<Extract<PlanningWorkspaceSnapshot, { state: "branch-only" }>> {
+  async inspect(
+    identity: PlanningWorkspaceIdentity,
+  ): Promise<PlanningWorkspaceSnapshot> {
+    this.events.push("inspect");
+    assert.deepEqual(identity, this.snapshot.identity);
+    return this.snapshot;
+  }
+
+  async removeWorktree(input: {
+    runId: string;
+    phase: "spec" | "plan" | "implementation";
+    workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  }): Promise<
+    Extract<PlanningWorkspaceSnapshot, { state: "branch-only" | "missing" }>
+  > {
     this.events.push("remove-worktree");
-    if (this.snapshot.state !== "ready") {
-      throw new PlanningWorkspaceConflictError(
-        "branch-owned-by-other-worktree",
-        identity,
-      );
-    }
-    if (!this.snapshot.clean) {
-      throw new PlanningWorkspaceConflictError("dirty-worktree", identity);
-    }
+    assert.equal(input.runId, input.workspace.runId);
+    assert.equal(input.phase, input.workspace.phase);
+    if (this.snapshot.state !== "ready")
+      throw new PlanningWorkspaceConflictError("unsafe-registration", identity);
     this.snapshot = {
       state: "branch-only",
       identity,
-      headSha: this.snapshot.headSha,
+      headOid: this.snapshot.headOid,
     };
     return this.snapshot;
   }
 
   async removeBranch(input: {
-    identity: PlanningWorkspaceIdentity;
-    pushedHeadSha: string;
+    runId: string;
+    phase: "spec" | "plan" | "implementation";
+    workspace: PlanningWorkspaceOwnership<{
+      state: "worktree-removed";
+      pushedHeadOid: string;
+    }>;
   }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "missing" }>> {
     this.events.push("remove-branch");
-    if (
-      this.snapshot.state !== "branch-only" ||
-      this.snapshot.headSha !== input.pushedHeadSha
-    ) {
-      throw new PlanningWorkspaceConflictError("head-not-pushed", identity);
-    }
-    this.snapshot = { state: "missing", identity: input.identity };
+    assert.equal(input.runId, input.workspace.runId);
+    assert.equal(input.phase, input.workspace.phase);
+    this.snapshot = { state: "missing", identity };
     return this.snapshot;
   }
 }
 
-test("a coordinator can use the workspace lifecycle without Git commands", async () => {
+test("a coordinator uses pinned base and saved workspace ownership", async () => {
   const workspace = new FakePlanningWorkspace();
   const prepared = await workspace.prepare({
+    runId: "123e4567-e89b-42d3-a456-426614174000",
+    phase: "spec",
     identity,
-    remote: "origin",
-    baseBranch: "main",
+    base,
   });
-
-  assert.equal(prepared.created, true);
-  assert.equal(prepared.baseSha, "base-1");
-  assert.deepEqual(await workspace.inspect(identity), prepared.snapshot);
-
-  const branchOnly = await workspace.removeWorktree(identity);
-  assert.equal(branchOnly.state, "branch-only");
-
-  const missing = await workspace.removeBranch({
+  assert.equal(prepared.workspace.baseOid, base.baseOid);
+  const resumed = await workspace.resume({
+    runId: prepared.workspace.runId,
+    phase: "spec",
     identity,
-    pushedHeadSha: "head-1",
+    base,
+    saved: prepared.workspace,
+  });
+  assert.deepEqual(resumed, prepared.snapshot);
+  const branchOnly = await workspace.removeWorktree({
+    runId: prepared.workspace.runId,
+    phase: "spec",
+    workspace: prepared.workspace,
+  });
+  assert.equal(branchOnly.state, "branch-only");
+  const missing = await workspace.removeBranch({
+    runId: prepared.workspace.runId,
+    phase: "spec",
+    workspace: {
+      ...prepared.workspace,
+      cleanup: {
+        state: "worktree-removed",
+        pushedHeadOid: prepared.workspace.headOid,
+      },
+    },
   });
   assert.equal(missing.state, "missing");
   assert.deepEqual(workspace.events, [
     "prepare",
-    "inspect",
+    "resume",
     "remove-worktree",
     "remove-branch",
   ]);
@@ -121,7 +164,6 @@ test("workspace conflict error keeps the reason and identity", () => {
     "unregistered-path",
     identity,
   );
-
   assert.equal(error.name, "PlanningWorkspaceConflictError");
   assert.equal(error.reason, "unregistered-path");
   assert.deepEqual(error.identity, identity);

--- a/src/git/planning-workspaces.ts
+++ b/src/git/planning-workspaces.ts
@@ -1,42 +1,77 @@
-export type PlanningWorkspaceIdentity = {
-  readonly branch: string;
-  readonly worktreePath: string;
-};
+import type { CommandResult } from "../process/command.ts";
+import type { PlanningPhaseKind } from "../workflow/planning-pull-request-markers.ts";
+
+export type PlanningWorkspaceIdentity = Readonly<{
+  branch: string;
+  worktreePath: string;
+}>;
+
+export type PlanningArtifactCandidates = Readonly<{
+  spec: readonly string[];
+  plan: readonly string[];
+}>;
+
+export type PlanningRemoteBaseSnapshot = Readonly<{
+  remote: string;
+  baseBranch: string;
+  baseOid: string;
+  artifactCandidates: PlanningArtifactCandidates;
+}>;
+
+export type PlanningWorkspaceCleanup =
+  | Readonly<{ state: "ready" }>
+  | Readonly<{ state: "worktree-removed"; pushedHeadOid: string }>
+  | Readonly<{ state: "removed"; pushedHeadOid: string }>;
+
+export type PlanningWorkspaceOwnership<
+  Cleanup extends PlanningWorkspaceCleanup = PlanningWorkspaceCleanup,
+> = Readonly<{
+  runId: string;
+  phase: PlanningPhaseKind;
+  identity: PlanningWorkspaceIdentity;
+  remote: string;
+  baseBranch: string;
+  baseOid: string;
+  headOid: string;
+  cleanup: Cleanup;
+}>;
 
 export type PlanningWorkspaceSnapshot =
-  | {
-      readonly state: "missing";
-      readonly identity: PlanningWorkspaceIdentity;
-    }
-  | {
-      readonly state: "branch-only";
-      readonly identity: PlanningWorkspaceIdentity;
-      readonly headSha: string;
-    }
-  | {
-      readonly state: "ready";
-      readonly identity: PlanningWorkspaceIdentity;
-      readonly headSha: string;
-      readonly clean: boolean;
-    };
+  | Readonly<{ state: "missing"; identity: PlanningWorkspaceIdentity }>
+  | Readonly<{
+      state: "branch-only";
+      identity: PlanningWorkspaceIdentity;
+      headOid: string;
+    }>
+  | Readonly<{
+      state: "ready";
+      identity: PlanningWorkspaceIdentity;
+      headOid: string;
+      clean: boolean;
+    }>;
 
-export type PreparedPlanningWorkspace = {
-  readonly created: boolean;
-  readonly remote: string;
-  readonly baseBranch: string;
-  readonly baseSha: string;
-  readonly snapshot: Extract<PlanningWorkspaceSnapshot, { state: "ready" }>;
-};
+export type PreparedPlanningWorkspace = Readonly<{
+  created: true;
+  base: PlanningRemoteBaseSnapshot;
+  workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  snapshot: Extract<PlanningWorkspaceSnapshot, { state: "ready" }>;
+}>;
 
 export type PlanningWorkspaceConflictReason =
+  | "invalid-saved-identity"
+  | "branch-collision"
+  | "path-collision"
   | "path-owned-by-other-branch"
   | "branch-owned-by-other-worktree"
   | "unregistered-path"
   | "detached-worktree"
-  | "base-sha-mismatch"
-  | "head-sha-mismatch"
+  | "unsafe-registration"
+  | "base-oid-mismatch"
+  | "head-oid-mismatch"
   | "dirty-worktree"
-  | "head-not-pushed";
+  | "remote-head-mismatch"
+  | "outside-worktree-root"
+  | "missing-workspace";
 
 export class PlanningWorkspaceConflictError extends Error {
   readonly reason: PlanningWorkspaceConflictReason;
@@ -53,27 +88,77 @@ export class PlanningWorkspaceConflictError extends Error {
   }
 }
 
+export type PlanningWorkspaceOperation =
+  | "fetch"
+  | "ref-resolution"
+  | "tree-inspection"
+  | "worktree-inspection"
+  | "worktree-add"
+  | "worktree-remove"
+  | "status"
+  | "remote-head-inspection"
+  | "branch-deletion";
+
+export class PlanningWorkspaceCommandError extends Error {
+  readonly operation: PlanningWorkspaceOperation;
+  readonly exitCode: number;
+
+  constructor(operation: PlanningWorkspaceOperation, result: CommandResult) {
+    super(`Planning workspace command failed: ${operation} (${result.code})`);
+    this.name = "PlanningWorkspaceCommandError";
+    this.operation = operation;
+    this.exitCode = result.code;
+    Object.defineProperty(this, "diagnostics", {
+      enumerable: false,
+      value: Object.freeze({ ...result }),
+    });
+  }
+
+  declare readonly diagnostics: Readonly<CommandResult>;
+}
+
+export class PlanningWorkspaceResponseError extends Error {
+  readonly operation: PlanningWorkspaceOperation;
+  readonly reason: string;
+
+  constructor(operation: PlanningWorkspaceOperation, reason: string) {
+    super(`Planning workspace response is invalid: ${operation}/${reason}`);
+    this.name = "PlanningWorkspaceResponseError";
+    this.operation = operation;
+    this.reason = reason;
+  }
+}
+
 export interface PlanningWorkspaceLifecycle {
   prepare(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
     identity: PlanningWorkspaceIdentity;
-    remote: string;
-    baseBranch: string;
-    resume?: {
-      baseSha: string;
-      headSha: string;
-    };
+    base: PlanningRemoteBaseSnapshot;
   }): Promise<PreparedPlanningWorkspace>;
-
+  resume(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    identity: PlanningWorkspaceIdentity;
+    base: PlanningRemoteBaseSnapshot;
+    saved: PlanningWorkspaceOwnership;
+  }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "ready" }>>;
   inspect(
     identity: PlanningWorkspaceIdentity,
   ): Promise<PlanningWorkspaceSnapshot>;
-
-  removeWorktree(
-    identity: PlanningWorkspaceIdentity,
-  ): Promise<Extract<PlanningWorkspaceSnapshot, { state: "branch-only" }>>;
-
+  removeWorktree(input: {
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  }): Promise<
+    Extract<PlanningWorkspaceSnapshot, { state: "branch-only" | "missing" }>
+  >;
   removeBranch(input: {
-    identity: PlanningWorkspaceIdentity;
-    pushedHeadSha: string;
+    runId: string;
+    phase: PlanningPhaseKind;
+    workspace: PlanningWorkspaceOwnership<{
+      state: "worktree-removed";
+      pushedHeadOid: string;
+    }>;
   }): Promise<Extract<PlanningWorkspaceSnapshot, { state: "missing" }>>;
 }

--- a/src/git/planning-worktree-porcelain.test.ts
+++ b/src/git/planning-worktree-porcelain.test.ts
@@ -46,6 +46,7 @@ test("rejects every unsafe branch spelling", () => {
     "topic*next",
     "topic[next",
     "topic next",
+    "topic\u00a0next",
     "topic\u0001next",
     "a/" + "x".repeat(1024),
   ]) {
@@ -58,9 +59,14 @@ test("rejects every unsafe branch spelling", () => {
 });
 
 test("strictly parses marker field values and record coherence", () => {
+  assert.equal(
+    parsePlanningWorktreePorcelain(
+      `worktree /repo\0HEAD ${oid}\0detached\0locked held by CI\0prunable retry after cleanup\0\0`,
+    ).malformed,
+    false,
+  );
   const invalid = [
     `worktree /repo\0HEAD ${oid}\0detached value\0\0`,
-    `worktree /repo\0HEAD ${oid}\0locked two words\0\0`,
     `worktree /repo\0HEAD ${oid}\0prunable bad\u0001\0\0`,
     `worktree /repo\0HEAD ${oid}\0branch refs/heads/topic\0detached\0\0`,
     `worktree /repo\0HEAD ${oid}\0unknown value\0\0`,

--- a/src/git/planning-worktree-porcelain.test.ts
+++ b/src/git/planning-worktree-porcelain.test.ts
@@ -27,6 +27,12 @@ test("parses complete attached and detached worktree porcelain", () => {
 });
 test("marks malformed duplicate and unterminated records unsafe", () => {
   assert.equal(
+    parsePlanningWorktreePorcelain(
+      `worktree /repo\0HEAD ${oid}\0branch refs/heads/topic\0detached\0\0`,
+    ).malformed,
+    true,
+  );
+  assert.equal(
     parsePlanningWorktreePorcelain(`worktree /repo\0HEAD ${oid}`).malformed,
     true,
   );

--- a/src/git/planning-worktree-porcelain.test.ts
+++ b/src/git/planning-worktree-porcelain.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { parsePlanningWorktreePorcelain } from "./planning-worktree-porcelain.ts";
 const oid = "a".repeat(40);
+const attached = (branch = "topic") =>
+  `worktree /repo\0HEAD ${oid}\0branch refs/heads/${branch}\0\0`;
+
 test("parses complete attached and detached worktree porcelain", () => {
   const result = parsePlanningWorktreePorcelain(
-    `worktree /repo\0HEAD ${oid}\0branch refs/heads/topic\0\0worktree /other\0HEAD ${oid}\0detached\0\0`,
+    `${attached()}worktree /other\0HEAD ${oid}\0detached\0locked held\0prunable reason\0\0`,
   );
   assert.equal(result.malformed, false);
   assert.deepEqual(result.entries, [
@@ -20,26 +23,54 @@ test("parses complete attached and detached worktree porcelain", () => {
       path: "/other",
       headOid: oid,
       detached: true,
-      locked: false,
-      prunable: false,
+      locked: true,
+      prunable: true,
     },
   ]);
 });
-test("marks malformed duplicate and unterminated records unsafe", () => {
-  assert.equal(
-    parsePlanningWorktreePorcelain(
-      `worktree /repo\0HEAD ${oid}\0branch refs/heads/topic\0detached\0\0`,
-    ).malformed,
-    true,
-  );
-  assert.equal(
-    parsePlanningWorktreePorcelain(`worktree /repo\0HEAD ${oid}`).malformed,
-    true,
-  );
-  assert.equal(
-    parsePlanningWorktreePorcelain(
-      `worktree /repo\0HEAD ${oid}\0branch refs/heads/a\0branch refs/heads/a\0\0`,
-    ).malformed,
-    true,
-  );
+
+test("rejects every unsafe branch spelling", () => {
+  for (const branch of [
+    "",
+    "-topic",
+    "/topic",
+    "topic/",
+    "topic.",
+    "topic..next",
+    "topic@{x",
+    "topic\\next",
+    "topic~next",
+    "topic^next",
+    "topic:next",
+    "topic?next",
+    "topic*next",
+    "topic[next",
+    "topic next",
+    "topic\u0001next",
+    "a/" + "x".repeat(1024),
+  ]) {
+    assert.equal(
+      parsePlanningWorktreePorcelain(attached(branch)).malformed,
+      true,
+      branch,
+    );
+  }
+});
+
+test("strictly parses marker field values and record coherence", () => {
+  const invalid = [
+    `worktree /repo\0HEAD ${oid}\0detached value\0\0`,
+    `worktree /repo\0HEAD ${oid}\0locked two words\0\0`,
+    `worktree /repo\0HEAD ${oid}\0prunable bad\u0001\0\0`,
+    `worktree /repo\0HEAD ${oid}\0branch refs/heads/topic\0detached\0\0`,
+    `worktree /repo\0HEAD ${oid}\0unknown value\0\0`,
+    `worktree /repo\0HEAD ${oid}\0detached\0detached\0\0`,
+    `${attached()}worktree /other\0HEAD ${oid}\0detached extra\0\0`,
+  ];
+  for (const output of invalid)
+    assert.equal(
+      parsePlanningWorktreePorcelain(output).malformed,
+      true,
+      output,
+    );
 });

--- a/src/git/planning-worktree-porcelain.test.ts
+++ b/src/git/planning-worktree-porcelain.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parsePlanningWorktreePorcelain } from "./planning-worktree-porcelain.ts";
+const oid = "a".repeat(40);
+test("parses complete attached and detached worktree porcelain", () => {
+  const result = parsePlanningWorktreePorcelain(
+    `worktree /repo\0HEAD ${oid}\0branch refs/heads/topic\0\0worktree /other\0HEAD ${oid}\0detached\0\0`,
+  );
+  assert.equal(result.malformed, false);
+  assert.deepEqual(result.entries, [
+    {
+      path: "/repo",
+      headOid: oid,
+      branch: "topic",
+      detached: false,
+      locked: false,
+      prunable: false,
+    },
+    {
+      path: "/other",
+      headOid: oid,
+      detached: true,
+      locked: false,
+      prunable: false,
+    },
+  ]);
+});
+test("marks malformed duplicate and unterminated records unsafe", () => {
+  assert.equal(
+    parsePlanningWorktreePorcelain(`worktree /repo\0HEAD ${oid}`).malformed,
+    true,
+  );
+  assert.equal(
+    parsePlanningWorktreePorcelain(
+      `worktree /repo\0HEAD ${oid}\0branch refs/heads/a\0branch refs/heads/a\0\0`,
+    ).malformed,
+    true,
+  );
+});

--- a/src/git/planning-worktree-porcelain.test.ts
+++ b/src/git/planning-worktree-porcelain.test.ts
@@ -59,12 +59,14 @@ test("rejects every unsafe branch spelling", () => {
 });
 
 test("strictly parses marker field values and record coherence", () => {
-  assert.equal(
-    parsePlanningWorktreePorcelain(
-      `worktree /repo\0HEAD ${oid}\0detached\0locked held by CI\0prunable retry after cleanup\0\0`,
-    ).malformed,
-    false,
-  );
+  for (const reason of ["held by CI", "x".repeat(2048)]) {
+    assert.equal(
+      parsePlanningWorktreePorcelain(
+        `worktree /repo\0HEAD ${oid}\0detached\0locked ${reason}\0prunable retry after cleanup\0\0`,
+      ).malformed,
+      false,
+    );
+  }
   const invalid = [
     `worktree /repo\0HEAD ${oid}\0detached value\0\0`,
     `worktree /repo\0HEAD ${oid}\0prunable bad\u0001\0\0`,

--- a/src/git/planning-worktree-porcelain.ts
+++ b/src/git/planning-worktree-porcelain.ts
@@ -12,8 +12,8 @@ export type PlanningWorktreeRegistration = Readonly<{
 function validMarkerValue(value: string): boolean {
   return (
     value.length > 0 &&
-    !/[\x00-\x1f\x7f\r\n]/u.test(value) &&
-    !value.includes(" ")
+    value.length <= 1024 &&
+    !/[\x00-\x1f\x7f\r\n]/u.test(value)
   );
 }
 export function parsePlanningWorktreePorcelain(output: string): Readonly<{

--- a/src/git/planning-worktree-porcelain.ts
+++ b/src/git/planning-worktree-porcelain.ts
@@ -10,11 +10,7 @@ export type PlanningWorktreeRegistration = Readonly<{
   prunable: boolean;
 }>;
 function validMarkerValue(value: string): boolean {
-  return (
-    value.length > 0 &&
-    value.length <= 1024 &&
-    !/[\x00-\x1f\x7f\r\n]/u.test(value)
-  );
+  return value.length > 0 && !/[\x00-\x1f\x7f\r\n]/u.test(value);
 }
 export function parsePlanningWorktreePorcelain(output: string): Readonly<{
   entries: readonly PlanningWorktreeRegistration[];

--- a/src/git/planning-worktree-porcelain.ts
+++ b/src/git/planning-worktree-porcelain.ts
@@ -1,4 +1,6 @@
 import { isAbsolute, normalize } from "node:path";
+import { isPlanningBranch, planningOid } from "./planning-git-validation.ts";
+
 export type PlanningWorktreeRegistration = Readonly<{
   path: string;
   headOid: string;
@@ -7,21 +9,6 @@ export type PlanningWorktreeRegistration = Readonly<{
   locked: boolean;
   prunable: boolean;
 }>;
-const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
-function validBranch(branch: string): boolean {
-  return (
-    branch.length > 0 &&
-    branch.length <= 1024 &&
-    !branch.startsWith("-") &&
-    !branch.startsWith("/") &&
-    !branch.endsWith("/") &&
-    !branch.endsWith(".") &&
-    !/[\x00-\x20\\~^:?*[]/u.test(branch) &&
-    !branch.includes("..") &&
-    !branch.includes("@{") &&
-    !branch.split("/").some((part) => part.length === 0)
-  );
-}
 function validMarkerValue(value: string): boolean {
   return (
     value.length > 0 &&
@@ -76,11 +63,11 @@ export function parsePlanningWorktreePorcelain(output: string): Readonly<{
       path === undefined ||
       head === undefined ||
       !isAbsolute(path) ||
-      !OID.test(head) ||
+      !planningOid.test(head) ||
       (ref !== undefined &&
         (!ref.startsWith("refs/heads/") ||
           ref.length === 11 ||
-          !validBranch(ref.slice(11)))) ||
+          !isPlanningBranch(ref.slice(11)))) ||
       (values.has("detached") && ref !== undefined) ||
       (!values.has("detached") && ref === undefined)
     ) {

--- a/src/git/planning-worktree-porcelain.ts
+++ b/src/git/planning-worktree-porcelain.ts
@@ -8,8 +8,27 @@ export type PlanningWorktreeRegistration = Readonly<{
   prunable: boolean;
 }>;
 const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
-const BRANCH =
-  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
+function validBranch(branch: string): boolean {
+  return (
+    branch.length > 0 &&
+    branch.length <= 1024 &&
+    !branch.startsWith("-") &&
+    !branch.startsWith("/") &&
+    !branch.endsWith("/") &&
+    !branch.endsWith(".") &&
+    !/[\x00-\x20\\~^:?*[]/u.test(branch) &&
+    !branch.includes("..") &&
+    !branch.includes("@{") &&
+    !branch.split("/").some((part) => part.length === 0)
+  );
+}
+function validMarkerValue(value: string): boolean {
+  return (
+    value.length > 0 &&
+    !/[\x00-\x1f\x7f\r\n]/u.test(value) &&
+    !value.includes(" ")
+  );
+}
 export function parsePlanningWorktreePorcelain(output: string): Readonly<{
   entries: readonly PlanningWorktreeRegistration[];
   malformed: boolean;
@@ -24,7 +43,9 @@ export function parsePlanningWorktreePorcelain(output: string): Readonly<{
     const values = new Map<string, string>();
     let malformed = false;
     for (const field of fields) {
-      const [key, ...rest] = field.split(" ");
+      const separator = field.indexOf(" ");
+      const key = separator === -1 ? field : field.slice(0, separator);
+      const value = separator === -1 ? "" : field.slice(separator + 1);
       if (
         ![
           "worktree",
@@ -33,13 +54,19 @@ export function parsePlanningWorktreePorcelain(output: string): Readonly<{
           "detached",
           "locked",
           "prunable",
-        ].includes(key!) ||
-        values.has(key!)
+        ].includes(key) ||
+        values.has(key) ||
+        (key === "detached" && value !== "") ||
+        ((key === "locked" || key === "prunable") &&
+          value !== "" &&
+          !validMarkerValue(value)) ||
+        ((key === "worktree" || key === "HEAD" || key === "branch") &&
+          value === "")
       ) {
         malformed = true;
         break;
       }
-      values.set(key!, rest.join(" "));
+      values.set(key, value);
     }
     const path = values.get("worktree"),
       head = values.get("HEAD"),
@@ -53,7 +80,7 @@ export function parsePlanningWorktreePorcelain(output: string): Readonly<{
       (ref !== undefined &&
         (!ref.startsWith("refs/heads/") ||
           ref.length === 11 ||
-          !BRANCH.test(ref.slice(11)))) ||
+          !validBranch(ref.slice(11)))) ||
       (values.has("detached") && ref !== undefined) ||
       (!values.has("detached") && ref === undefined)
     ) {

--- a/src/git/planning-worktree-porcelain.ts
+++ b/src/git/planning-worktree-porcelain.ts
@@ -8,6 +8,8 @@ export type PlanningWorktreeRegistration = Readonly<{
   prunable: boolean;
 }>;
 const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const BRANCH =
+  /^(?!-)(?!\/)(?!.*(?:\.\.|@\{|[\s\\~^:?*[]))(?!.*(?:\/\/|\/$|\.$)).+$/u;
 export function parsePlanningWorktreePorcelain(output: string): Readonly<{
   entries: readonly PlanningWorktreeRegistration[];
   malformed: boolean;
@@ -49,7 +51,10 @@ export function parsePlanningWorktreePorcelain(output: string): Readonly<{
       !isAbsolute(path) ||
       !OID.test(head) ||
       (ref !== undefined &&
-        (!ref.startsWith("refs/heads/") || ref.length === 11)) ||
+        (!ref.startsWith("refs/heads/") ||
+          ref.length === 11 ||
+          !BRANCH.test(ref.slice(11)))) ||
+      (values.has("detached") && ref !== undefined) ||
       (!values.has("detached") && ref === undefined)
     ) {
       return { entries: [], malformed: true };

--- a/src/git/planning-worktree-porcelain.ts
+++ b/src/git/planning-worktree-porcelain.ts
@@ -1,0 +1,73 @@
+import { isAbsolute, normalize } from "node:path";
+export type PlanningWorktreeRegistration = Readonly<{
+  path: string;
+  headOid: string;
+  branch?: string;
+  detached: boolean;
+  locked: boolean;
+  prunable: boolean;
+}>;
+const OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+export function parsePlanningWorktreePorcelain(output: string): Readonly<{
+  entries: readonly PlanningWorktreeRegistration[];
+  malformed: boolean;
+}> {
+  if (output !== "" && !output.endsWith("\0\0"))
+    return { entries: [], malformed: true };
+  const entries: PlanningWorktreeRegistration[] = [];
+  const paths = new Set<string>(),
+    branches = new Set<string>();
+  for (const block of output.split("\0\0").filter(Boolean)) {
+    const fields = block.split("\0");
+    const values = new Map<string, string>();
+    let malformed = false;
+    for (const field of fields) {
+      const [key, ...rest] = field.split(" ");
+      if (
+        ![
+          "worktree",
+          "HEAD",
+          "branch",
+          "detached",
+          "locked",
+          "prunable",
+        ].includes(key!) ||
+        values.has(key!)
+      ) {
+        malformed = true;
+        break;
+      }
+      values.set(key!, rest.join(" "));
+    }
+    const path = values.get("worktree"),
+      head = values.get("HEAD"),
+      ref = values.get("branch");
+    if (
+      malformed ||
+      path === undefined ||
+      head === undefined ||
+      !isAbsolute(path) ||
+      !OID.test(head) ||
+      (ref !== undefined &&
+        (!ref.startsWith("refs/heads/") || ref.length === 11)) ||
+      (!values.has("detached") && ref === undefined)
+    ) {
+      return { entries: [], malformed: true };
+    }
+    const branch = ref?.slice("refs/heads/".length);
+    const normalized = normalize(path);
+    if (paths.has(normalized) || (branch !== undefined && branches.has(branch)))
+      return { entries: [], malformed: true };
+    paths.add(normalized);
+    if (branch !== undefined) branches.add(branch);
+    entries.push({
+      path: normalized,
+      headOid: head,
+      ...(branch === undefined ? {} : { branch }),
+      detached: values.has("detached"),
+      locked: values.has("locked"),
+      prunable: values.has("prunable"),
+    });
+  }
+  return { entries, malformed: false };
+}

--- a/src/workflow/planning-issue-lock.test.ts
+++ b/src/workflow/planning-issue-lock.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+  PlanningIssueLockConflictError,
   acquirePlanningIssueLock,
   assertPlanningIssueLockOwned,
   parsePlanningIssueLockRecord,
@@ -77,6 +79,156 @@ test("propagates unexpected process liveness failures", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+test("concurrent acquisition permits exactly one ownership ID", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+  try {
+    const results = await Promise.allSettled([
+      acquirePlanningIssueLock(
+        dir,
+        { issueNumber: 187, runId },
+        { ownershipId, hostname: "local.test" },
+      ),
+      acquirePlanningIssueLock(
+        dir,
+        { issueNumber: 187, runId },
+        {
+          ownershipId: "123e4567-e89b-42d3-a456-426614174002",
+          hostname: "local.test",
+          processState: () => "alive",
+        },
+      ),
+    ]);
+    assert.equal(
+      results.filter((result) => result.status === "fulfilled").length,
+      1,
+    );
+    assert.equal(
+      results.filter((result) => result.status === "rejected").length,
+      1,
+    );
+    const winner = results.find(
+      (
+        result,
+      ): result is PromiseFulfilledResult<
+        Awaited<ReturnType<typeof acquirePlanningIssueLock>>
+      > => result.status === "fulfilled",
+    );
+    assert.ok(winner);
+    await releasePlanningIssueLock(winner.value);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("existing lock diagnostics classify safely and fingerprint exact bytes", async () => {
+  const cases = [
+    {
+      ownerHost: "local.test",
+      requesterHost: "local.test",
+      state: "alive" as const,
+      expected: "active",
+    },
+    {
+      ownerHost: "local.test",
+      requesterHost: "local.test",
+      state: "dead" as const,
+      expected: "stale",
+    },
+    {
+      ownerHost: "local.test",
+      requesterHost: "local.test",
+      state: "unverifiable" as const,
+      expected: "unverifiable",
+    },
+    {
+      ownerHost: "remote.test",
+      requesterHost: "local.test",
+      state: "alive" as const,
+      expected: "unverifiable",
+    },
+  ];
+  for (const item of cases) {
+    const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+    try {
+      const lock = await acquirePlanningIssueLock(
+        dir,
+        { issueNumber: 187, runId },
+        {
+          ownershipId,
+          pid: 1234,
+          hostname: item.ownerHost,
+          now: () => new Date("2026-09-07T12:00:00.000Z"),
+        },
+      );
+      const bytes = await readFile(lock.path, "utf8");
+      let processChecks = 0;
+      await assert.rejects(
+        acquirePlanningIssueLock(
+          dir,
+          { issueNumber: 187, runId },
+          {
+            ownershipId: "123e4567-e89b-42d3-a456-426614174002",
+            hostname: item.requesterHost,
+            processState: () => {
+              processChecks += 1;
+              return item.state;
+            },
+          },
+        ),
+        (error: unknown) => {
+          assert.ok(error instanceof PlanningIssueLockConflictError);
+          assert.equal(error.diagnostic.classification, item.expected);
+          assert.equal(
+            error.diagnostic.fingerprint,
+            createHash("sha256").update(bytes).digest("hex"),
+          );
+          assert.deepEqual(error.diagnostic.owner, {
+            issueNumber: 187,
+            runId,
+            pid: 1234,
+            hostname: item.ownerHost,
+            acquiredAt: "2026-09-07T12:00:00.000Z",
+          });
+          assert.equal("ownershipId" in (error.diagnostic.owner ?? {}), false);
+          return true;
+        },
+      );
+      assert.equal(
+        processChecks,
+        item.ownerHost === item.requesterHost ? 1 : 0,
+      );
+      await releasePlanningIssueLock(lock);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("malformed or replaced lock bytes are fingerprinted and never removed", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+  try {
+    const lock = await acquirePlanningIssueLock(
+      dir,
+      { issueNumber: 187, runId },
+      { ownershipId, hostname: "local.test" },
+    );
+    const malformed = "{not-json\n";
+    await writeFile(lock.path, malformed);
+    await assert.rejects(
+      acquirePlanningIssueLock(dir, { issueNumber: 187, runId }),
+      (error: unknown) =>
+        error instanceof PlanningIssueLockConflictError &&
+        error.diagnostic.classification === "malformed" &&
+        error.diagnostic.fingerprint ===
+          createHash("sha256").update(malformed).digest("hex"),
+    );
+    await assert.rejects(releasePlanningIssueLock(lock));
+    assert.equal(await readFile(lock.path, "utf8"), malformed);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("classifies competing valid local locks without takeover", async () => {
   const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
   try {

--- a/src/workflow/planning-issue-lock.test.ts
+++ b/src/workflow/planning-issue-lock.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  acquirePlanningIssueLock,
+  assertPlanningIssueLockOwned,
+  parsePlanningIssueLockRecord,
+  releasePlanningIssueLock,
+} from "./planning-issue-lock.ts";
+
+const runId = "123e4567-e89b-42d3-a456-426614174000";
+const ownershipId = "123e4567-e89b-42d3-a456-426614174001";
+test("acquires a mode-0600 owner lock and releases idempotently", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+  try {
+    const lock = await acquirePlanningIssueLock(
+      dir,
+      { issueNumber: 187, runId },
+      {
+        ownershipId,
+        pid: 1234,
+        hostname: "local.test",
+        now: () => new Date("2026-09-07T12:00:00.000Z"),
+      },
+    );
+    assert.equal(
+      lock.path,
+      join(dir, "planning-pr-v1", "locks", "issue-187.lock"),
+    );
+    assert.equal((await stat(lock.path)).mode & 0o777, 0o600);
+    assert.deepEqual(
+      Object.keys(
+        parsePlanningIssueLockRecord(await readFile(lock.path, "utf8")),
+      ),
+      [
+        "version",
+        "issueNumber",
+        "runId",
+        "ownershipId",
+        "pid",
+        "hostname",
+        "acquiredAt",
+      ],
+    );
+    await assertPlanningIssueLockOwned(lock, { issueNumber: 187, runId });
+    await releasePlanningIssueLock(lock);
+    await releasePlanningIssueLock(lock);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+test("classifies competing valid local locks without takeover", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+  try {
+    await acquirePlanningIssueLock(
+      dir,
+      { issueNumber: 187, runId },
+      { ownershipId, pid: 1234, hostname: "local.test" },
+    );
+    await assert.rejects(
+      acquirePlanningIssueLock(
+        dir,
+        { issueNumber: 187, runId },
+        {
+          ownershipId: "123e4567-e89b-42d3-a456-426614174002",
+          hostname: "local.test",
+          processState: () => "dead",
+        },
+      ),
+      (error: unknown) =>
+        (error as { diagnostic?: { classification?: string } }).diagnostic
+          ?.classification === "stale",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/workflow/planning-issue-lock.test.ts
+++ b/src/workflow/planning-issue-lock.test.ts
@@ -229,6 +229,29 @@ test("malformed or replaced lock bytes are fingerprinted and never removed", asy
   }
 });
 
+test("malformed binary lock fingerprints the exact on-disk bytes", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+  try {
+    const lock = await acquirePlanningIssueLock(
+      dir,
+      { issueNumber: 187, runId },
+      { ownershipId, hostname: "local.test" },
+    );
+    const bytes = Buffer.from([0xff, 0xfe, 0x7b, 0x0a]);
+    await writeFile(lock.path, bytes);
+    await assert.rejects(
+      acquirePlanningIssueLock(dir, { issueNumber: 187, runId }),
+      (error: unknown) =>
+        error instanceof PlanningIssueLockConflictError &&
+        error.diagnostic.classification === "malformed" &&
+        error.diagnostic.fingerprint ===
+          createHash("sha256").update(bytes).digest("hex"),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("classifies competing valid local locks without takeover", async () => {
   const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
   try {

--- a/src/workflow/planning-issue-lock.test.ts
+++ b/src/workflow/planning-issue-lock.test.ts
@@ -51,6 +51,32 @@ test("acquires a mode-0600 owner lock and releases idempotently", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+test("propagates unexpected process liveness failures", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
+  try {
+    await acquirePlanningIssueLock(
+      dir,
+      { issueNumber: 187, runId },
+      { ownershipId, pid: 1234, hostname: "local.test" },
+    );
+    await assert.rejects(
+      acquirePlanningIssueLock(
+        dir,
+        { issueNumber: 187, runId },
+        {
+          ownershipId: "123e4567-e89b-42d3-a456-426614174002",
+          hostname: "local.test",
+          processState: () => {
+            throw new Error("liveness failed");
+          },
+        },
+      ),
+      /liveness failed/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 test("classifies competing valid local locks without takeover", async () => {
   const dir = await mkdtemp(join(tmpdir(), "planning-lock-"));
   try {

--- a/src/workflow/planning-issue-lock.ts
+++ b/src/workflow/planning-issue-lock.ts
@@ -188,22 +188,37 @@ export async function acquirePlanningIssueLock(
     handle = await open(path, "wx", 0o600);
     await handle.writeFile(`${JSON.stringify(record)}\n`);
     await handle.sync();
+    await handle.close();
+    handle = undefined;
     return { path, record };
   } catch (error) {
-    if (handle !== undefined) {
+    if (handle === undefined) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new PlanningIssueLockConflictError(
+          diagnostic(path, await readFile(path, "utf8"), options),
+        );
+      }
+      throw error;
+    }
+    const failures: unknown[] = [error];
+    try {
       await handle.close();
-      await unlink(path).catch((unlinkError: unknown) => {
-        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT")
-          throw unlinkError;
+    } catch (closeError) {
+      failures.push(closeError);
+    }
+    try {
+      await unlink(path);
+    } catch (unlinkError) {
+      if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") {
+        failures.push(unlinkError);
+      }
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(failures, "Planning issue lock cleanup failed", {
+        cause: error,
       });
     }
-    if ((error as NodeJS.ErrnoException).code === "EEXIST")
-      throw new PlanningIssueLockConflictError(
-        diagnostic(path, await readFile(path, "utf8"), options),
-      );
     throw error;
-  } finally {
-    if (handle !== undefined) await handle.close().catch(() => undefined);
   }
 }
 export async function assertPlanningIssueLockOwned(

--- a/src/workflow/planning-issue-lock.ts
+++ b/src/workflow/planning-issue-lock.ts
@@ -225,10 +225,6 @@ export async function assertPlanningIssueLockOwned(
   lock: PlanningIssueLock,
   expected: { issueNumber: number; runId: string; lockPath?: string },
 ): Promise<void> {
-  const path = planningIssueLockPath(
-    join(lock.path, "..", "..", "..", ".."),
-    expected.issueNumber,
-  );
   if (
     expected.lockPath !== undefined &&
     resolve(expected.lockPath) !== resolve(lock.path)
@@ -260,7 +256,6 @@ export async function assertPlanningIssueLockOwned(
       path: lock.path,
       fingerprint: "",
     });
-  void path;
 }
 export async function releasePlanningIssueLock(
   lock: PlanningIssueLock,

--- a/src/workflow/planning-issue-lock.ts
+++ b/src/workflow/planning-issue-lock.ts
@@ -123,13 +123,13 @@ function liveness(pid: number): "alive" | "dead" | "unverifiable" {
 }
 function diagnostic(
   path: string,
-  bytes: string,
+  bytes: Buffer,
   options: PlanningIssueLockOptions,
 ): PlanningIssueLockDiagnostic {
   const fingerprint = createHash("sha256").update(bytes).digest("hex");
   let record: PlanningIssueLockRecord;
   try {
-    record = parsePlanningIssueLockRecord(bytes);
+    record = parsePlanningIssueLockRecord(bytes.toString("utf8"));
   } catch {
     return { classification: "malformed", path, fingerprint };
   }
@@ -195,7 +195,7 @@ export async function acquirePlanningIssueLock(
     if (handle === undefined) {
       if ((error as NodeJS.ErrnoException).code === "EEXIST") {
         throw new PlanningIssueLockConflictError(
-          diagnostic(path, await readFile(path, "utf8"), options),
+          diagnostic(path, await readFile(path), options),
         );
       }
       throw error;

--- a/src/workflow/planning-issue-lock.ts
+++ b/src/workflow/planning-issue-lock.ts
@@ -192,7 +192,10 @@ export async function acquirePlanningIssueLock(
   } catch (error) {
     if (handle !== undefined) {
       await handle.close();
-      await unlink(path).catch(() => undefined);
+      await unlink(path).catch((unlinkError: unknown) => {
+        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT")
+          throw unlinkError;
+      });
     }
     if ((error as NodeJS.ErrnoException).code === "EEXIST")
       throw new PlanningIssueLockConflictError(

--- a/src/workflow/planning-issue-lock.ts
+++ b/src/workflow/planning-issue-lock.ts
@@ -127,33 +127,34 @@ function diagnostic(
   options: PlanningIssueLockOptions,
 ): PlanningIssueLockDiagnostic {
   const fingerprint = createHash("sha256").update(bytes).digest("hex");
+  let record: PlanningIssueLockRecord;
   try {
-    const record = parsePlanningIssueLockRecord(bytes);
-    const here = options.hostname ?? localHostname();
-    const state =
-      record.hostname === here
-        ? (options.processState ?? liveness)(record.pid)
-        : "unverifiable";
-    return {
-      classification:
-        state === "alive"
-          ? "active"
-          : state === "dead"
-            ? "stale"
-            : "unverifiable",
-      path,
-      fingerprint,
-      owner: {
-        issueNumber: record.issueNumber,
-        runId: record.runId,
-        pid: record.pid,
-        hostname: record.hostname,
-        acquiredAt: record.acquiredAt,
-      },
-    };
+    record = parsePlanningIssueLockRecord(bytes);
   } catch {
     return { classification: "malformed", path, fingerprint };
   }
+  const here = options.hostname ?? localHostname();
+  const state =
+    record.hostname === here
+      ? (options.processState ?? liveness)(record.pid)
+      : "unverifiable";
+  return {
+    classification:
+      state === "alive"
+        ? "active"
+        : state === "dead"
+          ? "stale"
+          : "unverifiable",
+    path,
+    fingerprint,
+    owner: {
+      issueNumber: record.issueNumber,
+      runId: record.runId,
+      pid: record.pid,
+      hostname: record.hostname,
+      acquiredAt: record.acquiredAt,
+    },
+  };
 }
 export class PlanningIssueLockConflictError extends Error {
   readonly diagnostic: PlanningIssueLockDiagnostic;

--- a/src/workflow/planning-issue-lock.ts
+++ b/src/workflow/planning-issue-lock.ts
@@ -1,0 +1,260 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, open, readFile, unlink } from "node:fs/promises";
+import { hostname as localHostname } from "node:os";
+import { join, resolve } from "node:path";
+
+export type PlanningIssueLockRecord = Readonly<{
+  version: 1;
+  issueNumber: number;
+  runId: string;
+  ownershipId: string;
+  pid: number;
+  hostname: string;
+  acquiredAt: string;
+}>;
+export type PlanningIssueLock = Readonly<{
+  path: string;
+  record: PlanningIssueLockRecord;
+}>;
+export type PlanningIssueLockOptions = Readonly<{
+  ownershipId?: string;
+  pid?: number;
+  hostname?: string;
+  now?: () => Date;
+  processState?: (pid: number) => "alive" | "dead" | "unverifiable";
+}>;
+export type PlanningIssueLockDiagnostic = Readonly<{
+  classification: "active" | "stale" | "unverifiable" | "malformed";
+  path: string;
+  fingerprint: string;
+  owner?: Readonly<{
+    issueNumber: number;
+    runId: string;
+    pid: number;
+    hostname: string;
+    acquiredAt: string;
+  }>;
+}>;
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const TIMESTAMP = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/u;
+const HOST = /^[A-Za-z0-9_][A-Za-z0-9._-]{0,252}$/u;
+function fail(reason: string): never {
+  throw new TypeError(`Planning issue lock is invalid: ${reason}`);
+}
+function positive(value: unknown): number {
+  return Number.isSafeInteger(value) && (value as number) > 0
+    ? (value as number)
+    : fail("positive-integer");
+}
+function uuid(value: unknown): string {
+  return typeof value === "string" && UUID.test(value) ? value : fail("uuid");
+}
+function time(value: unknown): string {
+  return typeof value === "string" &&
+    TIMESTAMP.test(value) &&
+    new Date(value).toISOString() === value
+    ? value
+    : fail("timestamp");
+}
+export function planningIssueLockPath(
+  runStateDir: string,
+  issueNumber: number,
+): string {
+  positive(issueNumber);
+  return join(
+    resolve(runStateDir),
+    "planning-pr-v1",
+    "locks",
+    `issue-${issueNumber}.lock`,
+  );
+}
+export function parsePlanningIssueLockRecord(
+  raw: string,
+): PlanningIssueLockRecord {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return fail("json");
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    return fail("object");
+  const v = value as Record<string, unknown>;
+  const keys = [
+    "version",
+    "issueNumber",
+    "runId",
+    "ownershipId",
+    "pid",
+    "hostname",
+    "acquiredAt",
+  ];
+  if (
+    Object.keys(v).length !== keys.length ||
+    keys.some((key) => !(key in v)) ||
+    Object.keys(v).some((key) => !keys.includes(key))
+  )
+    return fail("keys");
+  if (v.version !== 1) return fail("version");
+  const host =
+    typeof v.hostname === "string" && HOST.test(v.hostname)
+      ? v.hostname
+      : fail("hostname");
+  return {
+    version: 1,
+    issueNumber: positive(v.issueNumber),
+    runId: uuid(v.runId),
+    ownershipId: uuid(v.ownershipId),
+    pid: positive(v.pid),
+    hostname: host,
+    acquiredAt: time(v.acquiredAt),
+  };
+}
+function liveness(pid: number): "alive" | "dead" | "unverifiable" {
+  try {
+    process.kill(pid, 0);
+    return "alive";
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ESRCH"
+      ? "dead"
+      : "unverifiable";
+  }
+}
+function diagnostic(
+  path: string,
+  bytes: string,
+  options: PlanningIssueLockOptions,
+): PlanningIssueLockDiagnostic {
+  const fingerprint = createHash("sha256").update(bytes).digest("hex");
+  try {
+    const record = parsePlanningIssueLockRecord(bytes);
+    const here = options.hostname ?? localHostname();
+    const state =
+      record.hostname === here
+        ? (options.processState ?? liveness)(record.pid)
+        : "unverifiable";
+    return {
+      classification:
+        state === "alive"
+          ? "active"
+          : state === "dead"
+            ? "stale"
+            : "unverifiable",
+      path,
+      fingerprint,
+      owner: {
+        issueNumber: record.issueNumber,
+        runId: record.runId,
+        pid: record.pid,
+        hostname: record.hostname,
+        acquiredAt: record.acquiredAt,
+      },
+    };
+  } catch {
+    return { classification: "malformed", path, fingerprint };
+  }
+}
+export class PlanningIssueLockConflictError extends Error {
+  readonly diagnostic: PlanningIssueLockDiagnostic;
+  constructor(diagnostic: PlanningIssueLockDiagnostic) {
+    super(`Planning issue lock conflict: ${diagnostic.classification}`);
+    this.name = "PlanningIssueLockConflictError";
+    this.diagnostic = diagnostic;
+  }
+}
+export async function acquirePlanningIssueLock(
+  runStateDir: string,
+  input: { issueNumber: number; runId: string },
+  options: PlanningIssueLockOptions = {},
+): Promise<PlanningIssueLock> {
+  const path = planningIssueLockPath(runStateDir, input.issueNumber);
+  const record: PlanningIssueLockRecord = {
+    version: 1,
+    issueNumber: positive(input.issueNumber),
+    runId: uuid(input.runId),
+    ownershipId: uuid(options.ownershipId ?? randomUUID()),
+    pid: positive(options.pid ?? process.pid),
+    hostname: options.hostname ?? localHostname(),
+    acquiredAt: (options.now ?? (() => new Date()))().toISOString(),
+  };
+  if (!HOST.test(record.hostname)) fail("hostname");
+  await mkdir(join(resolve(runStateDir), "planning-pr-v1", "locks"), {
+    recursive: true,
+  });
+  let handle;
+  try {
+    handle = await open(path, "wx", 0o600);
+    await handle.writeFile(`${JSON.stringify(record)}\n`);
+    await handle.sync();
+    return { path, record };
+  } catch (error) {
+    if (handle !== undefined) {
+      await handle.close();
+      await unlink(path).catch(() => undefined);
+    }
+    if ((error as NodeJS.ErrnoException).code === "EEXIST")
+      throw new PlanningIssueLockConflictError(
+        diagnostic(path, await readFile(path, "utf8"), options),
+      );
+    throw error;
+  } finally {
+    if (handle !== undefined) await handle.close().catch(() => undefined);
+  }
+}
+export async function assertPlanningIssueLockOwned(
+  lock: PlanningIssueLock,
+  expected: { issueNumber: number; runId: string; lockPath?: string },
+): Promise<void> {
+  const path = planningIssueLockPath(
+    join(lock.path, "..", "..", "..", ".."),
+    expected.issueNumber,
+  );
+  if (
+    expected.lockPath !== undefined &&
+    resolve(expected.lockPath) !== resolve(lock.path)
+  )
+    throw new PlanningIssueLockConflictError({
+      classification: "malformed",
+      path: lock.path,
+      fingerprint: "",
+    });
+  if (
+    expected.issueNumber !== lock.record.issueNumber ||
+    expected.runId !== lock.record.runId
+  )
+    throw new PlanningIssueLockConflictError({
+      classification: "malformed",
+      path: lock.path,
+      fingerprint: "",
+    });
+  const current = parsePlanningIssueLockRecord(
+    await readFile(lock.path, "utf8"),
+  );
+  if (
+    current.issueNumber !== expected.issueNumber ||
+    current.runId !== expected.runId ||
+    current.ownershipId !== lock.record.ownershipId
+  )
+    throw new PlanningIssueLockConflictError({
+      classification: "malformed",
+      path: lock.path,
+      fingerprint: "",
+    });
+  void path;
+}
+export async function releasePlanningIssueLock(
+  lock: PlanningIssueLock,
+): Promise<void> {
+  try {
+    await assertPlanningIssueLockOwned(lock, {
+      issueNumber: lock.record.issueNumber,
+      runId: lock.record.runId,
+      lockPath: lock.path,
+    });
+    await unlink(lock.path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+}

--- a/src/workflow/planning-state-store.test.ts
+++ b/src/workflow/planning-state-store.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  acquirePlanningIssueLock,
+  releasePlanningIssueLock,
+} from "./planning-issue-lock.ts";
+import { createPlanningState } from "./planning-state.ts";
+import { PlanningStateStore } from "./planning-state-store.ts";
+const runId = "123e4567-e89b-42d3-a456-426614174000";
+test("initializes and atomically replaces canonical planning state under owner lock", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-store-"));
+  try {
+    const store = new PlanningStateStore(dir);
+    const state = createPlanningState({
+      issueNumber: 187,
+      issueTitle: "Example",
+      gates: { specRequired: false, planRequired: false },
+      runId,
+      now: "2026-09-07T12:00:00.000Z",
+    });
+    const lock = await acquirePlanningIssueLock(dir, {
+      issueNumber: 187,
+      runId,
+    });
+    await store.initialize({ state, lock });
+    assert.equal((await stat(store.path(187))).mode & 0o777, 0o600);
+    assert.match(await readFile(store.path(187), "utf8"), /\n$/);
+    const next = {
+      ...state,
+      revision: 1,
+      updatedAt: "2026-09-07T12:00:01.000Z",
+    };
+    assert.deepEqual(
+      await store.replace({
+        issueNumber: 187,
+        expectedRunId: runId,
+        expectedRevision: 0,
+        next,
+        lock,
+      }),
+      next,
+    );
+    await releasePlanningIssueLock(lock);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+test("pre-rename interruption preserves previous complete state", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-store-"));
+  try {
+    const normal = new PlanningStateStore(dir);
+    const state = createPlanningState({
+      issueNumber: 187,
+      issueTitle: "Example",
+      gates: { specRequired: false, planRequired: false },
+      runId,
+      now: "2026-09-07T12:00:00.000Z",
+    });
+    const lock = await acquirePlanningIssueLock(dir, {
+      issueNumber: 187,
+      runId,
+    });
+    await normal.initialize({ state, lock });
+    const broken = new PlanningStateStore(dir, {
+      beforeRename: async () => {
+        throw new Error("injected interruption");
+      },
+    });
+    await assert.rejects(
+      broken.replace({
+        issueNumber: 187,
+        expectedRunId: runId,
+        expectedRevision: 0,
+        next: { ...state, revision: 1, updatedAt: "2026-09-07T12:00:01.000Z" },
+        lock,
+      }),
+      /injected interruption/,
+    );
+    assert.deepEqual(await normal.read(187), state);
+    await releasePlanningIssueLock(lock);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/workflow/planning-state-store.test.ts
+++ b/src/workflow/planning-state-store.test.ts
@@ -1,14 +1,28 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import {
   acquirePlanningIssueLock,
   releasePlanningIssueLock,
 } from "./planning-issue-lock.ts";
-import { createPlanningState } from "./planning-state.ts";
-import { PlanningStateStore } from "./planning-state-store.ts";
+import {
+  PlanningStateValidationError,
+  createPlanningState,
+} from "./planning-state.ts";
+import {
+  PlanningStateConflictError,
+  PlanningStateStore,
+} from "./planning-state-store.ts";
 const runId = "123e4567-e89b-42d3-a456-426614174000";
 test("initializes and atomically replaces canonical planning state under owner lock", async () => {
   const dir = await mkdtemp(join(tmpdir(), "planning-store-"));
@@ -48,6 +62,99 @@ test("initializes and atomically replaces canonical planning state under owner l
     await rm(dir, { recursive: true, force: true });
   }
 });
+test("malformed reads fail closed with the canonical state path", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-store-"));
+  try {
+    const store = new PlanningStateStore(dir);
+    const path = store.path(187);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "{secret malformed bytes");
+    await assert.rejects(
+      store.read(187),
+      (error: unknown) =>
+        error instanceof PlanningStateValidationError &&
+        error.reason === "invalid-json" &&
+        error.path === "$" &&
+        error.statePath === path &&
+        !error.message.includes("secret"),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("replacement conflicts preserve the previous canonical bytes", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "planning-store-"));
+  try {
+    const store = new PlanningStateStore(dir);
+    const state = createPlanningState({
+      issueNumber: 187,
+      issueTitle: "Example",
+      gates: { specRequired: false, planRequired: false },
+      runId,
+      now: "2026-09-07T12:00:00.000Z",
+    });
+    const lock = await acquirePlanningIssueLock(dir, {
+      issueNumber: 187,
+      runId,
+    });
+    await store.initialize({ state, lock });
+    const previous = await readFile(store.path(187), "utf8");
+    const next = {
+      ...state,
+      revision: 1,
+      updatedAt: "2026-09-07T12:00:01.000Z",
+    };
+    for (const attempt of [
+      {
+        expectedRunId: "123e4567-e89b-42d3-a456-426614174099",
+        expectedRevision: 0,
+        reason: "run-id-mismatch",
+      },
+      {
+        expectedRunId: runId,
+        expectedRevision: 1,
+        reason: "revision-mismatch",
+      },
+    ]) {
+      await assert.rejects(
+        store.replace({
+          issueNumber: 187,
+          expectedRunId: attempt.expectedRunId,
+          expectedRevision: attempt.expectedRevision,
+          next,
+          lock,
+        }),
+        (error: unknown) =>
+          error instanceof PlanningStateConflictError &&
+          error.reason === attempt.reason,
+      );
+      assert.equal(await readFile(store.path(187), "utf8"), previous);
+    }
+    const wrongIssueLock = await acquirePlanningIssueLock(dir, {
+      issueNumber: 188,
+      runId,
+    });
+    await assert.rejects(
+      store.replace({
+        issueNumber: 187,
+        expectedRunId: runId,
+        expectedRevision: 0,
+        next,
+        lock: wrongIssueLock,
+      }),
+      (error: unknown) =>
+        error instanceof PlanningStateConflictError &&
+        error.reason === "lock-path-mismatch",
+    );
+    assert.equal(await readFile(store.path(187), "utf8"), previous);
+    await releasePlanningIssueLock(wrongIssueLock);
+    await releasePlanningIssueLock(lock);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("pre-rename interruption preserves previous complete state", async () => {
   const dir = await mkdtemp(join(tmpdir(), "planning-store-"));
   try {
@@ -80,6 +187,12 @@ test("pre-rename interruption preserves previous complete state", async () => {
       /injected interruption/,
     );
     assert.deepEqual(await normal.read(187), state);
+    assert.deepEqual(
+      (await readdir(dirname(normal.path(187)))).filter((name) =>
+        name.endsWith(".tmp"),
+      ),
+      [],
+    );
     await releasePlanningIssueLock(lock);
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/src/workflow/planning-state-store.ts
+++ b/src/workflow/planning-state-store.ts
@@ -147,6 +147,7 @@ export class PlanningStateStore {
     const temporary = `${path}.${randomUUID()}.tmp`;
     let renamed = false;
     let handle;
+    let primaryFailure: unknown;
     try {
       if (!replace) {
         try {
@@ -179,13 +180,32 @@ export class PlanningStateStore {
         )
           throw error;
       }
-    } finally {
-      if (handle !== undefined) await handle.close().catch(() => undefined);
-      if (!renamed)
-        await unlink(temporary).catch((unlinkError: unknown) => {
-          if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT")
-            throw unlinkError;
-        });
+    } catch (error) {
+      primaryFailure = error;
     }
+    const failures: unknown[] =
+      primaryFailure === undefined ? [] : [primaryFailure];
+    if (handle !== undefined) {
+      try {
+        await handle.close();
+      } catch (closeError) {
+        failures.push(closeError);
+      }
+    }
+    if (!renamed) {
+      try {
+        await unlink(temporary);
+      } catch (unlinkError) {
+        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") {
+          failures.push(unlinkError);
+        }
+      }
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(failures, "Planning state cleanup failed", {
+        cause: primaryFailure,
+      });
+    }
+    if (failures.length === 1) throw failures[0];
   }
 }

--- a/src/workflow/planning-state-store.ts
+++ b/src/workflow/planning-state-store.ts
@@ -3,6 +3,7 @@ import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import {
   assertPlanningIssueLockOwned,
+  planningIssueLockPath,
   type PlanningIssueLock,
 } from "./planning-issue-lock.ts";
 import {
@@ -111,28 +112,16 @@ export class PlanningStateStore {
     runId: string,
     path: string,
   ): Promise<void> {
+    const lockPath = planningIssueLockPath(this.runStateDir, issue);
     try {
       await assertPlanningIssueLockOwned(lock, {
         issueNumber: issue,
         runId,
-        lockPath: join(
-          this.runStateDir,
-          "planning-pr-v1",
-          "locks",
-          `issue-${issue}.lock`,
-        ),
+        lockPath,
       });
     } catch (_error) {
       throw new PlanningStateConflictError(
-        resolve(lock.path) !==
-          resolve(
-            join(
-              this.runStateDir,
-              "planning-pr-v1",
-              "locks",
-              `issue-${issue}.lock`,
-            ),
-          )
+        resolve(lock.path) !== resolve(lockPath)
           ? "lock-path-mismatch"
           : "lock-ownership-mismatch",
         path,

--- a/src/workflow/planning-state-store.ts
+++ b/src/workflow/planning-state-store.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import {
+  assertPlanningIssueLockOwned,
+  type PlanningIssueLock,
+} from "./planning-issue-lock.ts";
+import {
+  PlanningStateValidationError,
+  assertPlanningStateReplacement,
+  parsePlanningState,
+  serializePlanningState,
+  validatePlanningState,
+  type PlanningStateV1,
+} from "./planning-state.ts";
+export type PlanningStateConflictReason =
+  | "state-exists"
+  | "state-missing"
+  | "run-id-mismatch"
+  | "revision-mismatch"
+  | "lock-path-mismatch"
+  | "lock-ownership-mismatch";
+export class PlanningStateConflictError extends Error {
+  readonly reason: PlanningStateConflictReason;
+  readonly statePath: string;
+  constructor(reason: PlanningStateConflictReason, statePath: string) {
+    super(`Planning state conflict: ${reason}`);
+    this.name = "PlanningStateConflictError";
+    this.reason = reason;
+    this.statePath = statePath;
+  }
+}
+export function planningStatePath(
+  runStateDir: string,
+  issueNumber: number,
+): string {
+  if (!Number.isSafeInteger(issueNumber) || issueNumber < 1)
+    throw new RangeError("Issue number must be positive");
+  return join(
+    resolve(runStateDir),
+    "planning-pr-v1",
+    "issues",
+    `issue-${issueNumber}.json`,
+  );
+}
+export class PlanningStateStore {
+  readonly runStateDir: string;
+  readonly beforeRename:
+    | ((temporary: string, target: string) => Promise<void>)
+    | undefined;
+  constructor(
+    runStateDir: string,
+    options: {
+      beforeRename?: (temporary: string, target: string) => Promise<void>;
+    } = {},
+  ) {
+    this.runStateDir = resolve(runStateDir);
+    this.beforeRename = options.beforeRename;
+  }
+  path(issueNumber: number): string {
+    return planningStatePath(this.runStateDir, issueNumber);
+  }
+  async read(issueNumber: number): Promise<PlanningStateV1 | undefined> {
+    const path = this.path(issueNumber);
+    try {
+      return parsePlanningState(await readFile(path, "utf8"));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      if (error instanceof PlanningStateValidationError)
+        throw new PlanningStateValidationError(error.reason, error.path, path);
+      throw error;
+    }
+  }
+  async initialize(input: {
+    state: PlanningStateV1;
+    lock: PlanningIssueLock;
+  }): Promise<PlanningStateV1> {
+    const state = validatePlanningState(input.state);
+    const path = this.path(state.issueNumber);
+    await mkdir(dirname(path), { recursive: true });
+    if ((await this.read(state.issueNumber)) !== undefined)
+      throw new PlanningStateConflictError("state-exists", path);
+    await this.owned(input.lock, state.issueNumber, state.runId, path);
+    await this.write(path, state, false);
+    return state;
+  }
+  async replace(input: {
+    issueNumber: number;
+    expectedRunId: string;
+    expectedRevision: number;
+    next: PlanningStateV1;
+    lock: PlanningIssueLock;
+  }): Promise<PlanningStateV1> {
+    const path = this.path(input.issueNumber);
+    const current = await this.read(input.issueNumber);
+    if (current === undefined)
+      throw new PlanningStateConflictError("state-missing", path);
+    if (current.runId !== input.expectedRunId)
+      throw new PlanningStateConflictError("run-id-mismatch", path);
+    if (current.revision !== input.expectedRevision)
+      throw new PlanningStateConflictError("revision-mismatch", path);
+    const next = validatePlanningState(input.next);
+    assertPlanningStateReplacement(current, next);
+    await this.owned(input.lock, input.issueNumber, current.runId, path);
+    await this.write(path, next, true);
+    return next;
+  }
+  private async owned(
+    lock: PlanningIssueLock,
+    issue: number,
+    runId: string,
+    path: string,
+  ): Promise<void> {
+    try {
+      await assertPlanningIssueLockOwned(lock, {
+        issueNumber: issue,
+        runId,
+        lockPath: join(
+          this.runStateDir,
+          "planning-pr-v1",
+          "locks",
+          `issue-${issue}.lock`,
+        ),
+      });
+    } catch (_error) {
+      throw new PlanningStateConflictError(
+        resolve(lock.path) !==
+          resolve(
+            join(
+              this.runStateDir,
+              "planning-pr-v1",
+              "locks",
+              `issue-${issue}.lock`,
+            ),
+          )
+          ? "lock-path-mismatch"
+          : "lock-ownership-mismatch",
+        path,
+      );
+    }
+  }
+  private async write(
+    path: string,
+    state: PlanningStateV1,
+    replace: boolean,
+  ): Promise<void> {
+    const temporary = `${path}.${randomUUID()}.tmp`;
+    let renamed = false;
+    let handle;
+    try {
+      if (!replace) {
+        try {
+          await readFile(path);
+          throw new PlanningStateConflictError("state-exists", path);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+      }
+      handle = await open(temporary, "wx", 0o600);
+      await handle.writeFile(serializePlanningState(state));
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await this.beforeRename?.(temporary, path);
+      await rename(temporary, path);
+      renamed = true;
+      try {
+        const directory = await open(dirname(path), "r");
+        try {
+          await directory.sync();
+        } finally {
+          await directory.close();
+        }
+      } catch (error) {
+        if (
+          !["EINVAL", "ENOTSUP", "EPERM"].includes(
+            (error as NodeJS.ErrnoException).code ?? "",
+          )
+        )
+          throw error;
+      }
+    } finally {
+      if (handle !== undefined) await handle.close().catch(() => undefined);
+      if (!renamed) await unlink(temporary).catch(() => undefined);
+    }
+  }
+}

--- a/src/workflow/planning-state-store.ts
+++ b/src/workflow/planning-state-store.ts
@@ -181,7 +181,11 @@ export class PlanningStateStore {
       }
     } finally {
       if (handle !== undefined) await handle.close().catch(() => undefined);
-      if (!renamed) await unlink(temporary).catch(() => undefined);
+      if (!renamed)
+        await unlink(temporary).catch((unlinkError: unknown) => {
+          if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT")
+            throw unlinkError;
+        });
     }
   }
 }

--- a/src/workflow/planning-state-transitions.ts
+++ b/src/workflow/planning-state-transitions.ts
@@ -1,0 +1,216 @@
+import { isDeepStrictEqual } from "node:util";
+import type {
+  PlanningArtifactEvidence,
+  PlanningPhaseStateV1,
+  PlanningPullRequestEvidence,
+  PlanningWorkspaceEvidence,
+} from "./planning-state-types.ts";
+import { PlanningStateValidationError } from "./planning-state-validation.ts";
+
+type PhaseName =
+  | "pending"
+  | "workspace-ready"
+  | "pull-request-open"
+  | "complete-remote-base"
+  | "complete-merged-ready"
+  | "complete-merged-worktree-removed"
+  | "complete-merged-removed";
+
+function phaseName(phase: PlanningPhaseStateV1): PhaseName {
+  if (phase.status !== "complete") return phase.status;
+  if (phase.completion.kind === "remote-base") return "complete-remote-base";
+  if ("workspace" in phase) {
+    return `complete-merged-${phase.workspace.cleanup.state}`;
+  }
+  throw new TypeError("Merged planning phase requires workspace evidence");
+}
+
+const allowedTransitions: Readonly<Record<PhaseName, readonly PhaseName[]>> = {
+  pending: ["pending", "workspace-ready", "complete-remote-base"],
+  "workspace-ready": ["workspace-ready", "pull-request-open"],
+  "pull-request-open": ["pull-request-open", "complete-merged-ready"],
+  "complete-remote-base": ["complete-remote-base"],
+  "complete-merged-ready": [
+    "complete-merged-ready",
+    "complete-merged-worktree-removed",
+  ],
+  "complete-merged-worktree-removed": [
+    "complete-merged-worktree-removed",
+    "complete-merged-removed",
+  ],
+  "complete-merged-removed": ["complete-merged-removed"],
+};
+
+function fail(reason: string, index: number, suffix = ""): never {
+  throw new PlanningStateValidationError(reason, `$.phases[${index}]${suffix}`);
+}
+
+function assertSame(value: unknown, next: unknown, index: number): void {
+  if (!isDeepStrictEqual(value, next)) fail("immutable-evidence", index);
+}
+
+function workspaceStableEvidence(workspace: PlanningWorkspaceEvidence) {
+  const { headOid: _headOid, cleanup: _cleanup, ...stable } = workspace;
+  return stable;
+}
+
+function assertWorkspace(
+  current: PlanningWorkspaceEvidence,
+  next: PlanningWorkspaceEvidence,
+  allowHeadAdvance: boolean,
+  index: number,
+): void {
+  assertSame(
+    workspaceStableEvidence(current),
+    workspaceStableEvidence(next),
+    index,
+  );
+  if (allowHeadAdvance) {
+    if (current.cleanup.state !== "ready" || next.cleanup.state !== "ready") {
+      fail("immutable-evidence", index);
+    }
+    return;
+  }
+  if (current.headOid !== next.headOid) fail("immutable-evidence", index);
+  if (current.cleanup.state === next.cleanup.state) {
+    assertSame(current.cleanup, next.cleanup, index);
+    return;
+  }
+  if (
+    current.cleanup.state === "ready" &&
+    next.cleanup.state === "worktree-removed" &&
+    next.cleanup.pushedHeadOid === current.headOid
+  ) {
+    return;
+  }
+  if (
+    current.cleanup.state === "worktree-removed" &&
+    next.cleanup.state === "removed" &&
+    next.cleanup.pushedHeadOid === current.cleanup.pushedHeadOid
+  ) {
+    return;
+  }
+  fail("invalid-cleanup-transition", index, ".workspace.cleanup");
+}
+
+function artifactStableEvidence(artifact: PlanningArtifactEvidence) {
+  const { commitOid: _commitOid, ...stable } = artifact;
+  return stable;
+}
+
+function assertArtifacts(
+  current: readonly PlanningArtifactEvidence[],
+  next: readonly PlanningArtifactEvidence[],
+  allowHeadAdvance: boolean,
+  index: number,
+): void {
+  if (current.length !== next.length) fail("immutable-evidence", index);
+  for (let item = 0; item < current.length; item += 1) {
+    const left = current[item]!;
+    const right = next[item]!;
+    assertSame(
+      artifactStableEvidence(left),
+      artifactStableEvidence(right),
+      index,
+    );
+    if (
+      left.commitOid !== right.commitOid &&
+      !(allowHeadAdvance && left.source === "workspace")
+    ) {
+      fail("immutable-evidence", index);
+    }
+  }
+}
+
+function pullRequestStableEvidence(pullRequest: PlanningPullRequestEvidence) {
+  const { headOid: _headOid, ...stable } = pullRequest;
+  return stable;
+}
+
+function assertPullRequest(
+  current: PlanningPullRequestEvidence,
+  next: PlanningPullRequestEvidence,
+  allowHeadAdvance: boolean,
+  index: number,
+): void {
+  assertSame(
+    pullRequestStableEvidence(current),
+    pullRequestStableEvidence(next),
+    index,
+  );
+  if (!allowHeadAdvance && current.headOid !== next.headOid) {
+    fail("immutable-evidence", index);
+  }
+}
+
+export function assertPlanningPhaseReplacement(
+  current: PlanningPhaseStateV1,
+  next: PlanningPhaseStateV1,
+  index: number,
+): void {
+  const currentName = phaseName(current);
+  const nextName = phaseName(next);
+  if (!allowedTransitions[currentName].includes(nextName)) {
+    fail("invalid-transition", index, ".status");
+  }
+  if (current.status === "pending") return;
+  if (
+    current.status === "complete" &&
+    current.completion.kind === "remote-base"
+  ) {
+    assertSame(current, next, index);
+    return;
+  }
+  if (current.status === "workspace-ready") {
+    if (
+      next.status !== "workspace-ready" &&
+      next.status !== "pull-request-open"
+    ) {
+      fail("invalid-transition", index, ".status");
+    }
+    assertSame(current.base, next.base, index);
+    assertWorkspace(current.workspace, next.workspace, true, index);
+    return;
+  }
+  if (current.status === "pull-request-open") {
+    if (
+      next.status !== "pull-request-open" &&
+      !(
+        next.status === "complete" &&
+        next.completion.kind === "merged-pull-request" &&
+        "workspace" in next
+      )
+    ) {
+      fail("invalid-transition", index, ".status");
+    }
+    assertSame(current.base, next.base, index);
+    assertWorkspace(current.workspace, next.workspace, true, index);
+    assertArtifacts(current.artifacts, next.artifacts, true, index);
+    assertPullRequest(current.pullRequest, next.pullRequest, true, index);
+    return;
+  }
+  if (
+    current.completion.kind !== "merged-pull-request" ||
+    !("workspace" in current) ||
+    next.status !== "complete" ||
+    next.completion.kind !== "merged-pull-request" ||
+    !("workspace" in next)
+  ) {
+    fail("invalid-transition", index, ".status");
+  }
+  const allowHeadAdvance =
+    current.workspace.cleanup.state === "ready" &&
+    next.workspace.cleanup.state === "ready";
+  assertSame(current.base, next.base, index);
+  assertWorkspace(current.workspace, next.workspace, allowHeadAdvance, index);
+  assertArtifacts(current.artifacts, next.artifacts, allowHeadAdvance, index);
+  assertPullRequest(
+    current.pullRequest,
+    next.pullRequest,
+    allowHeadAdvance,
+    index,
+  );
+  if (current.completion.mergeOid !== next.completion.mergeOid) {
+    fail("immutable-evidence", index);
+  }
+}

--- a/src/workflow/planning-state-types.ts
+++ b/src/workflow/planning-state-types.ts
@@ -1,0 +1,69 @@
+import type {
+  PlanningRemoteBaseSnapshot,
+  PlanningWorkspaceOwnership,
+} from "../git/planning-workspaces.ts";
+import type { PullRequestReference } from "../host/pull-requests.ts";
+import type {
+  PlanningArtifactKind,
+  PlanningGateSnapshot,
+} from "./planning-pull-requests.ts";
+import type { PlanningPhaseKind } from "./planning-pull-request-markers.ts";
+
+export type PlanningBaseEvidence = PlanningRemoteBaseSnapshot;
+export type PlanningWorkspaceEvidence = PlanningWorkspaceOwnership;
+export type PlanningArtifactEvidence = Readonly<{
+  kind: PlanningArtifactKind;
+  path: string;
+  commitOid: string;
+  source: "remote-base" | "workspace";
+}>;
+export type PlanningPullRequestEvidence = Readonly<{
+  reference: PullRequestReference;
+  baseBranch: string;
+  headBranch: string;
+  headOid: string;
+}>;
+export type PlanningPhaseStateV1 =
+  | Readonly<{ kind: PlanningPhaseKind; status: "pending" }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "workspace-ready";
+      base: PlanningBaseEvidence;
+      workspace: PlanningWorkspaceEvidence;
+    }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "pull-request-open";
+      base: PlanningBaseEvidence;
+      workspace: PlanningWorkspaceEvidence;
+      artifacts: readonly PlanningArtifactEvidence[];
+      pullRequest: PlanningPullRequestEvidence;
+    }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "complete";
+      base: PlanningBaseEvidence;
+      artifacts: readonly PlanningArtifactEvidence[];
+      completion: Readonly<{ kind: "remote-base" }>;
+    }>
+  | Readonly<{
+      kind: PlanningPhaseKind;
+      status: "complete";
+      base: PlanningBaseEvidence;
+      workspace: PlanningWorkspaceEvidence;
+      artifacts: readonly PlanningArtifactEvidence[];
+      pullRequest: PlanningPullRequestEvidence;
+      completion: Readonly<{ kind: "merged-pull-request"; mergeOid: string }>;
+    }>;
+export type PlanningStateV1 = Readonly<{
+  version: 1;
+  workflowVersion: "planning-pr-v1";
+  runId: string;
+  issueNumber: number;
+  issueTitle: string;
+  gates: PlanningGateSnapshot;
+  phases: readonly PlanningPhaseStateV1[];
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+}>;

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -117,6 +117,18 @@ const worktreePath = (value: unknown, path: string): string => {
     ? v
     : fail("invalid-worktree-path", path);
 };
+const canonicalWorktreePath = (path: string): string => {
+  const output: string[] = [];
+  for (const segment of path.replace(/\\\\/gu, "/").split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (output.length === 0 || output[output.length - 1] === "..")
+        output.push(segment);
+      else output.pop();
+    } else output.push(segment);
+  }
+  return output.join("/");
+};
 
 function gates(value: unknown, path: string): PlanningGateSnapshot {
   const v = object(value, ["specRequired", "planRequired"], path);
@@ -420,9 +432,8 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
         p.workspace.baseOid !== p.base.baseOid
       )
         fail("workspace-mismatch", `$.phases[${i}].workspace`);
-      const normalizedPath = p.workspace.identity.worktreePath.replaceAll(
-        "\\\\",
-        "/",
+      const normalizedPath = canonicalWorktreePath(
+        p.workspace.identity.worktreePath,
       );
       if (
         branches.has(p.workspace.identity.branch) ||

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -119,7 +119,7 @@ const worktreePath = (value: unknown, path: string): string => {
 };
 const canonicalWorktreePath = (path: string): string => {
   const output: string[] = [];
-  for (const segment of path.replace(/\\\\/gu, "/").split("/")) {
+  for (const segment of path.replace(/\\/gu, "/").split("/")) {
     if (segment === "" || segment === ".") continue;
     if (segment === "..") {
       if (output.length === 0 || output[output.length - 1] === "..")

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -384,27 +384,31 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
     phases.some((item, i) => item.kind !== expected[i]?.kind)
   )
     fail("phase-sequence", "$.phases");
-  const statuses = phases.map((item) => item.status);
-  const active = statuses.filter(
-    (status) => status === "workspace-ready" || status === "pull-request-open",
-  );
-  if (active.length > 1) fail("multiple-active-phases", "$.phases");
+  let active = false;
   let pending = false;
-  let completed = false;
+  const branches = new Set<string>();
+  const worktreePaths = new Set<string>();
   for (let i = 0; i < phases.length; i += 1) {
     const p = phases[i]!;
-    if (p.status === "pending") pending = true;
-    else {
-      if (pending) fail("progress-order", `$.phases[${i}]`);
-      if (p.status === "complete") completed = true;
-      else if (completed) fail("progress-order", `$.phases[${i}]`);
+    if (p.status === "complete") {
+      if (active || pending) fail("progress-order", `$.phases[${i}]`);
+    } else if (
+      p.status === "workspace-ready" ||
+      p.status === "pull-request-open"
+    ) {
+      if (active || pending) fail("progress-order", `$.phases[${i}]`);
+      active = true;
+    } else {
+      pending = true;
     }
     const assigned = expected[i]!.artifactKinds;
     if (
       p.status !== "pending" &&
       "artifacts" in p &&
       (p.artifacts.length !== assigned.length ||
-        p.artifacts.some((a, j) => a.kind !== assigned[j]))
+        p.artifacts.some(
+          (artifact, index) => artifact.kind !== assigned[index],
+        ))
     )
       fail("artifact-kinds", `$.phases[${i}].artifacts`);
     if ("workspace" in p) {
@@ -416,11 +420,65 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
         p.workspace.baseOid !== p.base.baseOid
       )
         fail("workspace-mismatch", `$.phases[${i}].workspace`);
+      const normalizedPath = p.workspace.identity.worktreePath.replaceAll(
+        "\\\\",
+        "/",
+      );
+      if (
+        branches.has(p.workspace.identity.branch) ||
+        worktreePaths.has(normalizedPath)
+      )
+        fail(
+          "duplicate-workspace-identity",
+          `$.phases[${i}].workspace.identity`,
+        );
+      branches.add(p.workspace.identity.branch);
+      worktreePaths.add(normalizedPath);
       if (
         (p.status === "workspace-ready" || p.status === "pull-request-open") &&
         p.workspace.cleanup.state !== "ready"
       )
         fail("invalid-cleanup-progress", `$.phases[${i}].workspace.cleanup`);
+      if (
+        p.workspace.cleanup.state !== "ready" &&
+        p.workspace.cleanup.pushedHeadOid !== p.workspace.headOid
+      )
+        fail(
+          "cleanup-head-mismatch",
+          `$.phases[${i}].workspace.cleanup.pushedHeadOid`,
+        );
+    }
+    if ("artifacts" in p) {
+      for (let index = 0; index < p.artifacts.length; index += 1) {
+        const artifact = p.artifacts[index]!;
+        if (artifact.source === "remote-base") {
+          if (
+            artifact.commitOid !== p.base.baseOid ||
+            !p.base.artifactCandidates[artifact.kind].includes(artifact.path)
+          )
+            fail(
+              "remote-artifact-mismatch",
+              `$.phases[${i}].artifacts[${index}]`,
+            );
+        } else if (
+          !("workspace" in p) ||
+          artifact.commitOid !== p.workspace.headOid
+        ) {
+          fail(
+            "workspace-artifact-mismatch",
+            `$.phases[${i}].artifacts[${index}]`,
+          );
+        }
+      }
+    }
+    if ("pullRequest" in p) {
+      if (
+        !("workspace" in p) ||
+        p.pullRequest.baseBranch !== p.base.baseBranch ||
+        p.pullRequest.headBranch !== p.workspace.identity.branch ||
+        p.pullRequest.headOid !== p.workspace.headOid
+      )
+        fail("pull-request-mismatch", `$.phases[${i}].pullRequest`);
     }
   }
   const createdAt = timestamp(v.createdAt, "$.createdAt"),

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -1,4 +1,9 @@
-import { isPlanningBranch } from "../git/planning-git-validation.ts";
+import {
+  isPlanningArtifactPath,
+  isPlanningBranch,
+  isPlanningSingleLine,
+  planningOid,
+} from "../git/planning-git-validation.ts";
 import type {
   PlanningWorkspaceIdentity,
   PlanningWorkspaceOwnership,
@@ -23,7 +28,6 @@ import type {
 
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
-const FULL_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
 
 export class PlanningStateValidationError extends Error {
@@ -74,7 +78,7 @@ const uuid = (value: unknown, path: string): string => {
 };
 const oid = (value: unknown, path: string): string => {
   const v = string(value, path);
-  return FULL_OID.test(v) ? v : fail("invalid-oid", path);
+  return planningOid.test(v) ? v : fail("invalid-oid", path);
 };
 const timestamp = (value: unknown, path: string): string => {
   const v = string(value, path);
@@ -86,9 +90,7 @@ const timestamp = (value: unknown, path: string): string => {
 };
 const singleLine = (value: unknown, path: string): string => {
   const v = string(value, path);
-  return v.length > 0 && v.length <= 1024 && !/[\0\r\n]/u.test(v)
-    ? v
-    : fail("invalid-string", path);
+  return isPlanningSingleLine(v) ? v : fail("invalid-string", path);
 };
 const branch = (value: unknown, path: string): string => {
   const v = string(value, path);
@@ -96,13 +98,7 @@ const branch = (value: unknown, path: string): string => {
 };
 const artifactPath = (value: unknown, path: string): string => {
   const v = string(value, path);
-  return v.length > 0 &&
-    v.length <= 4096 &&
-    !/[\0\r\n\\]/u.test(v) &&
-    !v.startsWith("/") &&
-    !v.split("/").some((part) => part === "" || part === "." || part === "..")
-    ? v
-    : fail("invalid-path", path);
+  return isPlanningArtifactPath(v) ? v : fail("invalid-path", path);
 };
 const worktreePath = (value: unknown, path: string): string => {
   const v = string(value, path);

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -1,0 +1,441 @@
+import type {
+  PlanningWorkspaceIdentity,
+  PlanningWorkspaceOwnership,
+} from "../git/planning-workspaces.ts";
+import type {
+  PullRequestReference,
+  RepositoryIdentity,
+} from "../host/pull-requests.ts";
+import {
+  PLANNING_PR_WORKFLOW_VERSION,
+  type PlanningPhaseKind,
+} from "./planning-pull-request-markers.ts";
+import {
+  planningPhasePlan,
+  type PlanningArtifactKind,
+  type PlanningGateSnapshot,
+} from "./planning-pull-requests.ts";
+import type {
+  PlanningPhaseStateV1,
+  PlanningStateV1,
+} from "./planning-state-types.ts";
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const FULL_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+
+export class PlanningStateValidationError extends Error {
+  readonly reason: string;
+  readonly path: string;
+  readonly statePath?: string;
+  constructor(reason: string, path: string, statePath?: string) {
+    super(`Planning state is invalid: ${reason} at ${path}`);
+    this.name = "PlanningStateValidationError";
+    this.reason = reason;
+    this.path = path;
+    if (statePath !== undefined) this.statePath = statePath;
+  }
+}
+const fail = (reason: string, path: string): never => {
+  throw new PlanningStateValidationError(reason, path);
+};
+const object = (
+  value: unknown,
+  keys: readonly string[],
+  path: string,
+): Record<string, unknown> => {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    fail("expected-object", path);
+  const result = value as Record<string, unknown>;
+  for (const key of Object.keys(result))
+    if (!keys.includes(key)) fail("unknown-key", `${path}.${key}`);
+  for (const key of keys)
+    if (!(key in result)) fail("missing-key", `${path}.${key}`);
+  return result;
+};
+const string = (
+  value: unknown,
+  path: string,
+  reason = "invalid-string",
+): string => (typeof value === "string" ? value : fail(reason, path));
+const positive = (value: unknown, path: string): number =>
+  Number.isSafeInteger(value) && (value as number) > 0
+    ? (value as number)
+    : fail("invalid-positive-integer", path);
+const nonnegative = (value: unknown, path: string): number =>
+  Number.isSafeInteger(value) && (value as number) >= 0
+    ? (value as number)
+    : fail("invalid-nonnegative-integer", path);
+const uuid = (value: unknown, path: string): string => {
+  const v = string(value, path);
+  return UUID.test(v) ? v : fail("invalid-uuid", path);
+};
+const oid = (value: unknown, path: string): string => {
+  const v = string(value, path);
+  return FULL_OID.test(v) ? v : fail("invalid-oid", path);
+};
+const timestamp = (value: unknown, path: string): string => {
+  const v = string(value, path);
+  return ISO_TIMESTAMP.test(v) &&
+    !Number.isNaN(Date.parse(v)) &&
+    new Date(v).toISOString() === v
+    ? v
+    : fail("invalid-timestamp", path);
+};
+const singleLine = (value: unknown, path: string): string => {
+  const v = string(value, path);
+  return v.length > 0 && v.length <= 1024 && !/[\0\r\n]/u.test(v)
+    ? v
+    : fail("invalid-string", path);
+};
+const branch = (value: unknown, path: string): string => {
+  const v = singleLine(value, path);
+  return v.length <= 1024 &&
+    !v.startsWith("-") &&
+    !v.startsWith("/") &&
+    !v.endsWith("/") &&
+    !v.endsWith(".") &&
+    !/[\s\\~^:?*[\x00-\x1f]|\.\.|@\{/u.test(v) &&
+    !v.split("/").some((part) => part.length === 0)
+    ? v
+    : fail("invalid-branch", path);
+};
+const artifactPath = (value: unknown, path: string): string => {
+  const v = string(value, path);
+  return v.length > 0 &&
+    v.length <= 4096 &&
+    !/[\0\r\n\\]/u.test(v) &&
+    !v.startsWith("/") &&
+    !v.split("/").some((part) => part === "" || part === "." || part === "..")
+    ? v
+    : fail("invalid-path", path);
+};
+const worktreePath = (value: unknown, path: string): string => {
+  const v = string(value, path);
+  return v.length > 0 && v.length <= 4096 && !/[\0\r\n]/u.test(v)
+    ? v
+    : fail("invalid-worktree-path", path);
+};
+
+function gates(value: unknown, path: string): PlanningGateSnapshot {
+  const v = object(value, ["specRequired", "planRequired"], path);
+  if (
+    typeof v.specRequired !== "boolean" ||
+    typeof v.planRequired !== "boolean"
+  )
+    fail("invalid-gates", path);
+  return {
+    specRequired: v.specRequired as boolean,
+    planRequired: v.planRequired as boolean,
+  };
+}
+function candidates(
+  value: unknown,
+  path: string,
+): { spec: readonly string[]; plan: readonly string[] } {
+  const v = object(value, ["spec", "plan"], path);
+  return {
+    spec: paths(v.spec, `${path}.spec`),
+    plan: paths(v.plan, `${path}.plan`),
+  };
+}
+function paths(value: unknown, path: string): readonly string[] {
+  if (!Array.isArray(value)) fail("expected-array", path);
+  const output = (value as unknown[]).map((item, index) =>
+    artifactPath(item, `${path}[${index}]`),
+  );
+  if (new Set(output).size !== output.length) fail("duplicate-value", path);
+  return output;
+}
+function identity(value: unknown, path: string): PlanningWorkspaceIdentity {
+  const v = object(value, ["branch", "worktreePath"], path);
+  return {
+    branch: branch(v.branch, `${path}.branch`),
+    worktreePath: worktreePath(v.worktreePath, `${path}.worktreePath`),
+  };
+}
+function repository(value: unknown, path: string): RepositoryIdentity {
+  const v = object(value, ["provider", "host", "owner", "repository"], path);
+  const provider = string(v.provider, `${path}.provider`);
+  if (provider !== "github-gh" && provider !== "forgejo-tea")
+    fail("invalid-provider", `${path}.provider`);
+  return {
+    provider,
+    host: singleLine(v.host, `${path}.host`),
+    owner: singleLine(v.owner, `${path}.owner`),
+    repository: singleLine(v.repository, `${path}.repository`),
+  } as RepositoryIdentity;
+}
+function workspace(value: unknown, path: string) {
+  const v = object(
+    value,
+    [
+      "runId",
+      "phase",
+      "identity",
+      "remote",
+      "baseBranch",
+      "baseOid",
+      "headOid",
+      "cleanup",
+    ],
+    path,
+  );
+  const cleanupValue = v.cleanup as Record<string, unknown>;
+  const cleanup = object(
+    cleanupValue,
+    cleanupValue?.state === "ready" ? ["state"] : ["state", "pushedHeadOid"],
+    `${path}.cleanup`,
+  );
+  const state = string(cleanup.state, `${path}.cleanup.state`);
+  if (state !== "ready" && state !== "worktree-removed" && state !== "removed")
+    fail("invalid-cleanup", `${path}.cleanup.state`);
+  return {
+    runId: uuid(v.runId, `${path}.runId`),
+    phase: phase(v.phase, `${path}.phase`),
+    identity: identity(v.identity, `${path}.identity`),
+    remote: singleLine(v.remote, `${path}.remote`),
+    baseBranch: branch(v.baseBranch, `${path}.baseBranch`),
+    baseOid: oid(v.baseOid, `${path}.baseOid`),
+    headOid: oid(v.headOid, `${path}.headOid`),
+    cleanup:
+      state === "ready"
+        ? { state }
+        : {
+            state,
+            pushedHeadOid: oid(
+              cleanup.pushedHeadOid,
+              `${path}.cleanup.pushedHeadOid`,
+            ),
+          },
+  } as PlanningWorkspaceOwnership;
+}
+function base(value: unknown, path: string) {
+  const v = object(
+    value,
+    ["remote", "baseBranch", "baseOid", "artifactCandidates"],
+    path,
+  );
+  return {
+    remote: singleLine(v.remote, `${path}.remote`),
+    baseBranch: branch(v.baseBranch, `${path}.baseBranch`),
+    baseOid: oid(v.baseOid, `${path}.baseOid`),
+    artifactCandidates: candidates(
+      v.artifactCandidates,
+      `${path}.artifactCandidates`,
+    ),
+  };
+}
+function phase(value: unknown, path: string): PlanningPhaseKind {
+  const v = string(value, path);
+  return v === "spec" || v === "plan" || v === "implementation"
+    ? v
+    : fail("invalid-phase", path);
+}
+function artifacts(value: unknown, path: string) {
+  if (!Array.isArray(value)) fail("expected-array", path);
+  const output = (value as unknown[]).map((item, i) => {
+    const v = object(
+      item,
+      ["kind", "path", "commitOid", "source"],
+      `${path}[${i}]`,
+    );
+    const kind = string(v.kind, `${path}[${i}].kind`);
+    if (kind !== "spec" && kind !== "plan")
+      fail("invalid-artifact-kind", `${path}[${i}].kind`);
+    const source = string(v.source, `${path}[${i}].source`);
+    if (source !== "remote-base" && source !== "workspace")
+      fail("invalid-artifact-source", `${path}[${i}].source`);
+    return {
+      kind: kind as PlanningArtifactKind,
+      path: artifactPath(v.path, `${path}[${i}].path`),
+      commitOid: oid(v.commitOid, `${path}[${i}].commitOid`),
+      source: source as "remote-base" | "workspace",
+    };
+  });
+  if (new Set(output.map((item) => item.kind)).size !== output.length)
+    fail("duplicate-artifact-kind", path);
+  return output;
+}
+function pullRequest(value: unknown, path: string) {
+  const v = object(
+    value,
+    ["reference", "baseBranch", "headBranch", "headOid"],
+    path,
+  );
+  const ref = object(
+    v.reference,
+    ["targetRepository", "number"],
+    `${path}.reference`,
+  );
+  return {
+    reference: {
+      targetRepository: repository(
+        ref.targetRepository,
+        `${path}.reference.targetRepository`,
+      ),
+      number: positive(ref.number, `${path}.reference.number`),
+    } as PullRequestReference,
+    baseBranch: branch(v.baseBranch, `${path}.baseBranch`),
+    headBranch: branch(v.headBranch, `${path}.headBranch`),
+    headOid: oid(v.headOid, `${path}.headOid`),
+  };
+}
+
+function phaseState(value: unknown, path: string): PlanningPhaseStateV1 {
+  const raw = value as Record<string, unknown>;
+  const status = raw?.status;
+  const completion = raw?.completion as Record<string, unknown> | undefined;
+  const keys =
+    status === "pending"
+      ? ["kind", "status"]
+      : status === "workspace-ready"
+        ? ["kind", "status", "base", "workspace"]
+        : status === "pull-request-open"
+          ? ["kind", "status", "base", "workspace", "artifacts", "pullRequest"]
+          : completion?.kind === "remote-base"
+            ? ["kind", "status", "base", "artifacts", "completion"]
+            : [
+                "kind",
+                "status",
+                "base",
+                "workspace",
+                "artifacts",
+                "pullRequest",
+                "completion",
+              ];
+  const v = object(value, keys, path);
+  const kind = phase(v.kind, `${path}.kind`);
+  if (v.status === "pending") return { kind, status: "pending" };
+  if (v.status === "workspace-ready")
+    return {
+      kind,
+      status: "workspace-ready",
+      base: base(v.base, `${path}.base`),
+      workspace: workspace(v.workspace, `${path}.workspace`),
+    };
+  if (v.status === "pull-request-open")
+    return {
+      kind,
+      status: "pull-request-open",
+      base: base(v.base, `${path}.base`),
+      workspace: workspace(v.workspace, `${path}.workspace`),
+      artifacts: artifacts(v.artifacts, `${path}.artifacts`),
+      pullRequest: pullRequest(v.pullRequest, `${path}.pullRequest`),
+    };
+  if (v.status !== "complete") fail("invalid-status", `${path}.status`);
+  const c = v.completion as Record<string, unknown>;
+  if (c?.kind === "remote-base") {
+    object(c, ["kind"], `${path}.completion`);
+    return {
+      kind,
+      status: "complete",
+      base: base(v.base, `${path}.base`),
+      artifacts: artifacts(v.artifacts, `${path}.artifacts`),
+      completion: { kind: "remote-base" },
+    };
+  }
+  const merged = object(c, ["kind", "mergeOid"], `${path}.completion`);
+  if (merged.kind !== "merged-pull-request")
+    fail("invalid-completion", `${path}.completion.kind`);
+  return {
+    kind,
+    status: "complete",
+    base: base(v.base, `${path}.base`),
+    workspace: workspace(v.workspace, `${path}.workspace`),
+    artifacts: artifacts(v.artifacts, `${path}.artifacts`),
+    pullRequest: pullRequest(v.pullRequest, `${path}.pullRequest`),
+    completion: {
+      kind: "merged-pull-request",
+      mergeOid: oid(merged.mergeOid, `${path}.completion.mergeOid`),
+    },
+  };
+}
+
+export function validatePlanningState(value: unknown): PlanningStateV1 {
+  const v = object(
+    value,
+    [
+      "version",
+      "workflowVersion",
+      "runId",
+      "issueNumber",
+      "issueTitle",
+      "gates",
+      "phases",
+      "revision",
+      "createdAt",
+      "updatedAt",
+    ],
+    "$",
+  );
+  if (v.version !== 1) fail("unsupported-version", "$.version");
+  if (v.workflowVersion !== PLANNING_PR_WORKFLOW_VERSION)
+    fail("unsupported-workflow-version", "$.workflowVersion");
+  const parsedGates = gates(v.gates, "$.gates");
+  if (!Array.isArray(v.phases)) fail("expected-array", "$.phases");
+  const phases = (v.phases as unknown[]).map((item, i) =>
+    phaseState(item, `$.phases[${i}]`),
+  );
+  const expected = planningPhasePlan(parsedGates);
+  if (
+    phases.length !== expected.length ||
+    phases.some((item, i) => item.kind !== expected[i]?.kind)
+  )
+    fail("phase-sequence", "$.phases");
+  const statuses = phases.map((item) => item.status);
+  const active = statuses.filter(
+    (status) => status === "workspace-ready" || status === "pull-request-open",
+  );
+  if (active.length > 1) fail("multiple-active-phases", "$.phases");
+  let pending = false;
+  let completed = false;
+  for (let i = 0; i < phases.length; i += 1) {
+    const p = phases[i]!;
+    if (p.status === "pending") pending = true;
+    else {
+      if (pending) fail("progress-order", `$.phases[${i}]`);
+      if (p.status === "complete") completed = true;
+      else if (completed) fail("progress-order", `$.phases[${i}]`);
+    }
+    const assigned = expected[i]!.artifactKinds;
+    if (
+      p.status !== "pending" &&
+      "artifacts" in p &&
+      (p.artifacts.length !== assigned.length ||
+        p.artifacts.some((a, j) => a.kind !== assigned[j]))
+    )
+      fail("artifact-kinds", `$.phases[${i}].artifacts`);
+    if ("workspace" in p) {
+      if (
+        p.workspace.runId !== v.runId ||
+        p.workspace.phase !== p.kind ||
+        p.workspace.remote !== p.base.remote ||
+        p.workspace.baseBranch !== p.base.baseBranch ||
+        p.workspace.baseOid !== p.base.baseOid
+      )
+        fail("workspace-mismatch", `$.phases[${i}].workspace`);
+      if (
+        (p.status === "workspace-ready" || p.status === "pull-request-open") &&
+        p.workspace.cleanup.state !== "ready"
+      )
+        fail("invalid-cleanup-progress", `$.phases[${i}].workspace.cleanup`);
+    }
+  }
+  const createdAt = timestamp(v.createdAt, "$.createdAt"),
+    updatedAt = timestamp(v.updatedAt, "$.updatedAt");
+  if (updatedAt < createdAt) fail("timestamp-order", "$.updatedAt");
+  return {
+    version: 1,
+    workflowVersion: PLANNING_PR_WORKFLOW_VERSION,
+    runId: uuid(v.runId, "$.runId"),
+    issueNumber: positive(v.issueNumber, "$.issueNumber"),
+    issueTitle: singleLine(v.issueTitle, "$.issueTitle"),
+    gates: parsedGates,
+    phases,
+    revision: nonnegative(v.revision, "$.revision"),
+    createdAt,
+    updatedAt,
+  };
+}

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -1,3 +1,4 @@
+import { isPlanningBranch } from "../git/planning-git-validation.ts";
 import type {
   PlanningWorkspaceIdentity,
   PlanningWorkspaceOwnership,
@@ -90,16 +91,8 @@ const singleLine = (value: unknown, path: string): string => {
     : fail("invalid-string", path);
 };
 const branch = (value: unknown, path: string): string => {
-  const v = singleLine(value, path);
-  return v.length <= 1024 &&
-    !v.startsWith("-") &&
-    !v.startsWith("/") &&
-    !v.endsWith("/") &&
-    !v.endsWith(".") &&
-    !/[\s\\~^:?*[\x00-\x1f]|\.\.|@\{/u.test(v) &&
-    !v.split("/").some((part) => part.length === 0)
-    ? v
-    : fail("invalid-branch", path);
+  const v = string(value, path);
+  return isPlanningBranch(v) ? v : fail("invalid-branch", path);
 };
 const artifactPath = (value: unknown, path: string): string => {
   const v = string(value, path);
@@ -385,6 +378,13 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
   if (v.version !== 1) fail("unsupported-version", "$.version");
   if (v.workflowVersion !== PLANNING_PR_WORKFLOW_VERSION)
     fail("unsupported-workflow-version", "$.workflowVersion");
+  const parsedRunId = uuid(v.runId, "$.runId");
+  const parsedIssueNumber = positive(v.issueNumber, "$.issueNumber");
+  const parsedIssueTitle = singleLine(v.issueTitle, "$.issueTitle");
+  const parsedRevision = nonnegative(v.revision, "$.revision");
+  const createdAt = timestamp(v.createdAt, "$.createdAt");
+  const updatedAt = timestamp(v.updatedAt, "$.updatedAt");
+  if (updatedAt < createdAt) fail("timestamp-order", "$.updatedAt");
   const parsedGates = gates(v.gates, "$.gates");
   if (!Array.isArray(v.phases)) fail("expected-array", "$.phases");
   const phases = (v.phases as unknown[]).map((item, i) =>
@@ -425,7 +425,7 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
       fail("artifact-kinds", `$.phases[${i}].artifacts`);
     if ("workspace" in p) {
       if (
-        p.workspace.runId !== v.runId ||
+        p.workspace.runId !== parsedRunId ||
         p.workspace.phase !== p.kind ||
         p.workspace.remote !== p.base.remote ||
         p.workspace.baseBranch !== p.base.baseBranch ||
@@ -492,18 +492,15 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
         fail("pull-request-mismatch", `$.phases[${i}].pullRequest`);
     }
   }
-  const createdAt = timestamp(v.createdAt, "$.createdAt"),
-    updatedAt = timestamp(v.updatedAt, "$.updatedAt");
-  if (updatedAt < createdAt) fail("timestamp-order", "$.updatedAt");
   return {
     version: 1,
     workflowVersion: PLANNING_PR_WORKFLOW_VERSION,
-    runId: uuid(v.runId, "$.runId"),
-    issueNumber: positive(v.issueNumber, "$.issueNumber"),
-    issueTitle: singleLine(v.issueTitle, "$.issueTitle"),
+    runId: parsedRunId,
+    issueNumber: parsedIssueNumber,
+    issueTitle: parsedIssueTitle,
     gates: parsedGates,
     phases,
-    revision: nonnegative(v.revision, "$.revision"),
+    revision: parsedRevision,
     createdAt,
     updatedAt,
   };

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -94,6 +94,19 @@ function mergedState(
   };
 }
 
+function recordAt(
+  value: unknown,
+  ...segments: readonly (string | number)[]
+): Record<string, unknown> {
+  let current = value;
+  for (const segment of segments) {
+    assert.ok(current !== null && typeof current === "object");
+    current = (current as Record<string | number, unknown>)[segment];
+  }
+  assert.ok(current !== null && typeof current === "object");
+  return current as Record<string, unknown>;
+}
+
 function completeState(): unknown {
   const base = {
     remote: "origin",
@@ -178,6 +191,192 @@ test("creates and round-trips strict initial planning state", () => {
   ]);
   assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
 });
+test("round-trips pull request and every cleanup discriminator", () => {
+  const documents = [
+    mergedState({ state: "ready" }),
+    mergedState({ state: "worktree-removed", pushedHeadOid: oid }),
+    mergedState({ state: "removed", pushedHeadOid: oid }),
+  ];
+  const open = structuredClone(mergedState({ state: "ready" }));
+  recordAt(open, "phases", 0).status = "pull-request-open";
+  delete recordAt(open, "phases", 0).completion;
+  documents.push(open);
+  for (const document of documents) {
+    const state = validatePlanningState(document);
+    assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
+  }
+});
+
+test("rejects malformed scalars and nested state schemas with stable paths", () => {
+  const cases: ReadonlyArray<{
+    name: string;
+    reason: string;
+    path: string;
+    mutate: (document: Record<string, unknown>) => void;
+  }> = [
+    {
+      name: "run UUID",
+      reason: "invalid-uuid",
+      path: "$.runId",
+      mutate: (document) => {
+        document.runId = "not-a-uuid";
+      },
+    },
+    {
+      name: "issue number",
+      reason: "invalid-positive-integer",
+      path: "$.issueNumber",
+      mutate: (document) => {
+        document.issueNumber = 0;
+      },
+    },
+    {
+      name: "issue title",
+      reason: "invalid-string",
+      path: "$.issueTitle",
+      mutate: (document) => {
+        document.issueTitle = "bad\ntitle";
+      },
+    },
+    {
+      name: "revision",
+      reason: "invalid-nonnegative-integer",
+      path: "$.revision",
+      mutate: (document) => {
+        document.revision = -1;
+      },
+    },
+    {
+      name: "timestamp",
+      reason: "invalid-timestamp",
+      path: "$.createdAt",
+      mutate: (document) => {
+        document.createdAt = "2026-09-07";
+      },
+    },
+    {
+      name: "base OID",
+      reason: "invalid-oid",
+      path: "$.phases[0].base.baseOid",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "base").baseOid = "a".repeat(39);
+      },
+    },
+    {
+      name: "workspace branch",
+      reason: "invalid-branch",
+      path: "$.phases[0].workspace.identity.branch",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "workspace", "identity").branch =
+          "bad\u00a0branch";
+      },
+    },
+    {
+      name: "worktree path",
+      reason: "invalid-worktree-path",
+      path: "$.phases[0].workspace.identity.worktreePath",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "workspace", "identity").worktreePath =
+          "bad\0path";
+      },
+    },
+    {
+      name: "artifact path",
+      reason: "invalid-path",
+      path: "$.phases[0].artifacts[0].path",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "artifacts", 0).path = "../outside.md";
+      },
+    },
+    {
+      name: "pull request number",
+      reason: "invalid-positive-integer",
+      path: "$.phases[0].pullRequest.reference.number",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "pullRequest", "reference").number = 0;
+      },
+    },
+    {
+      name: "provider",
+      reason: "invalid-provider",
+      path: "$.phases[0].pullRequest.reference.targetRepository.provider",
+      mutate: (document) => {
+        recordAt(
+          document,
+          "phases",
+          0,
+          "pullRequest",
+          "reference",
+          "targetRepository",
+        ).provider = "unknown";
+      },
+    },
+    {
+      name: "cleanup unknown key",
+      reason: "unknown-key",
+      path: "$.phases[0].workspace.cleanup.extra",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "workspace", "cleanup").extra = true;
+      },
+    },
+    {
+      name: "candidate unknown key",
+      reason: "unknown-key",
+      path: "$.phases[0].base.artifactCandidates.extra",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "base", "artifactCandidates").extra =
+          [];
+      },
+    },
+    {
+      name: "repository unknown key",
+      reason: "unknown-key",
+      path: "$.phases[0].pullRequest.reference.targetRepository.extra",
+      mutate: (document) => {
+        recordAt(
+          document,
+          "phases",
+          0,
+          "pullRequest",
+          "reference",
+          "targetRepository",
+        ).extra = true;
+      },
+    },
+    {
+      name: "missing workspace head",
+      reason: "missing-key",
+      path: "$.phases[0].workspace.headOid",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "workspace").headOid;
+      },
+    },
+    {
+      name: "forbidden pending evidence",
+      reason: "unknown-key",
+      path: "$.phases[0].base",
+      mutate: (document) => {
+        recordAt(document, "phases", 0).status = "pending";
+      },
+    },
+  ];
+  for (const item of cases) {
+    const document = structuredClone(mergedState({ state: "ready" })) as Record<
+      string,
+      unknown
+    >;
+    item.mutate(document);
+    assert.throws(
+      () => validatePlanningState(document),
+      (error: unknown) =>
+        error instanceof PlanningStateValidationError &&
+        error.reason === item.reason &&
+        error.path === item.path,
+      item.name,
+    );
+  }
+});
+
 test("rejects unknown and contradictory persisted state", () => {
   const state = createPlanningState({
     issueNumber: 187,

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -11,8 +11,75 @@ import {
 
 const runId = "123e4567-e89b-42d3-a456-426614174000";
 const now = "2026-09-07T12:00:00.000Z";
+const oid = "a".repeat(40);
 const gates = { specRequired: true, planRequired: true };
 
+function completeState(): unknown {
+  const base = {
+    remote: "origin",
+    baseBranch: "main",
+    baseOid: oid,
+    artifactCandidates: {
+      spec: ["docs/specs/example-issue-187-spec.md"],
+      plan: ["docs/plans/example-issue-187-plan.md"],
+    },
+  };
+  const workspace = {
+    runId,
+    phase: "implementation",
+    identity: {
+      branch: "agent/issue-187-implementation",
+      worktreePath: ".worktrees/issue-187-implementation",
+    },
+    remote: "origin",
+    baseBranch: "main",
+    baseOid: oid,
+    headOid: oid,
+    cleanup: { state: "ready" },
+  };
+  return {
+    version: 1,
+    workflowVersion: "planning-pr-v1",
+    runId,
+    issueNumber: 187,
+    issueTitle: "Example",
+    gates,
+    revision: 0,
+    createdAt: now,
+    updatedAt: now,
+    phases: [
+      {
+        kind: "spec",
+        status: "complete",
+        base,
+        artifacts: [
+          {
+            kind: "spec",
+            path: base.artifactCandidates.spec[0],
+            commitOid: oid,
+            source: "remote-base",
+          },
+        ],
+        completion: { kind: "remote-base" },
+      },
+      {
+        kind: "plan",
+        status: "complete",
+        base,
+        artifacts: [
+          {
+            kind: "plan",
+            path: base.artifactCandidates.plan[0],
+            commitOid: oid,
+            source: "remote-base",
+          },
+        ],
+        completion: { kind: "remote-base" },
+      },
+      { kind: "implementation", status: "workspace-ready", base, workspace },
+    ],
+  };
+}
 test("creates and round-trips strict initial planning state", () => {
   const state = createPlanningState({
     issueNumber: 187,
@@ -31,7 +98,6 @@ test("creates and round-trips strict initial planning state", () => {
   ]);
   assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
 });
-
 test("rejects unknown and contradictory persisted state", () => {
   const state = createPlanningState({
     issueNumber: 187,
@@ -62,7 +128,49 @@ test("rejects unknown and contradictory persisted state", () => {
       error.reason === "invalid-json",
   );
 });
-
+test("accepts complete prefix then one active and rejects evidence contradictions", () => {
+  const state = completeState() as { phases: Array<Record<string, unknown>> };
+  assert.doesNotThrow(() => validatePlanningState(state));
+  const activeThenComplete = structuredClone(state);
+  activeThenComplete.phases[0] = {
+    kind: "spec",
+    status: "workspace-ready",
+    base: activeThenComplete.phases[0]!.base,
+    workspace: {
+      ...(activeThenComplete.phases[2]!.workspace as Record<string, unknown>),
+      phase: "spec",
+      identity: {
+        branch: "agent/issue-187-spec",
+        worktreePath: ".worktrees/issue-187-spec",
+      },
+    },
+  };
+  assert.throws(
+    () => validatePlanningState(activeThenComplete),
+    /progress-order/,
+  );
+  const wrongCandidate = structuredClone(state);
+  (
+    wrongCandidate.phases[0]!.artifacts as Array<Record<string, unknown>>
+  )[0]!.path = "docs/specs/other.md";
+  assert.throws(
+    () => validatePlanningState(wrongCandidate),
+    /remote-artifact-mismatch/,
+  );
+  const wrongCleanup = structuredClone(state);
+  (
+    (wrongCleanup.phases[2]!.workspace as Record<string, unknown>)
+      .cleanup as Record<string, unknown>
+  ).state = "worktree-removed";
+  (
+    (wrongCleanup.phases[2]!.workspace as Record<string, unknown>)
+      .cleanup as Record<string, unknown>
+  ).pushedHeadOid = "b".repeat(40);
+  assert.throws(
+    () => validatePlanningState(wrongCleanup),
+    /(?:cleanup-head-mismatch|invalid-cleanup-progress)/,
+  );
+});
 test("requires immutable identity and exactly one revision step", () => {
   const state = createPlanningState({
     issueNumber: 187,

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -193,6 +193,7 @@ test("creates and round-trips strict initial planning state", () => {
 });
 test("round-trips pull request and every cleanup discriminator", () => {
   const documents = [
+    completeState(),
     mergedState({ state: "ready" }),
     mergedState({ state: "worktree-removed", pushedHeadOid: oid }),
     mergedState({ state: "removed", pushedHeadOid: oid }),
@@ -214,6 +215,22 @@ test("rejects malformed scalars and nested state schemas with stable paths", () 
     path: string;
     mutate: (document: Record<string, unknown>) => void;
   }> = [
+    {
+      name: "version",
+      reason: "unsupported-version",
+      path: "$.version",
+      mutate: (document) => {
+        document.version = 2;
+      },
+    },
+    {
+      name: "workflow version",
+      reason: "unsupported-workflow-version",
+      path: "$.workflowVersion",
+      mutate: (document) => {
+        document.workflowVersion = "planning-pr-v2";
+      },
+    },
     {
       name: "run UUID",
       reason: "invalid-uuid",
@@ -252,6 +269,30 @@ test("rejects malformed scalars and nested state schemas with stable paths", () 
       path: "$.createdAt",
       mutate: (document) => {
         document.createdAt = "2026-09-07";
+      },
+    },
+    {
+      name: "gates",
+      reason: "invalid-gates",
+      path: "$.gates",
+      mutate: (document) => {
+        recordAt(document, "gates").specRequired = "yes";
+      },
+    },
+    {
+      name: "status",
+      reason: "invalid-status",
+      path: "$.phases[0].status",
+      mutate: (document) => {
+        recordAt(document, "phases", 0).status = "unknown";
+      },
+    },
+    {
+      name: "completion",
+      reason: "invalid-completion",
+      path: "$.phases[0].completion.kind",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "completion").kind = "unknown";
       },
     },
     {
@@ -344,11 +385,110 @@ test("rejects malformed scalars and nested state schemas with stable paths", () 
       },
     },
     {
+      name: "duplicate candidates",
+      reason: "duplicate-value",
+      path: "$.phases[0].base.artifactCandidates.spec",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "base", "artifactCandidates").spec = [
+          "docs/specs/a.md",
+          "docs/specs/a.md",
+        ];
+      },
+    },
+    {
+      name: "duplicate artifacts",
+      reason: "duplicate-artifact-kind",
+      path: "$.phases[0].artifacts",
+      mutate: (document) => {
+        recordAt(document, "phases", 0, "artifacts", 1).kind = "spec";
+      },
+    },
+    {
+      name: "missing top-level field",
+      reason: "missing-key",
+      path: "$.updatedAt",
+      mutate: (document) => {
+        delete document.updatedAt;
+      },
+    },
+    {
+      name: "missing gate",
+      reason: "missing-key",
+      path: "$.gates.planRequired",
+      mutate: (document) => {
+        delete recordAt(document, "gates").planRequired;
+      },
+    },
+    {
+      name: "missing candidate kind",
+      reason: "missing-key",
+      path: "$.phases[0].base.artifactCandidates.plan",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "base", "artifactCandidates")
+          .plan;
+      },
+    },
+    {
       name: "missing workspace head",
       reason: "missing-key",
       path: "$.phases[0].workspace.headOid",
       mutate: (document) => {
         delete recordAt(document, "phases", 0, "workspace").headOid;
+      },
+    },
+    {
+      name: "missing identity branch",
+      reason: "missing-key",
+      path: "$.phases[0].workspace.identity.branch",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "workspace", "identity").branch;
+      },
+    },
+    {
+      name: "missing cleanup state",
+      reason: "missing-key",
+      path: "$.phases[0].workspace.cleanup.state",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "workspace", "cleanup").state;
+      },
+    },
+    {
+      name: "missing artifact source",
+      reason: "missing-key",
+      path: "$.phases[0].artifacts[0].source",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "artifacts", 0).source;
+      },
+    },
+    {
+      name: "missing pull request head",
+      reason: "missing-key",
+      path: "$.phases[0].pullRequest.headOid",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "pullRequest").headOid;
+      },
+    },
+    {
+      name: "missing repository owner",
+      reason: "missing-key",
+      path: "$.phases[0].pullRequest.reference.targetRepository.owner",
+      mutate: (document) => {
+        delete recordAt(
+          document,
+          "phases",
+          0,
+          "pullRequest",
+          "reference",
+          "targetRepository",
+        ).owner;
+      },
+    },
+    {
+      name: "missing merge OID",
+      reason: "missing-key",
+      path: "$.phases[0].completion.mergeOid",
+      mutate: (document) => {
+        delete recordAt(document, "phases", 0, "completion").mergeOid;
       },
     },
     {
@@ -373,6 +513,36 @@ test("rejects malformed scalars and nested state schemas with stable paths", () 
         error.reason === item.reason &&
         error.path === item.path,
       item.name,
+    );
+  }
+});
+
+test("forbids evidence outside each phase discriminator", () => {
+  const workspaceReady = structuredClone(completeState());
+  recordAt(workspaceReady, "phases", 2).artifacts = [];
+  const pullRequestOpen = structuredClone(mergedState({ state: "ready" }));
+  recordAt(pullRequestOpen, "phases", 0).status = "pull-request-open";
+  const remoteComplete = structuredClone(completeState());
+  recordAt(remoteComplete, "phases", 0).workspace = recordAt(
+    completeState(),
+    "phases",
+    2,
+    "workspace",
+  );
+  const mergedComplete = structuredClone(mergedState({ state: "ready" }));
+  recordAt(mergedComplete, "phases", 0).unexpected = true;
+  for (const [document, path] of [
+    [workspaceReady, "$.phases[2].artifacts"],
+    [pullRequestOpen, "$.phases[0].completion"],
+    [remoteComplete, "$.phases[0].workspace"],
+    [mergedComplete, "$.phases[0].unexpected"],
+  ] as const) {
+    assert.throws(
+      () => validatePlanningState(document),
+      (error: unknown) =>
+        error instanceof PlanningStateValidationError &&
+        error.reason === "unknown-key" &&
+        error.path === path,
     );
   }
 });

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -14,6 +14,86 @@ const now = "2026-09-07T12:00:00.000Z";
 const oid = "a".repeat(40);
 const gates = { specRequired: true, planRequired: true };
 
+function pullRequest(headBranch: string, headOid: string) {
+  return {
+    reference: {
+      targetRepository: {
+        provider: "github-gh",
+        host: "github.com",
+        owner: "example",
+        repository: "patchmill",
+      },
+      number: 1,
+    },
+    baseBranch: "main",
+    headBranch,
+    headOid,
+  };
+}
+
+function mergedState(
+  cleanup:
+    | { state: "ready" }
+    | { state: "worktree-removed"; pushedHeadOid: string }
+    | { state: "removed"; pushedHeadOid: string },
+): unknown {
+  const base = {
+    remote: "origin",
+    baseBranch: "main",
+    baseOid: oid,
+    artifactCandidates: { spec: [], plan: [] },
+  };
+  const branch = "agent/issue-187-implementation";
+  const workspace = {
+    runId,
+    phase: "implementation",
+    identity: {
+      branch,
+      worktreePath: ".worktrees/issue-187-implementation",
+    },
+    remote: "origin",
+    baseBranch: "main",
+    baseOid: oid,
+    headOid: oid,
+    cleanup,
+  };
+  return {
+    version: 1,
+    workflowVersion: "planning-pr-v1",
+    runId,
+    issueNumber: 187,
+    issueTitle: "Example",
+    gates: { specRequired: false, planRequired: false },
+    phases: [
+      {
+        kind: "implementation",
+        status: "complete",
+        base,
+        workspace,
+        artifacts: [
+          {
+            kind: "spec",
+            path: "docs/specs/example-issue-187-spec.md",
+            commitOid: oid,
+            source: "workspace",
+          },
+          {
+            kind: "plan",
+            path: "docs/plans/example-issue-187-plan.md",
+            commitOid: oid,
+            source: "workspace",
+          },
+        ],
+        pullRequest: pullRequest(branch, oid),
+        completion: { kind: "merged-pull-request", mergeOid: "b".repeat(40) },
+      },
+    ],
+    revision: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 function completeState(): unknown {
   const base = {
     remote: "origin",
@@ -171,6 +251,142 @@ test("accepts complete prefix then one active and rejects evidence contradiction
     /(?:cleanup-head-mismatch|invalid-cleanup-progress)/,
   );
 });
+test("accepts both idempotent merged-workspace cleanup transitions", () => {
+  const ready = validatePlanningState(mergedState({ state: "ready" }));
+  const worktreeRemoved = validatePlanningState({
+    ...mergedState({ state: "worktree-removed", pushedHeadOid: oid }),
+    revision: 1,
+    updatedAt: "2026-09-07T12:00:01.000Z",
+  });
+  const removed = validatePlanningState({
+    ...mergedState({ state: "removed", pushedHeadOid: oid }),
+    revision: 2,
+    updatedAt: "2026-09-07T12:00:02.000Z",
+  });
+  assert.doesNotThrow(() =>
+    assertPlanningStateReplacement(ready, worktreeRemoved),
+  );
+  assert.doesNotThrow(() =>
+    assertPlanningStateReplacement(worktreeRemoved, removed),
+  );
+  assert.throws(
+    () =>
+      assertPlanningStateReplacement(ready, {
+        ...removed,
+        revision: 1,
+        updatedAt: "2026-09-07T12:00:01.000Z",
+      }),
+    /cleanup-transition/,
+  );
+});
+
+test("forward transitions preserve carried workspace and pull request evidence", () => {
+  const initial = completeState() as {
+    phases: Array<Record<string, unknown>>;
+  };
+  const ready = validatePlanningState({
+    ...initial,
+    phases: [
+      initial.phases[0],
+      initial.phases[1],
+      {
+        ...initial.phases[2],
+        status: "workspace-ready",
+      },
+    ],
+  });
+  const workspace = ready.phases[2]!;
+  assert.equal(workspace.status, "workspace-ready");
+  const open = validatePlanningState({
+    ...ready,
+    revision: 1,
+    updatedAt: "2026-09-07T12:00:01.000Z",
+    phases: [
+      ready.phases[0],
+      ready.phases[1],
+      {
+        ...workspace,
+        status: "pull-request-open",
+        artifacts: [],
+        pullRequest: pullRequest(workspace.workspace.identity.branch, oid),
+      },
+    ],
+  });
+  assert.doesNotThrow(() => assertPlanningStateReplacement(ready, open));
+  const completed = validatePlanningState({
+    ...open,
+    revision: 2,
+    updatedAt: "2026-09-07T12:00:02.000Z",
+    phases: [
+      open.phases[0],
+      open.phases[1],
+      {
+        ...open.phases[2],
+        status: "complete",
+        completion: {
+          kind: "merged-pull-request",
+          mergeOid: "b".repeat(40),
+        },
+      },
+    ],
+  });
+  assert.doesNotThrow(() => assertPlanningStateReplacement(open, completed));
+
+  const changedPullRequest = structuredClone(completed);
+  const phase = changedPullRequest.phases[2]!;
+  assert.ok("pullRequest" in phase);
+  phase.pullRequest.reference.number = 2;
+  assert.throws(
+    () => assertPlanningStateReplacement(open, changedPullRequest),
+    /immutable-evidence/,
+  );
+});
+
+test("rejects equivalent workspace paths across phases", () => {
+  const state = completeState() as {
+    phases: Array<Record<string, unknown>>;
+  };
+  const base = state.phases[0]!.base;
+  const merged = (
+    kind: "spec" | "plan",
+    branch: string,
+    worktreePath: string,
+  ) => ({
+    kind,
+    status: "complete",
+    base,
+    workspace: {
+      runId,
+      phase: kind,
+      identity: { branch, worktreePath },
+      remote: "origin",
+      baseBranch: "main",
+      baseOid: oid,
+      headOid: oid,
+      cleanup: { state: "ready" },
+    },
+    artifacts: [
+      {
+        kind,
+        path: `docs/${kind}s/example-issue-187-${kind}.md`,
+        commitOid: oid,
+        source: "workspace",
+      },
+    ],
+    pullRequest: pullRequest(branch, oid),
+    completion: { kind: "merged-pull-request", mergeOid: "b".repeat(40) },
+  });
+  state.phases = [
+    merged("spec", "agent/spec", ".worktrees\\x\\..\\topic"),
+    merged("plan", "agent/plan", ".worktrees/topic"),
+    { kind: "implementation", status: "pending" },
+  ];
+  assert.throws(
+    () => validatePlanningState(state),
+    /duplicate-workspace-identity/,
+  );
+});
+
 test("requires immutable identity and exactly one revision step", () => {
   const state = createPlanningState({
     issueNumber: 187,

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PlanningStateValidationError,
+  assertPlanningStateReplacement,
+  createPlanningState,
+  parsePlanningState,
+  serializePlanningState,
+  validatePlanningState,
+} from "./planning-state.ts";
+
+const runId = "123e4567-e89b-42d3-a456-426614174000";
+const now = "2026-09-07T12:00:00.000Z";
+const gates = { specRequired: true, planRequired: true };
+
+test("creates and round-trips strict initial planning state", () => {
+  const state = createPlanningState({
+    issueNumber: 187,
+    issueTitle: "Example",
+    gates,
+    runId,
+    now,
+  });
+  assert.equal(state.revision, 0);
+  assert.equal(state.createdAt, now);
+  assert.equal(state.updatedAt, now);
+  assert.deepEqual(state.phases, [
+    { kind: "spec", status: "pending" },
+    { kind: "plan", status: "pending" },
+    { kind: "implementation", status: "pending" },
+  ]);
+  assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
+});
+
+test("rejects unknown and contradictory persisted state", () => {
+  const state = createPlanningState({
+    issueNumber: 187,
+    issueTitle: "Example",
+    gates,
+    runId,
+    now,
+  });
+  assert.throws(
+    () => validatePlanningState({ ...state, extra: true }),
+    (error: unknown) =>
+      error instanceof PlanningStateValidationError &&
+      error.reason === "unknown-key" &&
+      error.path === "$.extra",
+  );
+  assert.throws(
+    () =>
+      validatePlanningState({ ...state, phases: [...state.phases].reverse() }),
+    (error: unknown) =>
+      error instanceof PlanningStateValidationError &&
+      error.reason === "phase-sequence" &&
+      error.path === "$.phases",
+  );
+  assert.throws(
+    () => parsePlanningState("{"),
+    (error: unknown) =>
+      error instanceof PlanningStateValidationError &&
+      error.reason === "invalid-json",
+  );
+});
+
+test("requires immutable identity and exactly one revision step", () => {
+  const state = createPlanningState({
+    issueNumber: 187,
+    issueTitle: "Example",
+    gates,
+    runId,
+    now,
+  });
+  const next = { ...state, revision: 1, updatedAt: "2026-09-07T12:00:01.000Z" };
+  assert.doesNotThrow(() => assertPlanningStateReplacement(state, next));
+  assert.throws(
+    () =>
+      assertPlanningStateReplacement(state, {
+        ...next,
+        runId: "123e4567-e89b-42d3-a456-426614174001",
+      }),
+    /immutable/,
+  );
+  assert.throws(
+    () => assertPlanningStateReplacement(state, { ...next, revision: 2 }),
+    /revision/,
+  );
+});

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -645,7 +645,7 @@ test("accepts both idempotent merged-workspace cleanup transitions", () => {
         revision: 1,
         updatedAt: "2026-09-07T12:00:01.000Z",
       }),
-    /cleanup-transition/,
+    /(?:cleanup-transition|invalid-transition)/,
   );
 });
 

--- a/src/workflow/planning-state.ts
+++ b/src/workflow/planning-state.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from "node:crypto";
+import { PLANNING_PR_WORKFLOW_VERSION } from "./planning-pull-request-markers.ts";
+import {
+  planningPhasePlan,
+  type PlanningGateSnapshot,
+} from "./planning-pull-requests.ts";
+import type { PlanningStateV1 } from "./planning-state-types.ts";
+import {
+  PlanningStateValidationError,
+  validatePlanningState as validate,
+} from "./planning-state-validation.ts";
+
+export * from "./planning-state-types.ts";
+export { PlanningStateValidationError } from "./planning-state-validation.ts";
+
+export function createPlanningState(input: {
+  issueNumber: number;
+  issueTitle: string;
+  gates: PlanningGateSnapshot;
+  runId?: string;
+  now?: string;
+}): PlanningStateV1 {
+  const now = input.now ?? new Date().toISOString();
+  return validate({
+    version: 1,
+    workflowVersion: PLANNING_PR_WORKFLOW_VERSION,
+    runId: input.runId ?? randomUUID(),
+    issueNumber: input.issueNumber,
+    issueTitle: input.issueTitle,
+    gates: input.gates,
+    phases: planningPhasePlan(input.gates).map(({ kind }) => ({
+      kind,
+      status: "pending",
+    })),
+    revision: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+export function validatePlanningState(value: unknown): PlanningStateV1 {
+  return validate(value);
+}
+export function parsePlanningState(raw: string): PlanningStateV1 {
+  try {
+    return validate(JSON.parse(raw) as unknown);
+  } catch (error) {
+    if (error instanceof PlanningStateValidationError) throw error;
+    throw new PlanningStateValidationError("invalid-json", "$");
+  }
+}
+export function serializePlanningState(state: PlanningStateV1): string {
+  return `${JSON.stringify(validate(state), null, 2)}\n`;
+}
+export function assertPlanningStateReplacement(
+  current: PlanningStateV1,
+  next: PlanningStateV1,
+): void {
+  const left = validate(current);
+  const right = validate(next);
+  for (const key of [
+    "version",
+    "workflowVersion",
+    "runId",
+    "issueNumber",
+    "issueTitle",
+    "createdAt",
+  ] as const)
+    if (left[key] !== right[key])
+      throw new PlanningStateValidationError("immutable-field", `$.${key}`);
+  if (
+    JSON.stringify(left.gates) !== JSON.stringify(right.gates) ||
+    left.phases.map((p) => p.kind).join() !==
+      right.phases.map((p) => p.kind).join()
+  )
+    throw new PlanningStateValidationError("immutable-field", "$.phases");
+  if (right.revision !== left.revision + 1)
+    throw new PlanningStateValidationError("revision-step", "$.revision");
+  if (right.updatedAt < left.updatedAt)
+    throw new PlanningStateValidationError("timestamp-order", "$.updatedAt");
+  for (let index = 0; index < left.phases.length; index += 1) {
+    const a = left.phases[index]!;
+    const b = right.phases[index]!;
+    const allowed: Record<string, readonly string[]> = {
+      pending: ["pending", "workspace-ready", "complete"],
+      "workspace-ready": ["workspace-ready", "pull-request-open"],
+      "pull-request-open": ["pull-request-open", "complete"],
+      complete: ["complete"],
+    };
+    if (!allowed[a.status]!.includes(b.status))
+      throw new PlanningStateValidationError(
+        "invalid-transition",
+        `$.phases[${index}].status`,
+      );
+    if (a.status === "complete" && b.status === "complete") {
+      const ak = a.completion.kind;
+      const bk = b.completion.kind;
+      if (ak !== bk)
+        throw new PlanningStateValidationError(
+          "invalid-transition",
+          `$.phases[${index}].completion`,
+        );
+      if (ak === "merged-pull-request" && bk === "merged-pull-request") {
+        const leftMerged = a as Extract<
+          typeof a,
+          { completion: { kind: "merged-pull-request" } }
+        >;
+        const rightMerged = b as Extract<
+          typeof b,
+          { completion: { kind: "merged-pull-request" } }
+        >;
+        if (
+          leftMerged.workspace.cleanup.state !==
+          rightMerged.workspace.cleanup.state
+        ) {
+          const edges: Record<string, string> = {
+            ready: "worktree-removed",
+            "worktree-removed": "removed",
+          };
+          if (
+            edges[leftMerged.workspace.cleanup.state] !==
+            rightMerged.workspace.cleanup.state
+          )
+            throw new PlanningStateValidationError(
+              "invalid-cleanup-transition",
+              `$.phases[${index}].workspace.cleanup`,
+            );
+        }
+      }
+    }
+  }
+}

--- a/src/workflow/planning-state.ts
+++ b/src/workflow/planning-state.ts
@@ -80,52 +80,101 @@ export function assertPlanningStateReplacement(
   for (let index = 0; index < left.phases.length; index += 1) {
     const a = left.phases[index]!;
     const b = right.phases[index]!;
-    const allowed: Record<string, readonly string[]> = {
-      pending: ["pending", "workspace-ready", "complete"],
-      "workspace-ready": ["workspace-ready", "pull-request-open"],
-      "pull-request-open": ["pull-request-open", "complete"],
-      complete: ["complete"],
-    };
-    if (!allowed[a.status]!.includes(b.status))
+    const completion = (phase: typeof b) =>
+      phase.status === "complete" ? phase.completion.kind : undefined;
+    const allowed =
+      (a.status === "pending" &&
+        (b.status === "pending" ||
+          b.status === "workspace-ready" ||
+          completion(b) === "remote-base")) ||
+      (a.status === "workspace-ready" &&
+        (b.status === "workspace-ready" || b.status === "pull-request-open")) ||
+      (a.status === "pull-request-open" &&
+        (b.status === "pull-request-open" ||
+          completion(b) === "merged-pull-request")) ||
+      (a.status === "complete" &&
+        b.status === "complete" &&
+        a.completion.kind === b.completion.kind);
+    if (!allowed)
       throw new PlanningStateValidationError(
         "invalid-transition",
         `$.phases[${index}].status`,
       );
-    if (a.status === "complete" && b.status === "complete") {
-      const ak = a.completion.kind;
-      const bk = b.completion.kind;
-      if (ak !== bk)
-        throw new PlanningStateValidationError(
-          "invalid-transition",
-          `$.phases[${index}].completion`,
-        );
-      if (ak === "merged-pull-request" && bk === "merged-pull-request") {
-        const leftMerged = a as Extract<
-          typeof a,
-          { completion: { kind: "merged-pull-request" } }
-        >;
-        const rightMerged = b as Extract<
-          typeof b,
-          { completion: { kind: "merged-pull-request" } }
-        >;
-        if (
-          leftMerged.workspace.cleanup.state !==
-          rightMerged.workspace.cleanup.state
-        ) {
-          const edges: Record<string, string> = {
-            ready: "worktree-removed",
-            "worktree-removed": "removed",
-          };
-          if (
-            edges[leftMerged.workspace.cleanup.state] !==
-            rightMerged.workspace.cleanup.state
-          )
-            throw new PlanningStateValidationError(
-              "invalid-cleanup-transition",
-              `$.phases[${index}].workspace.cleanup`,
-            );
-        }
+    const leftJson = JSON.parse(JSON.stringify(a)) as Record<string, unknown>;
+    const rightJson = JSON.parse(JSON.stringify(b)) as Record<string, unknown>;
+    const leftWorkspace = leftJson.workspace as
+      | Record<string, unknown>
+      | undefined;
+    const rightWorkspace = rightJson.workspace as
+      | Record<string, unknown>
+      | undefined;
+    if (
+      leftWorkspace !== undefined &&
+      rightWorkspace !== undefined &&
+      (leftWorkspace.cleanup as Record<string, unknown>).state === "ready" &&
+      (rightWorkspace.cleanup as Record<string, unknown>).state === "ready"
+    ) {
+      leftWorkspace.headOid = "<head>";
+      rightWorkspace.headOid = "<head>";
+      const leftArtifacts = leftJson.artifacts as
+        | Array<Record<string, unknown>>
+        | undefined;
+      const rightArtifacts = rightJson.artifacts as
+        | Array<Record<string, unknown>>
+        | undefined;
+      if (leftArtifacts !== undefined && rightArtifacts !== undefined) {
+        for (const artifact of leftArtifacts)
+          if (artifact.source === "workspace") artifact.commitOid = "<head>";
+        for (const artifact of rightArtifacts)
+          if (artifact.source === "workspace") artifact.commitOid = "<head>";
       }
+      const leftPull = leftJson.pullRequest as
+        | Record<string, unknown>
+        | undefined;
+      const rightPull = rightJson.pullRequest as
+        | Record<string, unknown>
+        | undefined;
+      if (leftPull !== undefined && rightPull !== undefined) {
+        leftPull.headOid = "<head>";
+        rightPull.headOid = "<head>";
+      }
+    }
+    if (
+      a.status === b.status &&
+      JSON.stringify(leftJson) !== JSON.stringify(rightJson)
+    )
+      throw new PlanningStateValidationError(
+        "immutable-evidence",
+        `$.phases[${index}]`,
+      );
+    if (
+      a.status === "complete" &&
+      b.status === "complete" &&
+      a.completion.kind === "merged-pull-request" &&
+      b.completion.kind === "merged-pull-request"
+    ) {
+      const leftMerged = a as Extract<
+        typeof a,
+        { completion: { kind: "merged-pull-request" } }
+      >;
+      const rightMerged = b as Extract<
+        typeof b,
+        { completion: { kind: "merged-pull-request" } }
+      >;
+      const edges: Record<string, string> = {
+        ready: "worktree-removed",
+        "worktree-removed": "removed",
+      };
+      if (
+        leftMerged.workspace.cleanup.state !==
+          rightMerged.workspace.cleanup.state &&
+        edges[leftMerged.workspace.cleanup.state] !==
+          rightMerged.workspace.cleanup.state
+      )
+        throw new PlanningStateValidationError(
+          "invalid-cleanup-transition",
+          `$.phases[${index}].workspace.cleanup`,
+        );
     }
   }
 }

--- a/src/workflow/planning-state.ts
+++ b/src/workflow/planning-state.ts
@@ -4,6 +4,7 @@ import {
   planningPhasePlan,
   type PlanningGateSnapshot,
 } from "./planning-pull-requests.ts";
+import { assertPlanningPhaseReplacement } from "./planning-state-transitions.ts";
 import type { PlanningStateV1 } from "./planning-state-types.ts";
 import {
   PlanningStateValidationError,
@@ -37,9 +38,11 @@ export function createPlanningState(input: {
     updatedAt: now,
   });
 }
+
 export function validatePlanningState(value: unknown): PlanningStateV1 {
   return validate(value);
 }
+
 export function parsePlanningState(raw: string): PlanningStateV1 {
   try {
     return validate(JSON.parse(raw) as unknown);
@@ -48,9 +51,11 @@ export function parsePlanningState(raw: string): PlanningStateV1 {
     throw new PlanningStateValidationError("invalid-json", "$");
   }
 }
+
 export function serializePlanningState(state: PlanningStateV1): string {
   return `${JSON.stringify(validate(state), null, 2)}\n`;
 }
+
 export function assertPlanningStateReplacement(
   current: PlanningStateV1,
   next: PlanningStateV1,
@@ -64,138 +69,29 @@ export function assertPlanningStateReplacement(
     "issueNumber",
     "issueTitle",
     "createdAt",
-  ] as const)
-    if (left[key] !== right[key])
+  ] as const) {
+    if (left[key] !== right[key]) {
       throw new PlanningStateValidationError("immutable-field", `$.${key}`);
+    }
+  }
   if (
     JSON.stringify(left.gates) !== JSON.stringify(right.gates) ||
-    left.phases.map((p) => p.kind).join() !==
-      right.phases.map((p) => p.kind).join()
-  )
+    left.phases.map((phase) => phase.kind).join() !==
+      right.phases.map((phase) => phase.kind).join()
+  ) {
     throw new PlanningStateValidationError("immutable-field", "$.phases");
-  if (right.revision !== left.revision + 1)
+  }
+  if (right.revision !== left.revision + 1) {
     throw new PlanningStateValidationError("revision-step", "$.revision");
-  if (right.updatedAt < left.updatedAt)
+  }
+  if (right.updatedAt < left.updatedAt) {
     throw new PlanningStateValidationError("timestamp-order", "$.updatedAt");
+  }
   for (let index = 0; index < left.phases.length; index += 1) {
-    const a = left.phases[index]!;
-    const b = right.phases[index]!;
-    const completion = (phase: typeof b) =>
-      phase.status === "complete" ? phase.completion.kind : undefined;
-    const allowed =
-      (a.status === "pending" &&
-        (b.status === "pending" ||
-          b.status === "workspace-ready" ||
-          completion(b) === "remote-base")) ||
-      (a.status === "workspace-ready" &&
-        (b.status === "workspace-ready" || b.status === "pull-request-open")) ||
-      (a.status === "pull-request-open" &&
-        (b.status === "pull-request-open" ||
-          completion(b) === "merged-pull-request")) ||
-      (a.status === "complete" &&
-        b.status === "complete" &&
-        a.completion.kind === b.completion.kind);
-    if (!allowed)
-      throw new PlanningStateValidationError(
-        "invalid-transition",
-        `$.phases[${index}].status`,
-      );
-    const leftJson = JSON.parse(JSON.stringify(a)) as Record<string, unknown>;
-    const rightJson = JSON.parse(JSON.stringify(b)) as Record<string, unknown>;
-    const leftWorkspace = leftJson.workspace as
-      | Record<string, unknown>
-      | undefined;
-    const rightWorkspace = rightJson.workspace as
-      | Record<string, unknown>
-      | undefined;
-    if (
-      leftWorkspace !== undefined &&
-      rightWorkspace !== undefined &&
-      (leftWorkspace.cleanup as Record<string, unknown>).state === "ready" &&
-      (rightWorkspace.cleanup as Record<string, unknown>).state === "ready"
-    ) {
-      leftWorkspace.headOid = "<head>";
-      rightWorkspace.headOid = "<head>";
-      const leftArtifacts = leftJson.artifacts as
-        | Array<Record<string, unknown>>
-        | undefined;
-      const rightArtifacts = rightJson.artifacts as
-        | Array<Record<string, unknown>>
-        | undefined;
-      if (leftArtifacts !== undefined && rightArtifacts !== undefined) {
-        for (const artifact of leftArtifacts)
-          if (artifact.source === "workspace") artifact.commitOid = "<head>";
-        for (const artifact of rightArtifacts)
-          if (artifact.source === "workspace") artifact.commitOid = "<head>";
-      }
-      const leftPull = leftJson.pullRequest as
-        | Record<string, unknown>
-        | undefined;
-      const rightPull = rightJson.pullRequest as
-        | Record<string, unknown>
-        | undefined;
-      if (leftPull !== undefined && rightPull !== undefined) {
-        leftPull.headOid = "<head>";
-        rightPull.headOid = "<head>";
-      }
-    }
-    if (
-      a.status === "complete" &&
-      b.status === "complete" &&
-      a.completion.kind === "merged-pull-request" &&
-      b.completion.kind === "merged-pull-request"
-    ) {
-      const leftMerged = a as Extract<
-        typeof a,
-        { completion: { kind: "merged-pull-request" } }
-      >;
-      const rightMerged = b as Extract<
-        typeof b,
-        { completion: { kind: "merged-pull-request" } }
-      >;
-      const edges: Record<string, string> = {
-        ready: "worktree-removed",
-        "worktree-removed": "removed",
-      };
-      if (
-        leftMerged.workspace.cleanup.state !==
-          rightMerged.workspace.cleanup.state &&
-        edges[leftMerged.workspace.cleanup.state] !==
-          rightMerged.workspace.cleanup.state
-      )
-        throw new PlanningStateValidationError(
-          "invalid-cleanup-transition",
-          `$.phases[${index}].workspace.cleanup`,
-        );
-      const leftCleanup = leftJson.workspace as Record<string, unknown>;
-      const rightCleanup = rightJson.workspace as Record<string, unknown>;
-      (leftCleanup.cleanup as Record<string, unknown>).state = "<cleanup>";
-      (rightCleanup.cleanup as Record<string, unknown>).state = "<cleanup>";
-      delete (leftCleanup.cleanup as Record<string, unknown>).pushedHeadOid;
-      delete (rightCleanup.cleanup as Record<string, unknown>).pushedHeadOid;
-    }
-    if (a.status === "workspace-ready" && b.status === "pull-request-open") {
-      delete rightJson.artifacts;
-      delete rightJson.pullRequest;
-      rightJson.status = "workspace-ready";
-    }
-    if (
-      a.status === "pull-request-open" &&
-      b.status === "complete" &&
-      b.completion.kind === "merged-pull-request"
-    ) {
-      delete rightJson.completion;
-      rightJson.status = "pull-request-open";
-    }
-    if (
-      (a.status === b.status ||
-        a.status === "workspace-ready" ||
-        a.status === "pull-request-open") &&
-      JSON.stringify(leftJson) !== JSON.stringify(rightJson)
-    )
-      throw new PlanningStateValidationError(
-        "immutable-evidence",
-        `$.phases[${index}]`,
-      );
+    assertPlanningPhaseReplacement(
+      left.phases[index]!,
+      right.phases[index]!,
+      index,
+    );
   }
 }

--- a/src/workflow/planning-state.ts
+++ b/src/workflow/planning-state.ts
@@ -140,14 +140,6 @@ export function assertPlanningStateReplacement(
       }
     }
     if (
-      a.status === b.status &&
-      JSON.stringify(leftJson) !== JSON.stringify(rightJson)
-    )
-      throw new PlanningStateValidationError(
-        "immutable-evidence",
-        `$.phases[${index}]`,
-      );
-    if (
       a.status === "complete" &&
       b.status === "complete" &&
       a.completion.kind === "merged-pull-request" &&
@@ -175,6 +167,35 @@ export function assertPlanningStateReplacement(
           "invalid-cleanup-transition",
           `$.phases[${index}].workspace.cleanup`,
         );
+      const leftCleanup = leftJson.workspace as Record<string, unknown>;
+      const rightCleanup = rightJson.workspace as Record<string, unknown>;
+      (leftCleanup.cleanup as Record<string, unknown>).state = "<cleanup>";
+      (rightCleanup.cleanup as Record<string, unknown>).state = "<cleanup>";
+      delete (leftCleanup.cleanup as Record<string, unknown>).pushedHeadOid;
+      delete (rightCleanup.cleanup as Record<string, unknown>).pushedHeadOid;
     }
+    if (a.status === "workspace-ready" && b.status === "pull-request-open") {
+      delete rightJson.artifacts;
+      delete rightJson.pullRequest;
+      rightJson.status = "workspace-ready";
+    }
+    if (
+      a.status === "pull-request-open" &&
+      b.status === "complete" &&
+      b.completion.kind === "merged-pull-request"
+    ) {
+      delete rightJson.completion;
+      rightJson.status = "pull-request-open";
+    }
+    if (
+      (a.status === b.status ||
+        a.status === "workspace-ready" ||
+        a.status === "pull-request-open") &&
+      JSON.stringify(leftJson) !== JSON.stringify(rightJson)
+    )
+      throw new PlanningStateValidationError(
+        "immutable-evidence",
+        `$.phases[${index}]`,
+      );
   }
 }


### PR DESCRIPTION
## Summary

- add strict versioned planning recovery state with immutable run identity, ownership-ID locks, and atomic complete-document replacement
- fetch and pin remote bases, discover planning artifacts from pinned trees, and create/resume exact Git workspaces
- enforce Patchmill-owned, clean, idempotent worktree and branch cleanup with exact remote-head and compare-and-swap proof
- add recording-runner and real-Git coverage for parsing, durability, collisions, resume, and destructive cleanup boundaries

## Validation

- focused issue suite: 38/38 passed
- `npm test`: 1,605/1,605 passed
- `npm run build`
- `npm run lint`
- `npm run check:types`
- `npm run check:architecture`
- `git diff --check`
- package/config/CLI/host compatibility diff: clean

## Reviews

- Final Codex full-worktree review: passed after accepted fix loops
- Final thermo-nuclear code-quality review: passed after structural fixes
- Final validation-readiness review: passed

## Human review rationale

This introduces strict durable-state and public workspace contracts plus guarded destructive Git cleanup operations. The new modules remain unwired from the current run-once workflow, but the safety and architecture boundaries warrant human review.

Closes #187

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Planning | gpt-5.6-sol | 3,702,719 | 41,458 | $4.2065 |
| Development environment | gpt-5.6-sol | 1,224,917 | 4,645 | $1.1658 |
| Implementation | gpt-5.6-sol | 52,607,216 | 185,282 | $46.7976 |
| Implementation | gpt-5.6-terra | 23,475,605 | 53,303 | $6.2820 |
| **Implementation subtotal** |  | **76,082,821** | **238,585** | **$53.0796** |
| **Total** |  | **81,010,457** | **284,688** | **$58.4518** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->