### PR TITLE
feat(run-once): publish planning pull request phases

### DIFF
--- a/docs/plans/2026-09-08-issue-188-execute-and-publish-planning-pull-request-phases.md
+++ b/docs/plans/2026-09-08-issue-188-execute-and-publish-planning-pull-request-phases.md
@@ -1,0 +1,1559 @@
+# Execute and Publish Planning Pull Request Phases Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run spec and plan agents in owned phase workspaces, publish each exact
+phase head through one recoverable planning pull request, clean up local phase
+resources through durable checkpoints, and verify merged artifacts on the saved
+base branch.
+
+**Architecture:** Refine the issue #187 strict phase-state graph first, then
+keep local Git proof, agent execution, pull request identity, remote
+publication, and reconciliation behind focused seams. The publisher owns
+mutation order and checkpointed cleanup; the reconciler owns status
+classification and merged-base proof. These services remain callable but unwired
+from the legacy run-once pipeline in this issue.
+
+**Tech Stack:** TypeScript, Node.js 24, Node's `node:test` runner, Git CLI
+through `CommandRunner`, the issue #184 `PullRequestHost` contract, issues #185
+and #186 host adapters, issue #187 planning state/workspace services, Prettier,
+ESLint, strict TypeScript, and dependency-cruiser.
+
+**Spec:**
+`docs/specs/2026-09-08-issue-188-execute-and-publish-planning-pull-request-phases-design.md`
+
+## Global Constraints
+
+- Begin implementation only after the issue #187 durable planning state and
+  workspace changes are present; rebase onto their merged commit rather than
+  recreating predecessor modules in this issue.
+- Preserve state `version: 1`, `workflowVersion: "planning-pr-v1"`, strict
+  unknown-field rejection, immutable Issue run identity, one-step revisions,
+  atomic complete-document replacement, and ownership-ID lock checks.
+- Publish only caller-selected `spec` and `plan` phases. The reusable artifact
+  runner may prepare artifacts assigned to `implementation`, but this issue does
+  not publish or enforce an implementation pull request.
+- Run every planning agent in the exact owned phase worktree and in assignment
+  order; spec precedes plan when both belong to one phase.
+- Treat zero, one, and multiple remote-base artifact candidates distinctly. A
+  phase is satisfied only by one candidate per assigned artifact; ambiguity
+  blocks before workspace or agent mutation.
+- Validate returned repository-relative artifact paths, configured-directory
+  containment, regular-file mode, exact live `HEAD`, ancestry, changed paths,
+  and tracked/untracked/ignored cleanliness before every artifact checkpoint.
+- Push exactly the saved phase object ID to its deterministic remote branch.
+  Never force-push, rebase, merge, delete the remote phase branch, or adopt a
+  conflicting remote object ID.
+- Resolve target and push-remote repository identities before push. GitHub
+  requires the same repository; Forgejo permits a different owner/repository on
+  the same provider host.
+- Search all pull request states exhaustively before create. Adopt only one pull
+  request matching both repositories, both branches, the exact head object ID,
+  issue, phase, canonical reference/URL, and exactly one `planning-pr-v1`
+  marker.
+- Never rewrite an adopted pull request body. Human text may differ as long as
+  the one exact ownership marker remains valid.
+- Follow this durable order: validate; resolve repositories; inspect/push exact
+  head; persist `branch-pushed`; discover/create/read back; persist
+  `pull-request-open/ready`; remove worktree; persist
+  `pull-request-open/worktree-removed`; remove local branch; persist
+  `pull-request-open/removed`; classify status.
+- No later remote or destructive local effect may run after a checkpoint write
+  fails. Retries recover push by exact remote-head observation, pull request
+  create by exhaustive discovery, and cleanup through issue #187 idempotent
+  lifecycle operations.
+- Only `PullRequestNotFoundError` proves a missing saved pull request.
+  Authentication, authorization, rate-limit, transport, incomplete-search,
+  invalid-JSON, malformed-response, and identity failures propagate without a
+  phase-state replacement.
+- `review-pending`, `merged`, and `satisfied-by-base` remain distinct from the
+  blocking `closed-unmerged`, `missing`, and `ambiguous` outcomes. Do not create
+  a replacement for a blocking outcome.
+- A host-reported merge completes only after cleanup is `removed`, the saved
+  remote/base branch is freshly fetched, the merge object is an ancestor of the
+  fetched tip, and every expected artifact is a regular file at both objects.
+- On merge, trust artifact files from the fetched base and do not compare their
+  blobs to the old workspace commit; reviewer edits and squash/rebase merges
+  must be preserved.
+- Error messages and enumerable fields must not expose pull request bodies, raw
+  command output, credentials, credential-bearing remote URLs, state bytes, or
+  Pi transcripts. Raw command diagnostics may be retained only as explicitly
+  non-enumerable data.
+- Keep effect modules focused and target fewer than 200 meaningful lines. Split
+  cleanup or validation by behavior before growing publisher/reconciler files
+  substantially beyond that target.
+- Do not route these services from `pipeline.ts` or `stage-advancement.ts`,
+  change lifecycle labels/comments, add compatibility migration or user docs, or
+  make live GitHub/Forgejo mutations in tests.
+- Add no dependency or configuration key. If `package.json`,
+  `package-lock.json`, or `npm-shrinkwrap.json` changes unexpectedly, run the
+  repository-required Nix build in addition to all commands below.
+
+---
+
+## File and Module Map
+
+### Durable workflow state
+
+- Modify `src/workflow/planning-state-types.ts` for partial workspace artifacts,
+  immutable publication evidence, canonical pull request evidence, cleanup
+  progress, and merged-base evidence.
+- Modify `src/workflow/planning-state-validation.ts` for strict variant parsing
+  and document-level publication/cleanup/merge invariants.
+- Modify `src/workflow/planning-state-transitions.ts` for the exact checkpoint
+  graph and evidence immutability rules.
+- Modify `src/workflow/planning-state.test.ts` for round trips, invalid states,
+  all valid edges, skipped-edge rejection, and idempotent replacements.
+
+### Git proof and publication
+
+- Create `src/git/planning-publication-git.ts` for artifact commit/worktree
+  validation, exact remote-head inspection/push, commit ancestry, and committed
+  regular-file proof.
+- Create `src/git/planning-publication-git.test.ts` for recording-runner
+  contracts and real-Git side-effect/recovery tests with a local bare remote.
+
+### Agent execution and prompts
+
+- Modify `src/cli/commands/run-once/prompts.ts` to add explicit planning review
+  context while defaulting existing callers to `legacy-label`.
+- Modify `src/cli/commands/run-once/prompts.test.ts` for all five context modes
+  and unchanged legacy text.
+- Create `src/cli/commands/run-once/planning-phase-artifacts.ts` for pure
+  remote-base resolution and ordered, checkpointed artifact execution.
+- Create `src/cli/commands/run-once/planning-phase-artifacts.test.ts` for
+  sequencing, resume, blocked results, validation, and checkpoint order.
+
+### Pull request identity and host construction
+
+- Create `src/workflow/planning-pull-request-validation.ts` for provider-neutral
+  repository rules, exact summary/reference/URL/branch/head/marker validation,
+  and sanitized typed failures.
+- Create `src/workflow/planning-pull-request-validation.test.ts` for exact
+  adoption rules and confidential error surfaces.
+- Modify `src/host/factory.ts` to add the dedicated `createPullRequestHost()`
+  factory.
+- Modify `src/host/factory.test.ts` to verify GitHub and Forgejo planning
+  adapter construction without changing existing provider factories.
+
+### Publication and reconciliation services
+
+- Create `src/cli/commands/run-once/planning-phase-cleanup.ts` for the two
+  checkpointed, idempotent local cleanup steps shared by publication and
+  reconciliation.
+- Create `src/cli/commands/run-once/planning-phase-publisher.ts` for workspace
+  validation, repository resolution, exact push recovery, exhaustive discovery,
+  create/adopt/read-back, state persistence, and cleanup orchestration.
+- Create `src/cli/commands/run-once/planning-phase-publisher.test.ts` for
+  ordered effect recording and failure injection after every side effect.
+- Create `src/cli/commands/run-once/planning-phase-reconciler.ts` for exact read
+  or discovery, cleanup gating, status classification, saved-base merge proof,
+  and completion persistence.
+- Create `src/cli/commands/run-once/planning-phase-reconciler.test.ts` for every
+  reconciliation outcome, unchanged-state host failures, and human-edited merge
+  artifacts.
+
+No production import is added from `pipeline.ts`, `stage-advancement.ts`, or the
+legacy Run recovery state.
+
+## Shared Public Shapes
+
+Use these names consistently across tasks:
+
+```ts
+// src/workflow/planning-state-types.ts
+export type PlanningPublicationEvidence = Readonly<{
+  targetRepository: RepositoryIdentity;
+  headRepository: RepositoryIdentity;
+  baseBranch: string;
+  headBranch: string;
+  headOid: string;
+}>;
+
+export type PlanningPullRequestEvidence = Readonly<{
+  reference: PullRequestReference;
+  url: string;
+}>;
+
+export type WorkspaceReadyPlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "workspace-ready";
+  base: PlanningBaseEvidence;
+  workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  artifacts: readonly PlanningArtifactEvidence[];
+}>;
+
+export type BranchPushedPlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "branch-pushed";
+  base: PlanningBaseEvidence;
+  workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  artifacts: readonly PlanningArtifactEvidence[];
+  publication: PlanningPublicationEvidence;
+}>;
+```
+
+`pull-request-open` retains `base`, `workspace`, complete `artifacts`, and
+`publication`, then adds `pullRequest`. Its workspace cleanup is `ready`,
+`worktree-removed`, or `removed`. Merged completion retains the same evidence,
+requires cleanup `removed`, and adds:
+
+```ts
+completion: Readonly<{
+  kind: "merged-pull-request";
+  mergeOid: string;
+  mergedBaseOid: string;
+}>;
+```
+
+The shared service result remains:
+
+```ts
+export type PlanningPhaseReconciliation =
+  | { kind: "review-pending"; pullRequest: PullRequestSummary }
+  | { kind: "merged"; pullRequest: PullRequestSummary; baseOid: string }
+  | { kind: "satisfied-by-base"; artifacts: PlanningArtifactEvidence[] }
+  | { kind: "closed-unmerged"; pullRequest: PullRequestSummary }
+  | { kind: "missing"; reference?: PullRequestReference }
+  | { kind: "ambiguous"; pullRequests: PullRequestSummary[] };
+```
+
+## Testing Value Gate
+
+All planned automated tests pass Patchmill's Testing Value Gate:
+
+- State and identity tests prove reusable strict parsing, authorization,
+  checkpoint ordering, and immutable recovery evidence.
+- Artifact-runner tests prove agent sequencing, validation, blocked-result
+  behavior, and a resumable same-phase spec checkpoint.
+- Recording effect tests prove external side-effect order and stop behavior at
+  meaningful interruption boundaries.
+- Real-Git tests prove non-force push recovery/conflict handling, destructive
+  cleanup preconditions, ancestry, regular-file modes, and preservation of
+  human-edited merged artifacts.
+- Prompt tests protect behavior visible to planning agents and prevent the
+  meaningful regression of describing an unapproved same-phase spec as approved.
+- No new test asserts documentation text, a dependency version, lockfile bytes,
+  static configuration, or import spelling. Dependency absence, legacy
+  non-wiring, module size, and forbidden command usage are checked directly in
+  Task 8.
+
+---
+
+### Task 1: Refine durable planning publication state
+
+**Files:**
+
+- Modify: `src/workflow/planning-state-types.ts`
+- Modify: `src/workflow/planning-state-validation.ts`
+- Modify: `src/workflow/planning-state-transitions.ts`
+- Modify: `src/workflow/planning-state.test.ts`
+
+**Interfaces:**
+
+- Consumes: issue #187 `PlanningStateV1`, `PlanningArtifactEvidence`, base and
+  workspace ownership evidence, strict parser, and replacement validator.
+- Consumes: `RepositoryIdentity` and `PullRequestReference` from
+  `src/host/pull-requests.ts`.
+- Produces: `PlanningPublicationEvidence`, canonical
+  `PlanningPullRequestEvidence`, `branch-pushed`, partial `workspace-ready`,
+  checkpointed `pull-request-open`, and `mergedBaseOid` completion.
+- Preserves: `PlanningStateStore.replace()` and its lock/revision behavior; the
+  store needs no new mutation API.
+
+- [ ] **Step 1: Update valid fixtures and write round-trip tests for every new
+      phase discriminator**
+
+Add fixture builders whose exact progression is:
+
+```text
+pending
+workspace-ready []
+workspace-ready [remote-base spec]
+workspace-ready [workspace spec]
+workspace-ready [workspace spec, workspace plan]
+branch-pushed
+pull-request-open/ready
+pull-request-open/worktree-removed
+pull-request-open/removed
+complete/merged-pull-request
+```
+
+Round-trip each through `serializePlanningState()` and `parsePlanningState()`.
+Also retain direct `pending -> complete/remote-base` coverage.
+
+- [ ] **Step 2: Run the focused state test to prove RED**
+
+```sh
+node --test src/workflow/planning-state.test.ts
+```
+
+Expected: FAIL because `workspace-ready` cannot contain artifacts,
+`branch-pushed` is unknown, pull request evidence lacks publication/URL fields,
+and merged completion lacks `mergedBaseOid`.
+
+- [ ] **Step 3: Refine the version-1 state declarations**
+
+Replace the issue #187 pull request shape with the shared public shapes above.
+Define the exact phase union as:
+
+```ts
+export type PlanningPhaseStateV1 =
+  | Readonly<{ kind: PlanningPhaseKind; status: "pending" }>
+  | WorkspaceReadyPlanningPhase
+  | BranchPushedPlanningPhase
+  | PullRequestOpenPlanningPhase
+  | RemoteBaseCompletePlanningPhase
+  | MergedPullRequestCompletePlanningPhase;
+```
+
+A `workspace-ready.artifacts` array is an ordered unique prefix/subset of the
+phase's assigned artifact kinds. `branch-pushed`, `pull-request-open`, and both
+completion variants require complete artifact evidence.
+
+- [ ] **Step 4: Write strict parser and cross-field rejection tests**
+
+Table-test unknown/missing keys and contradictions for every variant. Cover:
+
+- partial artifacts out of planner order, duplicate kinds, or an unassigned
+  kind;
+- workspace-source evidence not at the current workspace head;
+- remote-base evidence not at the original pinned base/candidate path;
+- incomplete artifacts in `branch-pushed` or `pull-request-open`;
+- target/head provider mismatch, invalid repository values, branch disagreement,
+  or publication head different from workspace head;
+- pull request reference target different from publication target, invalid
+  positive number, or unsafe URL syntax;
+- cleanup progress before pull request identity is durable;
+- cleanup `pushedHeadOid` different from publication/workspace head;
+- merged completion before cleanup `removed`, missing `mergedBaseOid`, or an
+  artifact whose source/OID is not `remote-base`/`mergedBaseOid`.
+
+Assert stable `PlanningStateValidationError.reason` and JSON path without
+serializing state bytes into the error.
+
+- [ ] **Step 5: Implement strict parsing and document invariants**
+
+Give each discriminator its exact key set. Parse publication repository
+identities with the existing provider values and bounded single-line fields.
+Parse pull request URLs as HTTP(S), reject credentials, query, fragment, CR/LF,
+and invalid URLs, but leave provider-specific summary matching to Task 5.
+
+Apply these document rules:
+
+1. `workspace-ready.artifacts` is an ordered unique subset of assigned kinds.
+2. Later variants contain every assigned kind in planner order.
+3. Publication base/head branches equal saved base/workspace branches; `headOid`
+   equals `workspace.headOid`.
+4. Pull request reference target equals publication target.
+5. `branch-pushed` has cleanup `ready`.
+6. Pull request cleanup advances only through `ready`,
+   `worktree-removed(pushedHeadOid)`, and `removed(pushedHeadOid)`.
+7. Merged completion keeps original base/publication/pull request/workspace
+   identity, requires cleanup `removed`, and uses `mergedBaseOid` for all
+   resulting artifact evidence.
+
+- [ ] **Step 6: Write the complete replacement-transition matrix**
+
+Test every allowed edge and a skipped/backward counterpart:
+
+```text
+pending -> pending | workspace-ready | complete/remote-base
+workspace-ready -> workspace-ready | branch-pushed
+branch-pushed -> branch-pushed | pull-request-open/ready
+pull-request-open/ready -> same | pull-request-open/worktree-removed
+pull-request-open/worktree-removed -> same | pull-request-open/removed
+pull-request-open/removed -> same | complete/merged-pull-request
+complete/* -> same complete/*
+```
+
+For `workspace-ready -> workspace-ready`, permit only appending the next
+assigned artifact or an exact idempotent replacement. If `workspace.headOid`
+advances, require every existing workspace-source artifact OID to advance with
+it while remote-base evidence stays unchanged. After `branch-pushed`, freeze
+workspace head, artifact paths/OIDs, both repositories, both branches, and
+publication head. At merge, permit artifact source/OID replacement only as the
+all-at-once conversion to remote-base evidence at `mergedBaseOid`.
+
+- [ ] **Step 7: Implement transition validation**
+
+Update `phaseName()` and `allowedTransitions` to match Step 6. Keep cleanup
+proof and publication/pull request evidence immutable after each durable
+boundary. Reject cleanup regression, pull request replacement, publication
+mutation, skipped checkpoints, partial merge conversion, and all revision or
+Issue run identity changes through the existing stable validation error.
+
+- [ ] **Step 8: Format and validate state/store compatibility**
+
+```sh
+npx --no-install prettier --write \
+  src/workflow/planning-state-types.ts \
+  src/workflow/planning-state-validation.ts \
+  src/workflow/planning-state-transitions.ts \
+  src/workflow/planning-state.test.ts
+node --test \
+  src/workflow/planning-state.test.ts \
+  src/workflow/planning-state-store.test.ts
+npm run check:contract-tests
+npm run check:types
+npm run check:architecture
+```
+
+Expected: strict state and store tests PASS; atomic storage and issue-lock APIs
+remain unchanged.
+
+- [ ] **Step 9: Commit the state refinement**
+
+```sh
+git add \
+  src/workflow/planning-state-types.ts \
+  src/workflow/planning-state-validation.ts \
+  src/workflow/planning-state-transitions.ts \
+  src/workflow/planning-state.test.ts
+git commit -m "feat(workflow): checkpoint planning publication state"
+```
+
+---
+
+### Task 2: Add exact Git validation and publication operations
+
+**Files:**
+
+- Create: `src/git/planning-publication-git.ts`
+- Create: `src/git/planning-publication-git.test.ts`
+
+**Interfaces:**
+
+- Consumes: `CommandRunner` from `src/process/command.ts` and issue #187
+  workspace ownership evidence.
+- Produces: `PlanningPublicationOperations`, `PlanningPublicationGit`,
+  `PlanningRemoteHead`, `PlanningPublicationGitError`, and stable
+  operation/reason unions.
+- Does not consume host/provider modules; `src/git/` stays below the outer-layer
+  architecture boundary.
+
+Use this public surface:
+
+```ts
+export type PlanningRemoteHead =
+  | Readonly<{ state: "missing" }>
+  | Readonly<{ state: "present"; headOid: string }>;
+export type PlanningArtifactCommitInput = Readonly<{
+  workspacePath: string;
+  previousHeadOid: string;
+  headOid: string;
+  artifactPath: string;
+}>;
+export type PlanningWorkspaceVerificationInput = Readonly<{
+  workspacePath: string;
+  baseOid: string;
+  headOid: string;
+  artifactPaths: readonly string[];
+}>;
+export type PlanningRemoteBranchInput = Readonly<{
+  remote: string;
+  branch: string;
+}>;
+export type PlanningExactPushInput = PlanningRemoteBranchInput &
+  Readonly<{ headOid: string }>;
+export type PlanningAncestryInput = Readonly<{
+  ancestorOid: string;
+  descendantOid: string;
+}>;
+export type PlanningRegularFilesInput = Readonly<{
+  commitOid: string;
+  paths: readonly string[];
+}>;
+
+export interface PlanningPublicationOperations {
+  verifyArtifactCommit(input: PlanningArtifactCommitInput): Promise<void>;
+  verifyWorkspace(input: PlanningWorkspaceVerificationInput): Promise<void>;
+  inspectRemoteHead(
+    input: PlanningRemoteBranchInput,
+  ): Promise<PlanningRemoteHead>;
+  ensureRemoteHead(
+    input: PlanningExactPushInput,
+  ): Promise<Readonly<{ pushed: boolean; headOid: string }>>;
+  assertAncestor(input: PlanningAncestryInput): Promise<void>;
+  assertRegularFiles(input: PlanningRegularFilesInput): Promise<void>;
+}
+
+export class PlanningPublicationGit implements PlanningPublicationOperations {
+  constructor(input: { runner: CommandRunner; repoRoot: string });
+  verifyArtifactCommit(input: PlanningArtifactCommitInput): Promise<void>;
+  verifyWorkspace(input: PlanningWorkspaceVerificationInput): Promise<void>;
+  inspectRemoteHead(
+    input: PlanningRemoteBranchInput,
+  ): Promise<PlanningRemoteHead>;
+  ensureRemoteHead(
+    input: PlanningExactPushInput,
+  ): Promise<Readonly<{ pushed: boolean; headOid: string }>>;
+  assertAncestor(input: PlanningAncestryInput): Promise<void>;
+  assertRegularFiles(input: PlanningRegularFilesInput): Promise<void>;
+}
+```
+
+- [ ] **Step 1: Write failing artifact/workspace validation tests**
+
+Use a recording runner to prove `verifyArtifactCommit()` checks, in order:
+
+1. exact worktree `HEAD^{commit}` equals returned `headOid`;
+2. `previousHeadOid` is an ancestor of `headOid`;
+3. the artifact's exact `ls-tree -z` entry is mode `100644` or `100755`, type
+   `blob`, at the expected repository-relative path;
+4. `git diff --name-only -z previousHeadOid headOid --` contains only that path;
+5. `git status --porcelain=v1 -z --untracked-files=all --ignored=matching` is
+   empty.
+
+Add meaningful rejection cases for absolute/path-escape input, missing commit,
+wrong live head, non-descendant head, symlink, gitlink/submodule, absent
+artifact, unrelated changed path, malformed Git output, and
+tracked/untracked/ignored residue. `verifyWorkspace()` must prove the saved
+head, base ancestry, every expected committed regular file, and the same strict
+cleanliness before publication.
+
+- [ ] **Step 2: Write failing exact remote-head and push-recovery tests**
+
+Assert `inspectRemoteHead()` uses:
+
+```ts
+["ls-remote", "--exit-code", "--heads", "--", remote, `refs/heads/${branch}`];
+```
+
+Treat Git's exact no-match exit as `missing`; reject every other nonzero result
+as a command failure and malformed/multiple/wrong-ref output as a response
+failure.
+
+For `ensureRemoteHead()`, cover:
+
+- absent => one exact non-force push, post-push observation, `pushed: true`;
+- already equal => no push, `pushed: false`;
+- different OID => conflict and no push;
+- post-push absent/different => conflict.
+
+Require the push refspec to be exactly `<headOid>:refs/heads/<branch>` and
+assert arguments contain no `--force`, `-f`, or leading `+`.
+
+- [ ] **Step 3: Run the new Git test to prove RED**
+
+```sh
+node --test src/git/planning-publication-git.test.ts
+```
+
+Expected: FAIL because the publication Git adapter does not exist.
+
+- [ ] **Step 4: Implement safe scalar, response, and error handling**
+
+Reuse issue #187 full-OID, branch, repository-relative path, and single-line
+validation. Bind the adapter to one canonical repository root. Resolve the
+workspace path, require it to be a real directory supplied by the owned
+workspace caller, and pass values only as command-array arguments.
+
+`PlanningPublicationGitError` exposes only stable `operation`, `reason`, and
+optional `exitCode`; attach raw `CommandResult` diagnostics as frozen,
+non-enumerable data. Do not place a remote URL, command arguments, stdout, or
+stderr in its message or enumerable fields.
+
+- [ ] **Step 5: Implement artifact and workspace proof**
+
+Use `git -C <workspace>` for live-head, diff, tree, and status checks. Strictly
+parse NUL output and require exactly one regular-file tree entry per requested
+path. A `merge-base --is-ancestor` exit `1` is a stable `not-ancestor` conflict;
+other nonzero results are command failures. Reject any nonempty status,
+including ignored content, rather than filtering operator files.
+
+- [ ] **Step 6: Implement remote inspection, exact push, ancestry, and tree
+      proof**
+
+`ensureRemoteHead()` performs inspect -> optional push -> inspect. Push through:
+
+```ts
+await runner.run(
+  "git",
+  [
+    "push",
+    "--porcelain",
+    "--no-force",
+    "--",
+    remote,
+    `${headOid}:refs/heads/${branch}`,
+  ],
+  { cwd: repoRoot },
+);
+```
+
+Require the final remote OID to equal `headOid` before returning. Implement
+`assertAncestor()` and `assertRegularFiles()` as read-only object checks used by
+reconciliation; neither fetches or resolves a moving branch.
+
+- [ ] **Step 7: Add real-Git regression tests**
+
+Create a temporary seed repository and local bare remote. Prove:
+
+- absent branch publication and matching-head retry;
+- a conflicting remote head blocks without changing it;
+- a local saved commit can be pushed by full OID from the linked-worktree object
+  database;
+- symlink and gitlink modes fail regular-file proof;
+- merge ancestry succeeds for an ancestor and blocks an unrelated commit;
+- dirty and ignored worktree content blocks validation.
+
+Capture commands and assert no force push, reset, clean, merge, rebase, or
+remote branch deletion occurs.
+
+- [ ] **Step 8: Format, run focused Git validation, and commit**
+
+```sh
+npx --no-install prettier --write \
+  src/git/planning-publication-git.ts \
+  src/git/planning-publication-git.test.ts
+node --test \
+  src/git/planning-publication-git.test.ts \
+  src/git/planning-workspace-git.test.ts \
+  src/git/planning-remote-base.test.ts
+npm run check:types
+npm run check:architecture
+git add \
+  src/git/planning-publication-git.ts \
+  src/git/planning-publication-git.test.ts
+git commit -m "feat(git): publish exact planning phase heads"
+```
+
+---
+
+### Task 3: Add explicit planning review prompt contexts
+
+**Files:**
+
+- Modify: `src/cli/commands/run-once/prompts.ts`
+- Modify: `src/cli/commands/run-once/prompts.test.ts`
+
+**Interfaces:**
+
+- Produces: `PlanningReviewContext` and an optional `reviewContext` on
+  `SpecCreationPromptInput` and `PlanCreationPromptInput`.
+- Preserves: every existing caller by defaulting omitted context to
+  `legacy-label` with byte-for-byte equivalent legacy review instructions.
+- Consumed by: Task 4's artifact runner.
+
+- [ ] **Step 1: Write failing tests for the five review contexts**
+
+Define the union:
+
+```ts
+export type PlanningReviewContext =
+  | "dedicated-pull-request"
+  | "same-phase-pull-request"
+  | "merged-base"
+  | "implementation-pull-request"
+  | "legacy-label";
+```
+
+Add tests that assert these behaviors:
+
+- dedicated spec/plan: the artifact is reviewed in the current planning pull
+  request;
+- same phase: spec and plan share the current plan pull request, and the spec is
+  not called already approved;
+- merged base: the plan treats the prior spec as coming from a verified merged
+  planning pull request on the saved base;
+- implementation: the ungated artifact travels with implementation code in the
+  implementation pull request;
+- omitted/legacy: all existing approval-label wording and result contracts stay
+  unchanged.
+
+- [ ] **Step 2: Run focused prompt tests to prove RED**
+
+```sh
+node --test --test-name-pattern="planning|review context|legacy" \
+  src/cli/commands/run-once/prompts.test.ts
+```
+
+Expected: FAIL because the prompt inputs do not accept or render review context.
+
+- [ ] **Step 3: Implement narrow context rendering**
+
+Add one private renderer beside the current spec/plan workflow construction. Use
+these exact concepts in generated instructions:
+
+```text
+dedicated-pull-request: review this artifact in the current planning pull request
+same-phase-pull-request: review spec and plan together; do not call the spec already approved
+merged-base: use the verified merged-base spec as source material
+implementation-pull-request: carry this artifact with implementation code; no planning PR is created for it
+legacy-label: preserve the current manual approval-label instruction
+```
+
+Do not refactor unrelated sections of the already-large prompt module. Context
+changes the review explanation only; the existing configured planning skill,
+self-review/plan validation, artifact path, commit-only-artifact, todo, Testing
+Value Gate, blocker, and terminal JSON instructions remain present.
+
+- [ ] **Step 4: Format, validate all prompt behavior, and commit**
+
+```sh
+npx --no-install prettier --write \
+  src/cli/commands/run-once/prompts.ts \
+  src/cli/commands/run-once/prompts.test.ts
+node --test src/cli/commands/run-once/prompts.test.ts
+npm run check:types
+npm run check:architecture
+git add \
+  src/cli/commands/run-once/prompts.ts \
+  src/cli/commands/run-once/prompts.test.ts
+git commit -m "feat(run-once): describe planning pull request review"
+```
+
+---
+
+### Task 4: Implement the artifact phase runner
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/planning-phase-artifacts.ts`
+- Create: `src/cli/commands/run-once/planning-phase-artifacts.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlannedPhase`, issue #187 pinned base/workspace evidence,
+  `PlanningPublicationGit`, `buildSpecPath()`, `buildPlanPath()`, prompt
+  builders, `runPiPrompt()`, and `runOncePlanningPiProfile()`.
+- Produces: pure base resolution plus a runner that receives one owned
+  `workspace-ready` phase and checkpoints each verified artifact through a
+  caller callback.
+
+Use these seams:
+
+```ts
+export type PlanningPhaseArtifactResolution =
+  | Readonly<{
+      kind: "satisfied-by-base";
+      artifacts: readonly PlanningArtifactEvidence[];
+    }>
+  | Readonly<{
+      kind: "workspace-required";
+      artifacts: readonly PlanningArtifactEvidence[];
+      missing: readonly PlanningArtifactKind[];
+    }>;
+
+export interface PlanningArtifactAgent {
+  run(input: {
+    kind: PlanningArtifactKind;
+    cwd: string;
+    prompt: string;
+  }): Promise<AgentIssuePiResult>;
+}
+
+export type PlanningArtifactCheckpoint = (
+  phase: Extract<PlanningPhaseStateV1, { status: "workspace-ready" }>,
+) => Promise<void>;
+
+export function resolvePlanningPhaseArtifacts(input: {
+  phase: PlannedPhase;
+  base: PlanningRemoteBaseSnapshot;
+}): PlanningPhaseArtifactResolution;
+
+export async function runPlanningPhaseArtifacts(input: {
+  issue: IssueSummary;
+  phase: PlannedPhase;
+  current: Extract<PlanningPhaseStateV1, { status: "workspace-ready" }>;
+  repoRoot: string;
+  specsDir: string;
+  plansDir: string;
+  projectPolicy: PatchmillProjectPolicy;
+  skills: PatchmillSkillsConfig;
+  triageLabels: PromptTriageLabels;
+  artifactDate: Date;
+  agent: PlanningArtifactAgent;
+  git: Pick<PlanningPublicationOperations, "verifyArtifactCommit">;
+  checkpoint: PlanningArtifactCheckpoint;
+}): Promise<
+  | { kind: "workspace-ready"; phase: WorkspaceReadyPlanningPhase }
+  | { kind: "blocked"; result: AgentIssueBlockedResult }
+>;
+```
+
+- [ ] **Step 1: Write base-resolution tests**
+
+Cover spec-only, plan-only, same-phase `spec -> plan`, and
+implementation-carried assignments. For each assigned kind assert:
+
+- zero candidates appears in `missing`;
+- one candidate becomes `source: "remote-base"` at `base.baseOid`;
+- mixed same-phase candidates retain planner order;
+- all single candidates return `satisfied-by-base`;
+- more than one candidate throws a sanitized
+  `PlanningPhaseArtifactError("ambiguous-base-artifact")` before any supplied
+  workspace preparation or agent callback can run.
+
+The later integration caller must invoke this pure resolver before issue #187
+`PlanningWorkspaceLifecycle.prepare()`.
+
+- [ ] **Step 2: Write ordered agent/checkpoint tests**
+
+Use recording fakes and assert this event order for a same-phase run:
+
+```ts
+assert.deepEqual(events, [
+  "agent:spec",
+  "git:verify-spec",
+  "checkpoint:spec",
+  "agent:plan",
+  "git:verify-plan",
+  "checkpoint:spec+plan",
+]);
+```
+
+After the plan commit, assert both workspace-source artifacts use the latest
+saved workspace head. Start a retry from the first checkpoint and assert the
+spec agent is skipped, the plan uses the saved spec/head, and no previous
+artifact is lost.
+
+- [ ] **Step 3: Write result, path, and blocked-flow tests**
+
+Cover:
+
+- `spec-created`/`plan-created` with required nonempty commit OID;
+- wrong terminal result kind, missing commit, or missing result path;
+- absolute paths, `..` escapes, backslashes, wrong configured artifact
+  directory, symlink/submodule/regular-file failures delegated to the Git seam;
+- returned commit missing, wrong live head, non-descendant, unrelated changes,
+  and dirty residue delegated to the Git seam;
+- a blocked spec returns unchanged prior state and never runs plan;
+- a checkpoint failure stops before the next agent and propagates without
+  updating the in-memory phase.
+
+- [ ] **Step 4: Run the artifact test to prove RED**
+
+```sh
+node --test src/cli/commands/run-once/planning-phase-artifacts.test.ts
+```
+
+Expected: FAIL because the artifact phase service does not exist.
+
+- [ ] **Step 5: Implement resolution, context selection, and exact path
+      containment**
+
+Resolve candidates in `phase.artifactKinds` order. For agent prompts select:
+
+```ts
+phase.kind === "implementation"
+  ? "implementation-pull-request"
+  : phase.artifactKinds.length > 1
+    ? "same-phase-pull-request"
+    : kind === "plan" && current.artifacts.some((a) => a.kind === "spec")
+      ? "merged-base"
+      : "dedicated-pull-request";
+```
+
+Mirror configured spec/plan directories into the owned workspace using the
+existing `configuredPathRelativeToRepo()` convention. Normalize each returned
+path to `/`, require repository-relative containment in the matching mirrored
+directory, and pass that exact path to Git verification. Do not accept a path
+merely because its basename looks correct.
+
+- [ ] **Step 6: Implement the production planning-agent adapter**
+
+Export a small `createPlanningArtifactAgent()` that computes
+`runOncePlanningPiProfile(skills, workspaceRoot)` for each run and calls
+`runPiPrompt(runner, workspaceRoot, prompt, ...)` with:
+
+```ts
+{
+  stage: "pi-plan",
+  issueNumber,
+  repoRoot: workspaceRoot,
+  skillPaths: profile.additionalSkillPaths,
+  extensionArgs: profileExtensionArgs(profile),
+  observeSession: true,
+  ...callerObservationAndProgressOptions,
+}
+```
+
+Keep the fakeable `PlanningArtifactAgent` seam so service tests create no Pi
+session. Reuse existing prompt result parsing and blocked-result types rather
+than creating a second JSON parser.
+
+- [ ] **Step 7: Implement post-agent checkpointing**
+
+For each still-missing kind:
+
+1. Build the expected path and prompt in the phase workspace.
+2. Await the matching agent terminal result.
+3. Return immediately on `blocked`.
+4. Normalize and directory-check its returned path and require its commit.
+5. Call `verifyArtifactCommit()` using the previously saved workspace head.
+6. Advance `workspace.headOid` to the verified commit.
+7. Update every existing workspace-source artifact OID to that new head and
+   append the newly verified artifact in planner order.
+8. Await `checkpoint(nextWorkspaceReadyPhase)` before invoking another agent.
+
+The service does not push, call a host, publish comments, mutate labels, or
+remove a workspace.
+
+- [ ] **Step 8: Format, run focused runner tests, and commit**
+
+```sh
+npx --no-install prettier --write \
+  src/cli/commands/run-once/planning-phase-artifacts.ts \
+  src/cli/commands/run-once/planning-phase-artifacts.test.ts
+node --test \
+  src/cli/commands/run-once/planning-phase-artifacts.test.ts \
+  src/cli/commands/run-once/prompts.test.ts \
+  src/cli/commands/run-once/pi.test.ts
+npm run check:contract-tests
+npm run check:types
+npm run check:architecture
+git add \
+  src/cli/commands/run-once/planning-phase-artifacts.ts \
+  src/cli/commands/run-once/planning-phase-artifacts.test.ts
+git commit -m "feat(run-once): run planning phase artifacts"
+```
+
+---
+
+### Task 5: Add exact pull request validation and factory wiring
+
+**Files:**
+
+- Create: `src/workflow/planning-pull-request-validation.ts`
+- Create: `src/workflow/planning-pull-request-validation.test.ts`
+- Modify: `src/host/factory.ts`
+- Modify: `src/host/factory.test.ts`
+
+**Interfaces:**
+
+- Consumes: normalized `PullRequestSummary`, state publication evidence,
+  `parsePlanningPullRequestMarker()`, `parsePullRequestUrl()`, and repository
+  identity comparison.
+- Produces: `assertPlanningPublicationRepositories()` and
+  `validatePlanningPullRequestSummary()` with sanitized typed failures.
+- Produces: `createPullRequestHost()` returning the existing `PullRequestHost`
+  interface.
+
+Use this validation result:
+
+```ts
+export type ValidatedPlanningPullRequest = Readonly<{
+  summary: PullRequestSummary;
+  reference: PullRequestReference;
+  url: string;
+}>;
+
+export function validatePlanningPullRequestSummary(input: {
+  summary: PullRequestSummary;
+  issueNumber: number;
+  phase: "spec" | "plan";
+  publication: PlanningPublicationEvidence;
+  expectedReference?: PullRequestReference;
+}): ValidatedPlanningPullRequest;
+```
+
+- [ ] **Step 1: Write provider repository-rule and exact-summary tests**
+
+Assert publication accepts:
+
+- GitHub only when target and head are the same repository identity;
+- Forgejo when provider and case-insensitive host match, including cross-owner
+  or cross-repository heads.
+
+Reject mixed providers, cross-host Forgejo, and forked/cross-repository GitHub.
+For summaries, mutate one field at a time and reject target repository, head
+repository, base branch, head branch, head SHA, issue marker, phase marker,
+workflow version, reference number/target, URL provider path, URL owner/repo,
+URL number, duplicate marker, missing marker, unsupported marker, and malformed
+URL.
+
+- [ ] **Step 2: Write confidentiality tests**
+
+Use bodies containing credentials and sentinel private text. Catch every marker
+parser/identity failure and map it to `PlanningPullRequestValidationError` whose
+enumerable data contains only `reason`. Assert `JSON.stringify(error)`,
+`error.message`, and enumerable fields do not contain the body, URL credentials,
+command output, or sentinel.
+
+- [ ] **Step 3: Run validation tests to prove RED**
+
+```sh
+node --test src/workflow/planning-pull-request-validation.test.ts
+```
+
+Expected: FAIL because the shared exact validation helper does not exist.
+
+- [ ] **Step 4: Implement exact validation**
+
+Call `assertPlanningPublicationRepositories()` before remote mutation. For a
+summary, compare repository identities case-insensitively through
+`sameRepositoryIdentity()` while requiring branch and OID strings exactly. Parse
+the one final top-level marker and require exact issue and phase. Build the
+canonical reference from validated summary target/number, then verify its URL
+through the provider path segment (`pull` for GitHub, `pulls` for Forgejo),
+owner/repository, host, and number. If `expectedReference` is supplied, require
+exact target and number agreement.
+
+Catch `PlanningPullRequestMarkerError` without retaining its `marker` field or
+body on the replacement error. Return the original summary only on success;
+never include it in a validation error.
+
+- [ ] **Step 5: Write and implement factory tests**
+
+Add this factory signature:
+
+```ts
+export function createPullRequestHost(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  remote: string;
+  host: PatchmillHostConfig;
+}): PullRequestHost;
+```
+
+Construct:
+
+```ts
+case "github-gh":
+  return new GitHubGhPullRequestHost({
+    runner: options.runner,
+    repoRoot: options.repoRoot,
+    pushRemote: options.remote,
+  });
+case "forgejo-tea":
+  return new ForgejoTeaPullRequestHost({
+    runner: options.runner,
+    repoRoot: options.repoRoot,
+    pushRemote: options.remote,
+    login: options.host.login,
+  });
+```
+
+Assert both concrete adapter classes and provider IDs. Retain existing issue,
+setup, and run-once provider factory tests. Do not instantiate this factory from
+the legacy pipeline.
+
+- [ ] **Step 6: Format, validate, and commit**
+
+```sh
+npx --no-install prettier --write \
+  src/workflow/planning-pull-request-validation.ts \
+  src/workflow/planning-pull-request-validation.test.ts \
+  src/host/factory.ts \
+  src/host/factory.test.ts
+node --test \
+  src/workflow/planning-pull-request-validation.test.ts \
+  src/workflow/planning-pull-requests.test.ts \
+  src/host/factory.test.ts \
+  src/host/github-gh-pull-requests.test.ts \
+  src/host/forgejo-tea-pull-requests.test.ts
+npm run check:types
+npm run check:architecture
+git add \
+  src/workflow/planning-pull-request-validation.ts \
+  src/workflow/planning-pull-request-validation.test.ts \
+  src/host/factory.ts \
+  src/host/factory.test.ts
+git commit -m "feat(host): validate planning pull request ownership"
+```
+
+---
+
+### Task 6: Publish and clean up planning phases
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/planning-phase-cleanup.ts`
+- Create: `src/cli/commands/run-once/planning-phase-publisher.ts`
+- Create: `src/cli/commands/run-once/planning-phase-publisher.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PullRequestHost`, `PlanningPublicationGit`, issue #187
+  `PlanningWorkspaceLifecycle`, `PlanningStateStore.replace()`, and the
+  caller-owned `PlanningIssueLock`.
+- Consumes: exact validation plus `planningPullRequestTitle()` and
+  `planningPullRequestBody()`.
+- Produces: resumable publication from `workspace-ready`, `branch-pushed`, or
+  `pull-request-open` without selecting another phase or acquiring/releasing a
+  lock.
+
+Use this public result:
+
+```ts
+export type PlanningPhasePublicationResult =
+  | Readonly<{
+      kind: "published";
+      state: PlanningStateV1;
+      pullRequest: PullRequestSummary;
+    }>
+  | Readonly<{
+      kind: "ambiguous";
+      state: PlanningStateV1;
+      pullRequests: readonly PullRequestSummary[];
+    }>;
+
+export async function publishPlanningPhase(input: {
+  state: PlanningStateV1;
+  phaseIndex: number;
+  lock: PlanningIssueLock;
+  stateStore: Pick<PlanningStateStore, "replace">;
+  host: PullRequestHost;
+  git: Pick<
+    PlanningPublicationOperations,
+    "verifyWorkspace" | "inspectRemoteHead" | "ensureRemoteHead"
+  >;
+  workspaces: PlanningWorkspaceLifecycle;
+  now?: () => Date;
+}): Promise<PlanningPhasePublicationResult>;
+```
+
+- [ ] **Step 1: Build a recording state/host/Git/workspace fixture**
+
+Create valid spec and plan phase fixtures for all three accepted statuses. The
+fake store must call `assertPlanningStateReplacement()`, require the exact lock,
+record the complete replacement, and return it. Record every method call in one
+ordered array. Never use a live host.
+
+- [ ] **Step 2: Write exact push and checkpoint-recovery tests**
+
+For `workspace-ready`, assert this order:
+
+```text
+workspace resume/validation
+artifact workspace verification
+resolve target repository
+resolve head repository
+validate provider repository rules
+inspect/push/reinspect exact head
+state replace -> branch-pushed
+pull request discovery
+```
+
+Inject a state-write failure immediately after a successful push and assert no
+host discovery/create or cleanup follows. Retry with the remote already at the
+saved OID; assert no second push, then persist the same `branch-pushed`
+evidence. A different remote OID must block before any state or host call.
+
+- [ ] **Step 3: Write discovery, creation, and adoption tests**
+
+From durable `branch-pushed` state, cover:
+
+- zero exhaustive matches => create once with deterministic title/body, artifact
+  paths, and one exact ownership marker;
+- one exact match => adopt without create and without body update;
+- more than one match => `ambiguous` before validation preference or create;
+- incomplete search => propagate and do not create;
+- one malformed marker, duplicate marker, wrong identity/branch/head, or
+  noncanonical reference/URL => block and do not create;
+- created/adopted summary => derive reference, call `getPullRequest()` exactly
+  once, revalidate exact read-back, then persist `pull-request-open/ready` with
+  canonical reference and URL;
+- a read-back mismatch or state-write failure => retain `branch-pushed` and skip
+  cleanup.
+
+Assert created or adopted pull requests may already be `merged` or
+`closed-unmerged`; publisher persists identity but does not reinterpret status.
+
+- [ ] **Step 4: Write interrupted-create recovery**
+
+Make `createPullRequest()` record a remote creation and then throw as if its
+response was interrupted. Assert durable state remains `branch-pushed` and the
+workspace remains. On retry, make exhaustive discovery return that one exact
+pull request; assert it is adopted, read back, and checkpointed with no second
+create.
+
+- [ ] **Step 5: Write every cleanup checkpoint/retry test**
+
+After pull request identity is durable, assert:
+
+```text
+get and validate exact pull request
+inspect exact pushed remote head
+removeWorktree
+state replace -> pull-request-open/worktree-removed
+removeBranch
+state replace -> pull-request-open/removed
+```
+
+Inject failure:
+
+1. before worktree removal;
+2. after removal but before its state write;
+3. after the worktree-removed checkpoint;
+4. after branch deletion but before its state write;
+5. after the removed checkpoint.
+
+For each retry, assert only the issue #187 lifecycle operation permitted by the
+saved cleanup discriminator runs, with the same ownership evidence. State-write
+failure must prevent the next destructive effect. Dirty workspace, changed local
+head, changed remote head, wrong registration, or lock/revision conflict must
+preserve the last durable boundary and never force removal.
+
+- [ ] **Step 6: Run publisher tests to prove RED**
+
+```sh
+node --test src/cli/commands/run-once/planning-phase-publisher.test.ts
+```
+
+Expected: FAIL because publisher and cleanup modules do not exist.
+
+- [ ] **Step 7: Implement complete-document checkpoint replacement**
+
+Keep one local `state` variable. For each checkpoint, replace only the selected
+phase, increment revision by exactly one, set `updatedAt` from `now()`, and
+call:
+
+```ts
+state = await stateStore.replace({
+  issueNumber: state.issueNumber,
+  expectedRunId: state.runId,
+  expectedRevision: state.revision,
+  next,
+  lock,
+});
+```
+
+Await it before any later effect. Reject an out-of-range phase index,
+implementation phase, incomplete workspace artifacts, or unsupported current
+status before mutation.
+
+- [ ] **Step 8: Implement branch and pull request publication**
+
+For `workspace-ready`, revalidate issue #187 ownership through `resume()`, call
+`verifyWorkspace()`, resolve both repository identities, enforce provider rules,
+and call `ensureRemoteHead()`. Immediately persist immutable publication
+identity as `branch-pushed`.
+
+For `branch-pushed`, use its exact repositories/branches in
+`findPullRequests()`. Count results before selecting. Create only on zero; on
+one validate it first; on multiple return `ambiguous`. For create, pass only the
+saved base/head branches plus deterministic title/body. Validate create output,
+then read exact reference with `getPullRequest()` and validate again before
+persisting `pull-request-open/ready`.
+
+- [ ] **Step 9: Implement shared checkpointed cleanup**
+
+In `planning-phase-cleanup.ts`, export `finishPlanningPhaseCleanup()` for a
+validated `pull-request-open` phase. Before starting, require the remote ref to
+equal `publication.headOid`.
+
+- `ready`: call `removeWorktree()`, persist `worktree-removed` with
+  `pushedHeadOid`, and only then continue.
+- `worktree-removed`: call `removeBranch()`; its issue #187 implementation
+  reproves the remote head and performs expected-old-OID deletion. Persist
+  `removed` only after success.
+- `removed`: perform no local mutation.
+
+Keep the remote branch. Export the helper for Task 7, but keep state replacement
+inside the caller-supplied checkpoint callback so publisher and reconciler each
+retain current revision safely.
+
+- [ ] **Step 10: Format, run focused publication tests, and commit**
+
+```sh
+npx --no-install prettier --write \
+  src/cli/commands/run-once/planning-phase-cleanup.ts \
+  src/cli/commands/run-once/planning-phase-publisher.ts \
+  src/cli/commands/run-once/planning-phase-publisher.test.ts
+node --test \
+  src/cli/commands/run-once/planning-phase-publisher.test.ts \
+  src/git/planning-publication-git.test.ts \
+  src/git/planning-workspace-git.test.ts \
+  src/workflow/planning-state.test.ts \
+  src/workflow/planning-state-store.test.ts
+npm run check:types
+npm run check:architecture
+git add \
+  src/cli/commands/run-once/planning-phase-cleanup.ts \
+  src/cli/commands/run-once/planning-phase-publisher.ts \
+  src/cli/commands/run-once/planning-phase-publisher.test.ts
+git commit -m "feat(run-once): publish planning pull requests"
+```
+
+---
+
+### Task 7: Reconcile planning pull request outcomes
+
+**Files:**
+
+- Create: `src/cli/commands/run-once/planning-phase-reconciler.ts`
+- Create: `src/cli/commands/run-once/planning-phase-reconciler.test.ts`
+
+**Interfaces:**
+
+- Consumes: exact validation, shared cleanup, `PullRequestHost`,
+  `PlanningRemoteBaseGit`, `PlanningPublicationGit`, issue #187 workspace/store,
+  and the caller-owned lock.
+- Produces: the exact `PlanningPhaseReconciliation` union shown above.
+- Performs no pull request create, push, force update, merge, remote branch
+  deletion, workspace preparation, or replacement planning pull request.
+
+Use this entry point:
+
+```ts
+export async function reconcilePlanningPhase(input: {
+  state: PlanningStateV1;
+  phaseIndex: number;
+  lock: PlanningIssueLock;
+  stateStore: Pick<PlanningStateStore, "replace">;
+  host: PullRequestHost;
+  remoteBase: Pick<PlanningRemoteBaseGit, "fetch">;
+  git: Pick<
+    PlanningPublicationOperations,
+    "inspectRemoteHead" | "assertAncestor" | "assertRegularFiles"
+  >;
+  workspaces: PlanningWorkspaceLifecycle;
+  now?: () => Date;
+}): Promise<
+  Readonly<{
+    state: PlanningStateV1;
+    outcome: PlanningPhaseReconciliation;
+  }>
+>;
+```
+
+- [ ] **Step 1: Write all public outcome tests**
+
+Cover:
+
+- `complete/remote-base` => `satisfied-by-base` with no host/Git mutation;
+- open exact pull request => cleanup completes, then `review-pending`;
+- merged exact pull request => cleanup plus merge proof, then `merged`;
+- closed without merge => cleanup completes, then `closed-unmerged`;
+- typed saved-reference absence => `missing` with reference;
+- branch-pushed exhaustive zero => `missing` without reference;
+- branch-pushed multiple => `ambiguous` with every result;
+- branch-pushed one exact result => validate/read back, persist pull request
+  identity, finish cleanup, then classify it.
+
+Assert closed, missing, and ambiguous outcomes never create a workspace or pull
+request and never advance the phase to complete.
+
+- [ ] **Step 2: Write typed host failure and unchanged-state tests**
+
+For a saved reference, only catch `PullRequestNotFoundError`. Table-test
+authentication, authorization, rate-limit, transport, incomplete-search,
+invalid-JSON, malformed-response, marker, and identity errors. Compare
+`serializePlanningState()` bytes before/after and assert no state replacement or
+cleanup occurred when the host read/discovery failed.
+
+For a branch-pushed discovery, zero exhaustive results proves missing; an
+`IncompletePullRequestSearchError` does not. Do not infer absence from an error
+message, command exit text, or HTTP-like string.
+
+- [ ] **Step 3: Write cleanup gating tests**
+
+Return no `review-pending`, `merged`, or `closed-unmerged` outcome until cleanup
+reaches `removed`. Inject dirty workspace, changed local/remote head, removal
+failure, and each cleanup checkpoint failure. Assert the last durable cleanup
+state is returned only through a later successful retry and merged-base fetch
+never begins early.
+
+- [ ] **Step 4: Write merged-base verification tests**
+
+For a merged summary with `mergeCommit`, assert this order after cleanup:
+
+```text
+fetch saved workspace.remote + saved base.baseBranch
+assert mergeCommit ancestor of fetched baseOid
+assert every expected path regular at mergeCommit
+assert every expected path regular at fetched baseOid
+state replace -> complete/merged-pull-request
+```
+
+Reject a missing merge object, unrelated/non-ancestor merge, fetch failure,
+missing artifact, symlink, or gitlink at either commit. Assert the original
+saved base branch/remote are passed to fetch even if test configuration/current
+checkout names differ.
+
+The completion checkpoint must retain publication, pull request, and removed
+workspace identity; set `mergeOid` and `mergedBaseOid`; and replace every
+artifact with the same kind/path plus `source: "remote-base"` and
+`commitOid: fetched.baseOid`.
+
+- [ ] **Step 5: Add the human-edit real-Git regression test**
+
+With a local bare remote:
+
+1. create and push a planning head containing artifact text A;
+2. create a review commit or squash result containing text B at the same path;
+3. merge/push that result to the saved base branch;
+4. return the merged object's OID from the fake host;
+5. reconcile.
+
+Assert completion succeeds, `mergedBaseOid` is the freshly fetched base tip, and
+artifact evidence points to that tip even though its blob differs from the old
+planning head. Add a guard assertion that the reconciler never requests a blob
+comparison with the workspace commit.
+
+- [ ] **Step 6: Run reconciler tests to prove RED**
+
+```sh
+node --test src/cli/commands/run-once/planning-phase-reconciler.test.ts
+```
+
+Expected: FAIL because the reconciler does not exist.
+
+- [ ] **Step 7: Implement exact discovery/read and status classification**
+
+For `branch-pushed`, perform exhaustive saved-identity discovery without create.
+Zero and multiple return blocking outcomes without state replacement. For one,
+validate discovery, call exact `getPullRequest()`, validate read-back,
+checkpoint `pull-request-open/ready`, and continue.
+
+For saved pull request evidence, call `getPullRequest(reference)` and validate
+against immutable publication plus expected reference before interpreting
+status. Catch only `PullRequestNotFoundError`. Pass the validated phase through
+`finishPlanningPhaseCleanup()`, then map open and closed-unmerged directly.
+
+- [ ] **Step 8: Implement verified merge completion**
+
+For merged status, require `mergeCommit`, fetch with the phase's saved remote
+and base branch, and invoke `assertAncestor()` plus `assertRegularFiles()` at
+both merge/base objects. Build all-at-once merged-base artifact evidence and
+persist one strict completion replacement. Await state persistence before
+returning `merged`; on any proof/store failure leave the published phase
+incomplete at its last cleanup checkpoint.
+
+- [ ] **Step 9: Format, validate focused reconciliation, and commit**
+
+```sh
+npx --no-install prettier --write \
+  src/cli/commands/run-once/planning-phase-reconciler.ts \
+  src/cli/commands/run-once/planning-phase-reconciler.test.ts
+node --test \
+  src/cli/commands/run-once/planning-phase-reconciler.test.ts \
+  src/cli/commands/run-once/planning-phase-publisher.test.ts \
+  src/git/planning-publication-git.test.ts \
+  src/git/planning-remote-base.test.ts \
+  src/workflow/planning-pull-request-validation.test.ts \
+  src/workflow/planning-state.test.ts
+npm run check:contract-tests
+npm run check:types
+npm run check:architecture
+git add \
+  src/cli/commands/run-once/planning-phase-reconciler.ts \
+  src/cli/commands/run-once/planning-phase-reconciler.test.ts
+git commit -m "feat(run-once): reconcile planning pull requests"
+```
+
+---
+
+### Task 8: Run full validation and audit scope
+
+**Files:**
+
+- Verify only; no production or test file is created in this task.
+
+**Interfaces:**
+
+- Verifies: all issue #188 acceptance criteria and predecessor state/workspace,
+  host, prompt, and legacy planning behavior.
+- Verifies: no legacy pipeline routing, dependency/config migration, live host
+  test, or implementation pull request behavior was added.
+
+- [ ] **Step 1: Run all issue-focused and predecessor tests together**
+
+```sh
+node --test \
+  src/workflow/planning-state.test.ts \
+  src/workflow/planning-state-store.test.ts \
+  src/workflow/planning-issue-lock.test.ts \
+  src/workflow/planning-pull-requests.test.ts \
+  src/workflow/planning-pull-request-validation.test.ts \
+  src/git/planning-remote-base.test.ts \
+  src/git/planning-workspaces.test.ts \
+  src/git/planning-workspace-git.test.ts \
+  src/git/planning-publication-git.test.ts \
+  src/host/factory.test.ts \
+  src/host/github-gh-pull-requests.test.ts \
+  src/host/github-gh-pull-request-operations.test.ts \
+  src/host/forgejo-tea-pull-requests.test.ts \
+  src/cli/commands/run-once/prompts.test.ts \
+  src/cli/commands/run-once/pi.test.ts \
+  src/cli/commands/run-once/planning-phase-artifacts.test.ts \
+  src/cli/commands/run-once/planning-phase-publisher.test.ts \
+  src/cli/commands/run-once/planning-phase-reconciler.test.ts
+```
+
+Expected: all focused state, Git, host, prompt, runner, publication, recovery,
+cleanup, and reconciliation tests PASS with no live provider mutation.
+
+- [ ] **Step 2: Run the approved spec's final validation commands**
+
+Run in this exact order:
+
+```sh
+npm run test:run-once
+npm test
+npm run build
+npm run lint
+npm run check:types
+npm run check:architecture
+git diff --check
+```
+
+Expected: every command exits with status `0`.
+
+- [ ] **Step 3: Verify dependency and legacy wiring scope directly**
+
+```sh
+git diff --exit-code main...HEAD -- \
+  package.json package-lock.json npm-shrinkwrap.json \
+  src/config \
+  src/cli/commands/run-once/pipeline.ts \
+  src/cli/commands/run-once/stage-advancement.ts
+git diff --name-only main...HEAD
+```
+
+Expected: the first command has no diff. The changed-file list is limited to the
+approved spec/plan and files named in this plan plus issue #187 prerequisite
+files already present in the implementation base. If npm dependency metadata
+changed unexpectedly, remove the accidental change or additionally run:
+
+```sh
+nix build
+```
+
+and record its result as required by `AGENTS.md`.
+
+- [ ] **Step 4: Audit side effects, confidentiality, and module boundaries**
+
+```sh
+rg -n -- "--force|-f|git clean|git reset|git merge|git rebase|push.*--delete" \
+  src/git/planning-publication-git.ts \
+  src/cli/commands/run-once/planning-phase-*.ts
+rg -n "body|stdout|stderr|diagnostics|ownershipId|remote" \
+  src/git/planning-publication-git.ts \
+  src/workflow/planning-pull-request-validation.ts \
+  src/cli/commands/run-once/planning-phase-*.ts
+wc -l \
+  src/git/planning-publication-git.ts \
+  src/workflow/planning-pull-request-validation.ts \
+  src/cli/commands/run-once/planning-phase-artifacts.ts \
+  src/cli/commands/run-once/planning-phase-cleanup.ts \
+  src/cli/commands/run-once/planning-phase-publisher.ts \
+  src/cli/commands/run-once/planning-phase-reconciler.ts
+```
+
+Inspect every match. Expected: no force/destructive forbidden operation; bodies
+are used only for deterministic create and marker validation; raw diagnostics
+are non-enumerable; no state bytes or credential-bearing URLs reach errors; and
+each effect module remains near the under-200-meaningful-line target or has a
+documented cohesive reason/split before handoff.
+
+- [ ] **Step 5: Record completion evidence**
+
+The implementation worker reports:
+
+- the seven implementation commit hashes;
+- focused and repository-wide validation results;
+- observed RED evidence for each production task before implementation;
+- the changed-file list and confirmation of no legacy pipeline wiring;
+- confirmation that each push, create, worktree removal, and branch removal has
+  both a durable checkpoint assertion and an interruption-recovery test;
+- confirmation that no npm dependency metadata changed, or the successful Nix
+  build result if it did;
+- residual risks, including provider CLI behavior not exercised against a live
+  host and platform-specific Git/filesystem behavior.

--- a/docs/specs/2026-09-08-issue-188-execute-and-publish-planning-pull-request-phases-design.md
+++ b/docs/specs/2026-09-08-issue-188-execute-and-publish-planning-pull-request-phases-design.md
@@ -1,0 +1,608 @@
+# Issue 188 execute and publish planning pull request phases design
+
+## Status
+
+This specification awaits document review.
+
+## Summary
+
+Issue #188 is the publication slice of the `planning-pr-v1` workflow approved in
+issue #180. Issues #184 through #187 provide the phase rules, pull request host
+adapters, strict Run recovery state, issue lock, remote-base inspection, and
+owned phase workspaces.
+
+This change adds three focused services:
+
+1. An artifact phase runner that invokes spec and plan agents in the supplied
+   phase workspace and checkpoints each verified artifact commit.
+2. A planning phase publisher that safely pushes one exact phase head, finds or
+   creates its planning pull request, persists each observed remote effect, and
+   completes checkpointed local cleanup.
+3. A reconciler that classifies review-pending, merged, closed-unmerged,
+   missing, and ambiguous remote states and verifies a merge against the saved
+   base branch before completing the phase.
+
+The services operate on one caller-selected phase while the caller owns the
+issue #187 lock. This slice does not select an issue, acquire the top-level
+lock, route the legacy run-once pipeline, or enforce the implementation pull
+request.
+
+## Goals
+
+- Run spec and plan agents only inside the current phase workspace.
+- Support a phase that creates both spec and plan, in that order.
+- Reuse unambiguous artifacts found in the phase's pinned remote base.
+- Validate every returned artifact path and commit before publication.
+- Push only the exact saved phase head without force-updating remote work.
+- Persist a checkpoint immediately after every observed remote mutation.
+- Recover an interrupted push or pull request create without duplication.
+- Adopt exactly one pull request with matching repositories, branches, head
+  object ID, issue, phase, and ownership marker.
+- Remove the local worktree and branch through the owned, idempotent issue #187
+  cleanup operations after pull request identity is durable.
+- Distinguish an open review, a verified merge, a closed-unmerged pull request,
+  a proven missing pull request, and ambiguous discovery.
+- Preserve human artifact edits by accepting merged-base contents rather than
+  requiring the planning branch's original artifact blob.
+- Leave phase state unchanged for host failures that do not prove absence.
+
+## Non-goals
+
+- Top-level run-once issue selection, planning state initialization, or issue
+  lock acquisition and release.
+- New lifecycle-label behavior or migration from approval labels and artifact
+  comments.
+- Implementation-agent execution, implementation pull request validation, or
+  direct-landing policy.
+- Replacing a closed-unmerged planning pull request.
+- Automatic pull request merge, force-push, rebase, or remote branch deletion.
+- Compatibility migration, configuration deprecations, or user documentation.
+- Live GitHub or Forgejo mutations in automated tests.
+
+## Existing constraints
+
+This design retains the predecessor contracts:
+
+- `planningPhasePlan()` determines the phase sequence from the immutable gate
+  snapshot.
+- `phaseWorkspaceIdentity()` supplies deterministic phase branches and paths.
+- `PlanningRemoteBaseGit` fetches and pins the saved remote and base branch and
+  returns all matching artifact candidates.
+- `PlanningWorkspaceLifecycle` creates, resumes, and removes only a workspace
+  proven to belong to the same Issue run and phase.
+- `PullRequestHost` supplies normalized, exhaustive provider operations.
+- `planningPullRequestTitle()`, `planningPullRequestBody()`, and the
+  `planning-pr-v1` marker supply provider-neutral planning pull request text.
+- `PlanningStateStore.replace()` performs strict, revision-checked, atomic state
+  replacement only while the matching ownership-ID issue lock is held.
+
+The issue #187 state is not yet connected to production. Issue #188 may refine
+its version-1 phase variants before first use, but it must retain strict
+parsing, immutable Run identity, atomic replacement, and the existing workspace
+ownership rules.
+
+## Approaches considered
+
+### Focused runner, publisher, and reconciler (chosen)
+
+Keep agent execution, remote mutation, and remote observation in separate
+modules. The publisher owns mutation order, while the reconciler owns status
+classification and merged-base proof. Both consume the same strict phase state.
+
+This makes every interruption boundary independently testable and prevents
+provider or Git details from leaking into phase selection.
+
+### Extend legacy `stage-advancement.ts`
+
+The legacy module combines local artifact discovery, approval labels, artifact
+comments, and current Run recovery state. Adding planning pull request state
+would couple the new workflow to behavior that issue #180 explicitly replaces
+and would make recovery depend on two state models. Reject this approach.
+
+### One phase coordinator with inline Git and host commands
+
+A single coordinator would reduce the number of call sites, but it would mix
+agent execution, push conflict handling, pull request adoption, cleanup, and
+merge verification. Interruption tests would become order-sensitive tests of a
+large module. Reject this approach; a later integration slice can compose the
+focused services.
+
+## Architecture and affected components
+
+### `src/cli/commands/run-once/planning-phase-artifacts.ts`
+
+Owns spec and plan agent sequencing in a caller-supplied workspace. It reuses
+the current prompt builders, planning Pi profile, result parser, artifact path
+builders, and blocked-result contract.
+
+It does not push, call a host, publish issue comments, mutate labels, or remove
+a workspace.
+
+### `src/cli/commands/run-once/planning-phase-publisher.ts`
+
+Owns the ordered publication transaction: validate, resolve repository identity,
+push, discover or create, persist pull request identity, and invoke checkpointed
+local cleanup.
+
+It accepts `PullRequestHost`, `PlanningWorkspaceLifecycle`,
+`PlanningStateStore`, and the caller-owned `PlanningIssueLock` as dependencies.
+It contains no GitHub- or Forgejo-specific parsing.
+
+### `src/cli/commands/run-once/planning-phase-reconciler.ts`
+
+Owns remote status classification and merged-base verification. It shares exact
+pull request identity validation with the publisher, but performs no create or
+push.
+
+### Focused shared helpers
+
+- A small Git publication adapter under `src/git/` owns remote-head inspection,
+  exact non-force push, commit ancestry, and regular-file checks.
+- A pure helper under `src/workflow/` validates a normalized planning pull
+  request summary and its marker against saved publication identity.
+- `src/host/factory.ts` gains a dedicated `createPullRequestHost()` factory that
+  constructs the existing GitHub or Forgejo planning adapter with the configured
+  repository root, remote, and login. This factory does not make the service
+  reachable from the legacy pipeline.
+- `src/cli/commands/run-once/prompts.ts` gains explicit planning review context
+  so dedicated, same-phase, and implementation-carried artifacts receive
+  accurate instructions while legacy prompt behavior remains unchanged.
+- The issue #187 planning state types, parser, replacement rules, and tests gain
+  the publication checkpoints described below.
+
+Each effect module should remain focused and target fewer than 200 meaningful
+lines. Extract Git validation and pull request identity helpers before allowing
+publisher or reconciler code to grow substantially beyond that target.
+
+## Durable phase state refinements
+
+The state must distinguish a locally committed workspace from a remotely pushed
+head. Reusing `workspace-ready` for both would make it impossible to prove that
+a push was checkpointed.
+
+### Workspace artifact progress
+
+A `workspace-ready` phase gains an `artifacts` array. It contains an ordered,
+unique subset of the artifact kinds assigned to the phase. A base artifact uses
+`source: "remote-base"`; an artifact committed in the workspace uses
+`source: "workspace"` and the current saved workspace head.
+
+The partial array allows a phase that owns both artifacts to checkpoint the spec
+before invoking the plan agent. Every state replacement updates all
+workspace-sourced artifact commit IDs to the newly verified workspace head,
+because that head contains the complete phase result so far.
+
+### Pushed branch checkpoint
+
+Add a `branch-pushed` phase variant containing:
+
+```ts
+type PlanningPublicationEvidence = {
+  targetRepository: RepositoryIdentity;
+  headRepository: RepositoryIdentity;
+  baseBranch: string;
+  headBranch: string;
+  headOid: string;
+};
+```
+
+The variant also retains the pinned base, owned workspace, and complete artifact
+evidence. The publication fields must agree with the workspace branch, saved
+base branch, and workspace head.
+
+This variant means the remote head was observed at the exact object ID. A crash
+between the remote push and state replacement is recovered by observing that
+same remote head and writing the checkpoint before any host create call.
+
+### Pull request checkpoint and cleanup
+
+`pull-request-open` retains the publication evidence and adds the canonical
+`PullRequestReference` and URL read from a validated host summary. Its workspace
+cleanup may be `ready`, `worktree-removed`, or `removed`; cleanup is expected to
+finish while the pull request is still open.
+
+The allowed transitions are:
+
+```text
+workspace-ready
+  -> workspace-ready
+  -> branch-pushed
+  -> pull-request-open/ready
+  -> pull-request-open/worktree-removed
+  -> pull-request-open/removed
+  -> complete/merged-pull-request
+```
+
+Every transition is idempotent at its current state. Remote-base completion
+remains the alternate transition directly from `pending` when every assigned
+artifact is already satisfied.
+
+### Merged-base evidence
+
+A merged completion adds the fetched base tip used for verification:
+
+```ts
+completion: {
+  kind: "merged-pull-request";
+  mergeOid: string;
+  mergedBaseOid: string;
+}
+```
+
+Its workspace cleanup must already be `removed`. Its artifact evidence uses
+`source: "remote-base"` and `commitOid: mergedBaseOid`, while retaining the
+expected artifact paths. This intentionally replaces workspace-source evidence
+at the merge transition. It records the content Patchmill will trust after human
+review rather than pretending the original branch commit survived a squash or
+human edit.
+
+Strict validation continues to reject unknown fields, skipped transitions,
+repository or branch disagreement, incomplete artifacts, cleanup regression, and
+mutable publication identity.
+
+## Artifact phase execution
+
+The phase runner receives the issue, planned phase, pinned base snapshot, owned
+ready workspace, and a callback that atomically replaces planning state under
+the caller's lock.
+
+### Base artifact resolution
+
+For each assigned artifact kind:
+
+- No candidate means the phase must create that artifact.
+- One candidate records remote-base artifact evidence.
+- More than one candidate is ambiguous and blocks before workspace or agent
+  mutation.
+
+If all assigned artifacts have one candidate, the caller records
+`complete/remote-base` and does not create a workspace or planning pull request.
+If only some exist, the phase workspace starts from the pinned base and agents
+create only the missing kinds.
+
+### Agent order and prompt context
+
+Missing artifacts run in phase assignment order, so spec always precedes plan.
+The prompt identifies one of these contexts:
+
+- `dedicated-pull-request`: this artifact will be reviewed in the current
+  planning pull request.
+- `same-phase-pull-request`: a spec and plan share the current plan pull
+  request; the spec is not described as already approved.
+- `merged-base`: a prior dedicated spec is available from the merged base.
+- `implementation-pull-request`: the ungated artifact will later travel with
+  implementation code.
+- `legacy-label`: preserves existing legacy prompt text.
+
+The reusable runner may prepare artifacts assigned to an implementation phase,
+but this issue publishes only `spec` and `plan` planning phases.
+
+Each agent still commits only its own artifact and returns the existing
+`spec-created` or `plan-created` result. Its prompt requires the configured
+planning skill's self-review or plan validation to pass before commit. A blocked
+result stops the phase before the next agent and leaves all previously
+checkpointed work intact.
+
+### Post-agent validation and checkpoint
+
+Before accepting each agent result, Patchmill verifies:
+
+1. The returned path is repository-relative, contained by the configured spec or
+   plan directory mirrored into the phase workspace, and names a regular file
+   rather than a symlink or submodule.
+2. The returned commit exists, equals the live phase workspace `HEAD`, and
+   descends from the previously saved phase head.
+3. The artifact is a regular file in that commit.
+4. The changes since the previous saved head are limited to the expected
+   artifact path.
+5. The worktree has no tracked, untracked, or ignored residue that would make
+   owned cleanup unsafe.
+
+The runner then replaces state with the new workspace head and artifact evidence
+before starting another agent or returning to the publisher. This checkpoint
+makes a successfully returned artifact commit resumable. A process interruption
+while an agent is active may leave uncheckpointed local work; the strict
+workspace adapter preserves it and blocks rather than resetting or silently
+adopting it.
+
+## Safe branch publication
+
+The publisher accepts only a `workspace-ready` planning phase with complete
+artifact evidence. It revalidates the clean workspace, saved head, artifact
+files, and commit ancestry before any remote mutation.
+
+It resolves target and configured push-remote identities through
+`PullRequestHost` before pushing. Provider rules remain authoritative: GitHub
+requires a same-repository head, while Forgejo may use a same-host, cross-owner
+head. The resolved identities become immutable publication evidence.
+
+The Git adapter inspects `refs/heads/<phase-branch>` on the configured remote:
+
+- An absent ref permits a non-force push of the exact saved object ID.
+- A ref already equal to the saved object ID is an interrupted-push recovery and
+  requires no mutation.
+- Any different object ID blocks. Patchmill does not force-update or adopt it.
+
+After a push, Patchmill reads the remote ref again and requires it to equal the
+saved workspace head. It immediately writes `branch-pushed` state. If that state
+write fails, no pull request call or local cleanup follows. A retry observes the
+exact remote head and writes the same checkpoint.
+
+## Exact pull request discovery and creation
+
+For a `branch-pushed` phase, the publisher searches all states using the saved
+target repository, base branch, head repository, and head branch. A successful
+host search is exhaustive by the issue #184 contract.
+
+The result rules are exact:
+
+- Zero matches permits one create attempt with the deterministic title, body,
+  artifact paths, and ownership marker.
+- One match is adoptable only after full summary and marker validation.
+- More than one match is `ambiguous`, even if only one appears desirable.
+- An incomplete search, malformed marker, duplicate marker, unsupported marker,
+  or identity mismatch blocks before create.
+
+For both an adopted and newly created pull request, Patchmill reads the exact
+reference through `getPullRequest()` and validates:
+
+- target and head repository identity;
+- exact saved base and head branches;
+- exact pushed head object ID;
+- issue number and phase in the single `planning-pr-v1` marker; and
+- a canonical reference and URL for the returned pull request.
+
+The publisher then writes `pull-request-open/ready`. The status name denotes the
+published waiting phase; the read-back summary may already report merged or
+closed, which the reconciler classifies immediately after cleanup.
+
+Patchmill never rewrites an adopted pull request body. Human text may change as
+long as the one exact ownership marker remains valid.
+
+A create error leaves durable `branch-pushed` state and the local workspace.
+Because every retry performs exhaustive discovery before create, a pull request
+created despite an interrupted response is adopted rather than duplicated. A
+failure to persist the read-back identity also retains the workspace and skips
+cleanup.
+
+## Checkpointed local cleanup
+
+Cleanup starts only after pull request identity is durable. The publisher uses
+the issue #187 ownership record and lifecycle methods:
+
+1. Validate the saved pull request and exact pushed remote head.
+2. Remove the clean worktree without force.
+3. Persist `pull-request-open/worktree-removed`.
+4. Remove the local branch only after proving the remote branch still equals the
+   pushed head.
+5. Persist `pull-request-open/removed`.
+6. Keep the remote head branch for the pull request.
+
+A retry after either local mutation invokes only the idempotent operation
+allowed by the saved cleanup discriminator. A dirty workspace, changed local
+head, changed remote head, or state-write failure blocks advancement and never
+uses force removal.
+
+## Reconciliation
+
+Reconciliation occurs before another phase workspace may be created. It first
+finishes any checkpointed cleanup. It then reads a saved pull request by exact
+reference, or performs exact discovery when only `branch-pushed` evidence
+exists.
+
+The public outcome is one of:
+
+```ts
+type PlanningPhaseReconciliation =
+  | { kind: "review-pending"; pullRequest: PullRequestSummary }
+  | { kind: "merged"; pullRequest: PullRequestSummary; baseOid: string }
+  | { kind: "satisfied-by-base"; artifacts: PlanningArtifactEvidence[] }
+  | { kind: "closed-unmerged"; pullRequest: PullRequestSummary }
+  | { kind: "missing"; reference?: PullRequestReference }
+  | { kind: "ambiguous"; pullRequests: PullRequestSummary[] };
+```
+
+`review-pending` stops normally for human review. `merged` and
+`satisfied-by-base` are the only outcomes that permit the caller to consider the
+phase complete. `closed-unmerged`, `missing`, and `ambiguous` are blocking
+outcomes; this slice returns them without creating a replacement workspace or
+pull request.
+
+Only `PullRequestNotFoundError` from `getPullRequest()` becomes `missing`.
+Authentication, authorization, rate-limit, transport, incomplete-search, invalid
+JSON, malformed-response, and identity errors propagate with no phase state
+replacement. Callers must not infer not-found from messages or exit text.
+
+Every fetched or discovered summary is revalidated against immutable publication
+evidence and the marker before its status is interpreted.
+
+## Merged pull request verification
+
+A normalized `merged` status does not complete the phase by itself. Patchmill:
+
+1. Requires the workspace cleanup discriminator to be `removed`.
+2. Fetches the phase's saved remote and saved base branch, producing a new
+   pinned remote-base tip.
+3. Verifies that the host-reported merge object ID is an ancestor of that exact
+   fetched tip.
+4. Verifies every expected artifact path is a regular file at the merge object
+   and at the fetched base tip.
+5. Creates remote-base artifact evidence at the fetched tip.
+6. Atomically records merged completion with both `mergeOid` and
+   `mergedBaseOid`.
+
+The check uses the saved base branch, not the current checkout or a newly
+configured branch. A missing merge object, non-ancestor merge, missing artifact,
+or non-regular artifact blocks completion.
+
+Patchmill does not compare merged artifact blobs with the old workspace commit.
+A reviewer may edit the spec or plan before merge, including through squash or
+rebase merge behavior. The verified merged-base files become authoritative and
+are inherited by the next phase workspace, preserving those human edits.
+
+## Side-effect checkpoints
+
+The required observable order for a new planning pull request is:
+
+```text
+validate artifact phase
+resolve target and head repositories
+inspect/push exact remote head
+persist branch-pushed
+find exact pull requests
+create only when none exists
+read back and validate exact pull request
+persist pull-request-open/ready
+remove worktree
+persist pull-request-open/worktree-removed
+remove local branch
+persist pull-request-open/removed
+classify review status
+```
+
+Every successful observed remote mutation is followed immediately by a
+representable state checkpoint. The unavoidable crash gap between a remote
+mutation and its local checkpoint is closed by observation before repetition:
+exact remote-head inspection recovers push, and exhaustive exact discovery plus
+the ownership marker recovers pull request creation.
+
+No later remote or destructive local side effect runs after a checkpoint write
+failure.
+
+## Error handling
+
+Use stable typed failures or reconciliation outcomes:
+
+- Artifact path, commit, cleanliness, and changed-file violations block while
+  preserving the owned workspace.
+- A remote branch at another object ID blocks without force-push.
+- Incomplete discovery and conflicting marker or pull request identity block
+  before create.
+- Closed-unmerged, missing, and ambiguous outcomes block phase advancement.
+- Non-not-found host failures stop the Run attempt without changing phase state.
+- A state conflict or lock-ownership failure stops all further effects.
+- Cleanup conflicts preserve local work and the last durable cleanup boundary.
+- Merge ancestry or artifact verification failures leave the phase published but
+  incomplete.
+
+Error messages and enumerable fields must not expose pull request bodies,
+command output, credentials, remote URLs with credentials, state bytes, or Pi
+transcripts.
+
+## Verification strategy
+
+These behaviors pass the Testing Value Gate because they protect external side
+effects, recovery, parsing, strict state transitions, and destructive Git
+operations.
+
+### Artifact runner tests
+
+Recording Pi and Git seams cover:
+
+- spec-only, plan-only, and same-phase spec-then-plan execution;
+- reuse of zero, one, and mixed remote-base artifacts;
+- rejection of multiple candidates before workspace creation;
+- a blocked spec stopping before plan execution;
+- checkpointing a verified spec before starting the plan agent;
+- path escape, wrong directory, symlink, submodule, missing commit, wrong head,
+  non-descendant commit, unrelated changes, and dirty residue;
+- accurate dedicated, same-phase, merged-base, implementation-carried, and
+  unchanged legacy prompt wording.
+
+### Publisher and recovery tests
+
+A recording state store, host, Git publisher, and workspace adapter assert exact
+ordering and inject failure after every effect. Tests cover:
+
+- a new push followed by `branch-pushed` persistence;
+- interruption after push but before persistence;
+- a matching remote head as idempotent push recovery;
+- a conflicting remote head without force-push;
+- one exact existing pull request adopted without create;
+- zero matches creating once and reading back;
+- interruption after create but before pull request persistence;
+- incomplete search, wrong or duplicate marker, identity mismatch, and multiple
+  exact matches blocking create;
+- state-write failure preventing every later side effect;
+- interruption before and after each cleanup checkpoint;
+- dirty workspace and changed local or remote head blocking cleanup.
+
+Each remote side effect therefore has both a durable state assertion and a
+recovery test.
+
+### Reconciler tests
+
+Tests cover every reconciliation union member and prove:
+
+- open is review-pending;
+- merged requires merge ancestry and every expected artifact on the saved base
+  branch;
+- closed-unmerged, missing, and ambiguous block advancement;
+- only typed proven absence becomes missing;
+- authentication, rate-limit, transport, incomplete-search, JSON, malformed
+  response, and identity failures leave phase state byte-for-byte unchanged;
+- an open or merged pull request cannot advance before cleanup completes;
+- a human-edited merged artifact is accepted from the fetched base even when its
+  blob differs from the pushed workspace artifact.
+
+Real-Git tests use temporary repositories and a local bare remote for push
+conflicts, interrupted push recovery, cleanup, merge ancestry, and merged
+artifact checks. Host tests remain fake or recording tests and create no live
+pull requests.
+
+### Final validation
+
+Implementation validation will run focused new tests and the predecessor state,
+workspace, host, prompt, and legacy planning tests, followed by:
+
+```sh
+npm run test:run-once
+npm test
+npm run build
+npm run lint
+npm run check:types
+npm run check:architecture
+git diff --check
+```
+
+No dependency change is planned, so a Nix build is not required. If npm
+dependency metadata changes unexpectedly, the repository-required Nix build must
+also run.
+
+## Compatibility
+
+The new services and pull request factory are not routed from the existing
+run-once pipeline in this slice. Legacy planning continues to use its current
+state, labels, comments, and prompt mode. The `planning-pr-v1` state remains in
+its separate issue #187 namespace.
+
+No glossary or ADR change is required. The design uses the established terms
+Issue run, Run attempt, Run recovery state, phase workspace, and planning pull
+request.
+
+## Acceptance criteria
+
+- Spec and plan agents run in the supplied phase workspace, validate through
+  their configured planning workflow before commit, and checkpoint only
+  independently verified artifact commits before push.
+- One phase can create spec then plan while retaining the first commit across a
+  retry.
+- Unambiguous remote-base artifacts are reused; multiple candidates block.
+- Exact push recovery and exact pull request adoption prevent duplicate remote
+  effects after interruption.
+- Every push, pull request creation, worktree removal, and branch removal has a
+  durable checkpoint and an interruption recovery test.
+- Every created or adopted planning pull request contains exactly one matching
+  `planning-pr-v1` ownership marker.
+- Cleanup completes before review or merge can unlock another phase.
+- Open, merged, closed-unmerged, missing, and ambiguous states remain distinct.
+- Closed-unmerged, missing, and ambiguous states cannot advance or create a
+  replacement pull request.
+- Only proven not-found becomes `missing`; every other host failure leaves phase
+  state unchanged.
+- Merge completion proves the host merge object and expected regular-file
+  artifacts on the saved base branch.
+- Merged-base artifact evidence, rather than the original workspace blob,
+  preserves human edits in merged planning pull requests.
+- Top-level selection and locking, implementation pull request enforcement, and
+  compatibility documentation remain out of scope.

--- a/src/cli/commands/run-once/planning-phase-artifacts.test.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.test.ts
@@ -352,3 +352,75 @@ test("rejects unexpected result paths before the Git validation seam", async () 
   );
   assert.equal(gitCalled, false);
 });
+
+test("propagates delegated Git validation failures and rejects malformed agent results", async () => {
+  const common = {
+    issue,
+    phase: {
+      kind: "spec" as const,
+      artifactKinds: ["spec"] as const,
+      pullRequestRequired: true,
+    },
+    current: {
+      kind: "spec" as const,
+      status: "workspace-ready" as const,
+      base,
+      workspace: {
+        ...workspace,
+        phase: "spec",
+        identity: { branch: "planning/spec", worktreePath: "/workspace" },
+      },
+      artifacts: [],
+    },
+    repoRoot: "/repo",
+    specsDir: "/repo/docs/specs",
+    plansDir: "/repo/docs/plans",
+    artifactDate: new Date("2026-09-08"),
+    checkpoint: async () => {},
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    skills: DEFAULT_PATCHMILL_SKILLS,
+    triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
+  };
+  await assert.rejects(
+    () =>
+      runPlanningPhaseArtifacts({
+        ...common,
+        agent: {
+          async run() {
+            return {
+              status: "spec-created",
+              specPath: "docs/specs/2026-09-08-issue-188-example-design.md",
+              commit: oid("b"),
+            };
+          },
+        },
+        git: {
+          async verifyArtifactCommit() {
+            throw new Error("dirty workspace");
+          },
+        },
+      }),
+    /dirty workspace/,
+  );
+  await assert.rejects(
+    () =>
+      runPlanningPhaseArtifacts({
+        ...common,
+        agent: {
+          async run() {
+            return {
+              status: "plan-created",
+              planPath: "docs/plans/x.md",
+              commit: oid("b"),
+            };
+          },
+        },
+        git: {
+          async verifyArtifactCommit() {
+            assert.fail("unexpected");
+          },
+        },
+      }),
+    /unexpected-agent-result/,
+  );
+});

--- a/src/cli/commands/run-once/planning-phase-artifacts.test.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.test.ts
@@ -233,6 +233,22 @@ test("resumes from a saved spec checkpoint without invoking spec again", async (
     `git:${oid("b")}`,
     `checkpoint:${oid("c")}`,
   ]);
+  assert.equal(result.kind, "workspace-ready");
+  if (result.kind === "workspace-ready")
+    assert.deepEqual(result.phase.artifacts, [
+      {
+        kind: "spec",
+        path: "docs/specs/example.md",
+        source: "workspace",
+        commitOid: oid("c"),
+      },
+      {
+        kind: "plan",
+        path: "docs/plans/2026-09-08-issue-188-example.md",
+        source: "workspace",
+        commitOid: oid("c"),
+      },
+    ]);
 });
 
 test("stops on blocked spec or checkpoint failure before the plan agent", async () => {
@@ -303,54 +319,65 @@ test("stops on blocked spec or checkpoint failure before the plan agent", async 
   assert.deepEqual(calls, ["agent:spec", "git", "checkpoint"]);
 });
 
-test("rejects unexpected result paths before the Git validation seam", async () => {
-  let gitCalled = false;
-  await assert.rejects(
-    () =>
-      runPlanningPhaseArtifacts({
-        issue,
-        phase: {
-          kind: "spec",
-          artifactKinds: ["spec"],
-          pullRequestRequired: true,
-        },
-        current: {
-          kind: "spec",
-          status: "workspace-ready",
-          base,
-          workspace: {
-            ...workspace,
-            phase: "spec",
-            identity: { branch: "planning/spec", worktreePath: "/workspace" },
+test("rejects invalid artifact path forms before the Git validation seam", async () => {
+  for (const [label, specPath] of [
+    ["parent escape", "../escape.md"],
+    ["absolute path", "/repo/docs/specs/escape.md"],
+    ["backslash path", "docs\\specs\\escape.md"],
+    ["wrong configured directory", "docs/plans/escape.md"],
+  ] as const) {
+    let gitCalled = false;
+    await assert.rejects(
+      () =>
+        runPlanningPhaseArtifacts({
+          issue,
+          phase: {
+            kind: "spec",
+            artifactKinds: ["spec"],
+            pullRequestRequired: true,
           },
-          artifacts: [],
-        },
-        repoRoot: "/repo",
-        specsDir: "/repo/docs/specs",
-        plansDir: "/repo/docs/plans",
-        artifactDate: new Date("2026-09-08"),
-        agent: {
-          async run() {
-            return {
-              status: "spec-created",
-              specPath: "../escape.md",
-              commit: oid("b"),
-            };
+          current: {
+            kind: "spec",
+            status: "workspace-ready",
+            base,
+            workspace: {
+              ...workspace,
+              phase: "spec",
+              identity: {
+                branch: "planning/spec",
+                worktreePath: "/workspace",
+              },
+            },
+            artifacts: [],
           },
-        },
-        git: {
-          async verifyArtifactCommit() {
-            gitCalled = true;
+          repoRoot: "/repo",
+          specsDir: "/repo/docs/specs",
+          plansDir: "/repo/docs/plans",
+          artifactDate: new Date("2026-09-08"),
+          agent: {
+            async run() {
+              return {
+                status: "spec-created",
+                specPath,
+                commit: oid("b"),
+              };
+            },
           },
-        },
-        checkpoint: async () => {},
-        projectPolicy: DEFAULT_PATCHMILL_POLICY,
-        skills: DEFAULT_PATCHMILL_SKILLS,
-        triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
-      }),
-    /invalid-artifact-path/,
-  );
-  assert.equal(gitCalled, false);
+          git: {
+            async verifyArtifactCommit() {
+              gitCalled = true;
+            },
+          },
+          checkpoint: async () => {},
+          projectPolicy: DEFAULT_PATCHMILL_POLICY,
+          skills: DEFAULT_PATCHMILL_SKILLS,
+          triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
+        }),
+      /invalid-artifact-path/,
+      label,
+    );
+    assert.equal(gitCalled, false, label);
+  }
 });
 
 test("propagates delegated Git validation failures and rejects malformed agent results", async () => {

--- a/src/cli/commands/run-once/planning-phase-artifacts.test.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolvePlanningPhaseArtifacts,
+  runPlanningPhaseArtifacts,
+} from "./planning-phase-artifacts.ts";
+
+const oid = (letter: string) => letter.repeat(40);
+const base = {
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid("a"),
+  artifactCandidates: { spec: [], plan: [] },
+};
+const workspace = {
+  runId: "123e4567-e89b-42d3-a456-426614174000",
+  phase: "plan" as const,
+  identity: { branch: "planning/plan", worktreePath: "/repo/.worktrees/plan" },
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid("a"),
+  headOid: oid("a"),
+  cleanup: { state: "ready" as const },
+};
+const issue = {
+  number: 188,
+  title: "Example",
+  labels: [],
+  body: "",
+  state: "open" as const,
+};
+test("resolves mixed base candidates in planner order", () => {
+  const result = resolvePlanningPhaseArtifacts({
+    phase: {
+      kind: "plan",
+      artifactKinds: ["spec", "plan"],
+      pullRequestRequired: true,
+    },
+    base: {
+      ...base,
+      artifactCandidates: { spec: ["docs/specs/example.md"], plan: [] },
+    },
+  });
+  assert.deepEqual(result, {
+    kind: "workspace-required",
+    artifacts: [
+      {
+        kind: "spec",
+        path: "docs/specs/example.md",
+        source: "remote-base",
+        commitOid: oid("a"),
+      },
+    ],
+    missing: ["plan"],
+  });
+});
+test("blocks ambiguous base artifacts before agent execution", () => {
+  assert.throws(
+    () =>
+      resolvePlanningPhaseArtifacts({
+        phase: {
+          kind: "spec",
+          artifactKinds: ["spec"],
+          pullRequestRequired: true,
+        },
+        base: {
+          ...base,
+          artifactCandidates: {
+            spec: ["docs/specs/a.md", "docs/specs/b.md"],
+            plan: [],
+          },
+        },
+      }),
+    /ambiguous-base-artifact/,
+  );
+});
+test("checkpoints spec before running plan", async () => {
+  const events: string[] = [];
+  let head = oid("a");
+  const result = await runPlanningPhaseArtifacts({
+    issue,
+    phase: {
+      kind: "plan",
+      artifactKinds: ["spec", "plan"],
+      pullRequestRequired: true,
+    },
+    current: {
+      kind: "plan",
+      status: "workspace-ready",
+      base,
+      workspace,
+      artifacts: [],
+    },
+    repoRoot: "/repo",
+    specsDir: "/repo/docs/specs",
+    plansDir: "/repo/docs/plans",
+    artifactDate: new Date("2026-09-08"),
+    agent: {
+      async run({ kind }) {
+        events.push(`agent:${kind}`);
+        head = kind === "spec" ? oid("b") : oid("c");
+        return kind === "spec"
+          ? {
+              status: "spec-created",
+              specPath: "docs/specs/2026-09-08-issue-188-example-design.md",
+              commit: head,
+            }
+          : {
+              status: "plan-created",
+              planPath: "docs/plans/2026-09-08-issue-188-example.md",
+              commit: head,
+            };
+      },
+    },
+    git: {
+      async verifyArtifactCommit({ artifactPath }) {
+        events.push(`git:${artifactPath.includes("specs") ? "spec" : "plan"}`);
+      },
+    },
+    checkpoint: async (phase) => {
+      events.push(
+        `checkpoint:${phase.artifacts.map((item) => item.kind).join("+")}`,
+      );
+    },
+  });
+  assert.equal(result.kind, "workspace-ready");
+  assert.deepEqual(events, [
+    "agent:spec",
+    "git:spec",
+    "checkpoint:spec",
+    "agent:plan",
+    "git:plan",
+    "checkpoint:spec+plan",
+  ]);
+  if (result.kind === "workspace-ready")
+    assert.deepEqual(
+      result.phase.artifacts.map((item) => item.commitOid),
+      [oid("c"), oid("c")],
+    );
+});

--- a/src/cli/commands/run-once/planning-phase-artifacts.test.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.test.ts
@@ -177,3 +177,178 @@ test("checkpoints spec before running plan", async () => {
       [oid("c"), oid("c")],
     );
 });
+
+test("resumes from a saved spec checkpoint without invoking spec again", async () => {
+  const calls: string[] = [];
+  const result = await runPlanningPhaseArtifacts({
+    issue,
+    phase: {
+      kind: "plan",
+      artifactKinds: ["spec", "plan"],
+      pullRequestRequired: true,
+    },
+    current: {
+      kind: "plan",
+      status: "workspace-ready",
+      base,
+      workspace: { ...workspace, headOid: oid("b") },
+      artifacts: [
+        {
+          kind: "spec",
+          path: "docs/specs/example.md",
+          source: "workspace",
+          commitOid: oid("b"),
+        },
+      ],
+    },
+    repoRoot: "/repo",
+    specsDir: "/repo/docs/specs",
+    plansDir: "/repo/docs/plans",
+    artifactDate: new Date("2026-09-08"),
+    agent: {
+      async run({ kind }) {
+        calls.push(`agent:${kind}`);
+        return {
+          status: "plan-created",
+          planPath: "docs/plans/2026-09-08-issue-188-example.md",
+          commit: oid("c"),
+        };
+      },
+    },
+    git: {
+      async verifyArtifactCommit({ previousHeadOid }) {
+        calls.push(`git:${previousHeadOid}`);
+      },
+    },
+    checkpoint: async (phase) => {
+      calls.push(`checkpoint:${phase.workspace.headOid}`);
+    },
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    skills: DEFAULT_PATCHMILL_SKILLS,
+    triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
+  });
+  assert.equal(result.kind, "workspace-ready");
+  assert.deepEqual(calls, [
+    `agent:plan`,
+    `git:${oid("b")}`,
+    `checkpoint:${oid("c")}`,
+  ]);
+});
+
+test("stops on blocked spec or checkpoint failure before the plan agent", async () => {
+  const calls: string[] = [];
+  const input = {
+    issue,
+    phase: {
+      kind: "plan" as const,
+      artifactKinds: ["spec", "plan"] as const,
+      pullRequestRequired: true,
+    },
+    current: {
+      kind: "plan" as const,
+      status: "workspace-ready" as const,
+      base,
+      workspace,
+      artifacts: [],
+    },
+    repoRoot: "/repo",
+    specsDir: "/repo/docs/specs",
+    plansDir: "/repo/docs/plans",
+    artifactDate: new Date("2026-09-08"),
+    git: {
+      async verifyArtifactCommit() {
+        calls.push("git");
+      },
+    },
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    skills: DEFAULT_PATCHMILL_SKILLS,
+    triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
+  };
+  const blocked = await runPlanningPhaseArtifacts({
+    ...input,
+    agent: {
+      async run({ kind }) {
+        calls.push(`agent:${kind}`);
+        return { status: "blocked", reason: "needs input", questions: [] };
+      },
+    },
+    checkpoint: async () => {
+      calls.push("checkpoint");
+    },
+  });
+  assert.equal(blocked.kind, "blocked");
+  assert.deepEqual(calls, ["agent:spec"]);
+  calls.length = 0;
+  await assert.rejects(
+    () =>
+      runPlanningPhaseArtifacts({
+        ...input,
+        agent: {
+          async run({ kind }) {
+            calls.push(`agent:${kind}`);
+            return {
+              status: "spec-created",
+              specPath: "docs/specs/2026-09-08-issue-188-example-design.md",
+              commit: oid("b"),
+            };
+          },
+        },
+        checkpoint: async () => {
+          calls.push("checkpoint");
+          throw new Error("store failed");
+        },
+      }),
+    /store failed/,
+  );
+  assert.deepEqual(calls, ["agent:spec", "git", "checkpoint"]);
+});
+
+test("rejects unexpected result paths before the Git validation seam", async () => {
+  let gitCalled = false;
+  await assert.rejects(
+    () =>
+      runPlanningPhaseArtifacts({
+        issue,
+        phase: {
+          kind: "spec",
+          artifactKinds: ["spec"],
+          pullRequestRequired: true,
+        },
+        current: {
+          kind: "spec",
+          status: "workspace-ready",
+          base,
+          workspace: {
+            ...workspace,
+            phase: "spec",
+            identity: { branch: "planning/spec", worktreePath: "/workspace" },
+          },
+          artifacts: [],
+        },
+        repoRoot: "/repo",
+        specsDir: "/repo/docs/specs",
+        plansDir: "/repo/docs/plans",
+        artifactDate: new Date("2026-09-08"),
+        agent: {
+          async run() {
+            return {
+              status: "spec-created",
+              specPath: "../escape.md",
+              commit: oid("b"),
+            };
+          },
+        },
+        git: {
+          async verifyArtifactCommit() {
+            gitCalled = true;
+          },
+        },
+        checkpoint: async () => {},
+        projectPolicy: DEFAULT_PATCHMILL_POLICY,
+        skills: DEFAULT_PATCHMILL_SKILLS,
+        triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
+      }),
+    /invalid-artifact-path/,
+  );
+  assert.equal(gitCalled, false);
+});

--- a/src/cli/commands/run-once/planning-phase-artifacts.test.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
+import { DEFAULT_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
 import {
   resolvePlanningPhaseArtifacts,
   runPlanningPhaseArtifacts,
@@ -76,6 +78,7 @@ test("blocks ambiguous base artifacts before agent execution", () => {
 });
 test("checkpoints spec before running plan", async () => {
   const events: string[] = [];
+  const prompts: string[] = [];
   let head = oid("a");
   const result = await runPlanningPhaseArtifacts({
     issue,
@@ -96,7 +99,8 @@ test("checkpoints spec before running plan", async () => {
     plansDir: "/repo/docs/plans",
     artifactDate: new Date("2026-09-08"),
     agent: {
-      async run({ kind }) {
+      async run({ kind, prompt }) {
+        prompts.push(prompt);
         events.push(`agent:${kind}`);
         head = kind === "spec" ? oid("b") : oid("c");
         return kind === "spec"
@@ -122,6 +126,9 @@ test("checkpoints spec before running plan", async () => {
         `checkpoint:${phase.artifacts.map((item) => item.kind).join("+")}`,
       );
     },
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+    skills: DEFAULT_PATCHMILL_SKILLS,
+    triageLabels: { ready: "agent-ready", needsInfo: "needs-info" },
   });
   assert.equal(result.kind, "workspace-ready");
   assert.deepEqual(events, [
@@ -132,6 +139,7 @@ test("checkpoints spec before running plan", async () => {
     "git:plan",
     "checkpoint:spec+plan",
   ]);
+  assert.ok(prompts.every((prompt) => !prompt.includes("/repo/docs/")));
   if (result.kind === "workspace-ready")
     assert.deepEqual(
       result.phase.artifacts.map((item) => item.commitOid),

--- a/src/cli/commands/run-once/planning-phase-artifacts.test.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import { DEFAULT_PATCHMILL_SKILLS } from "../../../workflow/skills.ts";
 import {
+  createPlanningArtifactAgent,
   resolvePlanningPhaseArtifacts,
   runPlanningPhaseArtifacts,
 } from "./planning-phase-artifacts.ts";
@@ -31,6 +32,36 @@ const issue = {
   body: "",
   state: "open" as const,
 };
+test("production artifact agent keeps Pi operator state in the primary repository", async () => {
+  const calls: Array<{ cwd?: string; env?: NodeJS.ProcessEnv }> = [];
+  const agent = createPlanningArtifactAgent({
+    runner: {
+      async run(_command, _args, options) {
+        calls.push(options ?? {});
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            status: "spec-created",
+            specPath: "docs/specs/example.md",
+            commit: oid("b"),
+          }),
+          stderr: "",
+        };
+      },
+    },
+    repoRoot: "/primary",
+    skills: DEFAULT_PATCHMILL_SKILLS,
+    taskContract: DEFAULT_PATCHMILL_POLICY.pi.taskContract,
+    issueNumber: 188,
+  });
+  await agent.run({ kind: "spec", cwd: "/phase-worktree", prompt: "prompt" });
+  assert.equal(calls[0]?.cwd, "/phase-worktree");
+  assert.equal(
+    calls[0]?.env?.PI_CODING_AGENT_DIR,
+    "/primary/.patchmill/pi-agent",
+  );
+  assert.equal(calls[0]?.env?.PI_TODO_PATH, "/primary/.pi/todos");
+});
 test("resolves mixed base candidates in planner order", () => {
   const result = resolvePlanningPhaseArtifacts({
     phase: {

--- a/src/cli/commands/run-once/planning-phase-artifacts.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.ts
@@ -1,0 +1,231 @@
+import { isAbsolute, relative, resolve } from "node:path";
+import type { PlanningPublicationOperations } from "../../../git/planning-publication-git.ts";
+import type { PlanningRemoteBaseSnapshot } from "../../../git/planning-workspaces.ts";
+import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
+import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
+import type {
+  PlannedPhase,
+  PlanningArtifactKind,
+} from "../../../workflow/planning-pull-requests.ts";
+import type {
+  PlanningArtifactEvidence,
+  WorkspaceReadyPlanningPhase,
+} from "../../../workflow/planning-state-types.ts";
+import { buildPlanPath } from "./plans.ts";
+import {
+  buildSpecCreationPrompt,
+  buildPlanCreationPrompt,
+  type PromptTriageLabels,
+} from "./prompts.ts";
+import { configuredPathRelativeToRepo } from "./pipeline-workspace.ts";
+import { buildSpecPath } from "./specs.ts";
+import type {
+  AgentIssueBlockedResult,
+  AgentIssuePiResult,
+  IssueSummary,
+} from "./types.ts";
+
+export type PlanningPhaseArtifactResolution =
+  | Readonly<{
+      kind: "satisfied-by-base";
+      artifacts: readonly PlanningArtifactEvidence[];
+    }>
+  | Readonly<{
+      kind: "workspace-required";
+      artifacts: readonly PlanningArtifactEvidence[];
+      missing: readonly PlanningArtifactKind[];
+    }>;
+export interface PlanningArtifactAgent {
+  run(input: {
+    kind: PlanningArtifactKind;
+    cwd: string;
+    prompt: string;
+  }): Promise<AgentIssuePiResult>;
+}
+export type PlanningArtifactCheckpoint = (
+  phase: WorkspaceReadyPlanningPhase,
+) => Promise<void>;
+export class PlanningPhaseArtifactError extends Error {
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`Planning phase artifact failed: ${reason}`);
+    this.name = "PlanningPhaseArtifactError";
+    this.reason = reason;
+  }
+}
+export function resolvePlanningPhaseArtifacts(input: {
+  phase: PlannedPhase;
+  base: PlanningRemoteBaseSnapshot;
+}): PlanningPhaseArtifactResolution {
+  const artifacts: PlanningArtifactEvidence[] = [];
+  const missing: PlanningArtifactKind[] = [];
+  for (const kind of input.phase.artifactKinds) {
+    const candidates = input.base.artifactCandidates[kind];
+    if (candidates.length > 1)
+      throw new PlanningPhaseArtifactError("ambiguous-base-artifact");
+    if (candidates.length === 1)
+      artifacts.push({
+        kind,
+        path: candidates[0]!,
+        source: "remote-base",
+        commitOid: input.base.baseOid,
+      });
+    else missing.push(kind);
+  }
+  return missing.length === 0
+    ? { kind: "satisfied-by-base", artifacts }
+    : { kind: "workspace-required", artifacts, missing };
+}
+function reviewContext(
+  phase: PlannedPhase,
+  kind: PlanningArtifactKind,
+  current: WorkspaceReadyPlanningPhase,
+) {
+  return phase.kind === "implementation"
+    ? ("implementation-pull-request" as const)
+    : phase.artifactKinds.length > 1
+      ? ("same-phase-pull-request" as const)
+      : kind === "plan" &&
+          current.artifacts.some((artifact) => artifact.kind === "spec")
+        ? ("merged-base" as const)
+        : ("dedicated-pull-request" as const);
+}
+function containedPath(
+  repoRoot: string,
+  directory: string,
+  value: string,
+): string {
+  if (isAbsolute(value) || value.includes("\\"))
+    throw new PlanningPhaseArtifactError("invalid-artifact-path");
+  const root = resolve(repoRoot);
+  const expected = resolve(root, configuredPathRelativeToRepo(root, directory));
+  const absolute = resolve(root, value);
+  if (
+    relative(expected, absolute).startsWith("..") ||
+    relative(expected, absolute) === ""
+  )
+    throw new PlanningPhaseArtifactError("invalid-artifact-path");
+  return relative(root, absolute).replaceAll("\\", "/");
+}
+function resultFor(
+  kind: PlanningArtifactKind,
+  result: AgentIssuePiResult,
+): { path: string; commit: string } | AgentIssueBlockedResult {
+  if (result.status === "blocked") return result;
+  if (kind === "spec" && result.status === "spec-created" && result.commit)
+    return { path: result.specPath, commit: result.commit };
+  if (kind === "plan" && result.status === "plan-created" && result.commit)
+    return { path: result.planPath, commit: result.commit };
+  throw new PlanningPhaseArtifactError("unexpected-agent-result");
+}
+export async function runPlanningPhaseArtifacts(input: {
+  issue: IssueSummary;
+  phase: PlannedPhase;
+  current: WorkspaceReadyPlanningPhase;
+  repoRoot: string;
+  specsDir: string;
+  plansDir: string;
+  artifactDate: Date;
+  agent: PlanningArtifactAgent;
+  git: Pick<PlanningPublicationOperations, "verifyArtifactCommit">;
+  checkpoint: PlanningArtifactCheckpoint;
+  projectPolicy?: PatchmillProjectPolicy;
+  skills?: PatchmillSkillsConfig;
+  triageLabels?: PromptTriageLabels;
+}): Promise<
+  | { kind: "workspace-ready"; phase: WorkspaceReadyPlanningPhase }
+  | { kind: "blocked"; result: AgentIssueBlockedResult }
+> {
+  let current = input.current;
+  const missing = input.phase.artifactKinds.filter(
+    (kind) => !current.artifacts.some((artifact) => artifact.kind === kind),
+  );
+  for (const kind of missing) {
+    const expectedPath =
+      kind === "spec"
+        ? buildSpecPath(
+            input.specsDir,
+            input.issue.number,
+            input.issue.title,
+            input.artifactDate,
+          )
+        : buildPlanPath(
+            input.plansDir,
+            input.issue.number,
+            input.issue.title,
+            input.artifactDate,
+          );
+    const prompt =
+      input.projectPolicy === undefined
+        ? ""
+        : kind === "spec"
+          ? buildSpecCreationPrompt({
+              issue: input.issue,
+              specPath: expectedPath,
+              projectPolicy: input.projectPolicy,
+              ...(input.skills === undefined ? {} : { skills: input.skills }),
+              ...(input.triageLabels === undefined
+                ? {}
+                : { triageLabels: input.triageLabels }),
+              reviewContext: reviewContext(input.phase, kind, current),
+            })
+          : buildPlanCreationPrompt({
+              issue: input.issue,
+              ...(current.artifacts.find((artifact) => artifact.kind === "spec")
+                ?.path === undefined
+                ? {}
+                : {
+                    specPath: current.artifacts.find(
+                      (artifact) => artifact.kind === "spec",
+                    )!.path,
+                  }),
+              planPath: expectedPath,
+              projectPolicy: input.projectPolicy,
+              ...(input.skills === undefined ? {} : { skills: input.skills }),
+              ...(input.triageLabels === undefined
+                ? {}
+                : { triageLabels: input.triageLabels }),
+              reviewContext: reviewContext(input.phase, kind, current),
+            });
+    const result = resultFor(
+      kind,
+      await input.agent.run({
+        kind,
+        cwd: current.workspace.identity.worktreePath,
+        prompt,
+      }),
+    );
+    if ("status" in result) return { kind: "blocked", result };
+    const path = containedPath(
+      input.repoRoot,
+      kind === "spec" ? input.specsDir : input.plansDir,
+      result.path,
+    );
+    await input.git.verifyArtifactCommit({
+      workspacePath: current.workspace.identity.worktreePath,
+      previousHeadOid: current.workspace.headOid,
+      headOid: result.commit,
+      artifactPath: path,
+    });
+    const artifacts = [
+      ...current.artifacts.filter(
+        (artifact) => artifact.source === "remote-base",
+      ),
+      ...current.artifacts
+        .filter((artifact) => artifact.source === "workspace")
+        .map((artifact) => ({ ...artifact, commitOid: result.commit })),
+      { kind, path, source: "workspace" as const, commitOid: result.commit },
+    ].sort(
+      (left, right) =>
+        input.phase.artifactKinds.indexOf(left.kind) -
+        input.phase.artifactKinds.indexOf(right.kind),
+    );
+    current = {
+      ...current,
+      workspace: { ...current.workspace, headOid: result.commit },
+      artifacts,
+    };
+    await input.checkpoint(current);
+  }
+  return { kind: "workspace-ready", phase: current };
+}

--- a/src/cli/commands/run-once/planning-phase-artifacts.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.ts
@@ -1,6 +1,10 @@
 import { isAbsolute, relative, resolve } from "node:path";
 import type { PlanningPublicationOperations } from "../../../git/planning-publication-git.ts";
 import type { PlanningRemoteBaseSnapshot } from "../../../git/planning-workspaces.ts";
+import {
+  profileExtensionArgs,
+  runOncePlanningPiProfile,
+} from "../../../pi/resource-profiles.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
 import type {
@@ -19,9 +23,11 @@ import {
 } from "./prompts.ts";
 import { configuredPathRelativeToRepo } from "./pipeline-workspace.ts";
 import { buildSpecPath } from "./specs.ts";
+import { runPiPrompt, type RunPiPromptOptions } from "./pi.ts";
 import type {
   AgentIssueBlockedResult,
   AgentIssuePiResult,
+  CommandRunner,
   IssueSummary,
 } from "./types.ts";
 
@@ -45,6 +51,36 @@ export interface PlanningArtifactAgent {
 export type PlanningArtifactCheckpoint = (
   phase: WorkspaceReadyPlanningPhase,
 ) => Promise<void>;
+
+export function createPlanningArtifactAgent(input: {
+  runner: CommandRunner;
+  skills: PatchmillSkillsConfig;
+  issueNumber: number;
+  runOptions?: Omit<
+    RunPiPromptOptions,
+    | "stage"
+    | "issueNumber"
+    | "repoRoot"
+    | "skillPaths"
+    | "extensionArgs"
+    | "observeSession"
+  >;
+}): PlanningArtifactAgent {
+  return {
+    async run({ cwd, prompt }) {
+      const profile = runOncePlanningPiProfile(input.skills, cwd);
+      return runPiPrompt(input.runner, cwd, prompt, {
+        ...input.runOptions,
+        stage: "pi-plan",
+        issueNumber: input.issueNumber,
+        repoRoot: cwd,
+        skillPaths: profile.additionalSkillPaths,
+        extensionArgs: profileExtensionArgs(profile),
+        observeSession: true,
+      });
+    },
+  };
+}
 export class PlanningPhaseArtifactError extends Error {
   readonly reason: string;
   constructor(reason: string) {
@@ -76,6 +112,12 @@ export function resolvePlanningPhaseArtifacts(input: {
     ? { kind: "satisfied-by-base", artifacts }
     : { kind: "workspace-required", artifacts, missing };
 }
+function mergedBaseSpecPath(
+  current: WorkspaceReadyPlanningPhase,
+): string | undefined {
+  const candidates = current.base.artifactCandidates.spec;
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
 function reviewContext(
   phase: PlannedPhase,
   kind: PlanningArtifactKind,
@@ -86,7 +128,8 @@ function reviewContext(
     : phase.artifactKinds.length > 1
       ? ("same-phase-pull-request" as const)
       : kind === "plan" &&
-          current.artifacts.some((artifact) => artifact.kind === "spec")
+          (current.artifacts.some((artifact) => artifact.kind === "spec") ||
+            mergedBaseSpecPath(current) !== undefined)
         ? ("merged-base" as const)
         : ("dedicated-pull-request" as const);
 }
@@ -129,9 +172,9 @@ export async function runPlanningPhaseArtifacts(input: {
   agent: PlanningArtifactAgent;
   git: Pick<PlanningPublicationOperations, "verifyArtifactCommit">;
   checkpoint: PlanningArtifactCheckpoint;
-  projectPolicy?: PatchmillProjectPolicy;
-  skills?: PatchmillSkillsConfig;
-  triageLabels?: PromptTriageLabels;
+  projectPolicy: PatchmillProjectPolicy;
+  skills: PatchmillSkillsConfig;
+  triageLabels: PromptTriageLabels;
 }): Promise<
   | { kind: "workspace-ready"; phase: WorkspaceReadyPlanningPhase }
   | { kind: "blocked"; result: AgentIssueBlockedResult }
@@ -155,38 +198,32 @@ export async function runPlanningPhaseArtifacts(input: {
             input.issue.title,
             input.artifactDate,
           );
+    const expectedPathInWorkspace = configuredPathRelativeToRepo(
+      input.repoRoot,
+      expectedPath,
+    );
+    const specPath =
+      current.artifacts.find((artifact) => artifact.kind === "spec")?.path ??
+      mergedBaseSpecPath(current);
     const prompt =
-      input.projectPolicy === undefined
-        ? ""
-        : kind === "spec"
-          ? buildSpecCreationPrompt({
-              issue: input.issue,
-              specPath: expectedPath,
-              projectPolicy: input.projectPolicy,
-              ...(input.skills === undefined ? {} : { skills: input.skills }),
-              ...(input.triageLabels === undefined
-                ? {}
-                : { triageLabels: input.triageLabels }),
-              reviewContext: reviewContext(input.phase, kind, current),
-            })
-          : buildPlanCreationPrompt({
-              issue: input.issue,
-              ...(current.artifacts.find((artifact) => artifact.kind === "spec")
-                ?.path === undefined
-                ? {}
-                : {
-                    specPath: current.artifacts.find(
-                      (artifact) => artifact.kind === "spec",
-                    )!.path,
-                  }),
-              planPath: expectedPath,
-              projectPolicy: input.projectPolicy,
-              ...(input.skills === undefined ? {} : { skills: input.skills }),
-              ...(input.triageLabels === undefined
-                ? {}
-                : { triageLabels: input.triageLabels }),
-              reviewContext: reviewContext(input.phase, kind, current),
-            });
+      kind === "spec"
+        ? buildSpecCreationPrompt({
+            issue: input.issue,
+            specPath: expectedPathInWorkspace,
+            projectPolicy: input.projectPolicy,
+            skills: input.skills,
+            triageLabels: input.triageLabels,
+            reviewContext: reviewContext(input.phase, kind, current),
+          })
+        : buildPlanCreationPrompt({
+            issue: input.issue,
+            ...(specPath === undefined ? {} : { specPath }),
+            planPath: expectedPathInWorkspace,
+            projectPolicy: input.projectPolicy,
+            skills: input.skills,
+            triageLabels: input.triageLabels,
+            reviewContext: reviewContext(input.phase, kind, current),
+          });
     const result = resultFor(
       kind,
       await input.agent.run({

--- a/src/cli/commands/run-once/planning-phase-artifacts.ts
+++ b/src/cli/commands/run-once/planning-phase-artifacts.ts
@@ -1,10 +1,12 @@
 import { isAbsolute, relative, resolve } from "node:path";
+import { localPiAgentDir } from "../init/pi-agent-settings.ts";
 import type { PlanningPublicationOperations } from "../../../git/planning-publication-git.ts";
 import type { PlanningRemoteBaseSnapshot } from "../../../git/planning-workspaces.ts";
 import {
   profileExtensionArgs,
   runOncePlanningPiProfile,
 } from "../../../pi/resource-profiles.ts";
+import type { PatchmillPiTaskContract } from "../../../policy/task-contract.ts";
 import type { PatchmillProjectPolicy } from "../../../policy/types.ts";
 import type { PatchmillSkillsConfig } from "../../../workflow/skills.ts";
 import type {
@@ -54,7 +56,9 @@ export type PlanningArtifactCheckpoint = (
 
 export function createPlanningArtifactAgent(input: {
   runner: CommandRunner;
+  repoRoot: string;
   skills: PatchmillSkillsConfig;
+  taskContract: PatchmillPiTaskContract;
   issueNumber: number;
   runOptions?: Omit<
     RunPiPromptOptions,
@@ -74,6 +78,11 @@ export function createPlanningArtifactAgent(input: {
         stage: "pi-plan",
         issueNumber: input.issueNumber,
         repoRoot: cwd,
+        piAgentDir: localPiAgentDir(input.repoRoot),
+        taskContract: {
+          ...input.taskContract,
+          todoRoot: resolve(input.repoRoot, input.taskContract.todoRoot),
+        },
         skillPaths: profile.additionalSkillPaths,
         extensionArgs: profileExtensionArgs(profile),
         observeSession: true,

--- a/src/cli/commands/run-once/planning-phase-cleanup.test.ts
+++ b/src/cli/commands/run-once/planning-phase-cleanup.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PullRequestOpenPlanningPhase } from "../../../workflow/planning-state-types.ts";
+import { finishPlanningPhaseCleanup } from "./planning-phase-cleanup.ts";
+
+const oid = "a".repeat(40);
+const repository = {
+  provider: "github-gh" as const,
+  host: "github.com",
+  owner: "acme",
+  repository: "patchmill",
+};
+
+function readyPhase(): PullRequestOpenPlanningPhase {
+  return {
+    kind: "spec",
+    status: "pull-request-open",
+    base: {
+      remote: "origin",
+      baseBranch: "main",
+      baseOid: oid,
+      artifactCandidates: { spec: [], plan: [] },
+    },
+    workspace: {
+      runId: "123e4567-e89b-42d3-a456-426614174000",
+      phase: "spec",
+      identity: { branch: "planning/spec", worktreePath: "/workspace" },
+      remote: "origin",
+      baseBranch: "main",
+      baseOid: oid,
+      headOid: oid,
+      cleanup: { state: "ready" },
+    },
+    artifacts: [
+      {
+        kind: "spec",
+        path: "docs/specs/issue-188.md",
+        source: "workspace",
+        commitOid: oid,
+      },
+    ],
+    publication: {
+      targetRepository: repository,
+      headRepository: repository,
+      baseBranch: "main",
+      headBranch: "planning/spec",
+      headOid: oid,
+    },
+    pullRequest: {
+      reference: { targetRepository: repository, number: 188 },
+      url: "https://github.com/acme/patchmill/pull/188",
+    },
+  };
+}
+
+test("retries an uncheckpointed worktree removal from ready and durably removes the branch", async () => {
+  const events: string[] = [];
+  const commands: string[][] = [];
+  let worktreePresent = true;
+  let branchPresent = true;
+  let durable = readyPhase();
+  let failCheckpoint = true;
+  const run = async () =>
+    finishPlanningPhaseCleanup({
+      phase: durable,
+      remoteHead: async () => events.push("remote-head"),
+      workspaces: {
+        async removeWorktree() {
+          events.push(
+            `remove-worktree:${worktreePresent ? "present" : "absent"}`,
+          );
+          if (worktreePresent)
+            commands.push(["worktree", "remove", "--", "/workspace"]);
+          worktreePresent = false;
+          return {
+            state: "branch-only",
+            identity: durable.workspace.identity,
+            headOid: oid,
+          };
+        },
+        async removeBranch() {
+          events.push(`remove-branch:${branchPresent ? "present" : "absent"}`);
+          if (branchPresent)
+            commands.push([
+              "update-ref",
+              "-d",
+              "refs/heads/planning/spec",
+              oid,
+            ]);
+          branchPresent = false;
+          return { state: "missing", identity: durable.workspace.identity };
+        },
+      } as never,
+      checkpoint: async (next) => {
+        events.push(`checkpoint:${next.workspace.cleanup.state}`);
+        if (failCheckpoint) {
+          failCheckpoint = false;
+          throw new Error("checkpoint failed");
+        }
+        durable = next;
+      },
+    });
+
+  await assert.rejects(run, /checkpoint failed/);
+  assert.equal(durable.workspace.cleanup.state, "ready");
+  assert.equal(branchPresent, true);
+  await run();
+  assert.equal(durable.workspace.cleanup.state, "removed");
+  assert.deepEqual(events, [
+    "remote-head",
+    "remove-worktree:present",
+    "checkpoint:worktree-removed",
+    "remote-head",
+    "remove-worktree:absent",
+    "checkpoint:worktree-removed",
+    "remove-branch:present",
+    "checkpoint:removed",
+  ]);
+  assert.deepEqual(commands, [
+    ["worktree", "remove", "--", "/workspace"],
+    ["update-ref", "-d", "refs/heads/planning/spec", oid],
+  ]);
+  assert.ok(commands.every((command) => !command.includes("--force")));
+});
+
+test("retries an uncheckpointed branch removal from worktree-removed without force", async () => {
+  const events: string[] = [];
+  const commands: string[][] = [];
+  let branchPresent = true;
+  let durable: PullRequestOpenPlanningPhase = {
+    ...readyPhase(),
+    workspace: {
+      ...readyPhase().workspace,
+      cleanup: { state: "worktree-removed", pushedHeadOid: oid },
+    },
+  };
+  let failCheckpoint = true;
+  const run = async () =>
+    finishPlanningPhaseCleanup({
+      phase: durable,
+      remoteHead: async () => events.push("unexpected-remote-head"),
+      workspaces: {
+        async removeWorktree() {
+          events.push("unexpected-worktree");
+          throw new Error("unexpected worktree removal");
+        },
+        async removeBranch() {
+          events.push(`remove-branch:${branchPresent ? "present" : "absent"}`);
+          if (branchPresent)
+            commands.push([
+              "update-ref",
+              "-d",
+              "refs/heads/planning/spec",
+              oid,
+            ]);
+          branchPresent = false;
+          return { state: "missing", identity: durable.workspace.identity };
+        },
+      } as never,
+      checkpoint: async (next) => {
+        events.push(`checkpoint:${next.workspace.cleanup.state}`);
+        if (failCheckpoint) {
+          failCheckpoint = false;
+          throw new Error("checkpoint failed");
+        }
+        durable = next;
+      },
+    });
+
+  await assert.rejects(run, /checkpoint failed/);
+  assert.equal(durable.workspace.cleanup.state, "worktree-removed");
+  await run();
+  assert.equal(durable.workspace.cleanup.state, "removed");
+  assert.deepEqual(events, [
+    "remove-branch:present",
+    "checkpoint:removed",
+    "remove-branch:absent",
+    "checkpoint:removed",
+  ]);
+  assert.deepEqual(commands, [
+    ["update-ref", "-d", "refs/heads/planning/spec", oid],
+  ]);
+  assert.ok(commands.every((command) => !command.includes("--force")));
+});
+
+test("preserves ready cleanup state when an existing workspace is dirty or has a changed head", async () => {
+  for (const reason of ["dirty-worktree", "head-oid-mismatch"] as const) {
+    const durable = readyPhase();
+    const events: string[] = [];
+    await assert.rejects(
+      () =>
+        finishPlanningPhaseCleanup({
+          phase: durable,
+          remoteHead: async () => events.push("remote-head"),
+          workspaces: {
+            async removeWorktree() {
+              events.push(`conflict:${reason}`);
+              throw new Error(reason);
+            },
+          } as never,
+          checkpoint: async () => events.push("checkpoint"),
+        }),
+      new RegExp(reason),
+    );
+    assert.equal(durable.workspace.cleanup.state, "ready");
+    assert.deepEqual(events, ["remote-head", `conflict:${reason}`]);
+  }
+});

--- a/src/cli/commands/run-once/planning-phase-cleanup.ts
+++ b/src/cli/commands/run-once/planning-phase-cleanup.ts
@@ -1,0 +1,59 @@
+import type {
+  PlanningWorkspaceLifecycle,
+  PlanningWorkspaceOwnership,
+} from "../../../git/planning-workspaces.ts";
+import type {
+  BranchPushedPlanningPhase,
+  PullRequestOpenPlanningPhase,
+} from "../../../workflow/planning-state-types.ts";
+
+export async function finishPlanningPhaseCleanup(input: {
+  phase: PullRequestOpenPlanningPhase;
+  workspaces: PlanningWorkspaceLifecycle;
+  remoteHead: (phase: BranchPushedPlanningPhase) => Promise<void>;
+  checkpoint: (phase: PullRequestOpenPlanningPhase) => Promise<void>;
+}): Promise<PullRequestOpenPlanningPhase> {
+  let phase = input.phase;
+  if (phase.workspace.cleanup.state === "ready") {
+    await input.remoteHead({
+      ...phase,
+      status: "branch-pushed",
+      workspace: phase.workspace as BranchPushedPlanningPhase["workspace"],
+    });
+    await input.workspaces.removeWorktree({
+      runId: phase.workspace.runId,
+      phase: phase.kind,
+      workspace: phase.workspace as BranchPushedPlanningPhase["workspace"],
+    });
+    phase = {
+      ...phase,
+      workspace: {
+        ...phase.workspace,
+        cleanup: {
+          state: "worktree-removed",
+          pushedHeadOid: phase.publication.headOid,
+        },
+      },
+    };
+    await input.checkpoint(phase);
+  }
+  if (phase.workspace.cleanup.state === "worktree-removed") {
+    await input.workspaces.removeBranch({
+      runId: phase.workspace.runId,
+      phase: phase.kind,
+      workspace: phase.workspace as PlanningWorkspaceOwnership<{
+        state: "worktree-removed";
+        pushedHeadOid: string;
+      }>,
+    });
+    phase = {
+      ...phase,
+      workspace: {
+        ...phase.workspace,
+        cleanup: { state: "removed", pushedHeadOid: phase.publication.headOid },
+      },
+    };
+    await input.checkpoint(phase);
+  }
+  return phase;
+}

--- a/src/cli/commands/run-once/planning-phase-publisher.test.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.test.ts
@@ -79,6 +79,32 @@ test("rejects incomplete workspace artifacts before publication effects", async 
     /artifacts are incomplete/,
   );
 });
+test("blocks branch-pushed discovery when the saved remote head changed", async () => {
+  let discovered = false;
+  await assert.rejects(
+    () =>
+      publishPlanningPhase({
+        state,
+        phaseIndex: 0,
+        lock: {} as never,
+        stateStore: {} as never,
+        host: {
+          async findPullRequests() {
+            discovered = true;
+            return [];
+          },
+        } as never,
+        git: {
+          async inspectRemoteHead() {
+            return { state: "present", headOid: "b".repeat(40) };
+          },
+        } as never,
+        workspaces: {} as never,
+      }),
+    /remote head changed/,
+  );
+  assert.equal(discovered, false);
+});
 test("returns ambiguous discovery without creating a replacement pull request", async () => {
   const result = await publishPlanningPhase({
     state,

--- a/src/cli/commands/run-once/planning-phase-publisher.test.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.test.ts
@@ -58,6 +58,27 @@ const state = {
     { kind: "implementation" as const, status: "pending" as const },
   ],
 };
+test("rejects incomplete workspace artifacts before publication effects", async () => {
+  const partial = structuredClone(state);
+  partial.phases[0] = {
+    ...partial.phases[0],
+    status: "workspace-ready",
+    artifacts: [],
+  };
+  await assert.rejects(
+    () =>
+      publishPlanningPhase({
+        state: partial,
+        phaseIndex: 0,
+        lock: {} as never,
+        stateStore: {} as never,
+        host: {} as never,
+        git: {} as never,
+        workspaces: {} as never,
+      }),
+    /artifacts are incomplete/,
+  );
+});
 test("returns ambiguous discovery without creating a replacement pull request", async () => {
   const result = await publishPlanningPhase({
     state,

--- a/src/cli/commands/run-once/planning-phase-publisher.test.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { publishPlanningPhase } from "./planning-phase-publisher.ts";
+
+const oid = "a".repeat(40);
+const repository = {
+  provider: "github-gh" as const,
+  host: "github.com",
+  owner: "acme",
+  repository: "patchmill",
+};
+const state = {
+  version: 1 as const,
+  workflowVersion: "planning-pr-v1" as const,
+  runId: "123e4567-e89b-42d3-a456-426614174000",
+  issueNumber: 188,
+  issueTitle: "Example",
+  gates: { specRequired: true, planRequired: false },
+  revision: 1,
+  createdAt: "2026-09-08T12:00:00.000Z",
+  updatedAt: "2026-09-08T12:00:01.000Z",
+  phases: [
+    {
+      kind: "spec" as const,
+      status: "branch-pushed" as const,
+      base: {
+        remote: "origin",
+        baseBranch: "main",
+        baseOid: oid,
+        artifactCandidates: { spec: [], plan: [] },
+      },
+      workspace: {
+        runId: "123e4567-e89b-42d3-a456-426614174000",
+        phase: "spec" as const,
+        identity: { branch: "planning/spec", worktreePath: "/repo/worktree" },
+        remote: "origin",
+        baseBranch: "main",
+        baseOid: oid,
+        headOid: oid,
+        cleanup: { state: "ready" as const },
+      },
+      artifacts: [
+        {
+          kind: "spec" as const,
+          path: "docs/specs/example.md",
+          commitOid: oid,
+          source: "workspace" as const,
+        },
+      ],
+      publication: {
+        targetRepository: repository,
+        headRepository: repository,
+        baseBranch: "main",
+        headBranch: "planning/spec",
+        headOid: oid,
+      },
+    },
+    { kind: "implementation" as const, status: "pending" as const },
+  ],
+};
+test("returns ambiguous discovery without creating a replacement pull request", async () => {
+  const result = await publishPlanningPhase({
+    state,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace() {
+        throw new Error("unexpected");
+      },
+    },
+    host: {
+      id: "github-gh",
+      async resolveTargetRepositoryIdentity() {
+        return repository;
+      },
+      async resolveRemoteRepositoryIdentity() {
+        return repository;
+      },
+      async createPullRequest() {
+        throw new Error("unexpected");
+      },
+      async findPullRequests() {
+        return [{}, {}] as never;
+      },
+      async getPullRequest() {
+        throw new Error("unexpected");
+      },
+      async readPullRequestBody() {
+        return "";
+      },
+      async updatePullRequestBody() {},
+    },
+    git: {
+      async verifyWorkspace() {},
+      async inspectRemoteHead() {
+        return { state: "present" as const, headOid: oid };
+      },
+      async ensureRemoteHead() {
+        return { pushed: false, headOid: oid };
+      },
+    },
+    workspaces: {} as never,
+  });
+  assert.equal(result.kind, "ambiguous");
+  assert.equal(result.pullRequests.length, 2);
+});

--- a/src/cli/commands/run-once/planning-phase-publisher.test.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.test.ts
@@ -318,3 +318,136 @@ test("returns ambiguous discovery without creating a replacement pull request", 
   assert.equal(result.kind, "ambiguous");
   assert.equal(result.pullRequests.length, 2);
 });
+
+test("recovers an interrupted create by adopting the exact discovered pull request", async () => {
+  const events: string[] = [];
+  const created = pullRequest();
+  await assert.rejects(
+    () =>
+      publishPlanningPhase({
+        state,
+        phaseIndex: 0,
+        lock: {} as never,
+        stateStore: {} as never,
+        host: {
+          async findPullRequests() {
+            events.push("find:first");
+            return [];
+          },
+          async createPullRequest() {
+            events.push("create");
+            throw new Error("interrupted response");
+          },
+        } as never,
+        git: {
+          async inspectRemoteHead() {
+            events.push("inspect:first");
+            return { state: "present" as const, headOid: oid };
+          },
+        } as never,
+        workspaces: {} as never,
+      }),
+    /interrupted response/,
+  );
+  assert.deepEqual(events, ["inspect:first", "find:first", "create"]);
+  const retryEvents: string[] = [];
+  const retry = await publishPlanningPhase({
+    state,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace({ next }) {
+        return next;
+      },
+    },
+    host: {
+      async findPullRequests() {
+        retryEvents.push("find");
+        return [created];
+      },
+      async createPullRequest() {
+        retryEvents.push("create");
+        return created;
+      },
+      async getPullRequest() {
+        retryEvents.push("get");
+        return created;
+      },
+    } as never,
+    git: {
+      async inspectRemoteHead() {
+        retryEvents.push("inspect");
+        return { state: "present" as const, headOid: oid };
+      },
+    } as never,
+    workspaces: {
+      async removeWorktree() {
+        retryEvents.push("worktree");
+      },
+      async removeBranch() {
+        retryEvents.push("branch");
+      },
+    } as never,
+  });
+  assert.equal(retry.kind, "published");
+  assert.equal(retryEvents.includes("create"), false);
+  assert.deepEqual(retryEvents, [
+    "inspect",
+    "find",
+    "get",
+    "get",
+    "inspect",
+    "worktree",
+    "branch",
+    "get",
+  ]);
+});
+
+test("resumes cleanup from worktree-removed without removing the worktree again", async () => {
+  const resume = structuredClone(state);
+  resume.phases[0] = {
+    ...resume.phases[0],
+    status: "pull-request-open",
+    pullRequest: {
+      reference: { targetRepository: repository, number: 188 },
+      url: "https://github.com/acme/patchmill/pull/188",
+    },
+    workspace: {
+      ...resume.phases[0].workspace,
+      cleanup: { state: "worktree-removed", pushedHeadOid: oid },
+    },
+  };
+  const events: string[] = [];
+  await publishPlanningPhase({
+    state: resume,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace({ next }) {
+        events.push("replace");
+        return next;
+      },
+    },
+    host: {
+      async getPullRequest() {
+        events.push("get");
+        return pullRequest();
+      },
+    } as never,
+    git: {
+      async inspectRemoteHead() {
+        events.push("inspect");
+        return { state: "present" as const, headOid: oid };
+      },
+    } as never,
+    workspaces: {
+      async removeWorktree() {
+        events.push("worktree");
+      },
+      async removeBranch() {
+        events.push("branch");
+      },
+    } as never,
+  });
+  assert.deepEqual(events, ["get", "branch", "replace", "get"]);
+});

--- a/src/cli/commands/run-once/planning-phase-publisher.test.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.test.ts
@@ -58,6 +58,66 @@ const state = {
     { kind: "implementation" as const, status: "pending" as const },
   ],
 };
+test("stops after exact push when its branch checkpoint cannot persist", async () => {
+  const events: string[] = [];
+  const ready = structuredClone(state);
+  ready.phases[0] = { ...ready.phases[0], status: "workspace-ready" };
+  await assert.rejects(
+    () =>
+      publishPlanningPhase({
+        state: ready,
+        phaseIndex: 0,
+        lock: {} as never,
+        stateStore: {
+          async replace() {
+            events.push("replace");
+            throw new Error("store failed");
+          },
+        },
+        host: {
+          async resolveTargetRepositoryIdentity() {
+            events.push("target");
+            return repository;
+          },
+          async resolveRemoteRepositoryIdentity() {
+            events.push("head");
+            return repository;
+          },
+          async findPullRequests() {
+            events.push("find");
+            return [];
+          },
+        } as never,
+        git: {
+          async verifyWorkspace() {
+            events.push("verify");
+          },
+          async ensureRemoteHead() {
+            events.push("push");
+            return { pushed: true, headOid: oid };
+          },
+          async inspectRemoteHead() {
+            events.push("inspect");
+            return { state: "present" as const, headOid: oid };
+          },
+        },
+        workspaces: {
+          async resume() {
+            events.push("resume");
+          },
+        } as never,
+      }),
+    /store failed/,
+  );
+  assert.deepEqual(events, [
+    "resume",
+    "verify",
+    "target",
+    "head",
+    "push",
+    "replace",
+  ]);
+});
 test("rejects incomplete workspace artifacts before publication effects", async () => {
   const partial = structuredClone(state);
   partial.phases[0] = {

--- a/src/cli/commands/run-once/planning-phase-publisher.test.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { renderPlanningPullRequestMarker } from "../../../workflow/planning-pull-request-markers.ts";
 import { publishPlanningPhase } from "./planning-phase-publisher.ts";
 
 const oid = "a".repeat(40);
@@ -164,6 +165,112 @@ test("blocks branch-pushed discovery when the saved remote head changed", async 
     /remote head changed/,
   );
   assert.equal(discovered, false);
+});
+function pullRequest(status: "open" | "closed-unmerged" | "merged" = "open") {
+  return {
+    number: 188,
+    url: "https://github.com/acme/patchmill/pull/188",
+    targetRepository: repository,
+    headRepository: repository,
+    baseBranch: "main",
+    headBranch: "planning/spec",
+    headSha: oid,
+    body: renderPlanningPullRequestMarker({ issueNumber: 188, phase: "spec" }),
+    status,
+  };
+}
+test("creates, checkpoints, and cleans up one discovered-missing pull request", async () => {
+  const events: string[] = [];
+  const created = pullRequest();
+  const result = await publishPlanningPhase({
+    state,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace({ next }) {
+        events.push(`replace:${next.phases[0]!.status}`);
+        return next;
+      },
+    },
+    host: {
+      async findPullRequests() {
+        events.push("find");
+        return [];
+      },
+      async createPullRequest() {
+        events.push("create");
+        return created;
+      },
+      async getPullRequest() {
+        events.push("get");
+        return created;
+      },
+    } as never,
+    git: {
+      async inspectRemoteHead() {
+        events.push("inspect");
+        return { state: "present" as const, headOid: oid };
+      },
+    } as never,
+    workspaces: {
+      async removeWorktree() {
+        events.push("worktree");
+      },
+      async removeBranch() {
+        events.push("branch");
+      },
+    } as never,
+  });
+  assert.equal(result.kind, "published");
+  assert.deepEqual(events, [
+    "inspect",
+    "find",
+    "create",
+    "get",
+    "replace:pull-request-open",
+    "get",
+    "inspect",
+    "worktree",
+    "replace:pull-request-open",
+    "branch",
+    "replace:pull-request-open",
+    "get",
+  ]);
+});
+test("adopts one exact pull request without creating or rewriting it", async () => {
+  const events: string[] = [];
+  const adopted = pullRequest();
+  await publishPlanningPhase({
+    state,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace({ next }) {
+        return next;
+      },
+    },
+    host: {
+      async findPullRequests() {
+        events.push("find");
+        return [adopted];
+      },
+      async createPullRequest() {
+        events.push("create");
+        return adopted;
+      },
+      async getPullRequest() {
+        events.push("get");
+        return adopted;
+      },
+    } as never,
+    git: {
+      async inspectRemoteHead() {
+        return { state: "present" as const, headOid: oid };
+      },
+    } as never,
+    workspaces: { async removeWorktree() {}, async removeBranch() {} } as never,
+  });
+  assert.deepEqual(events, ["find", "get", "get", "get"]);
 });
 test("returns ambiguous discovery without creating a replacement pull request", async () => {
   const result = await publishPlanningPhase({

--- a/src/cli/commands/run-once/planning-phase-publisher.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.ts
@@ -1,0 +1,220 @@
+import type { PlanningPublicationOperations } from "../../../git/planning-publication-git.ts";
+import type { PlanningWorkspaceLifecycle } from "../../../git/planning-workspaces.ts";
+import type {
+  PullRequestHost,
+  PullRequestSummary,
+} from "../../../host/pull-requests.ts";
+import {
+  planningPullRequestBody,
+  planningPullRequestTitle,
+} from "../../../workflow/planning-pull-requests.ts";
+import type { PlanningIssueLock } from "../../../workflow/planning-issue-lock.ts";
+import type { PlanningStateStore } from "../../../workflow/planning-state-store.ts";
+import type {
+  PlanningPhaseStateV1,
+  PlanningStateV1,
+} from "../../../workflow/planning-state-types.ts";
+import {
+  assertPlanningPublicationRepositories,
+  validatePlanningPullRequestSummary,
+} from "../../../workflow/planning-pull-request-validation.ts";
+import { finishPlanningPhaseCleanup } from "./planning-phase-cleanup.ts";
+
+export type PlanningPhasePublicationResult =
+  | Readonly<{
+      kind: "published";
+      state: PlanningStateV1;
+      pullRequest: PullRequestSummary;
+    }>
+  | Readonly<{
+      kind: "ambiguous";
+      state: PlanningStateV1;
+      pullRequests: readonly PullRequestSummary[];
+    }>;
+function nextState(
+  state: PlanningStateV1,
+  phaseIndex: number,
+  phase: PlanningPhaseStateV1,
+  now: () => Date,
+): PlanningStateV1 {
+  return {
+    ...state,
+    revision: state.revision + 1,
+    updatedAt: now().toISOString(),
+    phases: state.phases.map((item, index) =>
+      index === phaseIndex ? phase : item,
+    ),
+  };
+}
+async function replace(input: {
+  state: PlanningStateV1;
+  phaseIndex: number;
+  phase: PlanningPhaseStateV1;
+  lock: PlanningIssueLock;
+  stateStore: Pick<PlanningStateStore, "replace">;
+  now: () => Date;
+}): Promise<PlanningStateV1> {
+  const next = nextState(input.state, input.phaseIndex, input.phase, input.now);
+  return input.stateStore.replace({
+    issueNumber: input.state.issueNumber,
+    expectedRunId: input.state.runId,
+    expectedRevision: input.state.revision,
+    next,
+    lock: input.lock,
+  });
+}
+export async function publishPlanningPhase(input: {
+  state: PlanningStateV1;
+  phaseIndex: number;
+  lock: PlanningIssueLock;
+  stateStore: Pick<PlanningStateStore, "replace">;
+  host: PullRequestHost;
+  git: Pick<
+    PlanningPublicationOperations,
+    "verifyWorkspace" | "inspectRemoteHead" | "ensureRemoteHead"
+  >;
+  workspaces: PlanningWorkspaceLifecycle;
+  now?: () => Date;
+}): Promise<PlanningPhasePublicationResult> {
+  const now = input.now ?? (() => new Date());
+  let state = input.state;
+  let phase = state.phases[input.phaseIndex];
+  if (phase === undefined || phase.kind === "implementation")
+    throw new RangeError("Planning phase is not publishable");
+  const phaseKind = phase.kind as "spec" | "plan";
+  if (phase.status === "workspace-ready") {
+    if (phase.artifacts.length === 0)
+      throw new Error("Planning workspace artifacts are incomplete");
+    await input.workspaces.resume({
+      runId: state.runId,
+      phase: phase.kind,
+      identity: phase.workspace.identity,
+      base: phase.base,
+      saved: phase.workspace,
+    });
+    await input.git.verifyWorkspace({
+      workspacePath: phase.workspace.identity.worktreePath,
+      baseOid: phase.base.baseOid,
+      headOid: phase.workspace.headOid,
+      artifactPaths: phase.artifacts.map((artifact) => artifact.path),
+    });
+    const targetRepository = await input.host.resolveTargetRepositoryIdentity();
+    const headRepository = await input.host.resolveRemoteRepositoryIdentity(
+      phase.base.remote,
+    );
+    const publication = {
+      targetRepository,
+      headRepository,
+      baseBranch: phase.base.baseBranch,
+      headBranch: phase.workspace.identity.branch,
+      headOid: phase.workspace.headOid,
+    };
+    assertPlanningPublicationRepositories(publication);
+    await input.git.ensureRemoteHead({
+      remote: phase.base.remote,
+      branch: phase.workspace.identity.branch,
+      headOid: phase.workspace.headOid,
+    });
+    phase = { ...phase, status: "branch-pushed", publication };
+    state = await replace({
+      state,
+      phaseIndex: input.phaseIndex,
+      phase,
+      lock: input.lock,
+      stateStore: input.stateStore,
+      now,
+    });
+  }
+  if (phase.status === "branch-pushed") {
+    const matches = await input.host.findPullRequests({
+      targetRepository: phase.publication.targetRepository,
+      baseBranch: phase.publication.baseBranch,
+      headRepository: phase.publication.headRepository,
+      headBranch: phase.publication.headBranch,
+    });
+    if (matches.length > 1)
+      return { kind: "ambiguous", state, pullRequests: matches };
+    let summary: PullRequestSummary;
+    if (matches.length === 1) summary = matches[0]!;
+    else
+      summary = await input.host.createPullRequest({
+        title: planningPullRequestTitle({
+          issueNumber: state.issueNumber,
+          phase: phaseKind,
+        }),
+        body: planningPullRequestBody({
+          issueNumber: state.issueNumber,
+          phase: phaseKind,
+          artifactPaths: phase.artifacts.map((artifact) => artifact.path),
+        }),
+        baseBranch: phase.publication.baseBranch,
+        headBranch: phase.publication.headBranch,
+      });
+    const validated = validatePlanningPullRequestSummary({
+      summary,
+      issueNumber: state.issueNumber,
+      phase: phaseKind,
+      publication: phase.publication,
+    });
+    const readBack = await input.host.getPullRequest(validated.reference);
+    const confirmed = validatePlanningPullRequestSummary({
+      summary: readBack,
+      issueNumber: state.issueNumber,
+      phase: phaseKind,
+      publication: phase.publication,
+      expectedReference: validated.reference,
+    });
+    phase = {
+      ...phase,
+      status: "pull-request-open",
+      pullRequest: { reference: confirmed.reference, url: confirmed.url },
+    };
+    state = await replace({
+      state,
+      phaseIndex: input.phaseIndex,
+      phase,
+      lock: input.lock,
+      stateStore: input.stateStore,
+      now,
+    });
+  }
+  if (phase.status !== "pull-request-open")
+    throw new Error("Planning phase publication state is invalid");
+  let pullRequest = await input.host.getPullRequest(
+    phase.pullRequest.reference,
+  );
+  validatePlanningPullRequestSummary({
+    summary: pullRequest,
+    issueNumber: state.issueNumber,
+    phase: phaseKind,
+    publication: phase.publication,
+    expectedReference: phase.pullRequest.reference,
+  });
+  phase = await finishPlanningPhaseCleanup({
+    phase,
+    workspaces: input.workspaces,
+    remoteHead: async (published) => {
+      const head = await input.git.inspectRemoteHead({
+        remote: published.base.remote,
+        branch: published.workspace.identity.branch,
+      });
+      if (
+        head.state !== "present" ||
+        head.headOid !== published.publication.headOid
+      )
+        throw new Error("Planning remote head changed");
+    },
+    checkpoint: async (next) => {
+      state = await replace({
+        state,
+        phaseIndex: input.phaseIndex,
+        phase: next,
+        lock: input.lock,
+        stateStore: input.stateStore,
+        now,
+      });
+    },
+  });
+  pullRequest = await input.host.getPullRequest(phase.pullRequest.reference);
+  return { kind: "published", state, pullRequest };
+}

--- a/src/cli/commands/run-once/planning-phase-publisher.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.ts
@@ -5,6 +5,7 @@ import type {
   PullRequestSummary,
 } from "../../../host/pull-requests.ts";
 import {
+  planningPhasePlan,
   planningPullRequestBody,
   planningPullRequestTitle,
 } from "../../../workflow/planning-pull-requests.ts";
@@ -82,8 +83,15 @@ export async function publishPlanningPhase(input: {
   if (phase === undefined || phase.kind === "implementation")
     throw new RangeError("Planning phase is not publishable");
   const phaseKind = phase.kind as "spec" | "plan";
+  const assignedArtifacts = planningPhasePlan(state.gates)[input.phaseIndex]!
+    .artifactKinds;
   if (phase.status === "workspace-ready") {
-    if (phase.artifacts.length === 0)
+    if (
+      phase.artifacts.length !== assignedArtifacts.length ||
+      phase.artifacts.some(
+        (artifact, index) => artifact.kind !== assignedArtifacts[index],
+      )
+    )
       throw new Error("Planning workspace artifacts are incomplete");
     await input.workspaces.resume({
       runId: state.runId,
@@ -216,5 +224,12 @@ export async function publishPlanningPhase(input: {
     },
   });
   pullRequest = await input.host.getPullRequest(phase.pullRequest.reference);
+  validatePlanningPullRequestSummary({
+    summary: pullRequest,
+    issueNumber: state.issueNumber,
+    phase: phaseKind,
+    publication: phase.publication,
+    expectedReference: phase.pullRequest.reference,
+  });
   return { kind: "published", state, pullRequest };
 }

--- a/src/cli/commands/run-once/planning-phase-publisher.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.ts
@@ -134,6 +134,15 @@ export async function publishPlanningPhase(input: {
     });
   }
   if (phase.status === "branch-pushed") {
+    const remoteHead = await input.git.inspectRemoteHead({
+      remote: phase.base.remote,
+      branch: phase.workspace.identity.branch,
+    });
+    if (
+      remoteHead.state !== "present" ||
+      remoteHead.headOid !== phase.publication.headOid
+    )
+      throw new Error("Planning remote head changed");
     const matches = await input.host.findPullRequests({
       targetRepository: phase.publication.targetRepository,
       baseBranch: phase.publication.baseBranch,

--- a/src/cli/commands/run-once/planning-phase-reconciler.real.test.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.real.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { PlanningPublicationGit } from "../../../git/planning-publication-git.ts";
+import { PlanningRemoteBaseGit } from "../../../git/planning-remote-base.ts";
+import { renderPlanningPullRequestMarker } from "../../../workflow/planning-pull-request-markers.ts";
+import { reconcilePlanningPhase } from "./planning-phase-reconciler.ts";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function commandRunner(calls: string[][]) {
+  return {
+    async run(command: string, args: string[], options?: { cwd?: string }) {
+      calls.push([command, ...args]);
+      try {
+        return {
+          code: 0,
+          stdout: execFileSync(command, args, {
+            cwd: options?.cwd,
+            encoding: "utf8",
+          }),
+          stderr: "",
+        };
+      } catch (error) {
+        const failure = error as {
+          status?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          code: failure.status ?? 1,
+          stdout: failure.stdout ?? "",
+          stderr: failure.stderr ?? "",
+        };
+      }
+    },
+  };
+}
+
+test("reconciliation trusts the fetched reviewed squash base artifact rather than the planning workspace blob", async () => {
+  const root = await mkdtemp(join(tmpdir(), "planning-reconcile-real-"));
+  const remote = join(root, "remote.git");
+  const repo = join(root, "repo");
+  const workspace = join(root, "workspace");
+  const commands: string[][] = [];
+  const repository = {
+    provider: "github-gh" as const,
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  };
+  try {
+    execFileSync("git", ["init", "--bare", "--initial-branch=main", remote]);
+    execFileSync("git", ["init", "-b", "main", repo]);
+    git(repo, "config", "user.name", "Patchmill Test");
+    git(repo, "config", "user.email", "patchmill@example.test");
+    await mkdir(join(repo, "docs/specs"), { recursive: true });
+    await writeFile(join(repo, "docs/specs/issue-188.md"), "base\n");
+    git(repo, "add", "docs/specs/issue-188.md");
+    git(repo, "commit", "-m", "base artifact");
+    const baseOid = git(repo, "rev-parse", "HEAD");
+    git(repo, "remote", "add", "origin", remote);
+    git(repo, "push", "origin", "main");
+    git(repo, "worktree", "add", "-b", "planning/spec", workspace, "HEAD");
+    await writeFile(join(workspace, "docs/specs/issue-188.md"), "planning A\n");
+    git(workspace, "commit", "-am", "planning artifact A");
+    const planningOid = git(workspace, "rev-parse", "HEAD");
+    const runner = commandRunner(commands);
+    const publication = new PlanningPublicationGit({ repoRoot: repo, runner });
+    await publication.ensureRemoteHead({
+      remote: "origin",
+      branch: "planning/spec",
+      headOid: planningOid,
+    });
+
+    git(repo, "merge", "--squash", "planning/spec");
+    await writeFile(join(repo, "docs/specs/issue-188.md"), "reviewed B\n");
+    git(repo, "add", "docs/specs/issue-188.md");
+    git(repo, "commit", "-m", "reviewed squash merge");
+    const reviewedBaseOid = git(repo, "rev-parse", "HEAD");
+    git(repo, "push", "origin", "main");
+
+    const initial = {
+      version: 1 as const,
+      workflowVersion: "planning-pr-v1" as const,
+      runId: "123e4567-e89b-42d3-a456-426614174000",
+      issueNumber: 188,
+      issueTitle: "Example",
+      gates: { specRequired: true, planRequired: false },
+      revision: 2,
+      createdAt: "2026-09-08T12:00:00.000Z",
+      updatedAt: "2026-09-08T12:00:00.000Z",
+      phases: [
+        {
+          kind: "spec" as const,
+          status: "pull-request-open" as const,
+          base: {
+            remote: "origin",
+            baseBranch: "main",
+            baseOid,
+            artifactCandidates: { spec: [], plan: [] },
+          },
+          workspace: {
+            runId: "123e4567-e89b-42d3-a456-426614174000",
+            phase: "spec" as const,
+            identity: { branch: "planning/spec", worktreePath: workspace },
+            remote: "origin",
+            baseBranch: "main",
+            baseOid,
+            headOid: planningOid,
+            cleanup: { state: "removed" as const, pushedHeadOid: planningOid },
+          },
+          artifacts: [
+            {
+              kind: "spec" as const,
+              path: "docs/specs/issue-188.md",
+              source: "workspace" as const,
+              commitOid: planningOid,
+            },
+          ],
+          publication: {
+            targetRepository: repository,
+            headRepository: repository,
+            baseBranch: "main",
+            headBranch: "planning/spec",
+            headOid: planningOid,
+          },
+          pullRequest: {
+            reference: { targetRepository: repository, number: 188 },
+            url: "https://github.com/acme/patchmill/pull/188",
+          },
+        },
+        { kind: "implementation" as const, status: "pending" as const },
+      ],
+    };
+    const merged = {
+      number: 188,
+      url: "https://github.com/acme/patchmill/pull/188",
+      status: "merged" as const,
+      mergeCommit: reviewedBaseOid,
+      targetRepository: repository,
+      baseBranch: "main",
+      headRepository: repository,
+      headBranch: "planning/spec",
+      headSha: planningOid,
+      body: renderPlanningPullRequestMarker({
+        issueNumber: 188,
+        phase: "spec",
+      }),
+    };
+    const result = await reconcilePlanningPhase({
+      state: initial,
+      phaseIndex: 0,
+      lock: {} as never,
+      stateStore: {
+        async replace({ next }) {
+          return next;
+        },
+      },
+      host: {
+        async getPullRequest() {
+          return merged;
+        },
+      } as never,
+      remoteBase: new PlanningRemoteBaseGit({
+        runner,
+        repoRoot: repo,
+        specsDir: "docs/specs",
+        plansDir: "docs/plans",
+      }),
+      git: publication,
+      workspaces: {} as never,
+    });
+
+    assert.deepEqual(result.outcome, {
+      kind: "merged",
+      pullRequest: merged,
+      baseOid: reviewedBaseOid,
+    });
+    const phase = result.state.phases[0]!;
+    assert.equal(phase.status, "complete");
+    assert.deepEqual(phase.artifacts, [
+      {
+        kind: "spec",
+        path: "docs/specs/issue-188.md",
+        source: "remote-base",
+        commitOid: reviewedBaseOid,
+      },
+    ]);
+    assert.deepEqual(phase.completion, {
+      kind: "merged-pull-request",
+      mergeOid: reviewedBaseOid,
+      mergedBaseOid: reviewedBaseOid,
+    });
+    assert.equal(
+      commands.some((command) => command.includes(planningOid)),
+      false,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/cli/commands/run-once/planning-phase-reconciler.test.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.test.ts
@@ -1,232 +1,432 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { PullRequestNotFoundError } from "../../../host/pull-requests.ts";
+import {
+  IncompletePullRequestSearchError,
+  PullRequestNotFoundError,
+  type PullRequestSummary,
+} from "../../../host/pull-requests.ts";
 import { renderPlanningPullRequestMarker } from "../../../workflow/planning-pull-request-markers.ts";
 import { reconcilePlanningPhase } from "./planning-phase-reconciler.ts";
 
-const oid = "a".repeat(40);
-const state = {
-  version: 1 as const,
-  workflowVersion: "planning-pr-v1" as const,
-  runId: "123e4567-e89b-42d3-a456-426614174000",
-  issueNumber: 188,
-  issueTitle: "Example",
-  gates: { specRequired: true, planRequired: false },
-  revision: 0,
-  createdAt: "2026-09-08T12:00:00.000Z",
-  updatedAt: "2026-09-08T12:00:00.000Z",
-  phases: [
-    {
-      kind: "spec" as const,
-      status: "complete" as const,
-      base: {
-        remote: "origin",
-        baseBranch: "main",
-        baseOid: oid,
-        artifactCandidates: { spec: ["docs/specs/example.md"], plan: [] },
-      },
-      artifacts: [
-        {
-          kind: "spec" as const,
-          path: "docs/specs/example.md",
-          source: "remote-base" as const,
-          commitOid: oid,
-        },
-      ],
-      completion: { kind: "remote-base" as const },
-    },
-    { kind: "implementation" as const, status: "pending" as const },
-  ],
+const baseOid = "a".repeat(40);
+const headOid = "b".repeat(40);
+const mergeOid = "c".repeat(40);
+const mergedBaseOid = "d".repeat(40);
+const repository = {
+  provider: "github-gh" as const,
+  host: "github.com",
+  owner: "acme",
+  repository: "patchmill",
 };
-test("uses the branch discovery read-back for cleanup and classification", async () => {
-  const repository = {
-    provider: "github-gh" as const,
-    host: "github.com",
-    owner: "acme",
-    repository: "patchmill",
-  };
-  const published = {
-    ...state,
-    phases: [
-      {
-        kind: "spec" as const,
-        status: "branch-pushed" as const,
-        base: {
-          ...state.phases[0]!.base,
-          artifactCandidates: { spec: [], plan: [] },
-        },
-        workspace: {
-          runId: state.runId,
-          phase: "spec" as const,
-          identity: { branch: "planning/spec", worktreePath: "/workspace" },
-          remote: "origin",
-          baseBranch: "main",
-          baseOid: oid,
-          headOid: oid,
-          cleanup: { state: "ready" as const },
-        },
-        artifacts: [
-          {
-            kind: "spec" as const,
-            path: "docs/specs/example.md",
-            source: "workspace" as const,
-            commitOid: oid,
-          },
-        ],
-        publication: {
-          targetRepository: repository,
-          headRepository: repository,
-          baseBranch: "main",
-          headBranch: "planning/spec",
-          headOid: oid,
-        },
-      },
-      { kind: "implementation" as const, status: "pending" as const },
-    ],
-  };
-  const summary = {
+const reference = { targetRepository: repository, number: 188 };
+
+function summary(
+  status: PullRequestSummary["status"] = "open",
+): PullRequestSummary {
+  const common = {
     number: 188,
     url: "https://github.com/acme/patchmill/pull/188",
     targetRepository: repository,
     headRepository: repository,
-    baseBranch: "main",
+    baseBranch: "saved-main",
     headBranch: "planning/spec",
-    headSha: oid,
+    headSha: headOid,
     body: renderPlanningPullRequestMarker({ issueNumber: 188, phase: "spec" }),
-    status: "open" as const,
   };
-  let getCalls = 0;
-  const result = await reconcilePlanningPhase({
-    state: published,
-    phaseIndex: 0,
-    lock: {} as never,
-    stateStore: {
-      async replace({ next }) {
-        return next;
-      },
+  return status === "merged"
+    ? { ...common, status, mergeCommit: mergeOid }
+    : { ...common, status };
+}
+
+function base() {
+  return {
+    remote: "saved-origin",
+    baseBranch: "saved-main",
+    baseOid,
+    artifactCandidates: { spec: [], plan: [] },
+  };
+}
+
+function workspace(
+  cleanup: "ready" | "worktree-removed" | "removed" = "ready",
+) {
+  return {
+    runId: "123e4567-e89b-42d3-a456-426614174000",
+    phase: "spec" as const,
+    identity: { branch: "planning/spec", worktreePath: "/workspace" },
+    remote: "saved-origin",
+    baseBranch: "saved-main",
+    baseOid,
+    headOid,
+    cleanup:
+      cleanup === "ready"
+        ? ({ state: "ready" } as const)
+        : ({ state: cleanup, pushedHeadOid: headOid } as const),
+  };
+}
+
+function artifacts() {
+  return [
+    {
+      kind: "spec" as const,
+      path: "docs/specs/example.md",
+      source: "workspace" as const,
+      commitOid: headOid,
     },
-    host: {
-      async findPullRequests() {
-        return [summary];
-      },
-      async getPullRequest() {
-        getCalls += 1;
-        return summary;
-      },
-    } as never,
-    remoteBase: {} as never,
-    git: {
-      async inspectRemoteHead() {
-        return { state: "present" as const, headOid: oid };
-      },
-    } as never,
-    workspaces: { async removeWorktree() {}, async removeBranch() {} } as never,
-  });
-  assert.equal(result.outcome.kind, "review-pending");
-  assert.equal(getCalls, 1);
-});
-test("maps only typed saved-reference absence to missing without cleanup", async () => {
-  const repository = {
-    provider: "github-gh" as const,
-    host: "github.com",
-    owner: "acme",
-    repository: "patchmill",
+  ];
+}
+
+function publication() {
+  return {
+    targetRepository: repository,
+    headRepository: repository,
+    baseBranch: "saved-main",
+    headBranch: "planning/spec",
+    headOid,
   };
-  const reference = { targetRepository: repository, number: 188 };
-  const saved = {
-    ...state,
-    phases: [
-      {
-        kind: "spec" as const,
-        status: "pull-request-open" as const,
-        base: {
-          ...state.phases[0]!.base,
-          artifactCandidates: { spec: [], plan: [] },
-        },
-        workspace: {
-          runId: state.runId,
-          phase: "spec" as const,
-          identity: { branch: "planning/spec", worktreePath: "/workspace" },
-          remote: "origin",
-          baseBranch: "main",
-          baseOid: oid,
-          headOid: oid,
-          cleanup: { state: "removed" as const, pushedHeadOid: oid },
-        },
-        artifacts: [
-          {
-            kind: "spec" as const,
-            path: "docs/specs/example.md",
-            source: "workspace" as const,
-            commitOid: oid,
+}
+
+function planningState(
+  phase:
+    | "remote-base"
+    | "branch-pushed"
+    | "open-ready"
+    | "open-worktree-removed"
+    | "open-removed" = "open-ready",
+) {
+  const first =
+    phase === "remote-base"
+      ? {
+          kind: "spec" as const,
+          status: "complete" as const,
+          base: {
+            ...base(),
+            artifactCandidates: { spec: ["docs/specs/example.md"], plan: [] },
           },
-        ],
-        publication: {
-          targetRepository: repository,
-          headRepository: repository,
-          baseBranch: "main",
-          headBranch: "planning/spec",
-          headOid: oid,
-        },
-        pullRequest: {
-          reference,
-          url: "https://github.com/acme/patchmill/pull/188",
-        },
-      },
+          artifacts: [
+            {
+              ...artifacts()[0]!,
+              source: "remote-base" as const,
+              commitOid: baseOid,
+            },
+          ],
+          completion: { kind: "remote-base" as const },
+        }
+      : phase === "branch-pushed"
+        ? {
+            kind: "spec" as const,
+            status: "branch-pushed" as const,
+            base: base(),
+            workspace: workspace(),
+            artifacts: artifacts(),
+            publication: publication(),
+          }
+        : {
+            kind: "spec" as const,
+            status: "pull-request-open" as const,
+            base: base(),
+            workspace: workspace(
+              phase === "open-ready"
+                ? "ready"
+                : phase === "open-worktree-removed"
+                  ? "worktree-removed"
+                  : "removed",
+            ),
+            artifacts: artifacts(),
+            publication: publication(),
+            pullRequest: {
+              reference,
+              url: "https://github.com/acme/patchmill/pull/188",
+            },
+          };
+  return {
+    version: 1 as const,
+    workflowVersion: "planning-pr-v1" as const,
+    runId: "123e4567-e89b-42d3-a456-426614174000",
+    issueNumber: 188,
+    issueTitle: "Example",
+    gates: { specRequired: true, planRequired: false },
+    revision: 0,
+    createdAt: "2026-09-08T12:00:00.000Z",
+    updatedAt: "2026-09-08T12:00:00.000Z",
+    phases: [
+      first,
       { kind: "implementation" as const, status: "pending" as const },
     ],
   };
-  const bytes = JSON.stringify(saved);
-  const missing = await reconcilePlanningPhase({
-    state: saved,
-    phaseIndex: 0,
-    lock: {} as never,
-    stateStore: {
-      async replace() {
-        throw new Error("unexpected");
-      },
-    },
-    host: {
-      async getPullRequest() {
-        throw new PullRequestNotFoundError(reference);
-      },
-    } as never,
-    remoteBase: {} as never,
-    git: {} as never,
-    workspaces: {} as never,
-  });
-  assert.equal(missing.outcome.kind, "missing");
-  assert.equal(JSON.stringify(saved), bytes);
-  await assert.rejects(
-    () =>
-      reconcilePlanningPhase({
-        state: saved,
-        phaseIndex: 0,
-        lock: {} as never,
-        stateStore: {} as never,
-        host: {
-          async getPullRequest() {
-            throw new Error("transport");
-          },
-        } as never,
-        remoteBase: {} as never,
-        git: {} as never,
-        workspaces: {} as never,
-      }),
-    /transport/,
-  );
-  assert.equal(JSON.stringify(saved), bytes);
-});
-test("returns remote-base completion without host or Git effects", async () => {
-  const result = await reconcilePlanningPhase({
+}
+
+function fixture(
+  input: {
+    state?: ReturnType<typeof planningState>;
+    pullRequest?: PullRequestSummary;
+    matches?: readonly PullRequestSummary[];
+    getError?: Error;
+    findError?: Error;
+    removeWorktreeError?: Error;
+    removeBranchError?: Error;
+    replaceErrorAt?: number;
+    fetchError?: Error;
+    ancestorError?: Error;
+    regularError?: Error;
+  } = {},
+) {
+  const events: string[] = [];
+  let replacements = 0;
+  const state = input.state ?? planningState();
+  const pullRequest = input.pullRequest ?? summary();
+  return {
     state,
-    phaseIndex: 0,
-    lock: {} as never,
-    stateStore: {} as never,
-    host: {} as never,
-    remoteBase: {} as never,
-    git: {} as never,
-    workspaces: {} as never,
-  });
+    events,
+    input: {
+      state,
+      phaseIndex: 0,
+      lock: {} as never,
+      stateStore: {
+        async replace({ next }: { next: typeof state }) {
+          replacements += 1;
+          events.push(
+            `replace:${next.phases[0]!.status}:${"completion" in next.phases[0]! ? "complete" : (next.phases[0]!.workspace?.cleanup.state ?? "ready")}`,
+          );
+          if (replacements === input.replaceErrorAt)
+            throw new Error("store failed");
+          return next;
+        },
+      },
+      host: {
+        async findPullRequests() {
+          events.push("find");
+          if (input.findError) throw input.findError;
+          return input.matches ?? [pullRequest];
+        },
+        async getPullRequest() {
+          events.push("get");
+          if (input.getError) throw input.getError;
+          return pullRequest;
+        },
+      } as never,
+      remoteBase: {
+        async fetch(value: { remote: string; baseBranch: string }) {
+          events.push(`fetch:${value.remote}:${value.baseBranch}`);
+          if (input.fetchError) throw input.fetchError;
+          return { ...base(), baseOid: mergedBaseOid };
+        },
+      },
+      git: {
+        async inspectRemoteHead() {
+          events.push("remote-head");
+          return { state: "present" as const, headOid };
+        },
+        async assertAncestor(value: {
+          ancestorOid: string;
+          descendantOid: string;
+        }) {
+          events.push(`ancestor:${value.ancestorOid}:${value.descendantOid}`);
+          if (input.ancestorError) throw input.ancestorError;
+        },
+        async assertRegularFiles(value: { commitOid: string }) {
+          events.push(`regular:${value.commitOid}`);
+          if (input.regularError) throw input.regularError;
+        },
+      },
+      workspaces: {
+        async removeWorktree() {
+          events.push("remove-worktree");
+          if (input.removeWorktreeError) throw input.removeWorktreeError;
+        },
+        async removeBranch() {
+          events.push("remove-branch");
+          if (input.removeBranchError) throw input.removeBranchError;
+        },
+      } as never,
+    },
+  };
+}
+
+test("returns remote-base completion without host or local effects", async () => {
+  const testFixture = fixture({ state: planningState("remote-base") });
+  const result = await reconcilePlanningPhase(testFixture.input);
   assert.equal(result.outcome.kind, "satisfied-by-base");
+  assert.deepEqual(testFixture.events, []);
+});
+
+test("classifies open and closed pull requests only after both cleanup checkpoints", async () => {
+  for (const [status, outcome] of [
+    ["open", "review-pending"],
+    ["closed-unmerged", "closed-unmerged"],
+  ] as const) {
+    const testFixture = fixture({ pullRequest: summary(status) });
+    const result = await reconcilePlanningPhase(testFixture.input);
+    assert.equal(result.outcome.kind, outcome);
+    assert.deepEqual(testFixture.events, [
+      "get",
+      "remote-head",
+      "remove-worktree",
+      "replace:pull-request-open:worktree-removed",
+      "remove-branch",
+      "replace:pull-request-open:removed",
+    ]);
+    assert.equal(result.state.phases[0]!.workspace!.cleanup.state, "removed");
+  }
+});
+
+test("classifies branch-pushed discovery outcomes without replacement creation", async () => {
+  for (const [matches, kind] of [
+    [[], "missing"],
+    [[summary(), summary()], "ambiguous"],
+  ] as const) {
+    const testFixture = fixture({
+      state: planningState("branch-pushed"),
+      matches,
+    });
+    const result = await reconcilePlanningPhase(testFixture.input);
+    assert.equal(result.outcome.kind, kind);
+    assert.deepEqual(testFixture.events, ["find"]);
+  }
+});
+
+test("adopts one discovered pull request, checkpoints identity, cleans up, and classifies it", async () => {
+  const testFixture = fixture({ state: planningState("branch-pushed") });
+  const result = await reconcilePlanningPhase(testFixture.input);
+  assert.equal(result.outcome.kind, "review-pending");
+  assert.deepEqual(testFixture.events, [
+    "find",
+    "get",
+    "replace:pull-request-open:ready",
+    "remote-head",
+    "remove-worktree",
+    "replace:pull-request-open:worktree-removed",
+    "remove-branch",
+    "replace:pull-request-open:removed",
+  ]);
+});
+
+test("maps only typed get absence to missing and leaves host failures byte-identical", async () => {
+  const saved = planningState("open-removed");
+  const bytes = JSON.stringify(saved);
+  const missingFixture = fixture({
+    state: saved,
+    getError: new PullRequestNotFoundError(reference),
+  });
+  const missing = await reconcilePlanningPhase(missingFixture.input);
+  assert.deepEqual(missing.outcome, { kind: "missing", reference });
+  assert.deepEqual(missingFixture.events, ["get"]);
+  assert.equal(JSON.stringify(saved), bytes);
+  for (const error of [
+    new Error("transport"),
+    new IncompletePullRequestSearchError({
+      targetRepository: repository,
+      baseBranch: "saved-main",
+      headRepository: repository,
+      headBranch: "planning/spec",
+    }),
+  ]) {
+    const testFixture = fixture({
+      state: planningState("open-ready"),
+      getError: error,
+    });
+    const before = JSON.stringify(testFixture.state);
+    await assert.rejects(
+      () => reconcilePlanningPhase(testFixture.input),
+      error,
+    );
+    assert.equal(JSON.stringify(testFixture.state), before);
+    assert.deepEqual(testFixture.events, ["get"]);
+  }
+});
+
+test("does not treat incomplete branch discovery as absence", async () => {
+  const error = new IncompletePullRequestSearchError({
+    targetRepository: repository,
+    baseBranch: "saved-main",
+    headRepository: repository,
+    headBranch: "planning/spec",
+  });
+  const testFixture = fixture({
+    state: planningState("branch-pushed"),
+    findError: error,
+  });
+  await assert.rejects(() => reconcilePlanningPhase(testFixture.input), error);
+  assert.deepEqual(testFixture.events, ["find"]);
+});
+
+test("stops cleanup at each durable boundary when removal or checkpoint fails", async () => {
+  for (const input of [
+    { removeWorktreeError: new Error("dirty") },
+    { replaceErrorAt: 1 },
+    { removeBranchError: new Error("branch failed") },
+    { replaceErrorAt: 2 },
+  ]) {
+    const testFixture = fixture(input);
+    await assert.rejects(() => reconcilePlanningPhase(testFixture.input));
+    const branch = testFixture.events.indexOf("remove-branch");
+    const failedFirstCheckpoint = input.replaceErrorAt === 1;
+    if (input.removeWorktreeError || failedFirstCheckpoint)
+      assert.equal(branch, -1);
+    assert.equal(
+      testFixture.events.includes(`fetch:saved-origin:saved-main`),
+      false,
+    );
+  }
+  const retryFixture = fixture({
+    state: planningState("open-worktree-removed"),
+  });
+  const result = await reconcilePlanningPhase(retryFixture.input);
+  assert.equal(result.outcome.kind, "review-pending");
+  assert.deepEqual(retryFixture.events, [
+    "get",
+    "remove-branch",
+    "replace:pull-request-open:removed",
+  ]);
+});
+
+test("proves and persists merged base artifacts without consulting workspace blobs", async () => {
+  const testFixture = fixture({ pullRequest: summary("merged") });
+  const result = await reconcilePlanningPhase(testFixture.input);
+  assert.equal(result.outcome.kind, "merged");
+  assert.deepEqual(testFixture.events, [
+    "get",
+    "remote-head",
+    "remove-worktree",
+    "replace:pull-request-open:worktree-removed",
+    "remove-branch",
+    "replace:pull-request-open:removed",
+    "fetch:saved-origin:saved-main",
+    `ancestor:${mergeOid}:${mergedBaseOid}`,
+    `regular:${mergeOid}`,
+    `regular:${mergedBaseOid}`,
+    "replace:complete:complete",
+  ]);
+  const phase = result.state.phases[0]!;
+  assert.equal(phase.status, "complete");
+  assert.deepEqual(phase.completion, {
+    kind: "merged-pull-request",
+    mergeOid,
+    mergedBaseOid,
+  });
+  assert.deepEqual(phase.artifacts, [
+    {
+      kind: "spec",
+      path: "docs/specs/example.md",
+      source: "remote-base",
+      commitOid: mergedBaseOid,
+    },
+  ]);
+  assert.equal(
+    testFixture.events.some((event) => event.includes(headOid)),
+    false,
+  );
+});
+
+test("keeps the published phase incomplete when merge proof fails", async () => {
+  const testFixture = fixture({
+    pullRequest: summary("merged"),
+    ancestorError: new Error("not ancestor"),
+  });
+  await assert.rejects(
+    () => reconcilePlanningPhase(testFixture.input),
+    /not ancestor/,
+  );
+  assert.equal(testFixture.events.includes("replace:complete:complete"), false);
+  assert.equal(testFixture.events.includes(`regular:${mergeOid}`), false);
 });

--- a/src/cli/commands/run-once/planning-phase-reconciler.test.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { renderPlanningPullRequestMarker } from "../../../workflow/planning-pull-request-markers.ts";
 import { reconcilePlanningPhase } from "./planning-phase-reconciler.ts";
 
 const oid = "a".repeat(40);
@@ -36,6 +37,93 @@ const state = {
     { kind: "implementation" as const, status: "pending" as const },
   ],
 };
+test("uses the branch discovery read-back for cleanup and classification", async () => {
+  const repository = {
+    provider: "github-gh" as const,
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  };
+  const published = {
+    ...state,
+    phases: [
+      {
+        kind: "spec" as const,
+        status: "branch-pushed" as const,
+        base: {
+          ...state.phases[0]!.base,
+          artifactCandidates: { spec: [], plan: [] },
+        },
+        workspace: {
+          runId: state.runId,
+          phase: "spec" as const,
+          identity: { branch: "planning/spec", worktreePath: "/workspace" },
+          remote: "origin",
+          baseBranch: "main",
+          baseOid: oid,
+          headOid: oid,
+          cleanup: { state: "ready" as const },
+        },
+        artifacts: [
+          {
+            kind: "spec" as const,
+            path: "docs/specs/example.md",
+            source: "workspace" as const,
+            commitOid: oid,
+          },
+        ],
+        publication: {
+          targetRepository: repository,
+          headRepository: repository,
+          baseBranch: "main",
+          headBranch: "planning/spec",
+          headOid: oid,
+        },
+      },
+      { kind: "implementation" as const, status: "pending" as const },
+    ],
+  };
+  const summary = {
+    number: 188,
+    url: "https://github.com/acme/patchmill/pull/188",
+    targetRepository: repository,
+    headRepository: repository,
+    baseBranch: "main",
+    headBranch: "planning/spec",
+    headSha: oid,
+    body: renderPlanningPullRequestMarker({ issueNumber: 188, phase: "spec" }),
+    status: "open" as const,
+  };
+  let getCalls = 0;
+  const result = await reconcilePlanningPhase({
+    state: published,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace({ next }) {
+        return next;
+      },
+    },
+    host: {
+      async findPullRequests() {
+        return [summary];
+      },
+      async getPullRequest() {
+        getCalls += 1;
+        return summary;
+      },
+    } as never,
+    remoteBase: {} as never,
+    git: {
+      async inspectRemoteHead() {
+        return { state: "present" as const, headOid: oid };
+      },
+    } as never,
+    workspaces: { async removeWorktree() {}, async removeBranch() {} } as never,
+  });
+  assert.equal(result.outcome.kind, "review-pending");
+  assert.equal(getCalls, 1);
+});
 test("returns remote-base completion without host or Git effects", async () => {
   const result = await reconcilePlanningPhase({
     state,

--- a/src/cli/commands/run-once/planning-phase-reconciler.test.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { reconcilePlanningPhase } from "./planning-phase-reconciler.ts";
+
+const oid = "a".repeat(40);
+const state = {
+  version: 1 as const,
+  workflowVersion: "planning-pr-v1" as const,
+  runId: "123e4567-e89b-42d3-a456-426614174000",
+  issueNumber: 188,
+  issueTitle: "Example",
+  gates: { specRequired: true, planRequired: false },
+  revision: 0,
+  createdAt: "2026-09-08T12:00:00.000Z",
+  updatedAt: "2026-09-08T12:00:00.000Z",
+  phases: [
+    {
+      kind: "spec" as const,
+      status: "complete" as const,
+      base: {
+        remote: "origin",
+        baseBranch: "main",
+        baseOid: oid,
+        artifactCandidates: { spec: ["docs/specs/example.md"], plan: [] },
+      },
+      artifacts: [
+        {
+          kind: "spec" as const,
+          path: "docs/specs/example.md",
+          source: "remote-base" as const,
+          commitOid: oid,
+        },
+      ],
+      completion: { kind: "remote-base" as const },
+    },
+    { kind: "implementation" as const, status: "pending" as const },
+  ],
+};
+test("returns remote-base completion without host or Git effects", async () => {
+  const result = await reconcilePlanningPhase({
+    state,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {} as never,
+    host: {} as never,
+    remoteBase: {} as never,
+    git: {} as never,
+    workspaces: {} as never,
+  });
+  assert.equal(result.outcome.kind, "satisfied-by-base");
+});

--- a/src/cli/commands/run-once/planning-phase-reconciler.test.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { PullRequestNotFoundError } from "../../../host/pull-requests.ts";
 import { renderPlanningPullRequestMarker } from "../../../workflow/planning-pull-request-markers.ts";
 import { reconcilePlanningPhase } from "./planning-phase-reconciler.ts";
 
@@ -123,6 +124,98 @@ test("uses the branch discovery read-back for cleanup and classification", async
   });
   assert.equal(result.outcome.kind, "review-pending");
   assert.equal(getCalls, 1);
+});
+test("maps only typed saved-reference absence to missing without cleanup", async () => {
+  const repository = {
+    provider: "github-gh" as const,
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  };
+  const reference = { targetRepository: repository, number: 188 };
+  const saved = {
+    ...state,
+    phases: [
+      {
+        kind: "spec" as const,
+        status: "pull-request-open" as const,
+        base: {
+          ...state.phases[0]!.base,
+          artifactCandidates: { spec: [], plan: [] },
+        },
+        workspace: {
+          runId: state.runId,
+          phase: "spec" as const,
+          identity: { branch: "planning/spec", worktreePath: "/workspace" },
+          remote: "origin",
+          baseBranch: "main",
+          baseOid: oid,
+          headOid: oid,
+          cleanup: { state: "removed" as const, pushedHeadOid: oid },
+        },
+        artifacts: [
+          {
+            kind: "spec" as const,
+            path: "docs/specs/example.md",
+            source: "workspace" as const,
+            commitOid: oid,
+          },
+        ],
+        publication: {
+          targetRepository: repository,
+          headRepository: repository,
+          baseBranch: "main",
+          headBranch: "planning/spec",
+          headOid: oid,
+        },
+        pullRequest: {
+          reference,
+          url: "https://github.com/acme/patchmill/pull/188",
+        },
+      },
+      { kind: "implementation" as const, status: "pending" as const },
+    ],
+  };
+  const bytes = JSON.stringify(saved);
+  const missing = await reconcilePlanningPhase({
+    state: saved,
+    phaseIndex: 0,
+    lock: {} as never,
+    stateStore: {
+      async replace() {
+        throw new Error("unexpected");
+      },
+    },
+    host: {
+      async getPullRequest() {
+        throw new PullRequestNotFoundError(reference);
+      },
+    } as never,
+    remoteBase: {} as never,
+    git: {} as never,
+    workspaces: {} as never,
+  });
+  assert.equal(missing.outcome.kind, "missing");
+  assert.equal(JSON.stringify(saved), bytes);
+  await assert.rejects(
+    () =>
+      reconcilePlanningPhase({
+        state: saved,
+        phaseIndex: 0,
+        lock: {} as never,
+        stateStore: {} as never,
+        host: {
+          async getPullRequest() {
+            throw new Error("transport");
+          },
+        } as never,
+        remoteBase: {} as never,
+        git: {} as never,
+        workspaces: {} as never,
+      }),
+    /transport/,
+  );
+  assert.equal(JSON.stringify(saved), bytes);
 });
 test("returns remote-base completion without host or Git effects", async () => {
   const result = await reconcilePlanningPhase({

--- a/src/cli/commands/run-once/planning-phase-reconciler.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.ts
@@ -1,0 +1,219 @@
+import type { PlanningPublicationOperations } from "../../../git/planning-publication-git.ts";
+import type { PlanningRemoteBaseGit } from "../../../git/planning-remote-base.ts";
+import type { PlanningWorkspaceLifecycle } from "../../../git/planning-workspaces.ts";
+import {
+  PullRequestNotFoundError,
+  type PullRequestHost,
+  type PullRequestReference,
+  type PullRequestSummary,
+} from "../../../host/pull-requests.ts";
+import type { PlanningIssueLock } from "../../../workflow/planning-issue-lock.ts";
+import type { PlanningStateStore } from "../../../workflow/planning-state-store.ts";
+import type {
+  PlanningArtifactEvidence,
+  PlanningPhaseStateV1,
+  PlanningStateV1,
+  PullRequestOpenPlanningPhase,
+} from "../../../workflow/planning-state-types.ts";
+import { validatePlanningPullRequestSummary } from "../../../workflow/planning-pull-request-validation.ts";
+import { finishPlanningPhaseCleanup } from "./planning-phase-cleanup.ts";
+
+export type PlanningPhaseReconciliation =
+  | { kind: "review-pending"; pullRequest: PullRequestSummary }
+  | { kind: "merged"; pullRequest: PullRequestSummary; baseOid: string }
+  | {
+      kind: "satisfied-by-base";
+      artifacts: readonly PlanningArtifactEvidence[];
+    }
+  | { kind: "closed-unmerged"; pullRequest: PullRequestSummary }
+  | { kind: "missing"; reference?: PullRequestReference }
+  | { kind: "ambiguous"; pullRequests: readonly PullRequestSummary[] };
+function nextState(
+  state: PlanningStateV1,
+  index: number,
+  phase: PlanningPhaseStateV1,
+  now: () => Date,
+): PlanningStateV1 {
+  return {
+    ...state,
+    revision: state.revision + 1,
+    updatedAt: now().toISOString(),
+    phases: state.phases.map((item, offset) =>
+      offset === index ? phase : item,
+    ),
+  };
+}
+async function replace(
+  state: PlanningStateV1,
+  index: number,
+  phase: PlanningPhaseStateV1,
+  lock: PlanningIssueLock,
+  stateStore: Pick<PlanningStateStore, "replace">,
+  now: () => Date,
+): Promise<PlanningStateV1> {
+  const next = nextState(state, index, phase, now);
+  return stateStore.replace({
+    issueNumber: state.issueNumber,
+    expectedRunId: state.runId,
+    expectedRevision: state.revision,
+    next,
+    lock,
+  });
+}
+export async function reconcilePlanningPhase(input: {
+  state: PlanningStateV1;
+  phaseIndex: number;
+  lock: PlanningIssueLock;
+  stateStore: Pick<PlanningStateStore, "replace">;
+  host: PullRequestHost;
+  remoteBase: Pick<PlanningRemoteBaseGit, "fetch">;
+  git: Pick<
+    PlanningPublicationOperations,
+    "inspectRemoteHead" | "assertAncestor" | "assertRegularFiles"
+  >;
+  workspaces: PlanningWorkspaceLifecycle;
+  now?: () => Date;
+}): Promise<
+  Readonly<{ state: PlanningStateV1; outcome: PlanningPhaseReconciliation }>
+> {
+  const now = input.now ?? (() => new Date());
+  let state = input.state;
+  let phase = state.phases[input.phaseIndex];
+  if (phase === undefined)
+    throw new RangeError("Planning phase index is invalid");
+  if (phase.status === "complete" && phase.completion.kind === "remote-base")
+    return {
+      state,
+      outcome: { kind: "satisfied-by-base", artifacts: phase.artifacts },
+    };
+  if (phase.status === "branch-pushed") {
+    const matches = await input.host.findPullRequests({
+      targetRepository: phase.publication.targetRepository,
+      baseBranch: phase.publication.baseBranch,
+      headRepository: phase.publication.headRepository,
+      headBranch: phase.publication.headBranch,
+    });
+    if (matches.length === 0) return { state, outcome: { kind: "missing" } };
+    if (matches.length > 1)
+      return { state, outcome: { kind: "ambiguous", pullRequests: matches } };
+    const phaseKind = phase.kind as "spec" | "plan";
+    const found = validatePlanningPullRequestSummary({
+      summary: matches[0]!,
+      issueNumber: state.issueNumber,
+      phase: phaseKind,
+      publication: phase.publication,
+    });
+    const read = await input.host.getPullRequest(found.reference);
+    const confirmed = validatePlanningPullRequestSummary({
+      summary: read,
+      issueNumber: state.issueNumber,
+      phase: phaseKind,
+      publication: phase.publication,
+      expectedReference: found.reference,
+    });
+    phase = {
+      ...phase,
+      status: "pull-request-open",
+      pullRequest: { reference: confirmed.reference, url: confirmed.url },
+    };
+    state = await replace(
+      state,
+      input.phaseIndex,
+      phase,
+      input.lock,
+      input.stateStore,
+      now,
+    );
+  }
+  if (phase.status !== "pull-request-open")
+    throw new Error("Planning phase is not reconcilable");
+  const phaseKind = phase.kind as "spec" | "plan";
+  let pullRequest: PullRequestSummary;
+  try {
+    pullRequest = await input.host.getPullRequest(phase.pullRequest.reference);
+  } catch (error) {
+    if (error instanceof PullRequestNotFoundError)
+      return {
+        state,
+        outcome: { kind: "missing", reference: phase.pullRequest.reference },
+      };
+    throw error;
+  }
+  validatePlanningPullRequestSummary({
+    summary: pullRequest,
+    issueNumber: state.issueNumber,
+    phase: phaseKind,
+    publication: phase.publication,
+    expectedReference: phase.pullRequest.reference,
+  });
+  phase = await finishPlanningPhaseCleanup({
+    phase: phase as PullRequestOpenPlanningPhase,
+    workspaces: input.workspaces,
+    remoteHead: async (published) => {
+      const head = await input.git.inspectRemoteHead({
+        remote: published.base.remote,
+        branch: published.workspace.identity.branch,
+      });
+      if (
+        head.state !== "present" ||
+        head.headOid !== published.publication.headOid
+      )
+        throw new Error("Planning remote head changed");
+    },
+    checkpoint: async (next) => {
+      state = await replace(
+        state,
+        input.phaseIndex,
+        next,
+        input.lock,
+        input.stateStore,
+        now,
+      );
+    },
+  });
+  if (pullRequest.status === "open")
+    return { state, outcome: { kind: "review-pending", pullRequest } };
+  if (pullRequest.status === "closed-unmerged")
+    return { state, outcome: { kind: "closed-unmerged", pullRequest } };
+  const snapshot = await input.remoteBase.fetch({
+    issueNumber: state.issueNumber,
+    remote: phase.base.remote,
+    baseBranch: phase.base.baseBranch,
+  });
+  await input.git.assertAncestor({
+    ancestorOid: pullRequest.mergeCommit,
+    descendantOid: snapshot.baseOid,
+  });
+  const paths = phase.artifacts.map((artifact) => artifact.path);
+  await input.git.assertRegularFiles({
+    commitOid: pullRequest.mergeCommit,
+    paths,
+  });
+  await input.git.assertRegularFiles({ commitOid: snapshot.baseOid, paths });
+  const completed = {
+    ...phase,
+    status: "complete" as const,
+    artifacts: phase.artifacts.map((artifact) => ({
+      ...artifact,
+      source: "remote-base" as const,
+      commitOid: snapshot.baseOid,
+    })),
+    completion: {
+      kind: "merged-pull-request" as const,
+      mergeOid: pullRequest.mergeCommit,
+      mergedBaseOid: snapshot.baseOid,
+    },
+  } as PlanningPhaseStateV1;
+  state = await replace(
+    state,
+    input.phaseIndex,
+    completed,
+    input.lock,
+    input.stateStore,
+    now,
+  );
+  return {
+    state,
+    outcome: { kind: "merged", pullRequest, baseOid: snapshot.baseOid },
+  };
+}

--- a/src/cli/commands/run-once/planning-phase-reconciler.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.ts
@@ -88,6 +88,7 @@ export async function reconcilePlanningPhase(input: {
       state,
       outcome: { kind: "satisfied-by-base", artifacts: phase.artifacts },
     };
+  let pullRequest: PullRequestSummary | undefined;
   if (phase.status === "branch-pushed") {
     const matches = await input.host.findPullRequests({
       targetRepository: phase.publication.targetRepository,
@@ -123,6 +124,7 @@ export async function reconcilePlanningPhase(input: {
       publication: phase.publication,
       expectedReference: found.reference,
     });
+    pullRequest = confirmed.summary;
     phase = {
       ...phase,
       status: "pull-request-open",
@@ -140,16 +142,19 @@ export async function reconcilePlanningPhase(input: {
   if (phase.status !== "pull-request-open")
     throw new Error("Planning phase is not reconcilable");
   const phaseKind = phase.kind as "spec" | "plan";
-  let pullRequest: PullRequestSummary;
-  try {
-    pullRequest = await input.host.getPullRequest(phase.pullRequest.reference);
-  } catch (error) {
-    if (error instanceof PullRequestNotFoundError)
-      return {
-        state,
-        outcome: { kind: "missing", reference: phase.pullRequest.reference },
-      };
-    throw error;
+  if (pullRequest === undefined) {
+    try {
+      pullRequest = await input.host.getPullRequest(
+        phase.pullRequest.reference,
+      );
+    } catch (error) {
+      if (error instanceof PullRequestNotFoundError)
+        return {
+          state,
+          outcome: { kind: "missing", reference: phase.pullRequest.reference },
+        };
+      throw error;
+    }
   }
   validatePlanningPullRequestSummary({
     summary: pullRequest,

--- a/src/cli/commands/run-once/planning-phase-reconciler.ts
+++ b/src/cli/commands/run-once/planning-phase-reconciler.ts
@@ -81,6 +81,8 @@ export async function reconcilePlanningPhase(input: {
   let phase = state.phases[input.phaseIndex];
   if (phase === undefined)
     throw new RangeError("Planning phase index is invalid");
+  if (phase.kind === "implementation")
+    throw new RangeError("Planning phase is not reconcilable");
   if (phase.status === "complete" && phase.completion.kind === "remote-base")
     return {
       state,
@@ -103,7 +105,17 @@ export async function reconcilePlanningPhase(input: {
       phase: phaseKind,
       publication: phase.publication,
     });
-    const read = await input.host.getPullRequest(found.reference);
+    let read: PullRequestSummary;
+    try {
+      read = await input.host.getPullRequest(found.reference);
+    } catch (error) {
+      if (error instanceof PullRequestNotFoundError)
+        return {
+          state,
+          outcome: { kind: "missing", reference: found.reference },
+        };
+      throw error;
+    }
     const confirmed = validatePlanningPullRequestSummary({
       summary: read,
       issueNumber: state.issueNumber,

--- a/src/cli/commands/run-once/planning-review-context.test.ts
+++ b/src/cli/commands/run-once/planning-review-context.test.ts
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import {
-  buildPlanCreationPrompt,
-  buildSpecCreationPrompt,
+  planningReviewInstruction,
+  specSourceInstruction,
   type PlanningReviewContext,
-} from "./prompts.ts";
+} from "./planning-review-context.ts";
+import { buildSpecCreationPrompt } from "./prompts.ts";
 import type { IssueSummary } from "./types.ts";
 
 const issue: IssueSummary = {
@@ -24,7 +25,12 @@ const expected: ReadonlyArray<[PlanningReviewContext, RegExp]> = [
   ["merged-base", /verified merged-base spec/u],
   ["implementation-pull-request", /no planning pull request is created/u],
 ];
-test("renders context-specific plan spec sources", () => {
+test("renders context-specific planning review and spec-source policy", () => {
+  assert.equal(planningReviewInstruction("legacy-label"), undefined);
+  assert.match(
+    planningReviewInstruction("same-phase-pull-request") ?? "",
+    /do not call the spec already approved/u,
+  );
   const expectedPlanSources: ReadonlyArray<[PlanningReviewContext, RegExp]> = [
     ["dedicated-pull-request", /approved spec/u],
     ["same-phase-pull-request", /current-phase spec.*not yet approved/u],
@@ -33,14 +39,10 @@ test("renders context-specific plan spec sources", () => {
     ["legacy-label", /approved spec/u],
   ];
   for (const [reviewContext, pattern] of expectedPlanSources) {
-    const prompt = buildPlanCreationPrompt({
-      issue,
-      specPath: "docs/specs/example.md",
-      planPath: "docs/plans/example.md",
-      projectPolicy: DEFAULT_PATCHMILL_POLICY,
-      reviewContext,
-    });
-    assert.match(prompt, pattern);
+    assert.match(
+      specSourceInstruction(reviewContext, "docs/specs/example.md"),
+      pattern,
+    );
   }
 });
 test("renders explicit planning review contexts without changing legacy default", () => {

--- a/src/cli/commands/run-once/planning-review-context.test.ts
+++ b/src/cli/commands/run-once/planning-review-context.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
+import {
+  buildSpecCreationPrompt,
+  type PlanningReviewContext,
+} from "./prompts.ts";
+import type { IssueSummary } from "./types.ts";
+
+const issue: IssueSummary = {
+  number: 188,
+  title: "Example",
+  labels: [],
+  body: "",
+  state: "open",
+};
+const expected: ReadonlyArray<[PlanningReviewContext, RegExp]> = [
+  [
+    "dedicated-pull-request",
+    /Review this artifact in the current planning pull request/u,
+  ],
+  ["same-phase-pull-request", /do not call the spec already approved/u],
+  ["merged-base", /verified merged-base spec/u],
+  ["implementation-pull-request", /no planning pull request is created/u],
+];
+test("renders explicit planning review contexts without changing legacy default", () => {
+  const input = {
+    issue,
+    specPath: "docs/specs/example.md",
+    projectPolicy: DEFAULT_PATCHMILL_POLICY,
+  };
+  for (const [reviewContext, pattern] of expected)
+    assert.match(buildSpecCreationPrompt({ ...input, reviewContext }), pattern);
+  assert.doesNotMatch(
+    buildSpecCreationPrompt(input),
+    /current planning pull request/u,
+  );
+});

--- a/src/cli/commands/run-once/planning-review-context.test.ts
+++ b/src/cli/commands/run-once/planning-review-context.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_PATCHMILL_POLICY } from "../../../policy/defaults.ts";
 import {
+  buildPlanCreationPrompt,
   buildSpecCreationPrompt,
   type PlanningReviewContext,
 } from "./prompts.ts";
@@ -23,6 +24,25 @@ const expected: ReadonlyArray<[PlanningReviewContext, RegExp]> = [
   ["merged-base", /verified merged-base spec/u],
   ["implementation-pull-request", /no planning pull request is created/u],
 ];
+test("renders context-specific plan spec sources", () => {
+  const expectedPlanSources: ReadonlyArray<[PlanningReviewContext, RegExp]> = [
+    ["dedicated-pull-request", /approved spec/u],
+    ["same-phase-pull-request", /current-phase spec.*not yet approved/u],
+    ["merged-base", /verified merged-base spec/u],
+    ["implementation-pull-request", /implementation-carried spec/u],
+    ["legacy-label", /approved spec/u],
+  ];
+  for (const [reviewContext, pattern] of expectedPlanSources) {
+    const prompt = buildPlanCreationPrompt({
+      issue,
+      specPath: "docs/specs/example.md",
+      planPath: "docs/plans/example.md",
+      projectPolicy: DEFAULT_PATCHMILL_POLICY,
+      reviewContext,
+    });
+    assert.match(prompt, pattern);
+  }
+});
 test("renders explicit planning review contexts without changing legacy default", () => {
   const input = {
     issue,

--- a/src/cli/commands/run-once/planning-review-context.test.ts
+++ b/src/cli/commands/run-once/planning-review-context.test.ts
@@ -6,7 +6,7 @@ import {
   specSourceInstruction,
   type PlanningReviewContext,
 } from "./planning-review-context.ts";
-import { buildSpecCreationPrompt } from "./prompts.ts";
+import { buildPlanCreationPrompt, buildSpecCreationPrompt } from "./prompts.ts";
 import type { IssueSummary } from "./types.ts";
 
 const issue: IssueSummary = {
@@ -45,6 +45,28 @@ test("renders context-specific planning review and spec-source policy", () => {
     );
   }
 });
+test("composes every planning review context into plan source instructions", () => {
+  const expectedPlanSources: ReadonlyArray<[PlanningReviewContext, RegExp]> = [
+    ["dedicated-pull-request", /approved spec/u],
+    ["same-phase-pull-request", /current-phase spec.*not yet approved/u],
+    ["merged-base", /verified merged-base spec/u],
+    ["implementation-pull-request", /implementation-carried spec/u],
+    ["legacy-label", /approved spec/u],
+  ];
+  for (const [reviewContext, pattern] of expectedPlanSources) {
+    assert.match(
+      buildPlanCreationPrompt({
+        issue,
+        specPath: "docs/specs/example.md",
+        planPath: "docs/plans/example.md",
+        projectPolicy: DEFAULT_PATCHMILL_POLICY,
+        reviewContext,
+      }),
+      pattern,
+    );
+  }
+});
+
 test("renders explicit planning review contexts without changing legacy default", () => {
   const input = {
     issue,

--- a/src/cli/commands/run-once/planning-review-context.ts
+++ b/src/cli/commands/run-once/planning-review-context.ts
@@ -1,0 +1,42 @@
+export type PlanningReviewContext =
+  | "dedicated-pull-request"
+  | "same-phase-pull-request"
+  | "merged-base"
+  | "implementation-pull-request"
+  | "legacy-label";
+
+export function planningReviewInstruction(
+  context: PlanningReviewContext,
+): string | undefined {
+  switch (context) {
+    case "dedicated-pull-request":
+      return "Review this artifact in the current planning pull request.";
+    case "same-phase-pull-request":
+      return "Review the spec and plan together in the current planning pull request; do not call the spec already approved.";
+    case "merged-base":
+      return "Use the verified merged-base spec as source material for this artifact.";
+    case "implementation-pull-request":
+      return "Carry this artifact with implementation code; no planning pull request is created for it.";
+    case "legacy-label":
+      return undefined;
+  }
+}
+
+export function specSourceInstruction(
+  context: PlanningReviewContext,
+  specPath: string | undefined,
+): string {
+  if (specPath === undefined)
+    return "No separate spec artifact was found; write the minimum design context needed in the implementation plan before task steps.";
+  switch (context) {
+    case "same-phase-pull-request":
+      return `Read and base the implementation plan on the current-phase spec at ${specPath}; it is not yet approved.`;
+    case "merged-base":
+      return `Read and base the implementation plan on the verified merged-base spec at ${specPath}.`;
+    case "implementation-pull-request":
+      return `Read and base the implementation plan on the implementation-carried spec at ${specPath}.`;
+    case "dedicated-pull-request":
+    case "legacy-label":
+      return `Read and base the implementation plan on the approved spec at ${specPath}.`;
+  }
+}

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -29,6 +29,13 @@ import {
   renderVisualEvidenceSkillStep,
 } from "./prompt-workflow.ts";
 
+export type PlanningReviewContext =
+  | "dedicated-pull-request"
+  | "same-phase-pull-request"
+  | "merged-base"
+  | "implementation-pull-request"
+  | "legacy-label";
+
 export type SpecCreationPromptInput = {
   issue: IssueSummary;
   specPath: string;
@@ -36,6 +43,7 @@ export type SpecCreationPromptInput = {
   specApprovalRequired?: boolean;
   skills?: PatchmillSkillsConfig;
   triageLabels?: Partial<PromptTriageLabels>;
+  reviewContext?: PlanningReviewContext;
 };
 
 export type PlanCreationPromptInput = {
@@ -46,6 +54,7 @@ export type PlanCreationPromptInput = {
   planApprovalRequired?: boolean;
   skills?: PatchmillSkillsConfig;
   triageLabels?: Partial<PromptTriageLabels>;
+  reviewContext?: PlanningReviewContext;
 };
 
 export type PromptTriageLabels = {
@@ -674,6 +683,23 @@ Return this exact JSON object after \`${targetBranch}\` is pushed successfully:
 ${renderPrCreatedContract(branch)}`;
 }
 
+function planningReviewInstruction(
+  context: PlanningReviewContext,
+): string | undefined {
+  switch (context) {
+    case "dedicated-pull-request":
+      return "Review this artifact in the current planning pull request.";
+    case "same-phase-pull-request":
+      return "Review the spec and plan together in the current planning pull request; do not call the spec already approved.";
+    case "merged-base":
+      return "Use the verified merged-base spec as source material for this artifact.";
+    case "implementation-pull-request":
+      return "Carry this artifact with implementation code; no planning pull request is created for it.";
+    case "legacy-label":
+      return undefined;
+  }
+}
+
 function numberedWorkflow(steps: string[]): string {
   return steps
     .filter((step) => step.trim().length > 0)
@@ -688,8 +714,12 @@ export function buildSpecCreationPrompt(
   const specApprovalRequired = input.specApprovalRequired ?? false;
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
   const { ready, needsInfo } = resolvePromptTriageLabels(input.triageLabels);
+  const reviewInstruction = planningReviewInstruction(
+    input.reviewContext ?? "legacy-label",
+  );
   const workflow = numberedWorkflow([
     renderPlanContextInstruction(projectPolicy),
+    ...(reviewInstruction === undefined ? [] : [reviewInstruction]),
     `Treat \`${ready}\` as meaning the issue is clear enough for automation to write a design spec. Do not implement code.`,
     "Write a concise design spec that captures requirements, proposed behavior, affected components, and verification strategy.",
     `Save the spec to ${specPath}.`,
@@ -754,8 +784,12 @@ export function buildPlanCreationPrompt(
   const planApprovalRequired = input.planApprovalRequired ?? false;
   const skills = input.skills ?? DEFAULT_PATCHMILL_SKILLS;
   const { ready, needsInfo } = resolvePromptTriageLabels(input.triageLabels);
+  const reviewInstruction = planningReviewInstruction(
+    input.reviewContext ?? "legacy-label",
+  );
   const workflow = numberedWorkflow([
     renderPlanContextInstruction(projectPolicy),
+    ...(reviewInstruction === undefined ? [] : [reviewInstruction]),
     specPath
       ? `Read and base the implementation plan on the approved spec at ${specPath}.`
       : "No separate spec artifact was found; write the minimum design context needed in the implementation plan before task steps.",

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -28,13 +28,13 @@ import {
   renderPlanningSkillStep,
   renderVisualEvidenceSkillStep,
 } from "./prompt-workflow.ts";
+import {
+  planningReviewInstruction,
+  specSourceInstruction,
+  type PlanningReviewContext,
+} from "./planning-review-context.ts";
 
-export type PlanningReviewContext =
-  | "dedicated-pull-request"
-  | "same-phase-pull-request"
-  | "merged-base"
-  | "implementation-pull-request"
-  | "legacy-label";
+export type { PlanningReviewContext } from "./planning-review-context.ts";
 
 export type SpecCreationPromptInput = {
   issue: IssueSummary;
@@ -681,42 +681,6 @@ Return this exact JSON object after \`${targetBranch}\` is pushed successfully:
 }
 
 ${renderPrCreatedContract(branch)}`;
-}
-
-function planningReviewInstruction(
-  context: PlanningReviewContext,
-): string | undefined {
-  switch (context) {
-    case "dedicated-pull-request":
-      return "Review this artifact in the current planning pull request.";
-    case "same-phase-pull-request":
-      return "Review the spec and plan together in the current planning pull request; do not call the spec already approved.";
-    case "merged-base":
-      return "Use the verified merged-base spec as source material for this artifact.";
-    case "implementation-pull-request":
-      return "Carry this artifact with implementation code; no planning pull request is created for it.";
-    case "legacy-label":
-      return undefined;
-  }
-}
-
-function specSourceInstruction(
-  context: PlanningReviewContext,
-  specPath: string | undefined,
-): string {
-  if (specPath === undefined)
-    return "No separate spec artifact was found; write the minimum design context needed in the implementation plan before task steps.";
-  switch (context) {
-    case "same-phase-pull-request":
-      return `Read and base the implementation plan on the current-phase spec at ${specPath}; it is not yet approved.`;
-    case "merged-base":
-      return `Read and base the implementation plan on the verified merged-base spec at ${specPath}.`;
-    case "implementation-pull-request":
-      return `Read and base the implementation plan on the implementation-carried spec at ${specPath}.`;
-    case "dedicated-pull-request":
-    case "legacy-label":
-      return `Read and base the implementation plan on the approved spec at ${specPath}.`;
-  }
 }
 
 function numberedWorkflow(steps: string[]): string {

--- a/src/cli/commands/run-once/prompts.ts
+++ b/src/cli/commands/run-once/prompts.ts
@@ -700,6 +700,25 @@ function planningReviewInstruction(
   }
 }
 
+function specSourceInstruction(
+  context: PlanningReviewContext,
+  specPath: string | undefined,
+): string {
+  if (specPath === undefined)
+    return "No separate spec artifact was found; write the minimum design context needed in the implementation plan before task steps.";
+  switch (context) {
+    case "same-phase-pull-request":
+      return `Read and base the implementation plan on the current-phase spec at ${specPath}; it is not yet approved.`;
+    case "merged-base":
+      return `Read and base the implementation plan on the verified merged-base spec at ${specPath}.`;
+    case "implementation-pull-request":
+      return `Read and base the implementation plan on the implementation-carried spec at ${specPath}.`;
+    case "dedicated-pull-request":
+    case "legacy-label":
+      return `Read and base the implementation plan on the approved spec at ${specPath}.`;
+  }
+}
+
 function numberedWorkflow(steps: string[]): string {
   return steps
     .filter((step) => step.trim().length > 0)
@@ -790,9 +809,7 @@ export function buildPlanCreationPrompt(
   const workflow = numberedWorkflow([
     renderPlanContextInstruction(projectPolicy),
     ...(reviewInstruction === undefined ? [] : [reviewInstruction]),
-    specPath
-      ? `Read and base the implementation plan on the approved spec at ${specPath}.`
-      : "No separate spec artifact was found; write the minimum design context needed in the implementation plan before task steps.",
+    specSourceInstruction(input.reviewContext ?? "legacy-label", specPath),
     `Treat \`${ready}\` as meaning the issue is already clear and unambiguous enough to plan. Do not run a separate brainstorming/requirements-discovery process by default.`,
     renderPlanningSkillStep(skills),
     `Do not substitute an ad-hoc planning process for the configured planning skill. The plan must be saved to ${planPath} and use checkbox steps suitable for agent execution.`,

--- a/src/git/planning-publication-git.real.test.ts
+++ b/src/git/planning-publication-git.real.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  PlanningPublicationGit,
+  PlanningPublicationGitError,
+} from "./planning-publication-git.ts";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function commandRunner(calls: string[][]) {
+  return {
+    async run(command: string, args: string[], options?: { cwd?: string }) {
+      calls.push([command, ...args]);
+      try {
+        return {
+          code: 0,
+          stdout: execFileSync(command, args, {
+            cwd: options?.cwd,
+            encoding: "utf8",
+          }),
+          stderr: "",
+        };
+      } catch (error) {
+        const failure = error as {
+          status?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          code: failure.status ?? 1,
+          stdout: failure.stdout ?? "",
+          stderr: failure.stderr ?? "",
+        };
+      }
+    },
+  };
+}
+
+test("publishes linked-worktree objects by full OID and proves real Git safety boundaries", async () => {
+  const root = await mkdtemp(join(tmpdir(), "planning-publication-real-"));
+  const remote = join(root, "remote.git");
+  const repo = join(root, "repo");
+  const workspace = join(root, "workspace");
+  const calls: string[][] = [];
+  try {
+    execFileSync("git", ["init", "--bare", "--initial-branch=main", remote]);
+    execFileSync("git", ["init", "-b", "main", repo]);
+    git(repo, "config", "user.name", "Patchmill Test");
+    git(repo, "config", "user.email", "patchmill@example.test");
+    await writeFile(join(repo, "README.md"), "base\n");
+    git(repo, "add", "README.md");
+    git(repo, "commit", "-m", "base");
+    const baseOid = git(repo, "rev-parse", "HEAD");
+    git(repo, "remote", "add", "origin", remote);
+    git(repo, "push", "origin", "main");
+    git(repo, "worktree", "add", "-b", "planning/spec", workspace, "HEAD");
+    await mkdir(join(workspace, "docs/specs"), { recursive: true });
+    await writeFile(join(workspace, "docs/specs/issue-188.md"), "artifact A\n");
+    git(workspace, "add", "docs/specs/issue-188.md");
+    git(workspace, "commit", "-m", "planning artifact");
+    const planningOid = git(workspace, "rev-parse", "HEAD");
+    const publication = new PlanningPublicationGit({
+      repoRoot: repo,
+      runner: commandRunner(calls),
+    });
+
+    assert.deepEqual(
+      await publication.ensureRemoteHead({
+        remote: "origin",
+        branch: "planning/spec",
+        headOid: planningOid,
+      }),
+      { pushed: true, headOid: planningOid },
+    );
+    assert.equal(
+      git(repo, "ls-remote", "origin", "refs/heads/planning/spec").split(
+        "\t",
+      )[0],
+      planningOid,
+    );
+    assert.deepEqual(
+      await publication.ensureRemoteHead({
+        remote: "origin",
+        branch: "planning/spec",
+        headOid: planningOid,
+      }),
+      { pushed: false, headOid: planningOid },
+    );
+
+    await publication.assertAncestor({
+      ancestorOid: baseOid,
+      descendantOid: planningOid,
+    });
+    await publication.assertRegularFiles({
+      commitOid: planningOid,
+      paths: ["docs/specs/issue-188.md"],
+    });
+    await writeFile(join(repo, "unrelated.md"), "unrelated\n");
+    git(repo, "add", "unrelated.md");
+    git(repo, "commit", "-m", "unrelated");
+    const unrelatedOid = git(repo, "rev-parse", "HEAD");
+    await assert.rejects(
+      () =>
+        publication.assertAncestor({
+          ancestorOid: unrelatedOid,
+          descendantOid: planningOid,
+        }),
+      /not-ancestor/,
+    );
+
+    git(repo, "push", "origin", "main");
+    git(remote, "update-ref", "refs/heads/planning/spec", unrelatedOid);
+    await assert.rejects(
+      () =>
+        publication.ensureRemoteHead({
+          remote: "origin",
+          branch: "planning/spec",
+          headOid: planningOid,
+        }),
+      /conflicting-head/,
+    );
+    assert.equal(
+      git(repo, "ls-remote", "origin", "refs/heads/planning/spec").split(
+        "\t",
+      )[0],
+      unrelatedOid,
+    );
+
+    await symlink("issue-188.md", join(workspace, "docs/specs/symlink.md"));
+    git(workspace, "add", "docs/specs/symlink.md");
+    git(workspace, "commit", "-m", "symlink artifact");
+    await assert.rejects(
+      () =>
+        publication.assertRegularFiles({
+          commitOid: git(workspace, "rev-parse", "HEAD"),
+          paths: ["docs/specs/symlink.md"],
+        }),
+      (error: unknown) =>
+        error instanceof PlanningPublicationGitError &&
+        error.reason === "non-regular-file",
+    );
+
+    git(
+      workspace,
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      `160000,${baseOid},docs/specs/gitlink.md`,
+    );
+    git(workspace, "commit", "-m", "gitlink artifact");
+    await assert.rejects(
+      () =>
+        publication.assertRegularFiles({
+          commitOid: git(workspace, "rev-parse", "HEAD"),
+          paths: ["docs/specs/gitlink.md"],
+        }),
+      /non-regular-file/,
+    );
+
+    await writeFile(join(workspace, "docs/specs/issue-188.md"), "dirty\n");
+    await assert.rejects(
+      () =>
+        publication.verifyWorkspace({
+          workspacePath: workspace,
+          baseOid,
+          headOid: git(workspace, "rev-parse", "HEAD"),
+          artifactPaths: ["docs/specs/issue-188.md"],
+        }),
+      /dirty-workspace/,
+    );
+    git(workspace, "checkout", "--", "docs/specs/issue-188.md");
+    await writeFile(join(workspace, ".gitignore"), "ignored-residue\n");
+    git(workspace, "add", ".gitignore");
+    git(workspace, "commit", "-m", "ignore residue");
+    await writeFile(join(workspace, "ignored-residue"), "ignored\n");
+    await assert.rejects(
+      () =>
+        publication.verifyWorkspace({
+          workspacePath: workspace,
+          baseOid,
+          headOid: git(workspace, "rev-parse", "HEAD"),
+          artifactPaths: ["docs/specs/issue-188.md"],
+        }),
+      /dirty-workspace/,
+    );
+
+    const pushCalls = calls.filter((call) => call[1] === "push");
+    assert.equal(pushCalls.length, 1);
+    assert.ok(pushCalls.every((call) => call.includes("--no-force")));
+    assert.ok(
+      calls.every(
+        (call) =>
+          !call.some((argument) =>
+            /^(--force|-f|reset|clean|merge|rebase|branch)$/u.test(argument),
+          ),
+      ),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/git/planning-publication-git.test.ts
+++ b/src/git/planning-publication-git.test.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
   PlanningPublicationGit,
@@ -190,6 +194,86 @@ test("blocks a conflicting remote head before push", async () => {
       error.reason === "conflicting-head",
   );
 });
+test("publishes a full OID to a local bare remote, retries safely, and preserves conflicts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "planning-publication-"));
+  const remote = join(root, "remote.git");
+  const repo = join(root, "repo");
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+  const runner = {
+    async run(command: string, args: string[], options?: { cwd?: string }) {
+      try {
+        return {
+          code: 0,
+          stdout: execFileSync(command, args, {
+            cwd: options?.cwd,
+            encoding: "utf8",
+          }),
+          stderr: "",
+        };
+      } catch (error) {
+        const failure = error as {
+          status?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          code: failure.status ?? 1,
+          stdout: failure.stdout ?? "",
+          stderr: failure.stderr ?? "",
+        };
+      }
+    },
+  };
+  try {
+    execFileSync("git", ["init", "--bare", "--initial-branch=main", remote]);
+    execFileSync("git", ["init", "-b", "main", repo]);
+    git(repo, "config", "user.name", "Patchmill Test");
+    git(repo, "config", "user.email", "patchmill@example.test");
+    await writeFile(join(repo, "artifact.md"), "A\\n");
+    git(repo, "add", "artifact.md");
+    git(repo, "commit", "-m", "artifact");
+    git(repo, "remote", "add", "origin", remote);
+    const headOid = git(repo, "rev-parse", "HEAD");
+    const publication = new PlanningPublicationGit({ repoRoot: repo, runner });
+    assert.deepEqual(
+      await publication.ensureRemoteHead({
+        remote: "origin",
+        branch: "planning/spec",
+        headOid,
+      }),
+      { pushed: true, headOid },
+    );
+    assert.deepEqual(
+      await publication.ensureRemoteHead({
+        remote: "origin",
+        branch: "planning/spec",
+        headOid,
+      }),
+      { pushed: false, headOid },
+    );
+    await writeFile(join(repo, "artifact.md"), "B\\n");
+    git(repo, "commit", "-am", "other");
+    await assert.rejects(
+      () =>
+        publication.ensureRemoteHead({
+          remote: "origin",
+          branch: "planning/spec",
+          headOid: git(repo, "rev-parse", "HEAD"),
+        }),
+      /conflicting-head/,
+    );
+    assert.equal(
+      git(repo, "ls-remote", "origin", "refs/heads/planning/spec").split(
+        "\t",
+      )[0],
+      headOid,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects a non-regular committed artifact", async () => {
   const git = new PlanningPublicationGit({
     repoRoot: "/repo",

--- a/src/git/planning-publication-git.test.ts
+++ b/src/git/planning-publication-git.test.ts
@@ -59,6 +59,112 @@ test("recovers an already-pushed exact phase head without a push", async () => {
     ],
   ]);
 });
+test("pushes a missing exact remote head and re-inspects it", async () => {
+  const calls: string[][] = [];
+  const results = [
+    { code: 2, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+    {
+      code: 0,
+      stdout: `${"a".repeat(40)}\trefs/heads/planning/spec\n`,
+      stderr: "",
+    },
+  ];
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run(_command, args) {
+        calls.push(args);
+        return results.shift()!;
+      },
+    },
+  });
+  assert.deepEqual(
+    await git.ensureRemoteHead({
+      remote: "origin",
+      branch: "planning/spec",
+      headOid: "a".repeat(40),
+    }),
+    { pushed: true, headOid: "a".repeat(40) },
+  );
+  assert.deepEqual(calls[1], [
+    "push",
+    "--porcelain",
+    "--no-force",
+    "--",
+    "origin",
+    `${"a".repeat(40)}:refs/heads/planning/spec`,
+  ]);
+});
+test("rejects malformed and failed remote observations", async () => {
+  for (const result of [
+    { code: 0, stdout: `not-an-oid\trefs/heads/planning/spec\n`, stderr: "" },
+    { code: 1, stdout: "", stderr: "failure" },
+  ]) {
+    const git = new PlanningPublicationGit({
+      repoRoot: "/repo",
+      runner: {
+        async run() {
+          return result;
+        },
+      },
+    });
+    await assert.rejects(
+      () =>
+        git.inspectRemoteHead({ remote: "origin", branch: "planning/spec" }),
+      PlanningPublicationGitError,
+    );
+  }
+});
+test("verifies committed artifacts and rejects dirty workspaces", async () => {
+  const regular = `100644 blob ${"b".repeat(40)}\tdocs/specs/a.md\0`;
+  const cleanResults = [
+    { code: 0, stdout: `${"b".repeat(40)}\n`, stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: regular, stderr: "" },
+    { code: 0, stdout: "docs/specs/a.md\0", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  ];
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run() {
+        return cleanResults.shift()!;
+      },
+    },
+  });
+  await git.verifyArtifactCommit({
+    workspacePath: "/workspace",
+    previousHeadOid: "a".repeat(40),
+    headOid: "b".repeat(40),
+    artifactPath: "docs/specs/a.md",
+  });
+  const dirtyResults = [
+    { code: 0, stdout: `${"b".repeat(40)}\n`, stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: regular, stderr: "" },
+    { code: 0, stdout: "docs/specs/a.md\0", stderr: "" },
+    { code: 0, stdout: "?? ignored\0", stderr: "" },
+  ];
+  const dirty = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run() {
+        return dirtyResults.shift()!;
+      },
+    },
+  });
+  await assert.rejects(
+    () =>
+      dirty.verifyArtifactCommit({
+        workspacePath: "/workspace",
+        previousHeadOid: "a".repeat(40),
+        headOid: "b".repeat(40),
+        artifactPath: "docs/specs/a.md",
+      }),
+    /dirty-workspace/,
+  );
+});
 test("blocks a conflicting remote head before push", async () => {
   const git = new PlanningPublicationGit({
     repoRoot: "/repo",

--- a/src/git/planning-publication-git.test.ts
+++ b/src/git/planning-publication-git.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PlanningPublicationGit,
+  PlanningPublicationGitError,
+} from "./planning-publication-git.ts";
+
+test("recovers an already-pushed exact phase head without a push", async () => {
+  const calls: string[][] = [];
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run(_command, args) {
+        calls.push(args);
+        return {
+          code: 0,
+          stdout: `${"a".repeat(40)}\trefs/heads/planning/spec\n`,
+          stderr: "",
+        };
+      },
+    },
+  });
+  const result = await git.ensureRemoteHead({
+    remote: "origin",
+    branch: "planning/spec",
+    headOid: "a".repeat(40),
+  });
+  assert.deepEqual(result, { pushed: false, headOid: "a".repeat(40) });
+  assert.deepEqual(calls, [
+    [
+      "ls-remote",
+      "--exit-code",
+      "--heads",
+      "--",
+      "origin",
+      "refs/heads/planning/spec",
+    ],
+  ]);
+});
+test("blocks a conflicting remote head before push", async () => {
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run() {
+        return {
+          code: 0,
+          stdout: `${"b".repeat(40)}\trefs/heads/planning/spec\n`,
+          stderr: "",
+        };
+      },
+    },
+  });
+  await assert.rejects(
+    () =>
+      git.ensureRemoteHead({
+        remote: "origin",
+        branch: "planning/spec",
+        headOid: "a".repeat(40),
+      }),
+    (error: unknown) =>
+      error instanceof PlanningPublicationGitError &&
+      error.reason === "conflicting-head",
+  );
+});
+test("rejects a non-regular committed artifact", async () => {
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run() {
+        return {
+          code: 0,
+          stdout: `120000 blob ${"a".repeat(40)}\tdocs/specs/a.md\0`,
+          stderr: "",
+        };
+      },
+    },
+  });
+  await assert.rejects(
+    () =>
+      git.assertRegularFiles({
+        commitOid: "a".repeat(40),
+        paths: ["docs/specs/a.md"],
+      }),
+    /non-regular-file/,
+  );
+});

--- a/src/git/planning-publication-git.test.ts
+++ b/src/git/planning-publication-git.test.ts
@@ -9,6 +9,70 @@ import {
   PlanningPublicationGitError,
 } from "./planning-publication-git.ts";
 
+test("reports the operation that rejected scalar input", async () => {
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run() {
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+  });
+  const cases: ReadonlyArray<[string, () => Promise<unknown>, string]> = [
+    [
+      "tree path",
+      () =>
+        git.assertRegularFiles({
+          commitOid: "a".repeat(40),
+          paths: ["../a.md"],
+        }),
+      "tree",
+    ],
+    [
+      "remote",
+      () =>
+        git.inspectRemoteHead({
+          remote: "bad\nremote",
+          branch: "planning/spec",
+        }),
+      "remote-head",
+    ],
+    [
+      "branch",
+      () => git.inspectRemoteHead({ remote: "origin", branch: "bad branch" }),
+      "remote-head",
+    ],
+    [
+      "push oid",
+      () =>
+        git.ensureRemoteHead({
+          remote: "origin",
+          branch: "planning/spec",
+          headOid: "not-an-oid",
+        }),
+      "push",
+    ],
+    [
+      "ancestry oid",
+      () =>
+        git.assertAncestor({
+          ancestorOid: "not-an-oid",
+          descendantOid: "a".repeat(40),
+        }),
+      "ancestry",
+    ],
+  ];
+  for (const [, operation, expectedOperation] of cases) {
+    await assert.rejects(
+      operation,
+      (error: unknown) =>
+        error instanceof PlanningPublicationGitError &&
+        error.operation === expectedOperation &&
+        error.reason === "invalid-input",
+    );
+  }
+});
+
 test("accepts an owned workspace outside the repository root", async () => {
   const git = new PlanningPublicationGit({
     repoRoot: "/repo",

--- a/src/git/planning-publication-git.test.ts
+++ b/src/git/planning-publication-git.test.ts
@@ -5,6 +5,28 @@ import {
   PlanningPublicationGitError,
 } from "./planning-publication-git.ts";
 
+test("accepts an owned workspace outside the repository root", async () => {
+  const git = new PlanningPublicationGit({
+    repoRoot: "/repo",
+    runner: {
+      async run() {
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    },
+  });
+  await assert.rejects(
+    () =>
+      git.verifyWorkspace({
+        workspacePath: "/other-worktrees/spec",
+        baseOid: "a".repeat(40),
+        headOid: "a".repeat(40),
+        artifactPaths: ["docs/specs/a.md"],
+      }),
+    (error: unknown) =>
+      error instanceof PlanningPublicationGitError &&
+      error.reason === "head-mismatch",
+  );
+});
 test("recovers an already-pushed exact phase head without a push", async () => {
   const calls: string[][] = [];
   const git = new PlanningPublicationGit({

--- a/src/git/planning-publication-git.ts
+++ b/src/git/planning-publication-git.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import type { CommandResult, CommandRunner } from "../process/command.ts";
 import {
   isPlanningArtifactPath,
@@ -107,10 +107,9 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
     this.repoRoot = resolve(input.repoRoot);
   }
   private workspace(path: string): string {
-    const resolved = resolve(path);
-    if (!isAbsolute(path) || relative(this.repoRoot, resolved).startsWith(".."))
+    if (!isAbsolute(path))
       throw new PlanningPublicationGitError("head", "invalid-workspace");
-    return resolved;
+    return resolve(path);
   }
   private async run(
     operation: PlanningPublicationGitOperation,

--- a/src/git/planning-publication-git.ts
+++ b/src/git/planning-publication-git.ts
@@ -56,13 +56,24 @@ export type PlanningPublicationGitOperation =
   | "status"
   | "remote-head"
   | "push";
+export type PlanningPublicationGitReason =
+  | "invalid-input"
+  | "invalid-workspace"
+  | "command-failed"
+  | "malformed-response"
+  | "head-mismatch"
+  | "not-ancestor"
+  | "non-regular-file"
+  | "dirty-workspace"
+  | "unexpected-changes"
+  | "conflicting-head";
 export class PlanningPublicationGitError extends Error {
   readonly operation: PlanningPublicationGitOperation;
-  readonly reason: string;
+  readonly reason: PlanningPublicationGitReason;
   readonly exitCode?: number;
   constructor(
     operation: PlanningPublicationGitOperation,
-    reason: string,
+    reason: PlanningPublicationGitReason,
     result?: CommandResult,
   ) {
     super(`Planning publication Git failed: ${operation}/${reason}`);
@@ -79,9 +90,13 @@ export class PlanningPublicationGitError extends Error {
   }
   declare readonly diagnostics: Readonly<CommandResult>;
 }
-function input(value: string, predicate: (value: string) => boolean): void {
+function input(
+  operation: PlanningPublicationGitOperation,
+  value: string,
+  predicate: (value: string) => boolean,
+): void {
   if (!predicate(value))
-    throw new PlanningPublicationGitError("head", "invalid-input");
+    throw new PlanningPublicationGitError(operation, "invalid-input");
 }
 function nulRecords(
   value: string,
@@ -125,12 +140,15 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
       );
     return result;
   }
-  private validateOid(value: string): void {
-    input(value, (item) => planningOid.test(item));
+  private validateOid(
+    operation: PlanningPublicationGitOperation,
+    value: string,
+  ): void {
+    input(operation, value, (item) => planningOid.test(item));
   }
   async assertAncestor(inputValue: PlanningAncestryInput): Promise<void> {
-    this.validateOid(inputValue.ancestorOid);
-    this.validateOid(inputValue.descendantOid);
+    this.validateOid("ancestry", inputValue.ancestorOid);
+    this.validateOid("ancestry", inputValue.descendantOid);
     const result = await this.runner.run(
       "git",
       [
@@ -153,11 +171,11 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
   async assertRegularFiles(
     inputValue: PlanningRegularFilesInput,
   ): Promise<void> {
-    this.validateOid(inputValue.commitOid);
+    this.validateOid("tree", inputValue.commitOid);
     if (inputValue.paths.length === 0)
       throw new PlanningPublicationGitError("tree", "invalid-input");
     for (const path of inputValue.paths) {
-      input(path, isPlanningArtifactPath);
+      input("tree", path, isPlanningArtifactPath);
       const result = await this.run(
         "tree",
         ["ls-tree", "-z", inputValue.commitOid, "--", path],
@@ -190,9 +208,9 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
     inputValue: PlanningArtifactCommitInput,
   ): Promise<void> {
     const workspacePath = this.workspace(inputValue.workspacePath);
-    this.validateOid(inputValue.previousHeadOid);
-    this.validateOid(inputValue.headOid);
-    input(inputValue.artifactPath, isPlanningArtifactPath);
+    this.validateOid("head", inputValue.previousHeadOid);
+    this.validateOid("head", inputValue.headOid);
+    input("tree", inputValue.artifactPath, isPlanningArtifactPath);
     const head = await this.run(
       "head",
       ["-C", workspacePath, "rev-parse", "--verify", "HEAD^{commit}"],
@@ -244,8 +262,8 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
     inputValue: PlanningWorkspaceVerificationInput,
   ): Promise<void> {
     const workspacePath = this.workspace(inputValue.workspacePath);
-    this.validateOid(inputValue.baseOid);
-    this.validateOid(inputValue.headOid);
+    this.validateOid("head", inputValue.baseOid);
+    this.validateOid("head", inputValue.headOid);
     const head = await this.run(
       "head",
       ["-C", workspacePath, "rev-parse", "--verify", "HEAD^{commit}"],
@@ -266,8 +284,8 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
   async inspectRemoteHead(
     inputValue: PlanningRemoteBranchInput,
   ): Promise<PlanningRemoteHead> {
-    input(inputValue.remote, isPlanningSingleLine);
-    input(inputValue.branch, isPlanningBranch);
+    input("remote-head", inputValue.remote, isPlanningSingleLine);
+    input("remote-head", inputValue.branch, isPlanningBranch);
     const result = await this.runner.run(
       "git",
       [
@@ -306,7 +324,7 @@ export class PlanningPublicationGit implements PlanningPublicationOperations {
   async ensureRemoteHead(
     inputValue: PlanningExactPushInput,
   ): Promise<Readonly<{ pushed: boolean; headOid: string }>> {
-    this.validateOid(inputValue.headOid);
+    this.validateOid("push", inputValue.headOid);
     const before = await this.inspectRemoteHead(inputValue);
     if (before.state === "present" && before.headOid !== inputValue.headOid)
       throw new PlanningPublicationGitError("remote-head", "conflicting-head");

--- a/src/git/planning-publication-git.ts
+++ b/src/git/planning-publication-git.ts
@@ -1,0 +1,333 @@
+import { isAbsolute, relative, resolve } from "node:path";
+import type { CommandResult, CommandRunner } from "../process/command.ts";
+import {
+  isPlanningArtifactPath,
+  isPlanningBranch,
+  isPlanningSingleLine,
+  planningOid,
+} from "./planning-git-validation.ts";
+
+export type PlanningRemoteHead =
+  | Readonly<{ state: "missing" }>
+  | Readonly<{ state: "present"; headOid: string }>;
+export type PlanningArtifactCommitInput = Readonly<{
+  workspacePath: string;
+  previousHeadOid: string;
+  headOid: string;
+  artifactPath: string;
+}>;
+export type PlanningWorkspaceVerificationInput = Readonly<{
+  workspacePath: string;
+  baseOid: string;
+  headOid: string;
+  artifactPaths: readonly string[];
+}>;
+export type PlanningRemoteBranchInput = Readonly<{
+  remote: string;
+  branch: string;
+}>;
+export type PlanningExactPushInput = PlanningRemoteBranchInput &
+  Readonly<{ headOid: string }>;
+export type PlanningAncestryInput = Readonly<{
+  ancestorOid: string;
+  descendantOid: string;
+}>;
+export type PlanningRegularFilesInput = Readonly<{
+  commitOid: string;
+  paths: readonly string[];
+}>;
+export interface PlanningPublicationOperations {
+  verifyArtifactCommit(input: PlanningArtifactCommitInput): Promise<void>;
+  verifyWorkspace(input: PlanningWorkspaceVerificationInput): Promise<void>;
+  inspectRemoteHead(
+    input: PlanningRemoteBranchInput,
+  ): Promise<PlanningRemoteHead>;
+  ensureRemoteHead(
+    input: PlanningExactPushInput,
+  ): Promise<Readonly<{ pushed: boolean; headOid: string }>>;
+  assertAncestor(input: PlanningAncestryInput): Promise<void>;
+  assertRegularFiles(input: PlanningRegularFilesInput): Promise<void>;
+}
+export type PlanningPublicationGitOperation =
+  | "head"
+  | "ancestry"
+  | "tree"
+  | "diff"
+  | "status"
+  | "remote-head"
+  | "push";
+export class PlanningPublicationGitError extends Error {
+  readonly operation: PlanningPublicationGitOperation;
+  readonly reason: string;
+  readonly exitCode?: number;
+  constructor(
+    operation: PlanningPublicationGitOperation,
+    reason: string,
+    result?: CommandResult,
+  ) {
+    super(`Planning publication Git failed: ${operation}/${reason}`);
+    this.name = "PlanningPublicationGitError";
+    this.operation = operation;
+    this.reason = reason;
+    if (result !== undefined) {
+      this.exitCode = result.code;
+      Object.defineProperty(this, "diagnostics", {
+        enumerable: false,
+        value: Object.freeze({ ...result }),
+      });
+    }
+  }
+  declare readonly diagnostics: Readonly<CommandResult>;
+}
+function input(value: string, predicate: (value: string) => boolean): void {
+  if (!predicate(value))
+    throw new PlanningPublicationGitError("head", "invalid-input");
+}
+function nulRecords(
+  value: string,
+  operation: PlanningPublicationGitOperation,
+): readonly string[] {
+  if (value !== "" && !value.endsWith("\0"))
+    throw new PlanningPublicationGitError(operation, "malformed-response");
+  return value.split("\0").filter(Boolean);
+}
+function treeRecord(record: string, path: string): void {
+  const parsed =
+    /^(100644|100755) blob ([0-9a-f]{40}|[0-9a-f]{64})\t([^\0\r\n]+)$/u.exec(
+      record,
+    );
+  if (parsed === null || parsed[3] !== path)
+    throw new PlanningPublicationGitError("tree", "non-regular-file");
+}
+export class PlanningPublicationGit implements PlanningPublicationOperations {
+  readonly runner: CommandRunner;
+  readonly repoRoot: string;
+  constructor(input: { runner: CommandRunner; repoRoot: string }) {
+    this.runner = input.runner;
+    this.repoRoot = resolve(input.repoRoot);
+  }
+  private workspace(path: string): string {
+    const resolved = resolve(path);
+    if (!isAbsolute(path) || relative(this.repoRoot, resolved).startsWith(".."))
+      throw new PlanningPublicationGitError("head", "invalid-workspace");
+    return resolved;
+  }
+  private async run(
+    operation: PlanningPublicationGitOperation,
+    args: string[],
+    cwd: string,
+  ): Promise<CommandResult> {
+    const result = await this.runner.run("git", args, { cwd });
+    if (result.code !== 0)
+      throw new PlanningPublicationGitError(
+        operation,
+        "command-failed",
+        result,
+      );
+    return result;
+  }
+  private validateOid(value: string): void {
+    input(value, (item) => planningOid.test(item));
+  }
+  async assertAncestor(inputValue: PlanningAncestryInput): Promise<void> {
+    this.validateOid(inputValue.ancestorOid);
+    this.validateOid(inputValue.descendantOid);
+    const result = await this.runner.run(
+      "git",
+      [
+        "merge-base",
+        "--is-ancestor",
+        inputValue.ancestorOid,
+        inputValue.descendantOid,
+      ],
+      { cwd: this.repoRoot },
+    );
+    if (result.code === 1)
+      throw new PlanningPublicationGitError("ancestry", "not-ancestor", result);
+    if (result.code !== 0)
+      throw new PlanningPublicationGitError(
+        "ancestry",
+        "command-failed",
+        result,
+      );
+  }
+  async assertRegularFiles(
+    inputValue: PlanningRegularFilesInput,
+  ): Promise<void> {
+    this.validateOid(inputValue.commitOid);
+    if (inputValue.paths.length === 0)
+      throw new PlanningPublicationGitError("tree", "invalid-input");
+    for (const path of inputValue.paths) {
+      input(path, isPlanningArtifactPath);
+      const result = await this.run(
+        "tree",
+        ["ls-tree", "-z", inputValue.commitOid, "--", path],
+        this.repoRoot,
+      );
+      const records = nulRecords(result.stdout, "tree");
+      if (records.length !== 1)
+        throw new PlanningPublicationGitError("tree", "non-regular-file");
+      treeRecord(records[0]!, path);
+    }
+  }
+  private async assertClean(workspacePath: string): Promise<void> {
+    const result = await this.run(
+      "status",
+      [
+        "-C",
+        workspacePath,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=matching",
+      ],
+      this.repoRoot,
+    );
+    if (result.stdout !== "")
+      throw new PlanningPublicationGitError("status", "dirty-workspace");
+  }
+  async verifyArtifactCommit(
+    inputValue: PlanningArtifactCommitInput,
+  ): Promise<void> {
+    const workspacePath = this.workspace(inputValue.workspacePath);
+    this.validateOid(inputValue.previousHeadOid);
+    this.validateOid(inputValue.headOid);
+    input(inputValue.artifactPath, isPlanningArtifactPath);
+    const head = await this.run(
+      "head",
+      ["-C", workspacePath, "rev-parse", "--verify", "HEAD^{commit}"],
+      this.repoRoot,
+    );
+    if (head.stdout.trim() !== inputValue.headOid)
+      throw new PlanningPublicationGitError("head", "head-mismatch");
+    await this.assertAncestor({
+      ancestorOid: inputValue.previousHeadOid,
+      descendantOid: inputValue.headOid,
+    });
+    const tree = await this.run(
+      "tree",
+      [
+        "-C",
+        workspacePath,
+        "ls-tree",
+        "-z",
+        inputValue.headOid,
+        "--",
+        inputValue.artifactPath,
+      ],
+      this.repoRoot,
+    );
+    const records = nulRecords(tree.stdout, "tree");
+    if (records.length !== 1)
+      throw new PlanningPublicationGitError("tree", "non-regular-file");
+    treeRecord(records[0]!, inputValue.artifactPath);
+    const diff = await this.run(
+      "diff",
+      [
+        "-C",
+        workspacePath,
+        "diff",
+        "--name-only",
+        "-z",
+        inputValue.previousHeadOid,
+        inputValue.headOid,
+        "--",
+      ],
+      this.repoRoot,
+    );
+    const changed = nulRecords(diff.stdout, "diff");
+    if (changed.length !== 1 || changed[0] !== inputValue.artifactPath)
+      throw new PlanningPublicationGitError("diff", "unexpected-changes");
+    await this.assertClean(workspacePath);
+  }
+  async verifyWorkspace(
+    inputValue: PlanningWorkspaceVerificationInput,
+  ): Promise<void> {
+    const workspacePath = this.workspace(inputValue.workspacePath);
+    this.validateOid(inputValue.baseOid);
+    this.validateOid(inputValue.headOid);
+    const head = await this.run(
+      "head",
+      ["-C", workspacePath, "rev-parse", "--verify", "HEAD^{commit}"],
+      this.repoRoot,
+    );
+    if (head.stdout.trim() !== inputValue.headOid)
+      throw new PlanningPublicationGitError("head", "head-mismatch");
+    await this.assertAncestor({
+      ancestorOid: inputValue.baseOid,
+      descendantOid: inputValue.headOid,
+    });
+    await this.assertRegularFiles({
+      commitOid: inputValue.headOid,
+      paths: inputValue.artifactPaths,
+    });
+    await this.assertClean(workspacePath);
+  }
+  async inspectRemoteHead(
+    inputValue: PlanningRemoteBranchInput,
+  ): Promise<PlanningRemoteHead> {
+    input(inputValue.remote, isPlanningSingleLine);
+    input(inputValue.branch, isPlanningBranch);
+    const result = await this.runner.run(
+      "git",
+      [
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        "--",
+        inputValue.remote,
+        `refs/heads/${inputValue.branch}`,
+      ],
+      { cwd: this.repoRoot },
+    );
+    if (result.code === 2 && result.stdout === "") return { state: "missing" };
+    if (result.code !== 0)
+      throw new PlanningPublicationGitError(
+        "remote-head",
+        "command-failed",
+        result,
+      );
+    const records = result.stdout.trim().split("\n").filter(Boolean);
+    if (records.length !== 1)
+      throw new PlanningPublicationGitError(
+        "remote-head",
+        "malformed-response",
+      );
+    const match = /^([0-9a-f]{40}|[0-9a-f]{64})\trefs\/heads\/(.+)$/u.exec(
+      records[0]!,
+    );
+    if (match === null || match[2] !== inputValue.branch)
+      throw new PlanningPublicationGitError(
+        "remote-head",
+        "malformed-response",
+      );
+    return { state: "present", headOid: match[1]! };
+  }
+  async ensureRemoteHead(
+    inputValue: PlanningExactPushInput,
+  ): Promise<Readonly<{ pushed: boolean; headOid: string }>> {
+    this.validateOid(inputValue.headOid);
+    const before = await this.inspectRemoteHead(inputValue);
+    if (before.state === "present" && before.headOid !== inputValue.headOid)
+      throw new PlanningPublicationGitError("remote-head", "conflicting-head");
+    if (before.state === "present")
+      return { pushed: false, headOid: inputValue.headOid };
+    await this.run(
+      "push",
+      [
+        "push",
+        "--porcelain",
+        "--no-force",
+        "--",
+        inputValue.remote,
+        `${inputValue.headOid}:refs/heads/${inputValue.branch}`,
+      ],
+      this.repoRoot,
+    );
+    const after = await this.inspectRemoteHead(inputValue);
+    if (after.state !== "present" || after.headOid !== inputValue.headOid)
+      throw new PlanningPublicationGitError("remote-head", "conflicting-head");
+    return { pushed: true, headOid: inputValue.headOid };
+  }
+}

--- a/src/git/planning-workspace-git.test.ts
+++ b/src/git/planning-workspace-git.test.ts
@@ -277,6 +277,55 @@ test("cleanup rejects dirty owned worktrees before destructive command", async (
   );
 });
 
+test("branch cleanup preserves an absent worktree branch when its local head changed", async () => {
+  const calls: string[][] = [];
+  const workspace: PlanningWorkspaceOwnership<{
+    state: "worktree-removed";
+    pushedHeadOid: string;
+  }> = {
+    runId: "123e4567-e89b-42d3-a456-426614174000",
+    phase: "spec",
+    identity,
+    remote: "origin",
+    baseBranch: "main",
+    baseOid: oid,
+    headOid: oid,
+    cleanup: { state: "worktree-removed", pushedHeadOid: oid },
+  };
+  const adapter = new PlanningWorkspaceGit({
+    runner: {
+      run: async (_command, args) => {
+        calls.push(args);
+        if (args[0] === "worktree") return { code: 0, stdout: "", stderr: "" };
+        if (args[0] === "show-ref") return { code: 0, stdout: "", stderr: "" };
+        if (args[0] === "rev-parse")
+          return { code: 0, stdout: `${"b".repeat(40)}\n`, stderr: "" };
+        if (args[0] === "ls-remote")
+          return {
+            code: 0,
+            stdout: `${oid}\trefs/heads/topic\n`,
+            stderr: "",
+          };
+        throw new Error(`unexpected command ${args.join(" ")}`);
+      },
+    },
+    repoRoot: "/repo",
+    worktreeRoot: "/repo/.worktrees",
+  });
+  await assert.rejects(
+    adapter.removeBranch({
+      runId: workspace.runId,
+      phase: workspace.phase,
+      workspace,
+    }),
+    /head-oid-mismatch/,
+  );
+  assert.equal(
+    calls.some((args) => args[0] === "update-ref"),
+    false,
+  );
+});
+
 test("branch cleanup requires exact remote proof and expected-old CAS", async () => {
   const runId = "123e4567-e89b-42d3-a456-426614174000";
   const workspace: PlanningWorkspaceOwnership<{

--- a/src/host/factory.test.ts
+++ b/src/host/factory.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   createIssueHostProvider,
+  createPullRequestHost,
   createRepositorySetupHostProvider,
 } from "./factory.ts";
+import { ForgejoTeaPullRequestHost } from "./forgejo-tea-pull-requests.ts";
 import { ForgejoTeaHostProvider } from "./forgejo-tea.ts";
+import { GitHubGhPullRequestHost } from "./github-gh-pull-requests.ts";
 import { GitHubGhHostProvider } from "./github-gh.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
 
@@ -34,6 +37,25 @@ test("createIssueHostProvider constructs GitHub gh provider", () => {
 
   assert.ok(provider instanceof GitHubGhHostProvider);
   assert.equal(provider.id, "github-gh");
+});
+
+test("createPullRequestHost constructs provider-specific planning adapters", () => {
+  const github = createPullRequestHost({
+    runner,
+    repoRoot: "/repo",
+    remote: "upstream",
+    host: { provider: "github-gh", login: "ignored" },
+  });
+  const forgejo = createPullRequestHost({
+    runner,
+    repoRoot: "/repo",
+    remote: "fork",
+    host: { provider: "forgejo-tea", login: "planning-agent" },
+  });
+  assert.ok(github instanceof GitHubGhPullRequestHost);
+  assert.equal(github.id, "github-gh");
+  assert.ok(forgejo instanceof ForgejoTeaPullRequestHost);
+  assert.equal(forgejo.id, "forgejo-tea");
 });
 
 test("createRepositorySetupHostProvider exposes setup repository capabilities", () => {

--- a/src/host/factory.test.ts
+++ b/src/host/factory.test.ts
@@ -39,23 +39,118 @@ test("createIssueHostProvider constructs GitHub gh provider", () => {
   assert.equal(provider.id, "github-gh");
 });
 
-test("createPullRequestHost constructs provider-specific planning adapters", () => {
-  const github = createPullRequestHost({
-    runner,
+test("createPullRequestHost passes the GitHub push remote to observable discovery commands", async () => {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const host = createPullRequestHost({
+    runner: {
+      async run(command, args) {
+        calls.push({ command, args });
+        if (command === "git")
+          return {
+            code: 0,
+            stdout: "https://github.com/acme/patchmill.git\n",
+            stderr: "",
+          };
+        if (args[0] === "pr") return { code: 0, stdout: "[]", stderr: "" };
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            nameWithOwner: "acme/patchmill",
+            url: "https://github.com/acme/patchmill",
+          }),
+          stderr: "",
+        };
+      },
+    },
     repoRoot: "/repo",
     remote: "upstream",
     host: { provider: "github-gh", login: "ignored" },
   });
-  const forgejo = createPullRequestHost({
-    runner,
+  assert.ok(host instanceof GitHubGhPullRequestHost);
+  await host.findPullRequests({
+    targetRepository: {
+      provider: "github-gh",
+      host: "github.com",
+      owner: "acme",
+      repository: "patchmill",
+    },
+    baseBranch: "main",
+    headRepository: {
+      provider: "github-gh",
+      host: "github.com",
+      owner: "acme",
+      repository: "patchmill",
+    },
+    headBranch: "planning/spec",
+  });
+  assert.ok(
+    calls.some(
+      ({ command, args }) =>
+        command === "git" &&
+        args.join(" ") === "remote get-url --push --all -- upstream",
+    ),
+  );
+});
+
+test("createPullRequestHost passes Forgejo push remote and login to observable discovery commands", async () => {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const host = createPullRequestHost({
+    runner: {
+      async run(command, args) {
+        calls.push({ command, args });
+        if (command === "git")
+          return {
+            code: 0,
+            stdout: "https://forge.example/contributor/widgets.git\n",
+            stderr: "",
+          };
+        if (args.some((value) => value.includes("pulls?state=all")))
+          return { code: 0, stdout: "[]", stderr: "" };
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            name: "widgets",
+            full_name: "platform/widgets",
+            owner: { login: "platform" },
+            html_url: "https://forge.example/platform/widgets",
+          }),
+          stderr: "",
+        };
+      },
+    },
     repoRoot: "/repo",
     remote: "fork",
     host: { provider: "forgejo-tea", login: "planning-agent" },
   });
-  assert.ok(github instanceof GitHubGhPullRequestHost);
-  assert.equal(github.id, "github-gh");
-  assert.ok(forgejo instanceof ForgejoTeaPullRequestHost);
-  assert.equal(forgejo.id, "forgejo-tea");
+  assert.ok(host instanceof ForgejoTeaPullRequestHost);
+  await host.findPullRequests({
+    targetRepository: {
+      provider: "forgejo-tea",
+      host: "forge.example",
+      owner: "platform",
+      repository: "widgets",
+    },
+    baseBranch: "main",
+    headRepository: {
+      provider: "forgejo-tea",
+      host: "forge.example",
+      owner: "platform",
+      repository: "widgets",
+    },
+    headBranch: "planning/spec",
+  });
+  assert.ok(
+    calls.some(
+      ({ command, args }) =>
+        command === "git" &&
+        args.join(" ") === "remote get-url --push --all -- fork",
+    ),
+  );
+  assert.ok(
+    calls
+      .filter(({ command }) => command === "tea")
+      .every(({ args }) => args.includes("planning-agent")),
+  );
 });
 
 test("createRepositorySetupHostProvider exposes setup repository capabilities", () => {

--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -1,5 +1,8 @@
 import type { PatchmillHostConfig } from "../config/types.ts";
 import type { CommandRunner } from "../cli/commands/triage/types.ts";
+import { ForgejoTeaPullRequestHost } from "./forgejo-tea-pull-requests.ts";
+import { GitHubGhPullRequestHost } from "./github-gh-pull-requests.ts";
+import type { PullRequestHost } from "./pull-requests.ts";
 import { ForgejoTeaHostProvider } from "./forgejo-tea.ts";
 import { GitHubGhHostProvider } from "./github-gh.ts";
 import type {
@@ -24,6 +27,29 @@ function createHostProvider(options: {
       return new GitHubGhHostProvider({
         runner: options.runner,
         repoRoot: options.repoRoot,
+      });
+  }
+}
+
+export function createPullRequestHost(options: {
+  runner: CommandRunner;
+  repoRoot: string;
+  remote: string;
+  host: PatchmillHostConfig;
+}): PullRequestHost {
+  switch (options.host.provider) {
+    case "github-gh":
+      return new GitHubGhPullRequestHost({
+        runner: options.runner,
+        repoRoot: options.repoRoot,
+        pushRemote: options.remote,
+      });
+    case "forgejo-tea":
+      return new ForgejoTeaPullRequestHost({
+        runner: options.runner,
+        repoRoot: options.repoRoot,
+        pushRemote: options.remote,
+        login: options.host.login,
       });
   }
 }

--- a/src/host/pull-requests.ts
+++ b/src/host/pull-requests.ts
@@ -1,4 +1,5 @@
 import type { PatchmillHostProviderId } from "../config/types.ts";
+export { sameRepositoryIdentity } from "../workflow/planning-publication-repositories.ts";
 
 export type RepositoryIdentity = {
   provider: PatchmillHostProviderId;
@@ -45,22 +46,6 @@ export type FindPullRequestsQuery = {
   headRepository: RepositoryIdentity;
   headBranch: string;
 };
-
-function sameCaseInsensitiveValue(left: string, right: string): boolean {
-  return left.toLowerCase() === right.toLowerCase();
-}
-
-export function sameRepositoryIdentity(
-  left: RepositoryIdentity,
-  right: RepositoryIdentity,
-): boolean {
-  return (
-    left.provider === right.provider &&
-    sameCaseInsensitiveValue(left.host, right.host) &&
-    sameCaseInsensitiveValue(left.owner, right.owner) &&
-    sameCaseInsensitiveValue(left.repository, right.repository)
-  );
-}
 
 export class IncompletePullRequestSearchError extends Error {
   readonly query: FindPullRequestsQuery;

--- a/src/host/pull-requests.ts
+++ b/src/host/pull-requests.ts
@@ -1,5 +1,4 @@
 import type { PatchmillHostProviderId } from "../config/types.ts";
-export { sameRepositoryIdentity } from "../workflow/planning-publication-repositories.ts";
 
 export type RepositoryIdentity = {
   provider: PatchmillHostProviderId;
@@ -46,6 +45,22 @@ export type FindPullRequestsQuery = {
   headRepository: RepositoryIdentity;
   headBranch: string;
 };
+
+function sameCaseInsensitiveValue(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export function sameRepositoryIdentity(
+  left: RepositoryIdentity,
+  right: RepositoryIdentity,
+): boolean {
+  return (
+    left.provider === right.provider &&
+    sameCaseInsensitiveValue(left.host, right.host) &&
+    sameCaseInsensitiveValue(left.owner, right.owner) &&
+    sameCaseInsensitiveValue(left.repository, right.repository)
+  );
+}
 
 export class IncompletePullRequestSearchError extends Error {
   readonly query: FindPullRequestsQuery;

--- a/src/workflow/planning-publication-repositories.test.ts
+++ b/src/workflow/planning-publication-repositories.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PlanningStateValidationError,
+  validatePlanningState,
+} from "./planning-state.ts";
+import {
+  PlanningPublicationRepositoryError,
+  assertPlanningPublicationRepositories,
+  sameRepositoryIdentity,
+} from "./planning-publication-repositories.ts";
+import {
+  assertPlanningPublicationRepositories as assertPullRequestPublicationRepositories,
+  PlanningPullRequestValidationError,
+  validatePlanningPullRequestSummary,
+} from "./planning-pull-request-validation.ts";
+import { renderPlanningPullRequestMarker } from "./planning-pull-request-markers.ts";
+
+const oid = "a".repeat(40);
+const github = {
+  provider: "github-gh" as const,
+  host: "github.com",
+  owner: "Acme",
+  repository: "Patchmill",
+};
+const forgejo = {
+  provider: "forgejo-tea" as const,
+  host: "forge.test",
+  owner: "Acme",
+  repository: "Patchmill",
+};
+
+test("uses one case-insensitive repository identity comparison", () => {
+  assert.equal(
+    sameRepositoryIdentity(github, {
+      ...github,
+      host: "GITHUB.COM",
+      owner: "acme",
+      repository: "patchmill",
+    }),
+    true,
+  );
+});
+
+test("pull request validation maps the shared policy failure to its typed error", () => {
+  assert.throws(
+    () =>
+      assertPullRequestPublicationRepositories({
+        targetRepository: github,
+        headRepository: { ...github, repository: "fork" },
+      }),
+    (error: unknown) =>
+      error instanceof PlanningPullRequestValidationError &&
+      error.reason === "github-head-mismatch",
+  );
+});
+
+test("state parsing and pull request validation agree on publication repositories", () => {
+  for (const [name, targetRepository, headRepository, allowed] of [
+    ["github same", github, { ...github, owner: "acme" }, true],
+    ["github fork", github, { ...github, repository: "fork" }, false],
+    ["forgejo same host", forgejo, { ...forgejo, owner: "fork" }, true],
+    ["forgejo host", forgejo, { ...forgejo, host: "other.test" }, false],
+    ["provider", github, forgejo, false],
+  ] as const) {
+    const publication = {
+      targetRepository,
+      headRepository,
+      baseBranch: "main",
+      headBranch: "planning/spec",
+      headOid: oid,
+    };
+    const summary = {
+      number: 188,
+      url: `https://${targetRepository.host}/${targetRepository.owner}/${targetRepository.repository}/${targetRepository.provider === "github-gh" ? "pull" : "pulls"}/188`,
+      targetRepository,
+      baseBranch: "main",
+      headRepository,
+      headBranch: "planning/spec",
+      headSha: oid,
+      body: renderPlanningPullRequestMarker({
+        issueNumber: 188,
+        phase: "spec",
+      }),
+      status: "open" as const,
+    };
+    const document = {
+      version: 1,
+      workflowVersion: "planning-pr-v1",
+      runId: "123e4567-e89b-42d3-a456-426614174000",
+      issueNumber: 188,
+      issueTitle: "Example",
+      gates: { specRequired: true, planRequired: false },
+      phases: [
+        {
+          kind: "spec",
+          status: "branch-pushed",
+          base: {
+            remote: "origin",
+            baseBranch: "main",
+            baseOid: oid,
+            artifactCandidates: { spec: ["docs/specs/a.md"], plan: [] },
+          },
+          workspace: {
+            runId: "123e4567-e89b-42d3-a456-426614174000",
+            phase: "spec",
+            identity: {
+              branch: "planning/spec",
+              worktreePath: ".worktrees/spec",
+            },
+            remote: "origin",
+            baseBranch: "main",
+            baseOid: oid,
+            headOid: oid,
+            cleanup: { state: "ready" },
+          },
+          artifacts: [
+            {
+              kind: "spec",
+              path: "docs/specs/a.md",
+              commitOid: oid,
+              source: "workspace",
+            },
+          ],
+          publication,
+        },
+        { kind: "implementation", status: "pending" },
+      ],
+      revision: 0,
+      createdAt: "2026-09-08T12:00:00.000Z",
+      updatedAt: "2026-09-08T12:00:00.000Z",
+    };
+    const attempts = [
+      () => assertPlanningPublicationRepositories(publication),
+      () => validatePlanningState(document),
+      () =>
+        validatePlanningPullRequestSummary({
+          summary,
+          issueNumber: 188,
+          phase: "spec",
+          publication,
+        }),
+    ];
+    for (const attempt of attempts) {
+      if (allowed) assert.doesNotThrow(attempt, name);
+      else
+        assert.throws(
+          attempt,
+          (error: unknown) =>
+            error instanceof PlanningPublicationRepositoryError ||
+            error instanceof PlanningStateValidationError ||
+            error instanceof PlanningPullRequestValidationError,
+          name,
+        );
+    }
+  }
+});

--- a/src/workflow/planning-publication-repositories.test.ts
+++ b/src/workflow/planning-publication-repositories.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { sameRepositoryIdentity } from "../host/pull-requests.ts";
 import {
   PlanningStateValidationError,
   validatePlanningState,
@@ -7,7 +8,6 @@ import {
 import {
   PlanningPublicationRepositoryError,
   assertPlanningPublicationRepositories,
-  sameRepositoryIdentity,
 } from "./planning-publication-repositories.ts";
 import {
   assertPlanningPublicationRepositories as assertPullRequestPublicationRepositories,

--- a/src/workflow/planning-publication-repositories.ts
+++ b/src/workflow/planning-publication-repositories.ts
@@ -1,4 +1,7 @@
-import type { RepositoryIdentity } from "../host/pull-requests.ts";
+import {
+  sameRepositoryIdentity,
+  type RepositoryIdentity,
+} from "../host/pull-requests.ts";
 
 export type PlanningPublicationRepositoryReason =
   | "provider-mismatch"
@@ -15,20 +18,11 @@ export class PlanningPublicationRepositoryError extends Error {
   }
 }
 
-function sameCaseInsensitiveValue(left: string, right: string): boolean {
-  return left.toLowerCase() === right.toLowerCase();
-}
-
-export function sameRepositoryIdentity(
+function sameRepositoryHost(
   left: RepositoryIdentity,
   right: RepositoryIdentity,
 ): boolean {
-  return (
-    left.provider === right.provider &&
-    sameCaseInsensitiveValue(left.host, right.host) &&
-    sameCaseInsensitiveValue(left.owner, right.owner) &&
-    sameCaseInsensitiveValue(left.repository, right.repository)
-  );
+  return left.host.toLowerCase() === right.host.toLowerCase();
 }
 
 export function assertPlanningPublicationRepositories(input: {
@@ -47,7 +41,7 @@ export function assertPlanningPublicationRepositories(input: {
   }
   if (
     targetRepository.provider === "forgejo-tea" &&
-    !sameCaseInsensitiveValue(targetRepository.host, headRepository.host)
+    !sameRepositoryHost(targetRepository, headRepository)
   ) {
     throw new PlanningPublicationRepositoryError("forgejo-host-mismatch");
   }

--- a/src/workflow/planning-publication-repositories.ts
+++ b/src/workflow/planning-publication-repositories.ts
@@ -1,0 +1,54 @@
+import type { RepositoryIdentity } from "../host/pull-requests.ts";
+
+export type PlanningPublicationRepositoryReason =
+  | "provider-mismatch"
+  | "github-head-mismatch"
+  | "forgejo-host-mismatch";
+
+export class PlanningPublicationRepositoryError extends Error {
+  readonly reason: PlanningPublicationRepositoryReason;
+
+  constructor(reason: PlanningPublicationRepositoryReason) {
+    super(`Planning publication repository is invalid: ${reason}`);
+    this.name = "PlanningPublicationRepositoryError";
+    this.reason = reason;
+  }
+}
+
+function sameCaseInsensitiveValue(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+export function sameRepositoryIdentity(
+  left: RepositoryIdentity,
+  right: RepositoryIdentity,
+): boolean {
+  return (
+    left.provider === right.provider &&
+    sameCaseInsensitiveValue(left.host, right.host) &&
+    sameCaseInsensitiveValue(left.owner, right.owner) &&
+    sameCaseInsensitiveValue(left.repository, right.repository)
+  );
+}
+
+export function assertPlanningPublicationRepositories(input: {
+  targetRepository: RepositoryIdentity;
+  headRepository: RepositoryIdentity;
+}): void {
+  const { targetRepository, headRepository } = input;
+  if (targetRepository.provider !== headRepository.provider) {
+    throw new PlanningPublicationRepositoryError("provider-mismatch");
+  }
+  if (
+    targetRepository.provider === "github-gh" &&
+    !sameRepositoryIdentity(targetRepository, headRepository)
+  ) {
+    throw new PlanningPublicationRepositoryError("github-head-mismatch");
+  }
+  if (
+    targetRepository.provider === "forgejo-tea" &&
+    !sameCaseInsensitiveValue(targetRepository.host, headRepository.host)
+  ) {
+    throw new PlanningPublicationRepositoryError("forgejo-host-mismatch");
+  }
+}

--- a/src/workflow/planning-pull-request-validation.test.ts
+++ b/src/workflow/planning-pull-request-validation.test.ts
@@ -206,3 +206,59 @@ test("rejects missing duplicate and unsupported markers without leaking body sen
     }
   }
 });
+
+test("rejects expected-reference and URL shape mismatches without exposing confidential bodies", () => {
+  const secret = "private-body-sentinel";
+  const expectedReference = { targetRepository: repository, number: 189 };
+  const cases = [
+    { name: "reference", summary, expectedReference },
+    {
+      name: "url number",
+      summary: {
+        ...summary,
+        url: "https://github.com/acme/patchmill/pull/189",
+      },
+    },
+    {
+      name: "provider segment",
+      summary: {
+        ...summary,
+        url: "https://github.com/acme/patchmill/pulls/188",
+      },
+    },
+    {
+      name: "credential URL",
+      summary: {
+        ...summary,
+        url: "https://token@example.com/acme/patchmill/pull/188",
+        body: secret,
+      },
+    },
+    {
+      name: "phase marker",
+      summary: {
+        ...summary,
+        body: `${secret}\n${renderPlanningPullRequestMarker({ issueNumber: 188, phase: "plan" })}`,
+      },
+    },
+  ];
+  for (const item of cases) {
+    assert.throws(
+      () =>
+        validatePlanningPullRequestSummary({
+          summary: item.summary,
+          issueNumber: 188,
+          phase: "spec",
+          publication,
+          ...(item.expectedReference === undefined
+            ? {}
+            : { expectedReference: item.expectedReference }),
+        }),
+      (error: unknown) =>
+        error instanceof PlanningPullRequestValidationError &&
+        !error.message.includes(secret) &&
+        !JSON.stringify(error).includes(secret),
+      item.name,
+    );
+  }
+});

--- a/src/workflow/planning-pull-request-validation.test.ts
+++ b/src/workflow/planning-pull-request-validation.test.ts
@@ -122,3 +122,87 @@ test("permits same-host Forgejo heads and rejects cross-host heads", () => {
     /forgejo-host-mismatch/,
   );
 });
+
+test("rejects every immutable pull request summary identity mutation", () => {
+  const mutations: Array<[string, (value: Record<string, unknown>) => void]> = [
+    [
+      "target repository",
+      (value) => {
+        value.targetRepository = { ...repository, repository: "other" };
+      },
+    ],
+    [
+      "head repository",
+      (value) => {
+        value.headRepository = { ...repository, repository: "other" };
+      },
+    ],
+    [
+      "base branch",
+      (value) => {
+        value.baseBranch = "other";
+      },
+    ],
+    [
+      "head branch",
+      (value) => {
+        value.headBranch = "planning/other";
+      },
+    ],
+    [
+      "head oid",
+      (value) => {
+        value.headSha = "b".repeat(40);
+      },
+    ],
+    [
+      "url",
+      (value) => {
+        value.url = "https://github.com/acme/other/pull/188";
+      },
+    ],
+  ];
+  for (const [name, mutate] of mutations) {
+    const value = structuredClone(summary) as Record<string, unknown>;
+    mutate(value);
+    assert.throws(
+      () =>
+        validatePlanningPullRequestSummary({
+          summary: value as never,
+          issueNumber: 188,
+          phase: "spec",
+          publication,
+        }),
+      PlanningPullRequestValidationError,
+      name,
+    );
+  }
+});
+
+test("rejects missing duplicate and unsupported markers without leaking body sentinels", () => {
+  const secret = "credential-sentinel-should-never-escape";
+  const bodies = [
+    secret,
+    `${secret}\n${renderPlanningPullRequestMarker({ issueNumber: 188, phase: "spec" })}\n${renderPlanningPullRequestMarker({ issueNumber: 188, phase: "spec" })}`,
+    `${secret}\n<!-- patchmill:planning-pr-v2 issue=188 phase=spec -->`,
+  ];
+  for (const body of bodies) {
+    try {
+      validatePlanningPullRequestSummary({
+        summary: { ...summary, body },
+        issueNumber: 188,
+        phase: "spec",
+        publication,
+      });
+      assert.fail("expected validation failure");
+    } catch (error) {
+      assert.ok(error instanceof PlanningPullRequestValidationError);
+      assert.equal(error.message.includes(secret), false);
+      assert.equal(JSON.stringify(error).includes(secret), false);
+      assert.equal(
+        Object.values(error).some((value) => String(value).includes(secret)),
+        false,
+      );
+    }
+  }
+});

--- a/src/workflow/planning-pull-request-validation.test.ts
+++ b/src/workflow/planning-pull-request-validation.test.ts
@@ -61,6 +61,31 @@ test("rejects a marker mismatch without disclosing the body", () => {
       error.reason === "ownership-marker",
   );
 });
+test("accepts a port-qualified Forgejo pull request URL", () => {
+  const forgejo = {
+    provider: "forgejo-tea" as const,
+    host: "forge.test:3000",
+    owner: "acme",
+    repository: "patchmill",
+  };
+  assert.doesNotThrow(() =>
+    validatePlanningPullRequestSummary({
+      summary: {
+        ...summary,
+        url: "https://forge.test:3000/acme/patchmill/pulls/188",
+        targetRepository: forgejo,
+        headRepository: forgejo,
+      },
+      issueNumber: 188,
+      phase: "spec",
+      publication: {
+        ...publication,
+        targetRepository: forgejo,
+        headRepository: forgejo,
+      },
+    }),
+  );
+});
 test("permits same-host Forgejo heads and rejects cross-host heads", () => {
   assert.doesNotThrow(() =>
     assertPlanningPublicationRepositories({

--- a/src/workflow/planning-pull-request-validation.test.ts
+++ b/src/workflow/planning-pull-request-validation.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderPlanningPullRequestMarker } from "./planning-pull-request-markers.ts";
+import {
+  assertPlanningPublicationRepositories,
+  PlanningPullRequestValidationError,
+  validatePlanningPullRequestSummary,
+} from "./planning-pull-request-validation.ts";
+
+const repository = {
+  provider: "github-gh" as const,
+  host: "github.com",
+  owner: "acme",
+  repository: "patchmill",
+};
+const publication = {
+  targetRepository: repository,
+  headRepository: repository,
+  baseBranch: "main",
+  headBranch: "planning/spec",
+  headOid: "a".repeat(40),
+};
+const summary = {
+  number: 188,
+  url: "https://github.com/acme/patchmill/pull/188",
+  targetRepository: repository,
+  baseBranch: "main",
+  headRepository: repository,
+  headBranch: "planning/spec",
+  headSha: "a".repeat(40),
+  body: `Human text\n\n${renderPlanningPullRequestMarker({ issueNumber: 188, phase: "spec" })}`,
+  status: "open" as const,
+};
+test("accepts exactly matching owned planning pull requests", () => {
+  assert.deepEqual(
+    validatePlanningPullRequestSummary({
+      summary,
+      issueNumber: 188,
+      phase: "spec",
+      publication,
+    }).reference.number,
+    188,
+  );
+});
+test("rejects a marker mismatch without disclosing the body", () => {
+  const secret = "https://token@example.test/private";
+  assert.throws(
+    () =>
+      validatePlanningPullRequestSummary({
+        summary: {
+          ...summary,
+          body: `${secret}\n${renderPlanningPullRequestMarker({ issueNumber: 187, phase: "spec" })}`,
+        },
+        issueNumber: 188,
+        phase: "spec",
+        publication,
+      }),
+    (error: unknown) =>
+      error instanceof PlanningPullRequestValidationError &&
+      !error.message.includes(secret) &&
+      error.reason === "ownership-marker",
+  );
+});
+test("permits same-host Forgejo heads and rejects cross-host heads", () => {
+  assert.doesNotThrow(() =>
+    assertPlanningPublicationRepositories({
+      targetRepository: {
+        provider: "forgejo-tea",
+        host: "forge.test",
+        owner: "one",
+        repository: "source",
+      },
+      headRepository: {
+        provider: "forgejo-tea",
+        host: "FORGE.TEST",
+        owner: "two",
+        repository: "fork",
+      },
+    }),
+  );
+  assert.throws(
+    () =>
+      assertPlanningPublicationRepositories({
+        targetRepository: {
+          provider: "forgejo-tea",
+          host: "forge.test",
+          owner: "one",
+          repository: "source",
+        },
+        headRepository: {
+          provider: "forgejo-tea",
+          host: "other.test",
+          owner: "two",
+          repository: "fork",
+        },
+      }),
+    /forgejo-host-mismatch/,
+  );
+});

--- a/src/workflow/planning-pull-request-validation.ts
+++ b/src/workflow/planning-pull-request-validation.ts
@@ -1,6 +1,7 @@
-import type {
-  PullRequestReference,
-  PullRequestSummary,
+import {
+  sameRepositoryIdentity,
+  type PullRequestReference,
+  type PullRequestSummary,
 } from "../host/pull-requests.ts";
 import { parsePullRequestUrl } from "../host/pull-request-reference.ts";
 import {
@@ -11,7 +12,6 @@ import type { PlanningPublicationEvidence } from "./planning-state-types.ts";
 import {
   assertPlanningPublicationRepositories as assertPublicationRepositories,
   PlanningPublicationRepositoryError,
-  sameRepositoryIdentity,
 } from "./planning-publication-repositories.ts";
 
 export type ValidatedPlanningPullRequest = Readonly<{

--- a/src/workflow/planning-pull-request-validation.ts
+++ b/src/workflow/planning-pull-request-validation.ts
@@ -1,8 +1,6 @@
-import {
-  sameRepositoryIdentity,
-  type PullRequestReference,
-  type PullRequestSummary,
-  type RepositoryIdentity,
+import type {
+  PullRequestReference,
+  PullRequestSummary,
 } from "../host/pull-requests.ts";
 import { parsePullRequestUrl } from "../host/pull-request-reference.ts";
 import {
@@ -10,6 +8,11 @@ import {
   PlanningPullRequestMarkerError,
 } from "./planning-pull-request-markers.ts";
 import type { PlanningPublicationEvidence } from "./planning-state-types.ts";
+import {
+  assertPlanningPublicationRepositories as assertPublicationRepositories,
+  PlanningPublicationRepositoryError,
+  sameRepositoryIdentity,
+} from "./planning-publication-repositories.ts";
 
 export type ValidatedPlanningPullRequest = Readonly<{
   summary: PullRequestSummary;
@@ -27,29 +30,16 @@ export class PlanningPullRequestValidationError extends Error {
 function fail(reason: string): never {
   throw new PlanningPullRequestValidationError(reason);
 }
-function sameForgejoHost(
-  left: RepositoryIdentity,
-  right: RepositoryIdentity,
-): boolean {
-  return (
-    left.provider === "forgejo-tea" &&
-    right.provider === "forgejo-tea" &&
-    left.host.toLowerCase() === right.host.toLowerCase()
-  );
-}
 export function assertPlanningPublicationRepositories(input: {
-  targetRepository: RepositoryIdentity;
-  headRepository: RepositoryIdentity;
+  targetRepository: PlanningPublicationEvidence["targetRepository"];
+  headRepository: PlanningPublicationEvidence["headRepository"];
 }): void {
-  if (input.targetRepository.provider !== input.headRepository.provider)
-    fail("provider-mismatch");
-  if (input.targetRepository.provider === "github-gh") {
-    if (!sameRepositoryIdentity(input.targetRepository, input.headRepository))
-      fail("github-head-mismatch");
-    return;
+  try {
+    assertPublicationRepositories(input);
+  } catch (error) {
+    if (error instanceof PlanningPublicationRepositoryError) fail(error.reason);
+    throw error;
   }
-  if (!sameForgejoHost(input.targetRepository, input.headRepository))
-    fail("forgejo-host-mismatch");
 }
 export function validatePlanningPullRequestSummary(input: {
   summary: PullRequestSummary;

--- a/src/workflow/planning-pull-request-validation.ts
+++ b/src/workflow/planning-pull-request-validation.ts
@@ -1,0 +1,121 @@
+import {
+  sameRepositoryIdentity,
+  type PullRequestReference,
+  type PullRequestSummary,
+  type RepositoryIdentity,
+} from "../host/pull-requests.ts";
+import { parsePullRequestUrl } from "../host/pull-request-reference.ts";
+import {
+  parsePlanningPullRequestMarker,
+  PlanningPullRequestMarkerError,
+} from "./planning-pull-request-markers.ts";
+import type { PlanningPublicationEvidence } from "./planning-state-types.ts";
+
+export type ValidatedPlanningPullRequest = Readonly<{
+  summary: PullRequestSummary;
+  reference: PullRequestReference;
+  url: string;
+}>;
+export class PlanningPullRequestValidationError extends Error {
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`Planning pull request is invalid: ${reason}`);
+    this.name = "PlanningPullRequestValidationError";
+    this.reason = reason;
+  }
+}
+function fail(reason: string): never {
+  throw new PlanningPullRequestValidationError(reason);
+}
+function sameForgejoHost(
+  left: RepositoryIdentity,
+  right: RepositoryIdentity,
+): boolean {
+  return (
+    left.provider === "forgejo-tea" &&
+    right.provider === "forgejo-tea" &&
+    left.host.toLowerCase() === right.host.toLowerCase()
+  );
+}
+export function assertPlanningPublicationRepositories(input: {
+  targetRepository: RepositoryIdentity;
+  headRepository: RepositoryIdentity;
+}): void {
+  if (input.targetRepository.provider !== input.headRepository.provider)
+    fail("provider-mismatch");
+  if (input.targetRepository.provider === "github-gh") {
+    if (!sameRepositoryIdentity(input.targetRepository, input.headRepository))
+      fail("github-head-mismatch");
+    return;
+  }
+  if (!sameForgejoHost(input.targetRepository, input.headRepository))
+    fail("forgejo-host-mismatch");
+}
+export function validatePlanningPullRequestSummary(input: {
+  summary: PullRequestSummary;
+  issueNumber: number;
+  phase: "spec" | "plan";
+  publication: PlanningPublicationEvidence;
+  expectedReference?: PullRequestReference;
+}): ValidatedPlanningPullRequest {
+  try {
+    assertPlanningPublicationRepositories(input.publication);
+    const { summary, publication } = input;
+    if (
+      !sameRepositoryIdentity(
+        summary.targetRepository,
+        publication.targetRepository,
+      )
+    )
+      fail("target-repository");
+    if (
+      !sameRepositoryIdentity(
+        summary.headRepository,
+        publication.headRepository,
+      )
+    )
+      fail("head-repository");
+    if (summary.baseBranch !== publication.baseBranch) fail("base-branch");
+    if (summary.headBranch !== publication.headBranch) fail("head-branch");
+    if (summary.headSha !== publication.headOid) fail("head-oid");
+    const marker = parsePlanningPullRequestMarker(summary.body);
+    if (
+      marker === undefined ||
+      marker.issueNumber !== input.issueNumber ||
+      marker.phase !== input.phase
+    )
+      fail("ownership-marker");
+    const segment =
+      summary.targetRepository.provider === "github-gh" ? "pull" : "pulls";
+    const parsed = parsePullRequestUrl(summary.url, segment);
+    if (
+      parsed.hostname.toLowerCase() !==
+        summary.targetRepository.host.toLowerCase() ||
+      parsed.owner.toLowerCase() !==
+        summary.targetRepository.owner.toLowerCase() ||
+      parsed.repository.toLowerCase() !==
+        summary.targetRepository.repository.toLowerCase() ||
+      parsed.number !== summary.number
+    )
+      fail("url");
+    const reference = {
+      targetRepository: summary.targetRepository,
+      number: summary.number,
+    };
+    if (
+      input.expectedReference !== undefined &&
+      (!sameRepositoryIdentity(
+        reference.targetRepository,
+        input.expectedReference.targetRepository,
+      ) ||
+        reference.number !== input.expectedReference.number)
+    )
+      fail("reference");
+    return { summary, reference, url: summary.url };
+  } catch (error) {
+    if (error instanceof PlanningPullRequestValidationError) throw error;
+    if (error instanceof PlanningPullRequestMarkerError)
+      fail("ownership-marker");
+    fail("malformed-summary");
+  }
+}

--- a/src/workflow/planning-pull-request-validation.ts
+++ b/src/workflow/planning-pull-request-validation.ts
@@ -89,7 +89,7 @@ export function validatePlanningPullRequestSummary(input: {
       summary.targetRepository.provider === "github-gh" ? "pull" : "pulls";
     const parsed = parsePullRequestUrl(summary.url, segment);
     if (
-      parsed.hostname.toLowerCase() !==
+      `${parsed.hostname}${parsed.port === "" ? "" : `:${parsed.port}`}`.toLowerCase() !==
         summary.targetRepository.host.toLowerCase() ||
       parsed.owner.toLowerCase() !==
         summary.targetRepository.owner.toLowerCase() ||

--- a/src/workflow/planning-state-publication-regressions.test.ts
+++ b/src/workflow/planning-state-publication-regressions.test.ts
@@ -1,0 +1,521 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertPlanningPhaseReplacement } from "./planning-state-transitions.ts";
+import {
+  PlanningStateValidationError,
+  validatePlanningState,
+} from "./planning-state.ts";
+
+const oid = (character: string) => character.repeat(40);
+const runId = "123e4567-e89b-42d3-a456-426614174000";
+const base = {
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid("a"),
+  artifactCandidates: { spec: ["docs/specs/a.md"], plan: [] },
+};
+const workspace = (cleanup: unknown = { state: "ready" }) => ({
+  runId,
+  phase: "spec",
+  identity: { branch: "planning/spec", worktreePath: ".worktrees/spec" },
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid("a"),
+  headOid: oid("b"),
+  cleanup,
+});
+const publication = {
+  targetRepository: {
+    provider: "github-gh",
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  },
+  headRepository: {
+    provider: "github-gh",
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  },
+  baseBranch: "main",
+  headBranch: "planning/spec",
+  headOid: oid("b"),
+};
+const artifact = (
+  source: "workspace" | "remote-base" = "workspace",
+  commitOid = oid("b"),
+) => ({
+  kind: "spec",
+  path: "docs/specs/a.md",
+  source,
+  commitOid,
+});
+const pullRequest = {
+  reference: { targetRepository: publication.targetRepository, number: 188 },
+  url: "https://github.com/acme/patchmill/pull/188",
+};
+function phase(
+  status: string,
+  cleanup: unknown = { state: "ready" },
+): Record<string, unknown> {
+  if (status === "pending") return { kind: "spec", status };
+  if (status === "workspace-ready")
+    return {
+      kind: "spec",
+      status,
+      base,
+      workspace: workspace(cleanup),
+      artifacts: [],
+    };
+  if (status === "branch-pushed")
+    return {
+      kind: "spec",
+      status,
+      base,
+      workspace: workspace(cleanup),
+      artifacts: [artifact()],
+      publication,
+    };
+  if (status === "pull-request-open")
+    return {
+      kind: "spec",
+      status,
+      base,
+      workspace: workspace(cleanup),
+      artifacts: [artifact()],
+      publication,
+      pullRequest,
+    };
+  if (status === "remote-base")
+    return {
+      kind: "spec",
+      status: "complete",
+      base,
+      artifacts: [artifact("remote-base", oid("a"))],
+      completion: { kind: "remote-base" },
+    };
+  return {
+    kind: "spec",
+    status: "complete",
+    base,
+    workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+    artifacts: [artifact("remote-base", oid("c"))],
+    publication,
+    pullRequest,
+    completion: {
+      kind: "merged-pull-request",
+      mergeOid: oid("d"),
+      mergedBaseOid: oid("c"),
+    },
+  };
+}
+function document(phaseValue: object) {
+  return {
+    version: 1,
+    workflowVersion: "planning-pr-v1",
+    runId,
+    issueNumber: 188,
+    issueTitle: "Example",
+    gates: { specRequired: true, planRequired: false },
+    phases: [phaseValue, { kind: "implementation", status: "pending" }],
+    revision: 0,
+    createdAt: "2026-09-08T12:00:00.000Z",
+    updatedAt: "2026-09-08T12:00:00.000Z",
+  };
+}
+function parsed(status: string, cleanup?: unknown) {
+  return validatePlanningState(document(phase(status, cleanup))).phases[0]!;
+}
+function invalid(value: unknown, reason: string, path: string): void {
+  assert.throws(
+    () => validatePlanningState(value),
+    (error: unknown) =>
+      error instanceof PlanningStateValidationError &&
+      error.reason === reason &&
+      error.path === path,
+  );
+}
+
+test("rejects nested unknown and missing fields at stable paths for every state variant", () => {
+  const cases: ReadonlyArray<
+    [string, string, (value: Record<string, unknown>) => void, string, string]
+  > = [
+    [
+      "pending unknown",
+      "pending",
+      (value) => {
+        value.extra = true;
+      },
+      "unknown-key",
+      "$.phases[0].extra",
+    ],
+    [
+      "workspace base missing",
+      "workspace-ready",
+      (value) => {
+        delete (value.base as Record<string, unknown>).remote;
+      },
+      "missing-key",
+      "$.phases[0].base.remote",
+    ],
+    [
+      "branch publication unknown",
+      "branch-pushed",
+      (value) => {
+        (value.publication as Record<string, unknown>).extra = true;
+      },
+      "unknown-key",
+      "$.phases[0].publication.extra",
+    ],
+    [
+      "open reference missing",
+      "pull-request-open",
+      (value) => {
+        delete (
+          (value.pullRequest as Record<string, unknown>).reference as Record<
+            string,
+            unknown
+          >
+        ).number;
+      },
+      "missing-key",
+      "$.phases[0].pullRequest.reference.number",
+    ],
+    [
+      "remote completion unknown",
+      "remote-base",
+      (value) => {
+        (value.completion as Record<string, unknown>).extra = true;
+      },
+      "unknown-key",
+      "$.phases[0].completion.extra",
+    ],
+    [
+      "merged completion missing",
+      "merged",
+      (value) => {
+        delete (value.completion as Record<string, unknown>).mergedBaseOid;
+      },
+      "missing-key",
+      "$.phases[0].completion.mergedBaseOid",
+    ],
+  ];
+  for (const [, status, mutate, reason, path] of cases) {
+    const value = structuredClone(phase(status));
+    mutate(value);
+    invalid(document(value), reason, path);
+  }
+});
+
+test("rejects artifact, publication, cleanup, pull request, and phase-order contradictions", () => {
+  const cases: ReadonlyArray<
+    [string, (value: Record<string, unknown>) => void, string, string]
+  > = [
+    [
+      "workspace artifact commit",
+      (value) => {
+        (value.artifacts as Record<string, unknown>[])[0]!.commitOid = oid("a");
+      },
+      "workspace-artifact-mismatch",
+      "$.phases[0].artifacts[0]",
+    ],
+    [
+      "remote artifact source",
+      (value) => {
+        (value.artifacts as Record<string, unknown>[])[0]!.source =
+          "remote-base";
+      },
+      "remote-artifact-mismatch",
+      "$.phases[0].artifacts[0]",
+    ],
+    [
+      "publication branch",
+      (value) => {
+        (value.publication as Record<string, unknown>).headBranch =
+          "planning/other";
+      },
+      "publication-mismatch",
+      "$.phases[0].publication",
+    ],
+    [
+      "cleanup head",
+      (value) => {
+        (value.workspace as Record<string, unknown>).cleanup = {
+          state: "removed",
+          pushedHeadOid: oid("c"),
+        };
+      },
+      "cleanup-head-mismatch",
+      "$.phases[0].workspace.cleanup.pushedHeadOid",
+    ],
+    [
+      "pull request target",
+      (value) => {
+        (
+          (value.pullRequest as Record<string, unknown>).reference as Record<
+            string,
+            unknown
+          >
+        ).targetRepository = {
+          ...publication.targetRepository,
+          repository: "other",
+        };
+      },
+      "pull-request-mismatch",
+      "$.phases[0].pullRequest",
+    ],
+  ];
+  for (const [, mutate, reason, path] of cases) {
+    const value = structuredClone(phase("pull-request-open"));
+    mutate(value);
+    invalid(document(value), reason, path);
+  }
+  const outOfOrder = document(phase("pending"));
+  outOfOrder.phases[1] = {
+    kind: "implementation",
+    status: "workspace-ready",
+    base: {
+      ...base,
+      artifactCandidates: { spec: [], plan: ["docs/plans/a.md"] },
+    },
+    workspace: {
+      ...workspace(),
+      phase: "implementation",
+      identity: {
+        branch: "planning/implementation",
+        worktreePath: ".worktrees/implementation",
+      },
+    },
+    artifacts: [],
+  };
+  invalid(outOfOrder, "progress-order", "$.phases[1]");
+});
+
+test("requires planner artifact order and source-specific commit evidence", () => {
+  const planBase = {
+    ...base,
+    artifactCandidates: {
+      spec: ["docs/specs/a.md"],
+      plan: ["docs/plans/a.md"],
+    },
+  };
+  const planWorkspace = {
+    ...workspace(),
+    phase: "plan",
+    identity: { branch: "planning/plan", worktreePath: ".worktrees/plan" },
+  };
+  const planPhase = {
+    kind: "plan",
+    status: "workspace-ready",
+    base: planBase,
+    workspace: planWorkspace,
+    artifacts: [
+      {
+        kind: "spec",
+        path: "docs/specs/a.md",
+        source: "remote-base",
+        commitOid: oid("a"),
+      },
+      {
+        kind: "plan",
+        path: "docs/plans/a.md",
+        source: "workspace",
+        commitOid: oid("b"),
+      },
+    ],
+  };
+  const value = {
+    ...document(planPhase),
+    gates: { specRequired: false, planRequired: true },
+    phases: [planPhase, { kind: "implementation", status: "pending" }],
+  };
+  assert.doesNotThrow(() => validatePlanningState(value));
+  const reversed = structuredClone(value);
+  reversed.phases[0].artifacts.reverse();
+  invalid(reversed, "artifact-kinds", "$.phases[0].artifacts");
+  const wrongRemoteCommit = structuredClone(value);
+  wrongRemoteCommit.phases[0].artifacts[0].commitOid = oid("c");
+  invalid(
+    wrongRemoteCommit,
+    "remote-artifact-mismatch",
+    "$.phases[0].artifacts[0]",
+  );
+});
+
+test("rejects duplicate and canonically equivalent workspace identities", () => {
+  const planBase = {
+    ...base,
+    artifactCandidates: {
+      spec: ["docs/specs/a.md"],
+      plan: ["docs/plans/a.md"],
+    },
+  };
+  const planWorkspace = {
+    ...workspace({ state: "removed", pushedHeadOid: oid("b") }),
+    phase: "plan",
+    identity: { branch: "planning/plan", worktreePath: ".worktrees/plan" },
+  };
+  const planPublication = { ...publication, headBranch: "planning/plan" };
+  const planPullRequest = {
+    reference: { targetRepository: publication.targetRepository, number: 189 },
+    url: "https://github.com/acme/patchmill/pull/189",
+  };
+  const completePlan = {
+    kind: "plan",
+    status: "complete",
+    base: planBase,
+    workspace: planWorkspace,
+    artifacts: [
+      {
+        kind: "plan",
+        path: "docs/plans/a.md",
+        source: "remote-base",
+        commitOid: oid("c"),
+      },
+    ],
+    publication: planPublication,
+    pullRequest: planPullRequest,
+    completion: {
+      kind: "merged-pull-request",
+      mergeOid: oid("d"),
+      mergedBaseOid: oid("c"),
+    },
+  };
+  const implementationWorkspace = {
+    ...workspace(),
+    phase: "implementation",
+    identity: {
+      branch: "planning/implementation",
+      worktreePath: ".worktrees/other/../plan",
+    },
+  };
+  const value = {
+    ...document(phase("remote-base")),
+    gates: { specRequired: true, planRequired: true },
+    phases: [
+      phase("remote-base"),
+      completePlan,
+      {
+        kind: "implementation",
+        status: "workspace-ready",
+        base: planBase,
+        workspace: implementationWorkspace,
+        artifacts: [],
+      },
+    ],
+  };
+  invalid(
+    value,
+    "duplicate-workspace-identity",
+    "$.phases[2].workspace.identity",
+  );
+  const duplicateBranch = structuredClone(value);
+  (duplicateBranch.phases[2].workspace.identity as { branch: string }).branch =
+    "planning/plan";
+  (
+    duplicateBranch.phases[2].workspace.identity as { worktreePath: string }
+  ).worktreePath = ".worktrees/implementation";
+  invalid(
+    duplicateBranch,
+    "duplicate-workspace-identity",
+    "$.phases[2].workspace.identity",
+  );
+});
+
+test("permits every checkpoint edge and rejects skipped or backward checkpoint edges", () => {
+  const ready = parsed("workspace-ready");
+  const artifactReady = validatePlanningState(
+    document({
+      ...phase("workspace-ready"),
+      workspace: { ...workspace(), headOid: oid("c") },
+      artifacts: [artifact("workspace", oid("c"))],
+    }),
+  ).phases[0]!;
+  const readyForPush = validatePlanningState(
+    document({ ...phase("workspace-ready"), artifacts: [artifact()] }),
+  ).phases[0]!;
+  const pushed = parsed("branch-pushed");
+  const open = parsed("pull-request-open");
+  const worktreeRemoved = parsed("pull-request-open", {
+    state: "worktree-removed",
+    pushedHeadOid: oid("b"),
+  });
+  const removed = parsed("pull-request-open", {
+    state: "removed",
+    pushedHeadOid: oid("b"),
+  });
+  const remoteBase = parsed("remote-base");
+  const merged = parsed("merged");
+  const allowed: ReadonlyArray<[typeof ready, typeof ready]> = [
+    [parsed("pending"), parsed("pending")],
+    [parsed("pending"), ready],
+    [parsed("pending"), remoteBase],
+    [ready, ready],
+    [ready, artifactReady],
+    [ready, readyForPush],
+    [readyForPush, pushed],
+    [pushed, pushed],
+    [pushed, open],
+    [open, open],
+    [open, worktreeRemoved],
+    [worktreeRemoved, worktreeRemoved],
+    [worktreeRemoved, removed],
+    [removed, removed],
+    [removed, merged],
+    [remoteBase, remoteBase],
+    [merged, merged],
+  ];
+  for (const [current, next] of allowed)
+    assert.doesNotThrow(() => assertPlanningPhaseReplacement(current, next, 0));
+  for (const [current, next] of [
+    [ready, open],
+    [pushed, removed],
+    [open, removed],
+    [worktreeRemoved, open],
+    [removed, open],
+  ] as const)
+    assert.throws(
+      () => assertPlanningPhaseReplacement(current, next, 0),
+      PlanningStateValidationError,
+    );
+});
+
+test("keeps immutable publication and pull request evidence after publication", () => {
+  const pushed = parsed("branch-pushed");
+  const open = parsed("pull-request-open");
+  for (const mutate of [
+    (value: Record<string, unknown>) => {
+      (value.publication as Record<string, unknown>).headOid = oid("c");
+    },
+    (value: Record<string, unknown>) => {
+      (value.workspace as Record<string, unknown>).headOid = oid("c");
+    },
+    (value: Record<string, unknown>) => {
+      (value.artifacts as Record<string, unknown>[])[0]!.path =
+        "docs/specs/other.md";
+    },
+    (value: Record<string, unknown>) => {
+      (
+        (value.pullRequest as Record<string, unknown>).reference as Record<
+          string,
+          unknown
+        >
+      ).number = 189;
+    },
+  ]) {
+    const next = structuredClone(open) as Record<string, unknown>;
+    mutate(next);
+    assert.throws(
+      () => assertPlanningPhaseReplacement(open, next as never, 0),
+      PlanningStateValidationError,
+    );
+  }
+  const changedPublication = structuredClone(pushed) as Record<string, unknown>;
+  (changedPublication.publication as Record<string, unknown>).headOid =
+    oid("c");
+  assert.throws(
+    () =>
+      assertPlanningPhaseReplacement(pushed, changedPublication as never, 0),
+    PlanningStateValidationError,
+  );
+});

--- a/src/workflow/planning-state-publication-regressions.test.ts
+++ b/src/workflow/planning-state-publication-regressions.test.ts
@@ -136,6 +136,61 @@ function invalid(value: unknown, reason: string, path: string): void {
   );
 }
 
+test("preserves strict v1 scalar and schema rejection reasons and paths", () => {
+  const cases: ReadonlyArray<
+    [string, (value: Record<string, unknown>) => void, string, string]
+  > = [
+    [
+      "unsupported version",
+      (value) => {
+        value.version = 2;
+      },
+      "unsupported-version",
+      "$.version",
+    ],
+    [
+      "negative revision",
+      (value) => {
+        value.revision = -1;
+      },
+      "invalid-nonnegative-integer",
+      "$.revision",
+    ],
+    [
+      "invalid timestamp",
+      (value) => {
+        value.updatedAt = "not-a-timestamp";
+      },
+      "invalid-timestamp",
+      "$.updatedAt",
+    ],
+    [
+      "invalid worktree path",
+      (value) => {
+        (
+          (value.phases as Array<Record<string, unknown>>)[0]!
+            .workspace as Record<string, unknown>
+        ).identity = { branch: "planning/spec", worktreePath: "" };
+      },
+      "invalid-worktree-path",
+      "$.phases[0].workspace.identity.worktreePath",
+    ],
+    [
+      "phase sequence",
+      (value) => {
+        (value.phases as Array<Record<string, unknown>>)[0]!.kind = "plan";
+      },
+      "phase-sequence",
+      "$.phases",
+    ],
+  ];
+  for (const [, mutate, reason, path] of cases) {
+    const value = structuredClone(document(phase("workspace-ready")));
+    mutate(value);
+    invalid(value, reason, path);
+  }
+});
+
 test("rejects nested unknown and missing fields at stable paths for every state variant", () => {
   const cases: ReadonlyArray<
     [string, string, (value: Record<string, unknown>) => void, string, string]
@@ -468,11 +523,16 @@ test("permits every checkpoint edge and rejects skipped or backward checkpoint e
   for (const [current, next] of allowed)
     assert.doesNotThrow(() => assertPlanningPhaseReplacement(current, next, 0));
   for (const [current, next] of [
+    [ready, parsed("pending")],
     [ready, open],
+    [pushed, ready],
     [pushed, removed],
+    [open, pushed],
     [open, removed],
     [worktreeRemoved, open],
     [removed, open],
+    [remoteBase, ready],
+    [merged, pushed],
   ] as const)
     assert.throws(
       () => assertPlanningPhaseReplacement(current, next, 0),

--- a/src/workflow/planning-state-transitions.ts
+++ b/src/workflow/planning-state-transitions.ts
@@ -2,7 +2,6 @@ import { isDeepStrictEqual } from "node:util";
 import type {
   PlanningArtifactEvidence,
   PlanningPhaseStateV1,
-  PlanningPullRequestEvidence,
   PlanningWorkspaceEvidence,
 } from "./planning-state-types.ts";
 import { PlanningStateValidationError } from "./planning-state-validation.ts";
@@ -10,207 +9,166 @@ import { PlanningStateValidationError } from "./planning-state-validation.ts";
 type PhaseName =
   | "pending"
   | "workspace-ready"
-  | "pull-request-open"
+  | "branch-pushed"
+  | "pull-request-open-ready"
+  | "pull-request-open-worktree-removed"
+  | "pull-request-open-removed"
   | "complete-remote-base"
-  | "complete-merged-ready"
-  | "complete-merged-worktree-removed"
-  | "complete-merged-removed";
-
+  | "complete-merged";
 function phaseName(phase: PlanningPhaseStateV1): PhaseName {
-  if (phase.status !== "complete") return phase.status;
-  if (phase.completion.kind === "remote-base") return "complete-remote-base";
-  if ("workspace" in phase) {
-    return `complete-merged-${phase.workspace.cleanup.state}`;
-  }
-  throw new TypeError("Merged planning phase requires workspace evidence");
+  if (phase.status === "complete")
+    return phase.completion.kind === "remote-base"
+      ? "complete-remote-base"
+      : "complete-merged";
+  if (phase.status !== "pull-request-open") return phase.status;
+  return `pull-request-open-${phase.workspace.cleanup.state}`;
 }
-
-const allowedTransitions: Readonly<Record<PhaseName, readonly PhaseName[]>> = {
+const allowed: Readonly<Record<PhaseName, readonly PhaseName[]>> = {
   pending: ["pending", "workspace-ready", "complete-remote-base"],
-  "workspace-ready": ["workspace-ready", "pull-request-open"],
-  "pull-request-open": ["pull-request-open", "complete-merged-ready"],
+  "workspace-ready": ["workspace-ready", "branch-pushed"],
+  "branch-pushed": ["branch-pushed", "pull-request-open-ready"],
+  "pull-request-open-ready": [
+    "pull-request-open-ready",
+    "pull-request-open-worktree-removed",
+  ],
+  "pull-request-open-worktree-removed": [
+    "pull-request-open-worktree-removed",
+    "pull-request-open-removed",
+  ],
+  "pull-request-open-removed": ["pull-request-open-removed", "complete-merged"],
   "complete-remote-base": ["complete-remote-base"],
-  "complete-merged-ready": [
-    "complete-merged-ready",
-    "complete-merged-worktree-removed",
-  ],
-  "complete-merged-worktree-removed": [
-    "complete-merged-worktree-removed",
-    "complete-merged-removed",
-  ],
-  "complete-merged-removed": ["complete-merged-removed"],
+  "complete-merged": ["complete-merged"],
 };
-
 function fail(reason: string, index: number, suffix = ""): never {
   throw new PlanningStateValidationError(reason, `$.phases[${index}]${suffix}`);
 }
-
-function assertSame(value: unknown, next: unknown, index: number): void {
-  if (!isDeepStrictEqual(value, next)) fail("immutable-evidence", index);
+function same(left: unknown, right: unknown, index: number): void {
+  if (!isDeepStrictEqual(left, right)) fail("immutable-evidence", index);
 }
-
-function workspaceStableEvidence(workspace: PlanningWorkspaceEvidence) {
-  const { headOid: _headOid, cleanup: _cleanup, ...stable } = workspace;
+function workspaceStable(workspace: PlanningWorkspaceEvidence) {
+  const { cleanup: _cleanup, ...stable } = workspace;
   return stable;
 }
-
 function assertWorkspace(
   current: PlanningWorkspaceEvidence,
   next: PlanningWorkspaceEvidence,
   allowHeadAdvance: boolean,
   index: number,
 ): void {
-  assertSame(
-    workspaceStableEvidence(current),
-    workspaceStableEvidence(next),
-    index,
-  );
-  if (allowHeadAdvance) {
-    if (current.cleanup.state !== "ready" || next.cleanup.state !== "ready") {
-      fail("immutable-evidence", index);
-    }
-    return;
-  }
-  if (current.headOid !== next.headOid) fail("immutable-evidence", index);
+  same(workspaceStable(current), workspaceStable(next), index);
+  if (!allowHeadAdvance && current.headOid !== next.headOid)
+    fail("immutable-evidence", index);
   if (current.cleanup.state === next.cleanup.state) {
-    assertSame(current.cleanup, next.cleanup, index);
+    same(current.cleanup, next.cleanup, index);
     return;
   }
   if (
     current.cleanup.state === "ready" &&
     next.cleanup.state === "worktree-removed" &&
     next.cleanup.pushedHeadOid === current.headOid
-  ) {
+  )
     return;
-  }
   if (
     current.cleanup.state === "worktree-removed" &&
     next.cleanup.state === "removed" &&
     next.cleanup.pushedHeadOid === current.cleanup.pushedHeadOid
-  ) {
+  )
     return;
-  }
   fail("invalid-cleanup-transition", index, ".workspace.cleanup");
 }
-
-function artifactStableEvidence(artifact: PlanningArtifactEvidence) {
-  const { commitOid: _commitOid, ...stable } = artifact;
-  return stable;
-}
-
 function assertArtifacts(
   current: readonly PlanningArtifactEvidence[],
   next: readonly PlanningArtifactEvidence[],
-  allowHeadAdvance: boolean,
+  allowAppend: boolean,
+  allowMergeConversion: boolean,
   index: number,
 ): void {
-  if (current.length !== next.length) fail("immutable-evidence", index);
-  for (let item = 0; item < current.length; item += 1) {
-    const left = current[item]!;
-    const right = next[item]!;
-    assertSame(
-      artifactStableEvidence(left),
-      artifactStableEvidence(right),
-      index,
-    );
+  if (allowMergeConversion) return;
+  if (
+    next.length < current.length ||
+    (!allowAppend && next.length !== current.length)
+  )
+    fail("immutable-evidence", index);
+  for (let offset = 0; offset < current.length; offset += 1) {
+    const left = current[offset]!;
+    const right = next[offset]!;
+    if (
+      left.kind !== right.kind ||
+      left.path !== right.path ||
+      left.source !== right.source
+    )
+      fail("immutable-evidence", index);
     if (
       left.commitOid !== right.commitOid &&
-      !(allowHeadAdvance && left.source === "workspace")
-    ) {
+      !(allowAppend && left.source === "workspace")
+    )
       fail("immutable-evidence", index);
-    }
   }
 }
-
-function pullRequestStableEvidence(pullRequest: PlanningPullRequestEvidence) {
-  const { headOid: _headOid, ...stable } = pullRequest;
-  return stable;
-}
-
-function assertPullRequest(
-  current: PlanningPullRequestEvidence,
-  next: PlanningPullRequestEvidence,
-  allowHeadAdvance: boolean,
-  index: number,
-): void {
-  assertSame(
-    pullRequestStableEvidence(current),
-    pullRequestStableEvidence(next),
-    index,
-  );
-  if (!allowHeadAdvance && current.headOid !== next.headOid) {
-    fail("immutable-evidence", index);
-  }
-}
-
 export function assertPlanningPhaseReplacement(
   current: PlanningPhaseStateV1,
   next: PlanningPhaseStateV1,
   index: number,
 ): void {
-  const currentName = phaseName(current);
-  const nextName = phaseName(next);
-  if (!allowedTransitions[currentName].includes(nextName)) {
-    fail("invalid-transition", index, ".status");
-  }
-  if (current.status === "pending") return;
-  if (
-    current.status === "complete" &&
-    current.completion.kind === "remote-base"
-  ) {
-    assertSame(current, next, index);
+  const from = phaseName(current);
+  const to = phaseName(next);
+  if (!allowed[from].includes(to)) fail("invalid-transition", index, ".status");
+  if (current.status === "pending" || current.status === "complete") {
+    same(current, next, index);
     return;
   }
   if (current.status === "workspace-ready") {
-    if (
-      next.status !== "workspace-ready" &&
-      next.status !== "pull-request-open"
-    ) {
+    if (next.status !== "workspace-ready" && next.status !== "branch-pushed")
       fail("invalid-transition", index, ".status");
-    }
-    assertSame(current.base, next.base, index);
-    assertWorkspace(current.workspace, next.workspace, true, index);
+    same(current.base, next.base, index);
+    assertWorkspace(
+      current.workspace,
+      next.workspace,
+      next.status === "workspace-ready",
+      index,
+    );
+    assertArtifacts(
+      current.artifacts,
+      next.artifacts,
+      next.status === "workspace-ready",
+      false,
+      index,
+    );
+    if (
+      next.status === "workspace-ready" &&
+      next.artifacts.length > current.artifacts.length + 1
+    )
+      fail("invalid-transition", index, ".artifacts");
     return;
   }
-  if (current.status === "pull-request-open") {
-    if (
-      next.status !== "pull-request-open" &&
-      !(
-        next.status === "complete" &&
-        next.completion.kind === "merged-pull-request" &&
-        "workspace" in next
-      )
-    ) {
+  if (current.status === "branch-pushed") {
+    if (next.status !== "branch-pushed" && next.status !== "pull-request-open")
       fail("invalid-transition", index, ".status");
-    }
-    assertSame(current.base, next.base, index);
-    assertWorkspace(current.workspace, next.workspace, true, index);
-    assertArtifacts(current.artifacts, next.artifacts, true, index);
-    assertPullRequest(current.pullRequest, next.pullRequest, true, index);
+    same(current.base, next.base, index);
+    same(current.workspace, next.workspace, index);
+    same(current.artifacts, next.artifacts, index);
+    same(current.publication, next.publication, index);
+    return;
+  }
+  if (next.status === "pull-request-open") {
+    same(current.base, next.base, index);
+    assertWorkspace(current.workspace, next.workspace, false, index);
+    same(current.artifacts, next.artifacts, index);
+    same(current.publication, next.publication, index);
+    same(current.pullRequest, next.pullRequest, index);
     return;
   }
   if (
-    current.completion.kind !== "merged-pull-request" ||
-    !("workspace" in current) ||
     next.status !== "complete" ||
     next.completion.kind !== "merged-pull-request" ||
-    !("workspace" in next)
-  ) {
+    !("workspace" in next) ||
+    !("publication" in next) ||
+    !("pullRequest" in next)
+  )
     fail("invalid-transition", index, ".status");
-  }
-  const allowHeadAdvance =
-    current.workspace.cleanup.state === "ready" &&
-    next.workspace.cleanup.state === "ready";
-  assertSame(current.base, next.base, index);
-  assertWorkspace(current.workspace, next.workspace, allowHeadAdvance, index);
-  assertArtifacts(current.artifacts, next.artifacts, allowHeadAdvance, index);
-  assertPullRequest(
-    current.pullRequest,
-    next.pullRequest,
-    allowHeadAdvance,
-    index,
-  );
-  if (current.completion.mergeOid !== next.completion.mergeOid) {
-    fail("immutable-evidence", index);
-  }
+  same(current.base, next.base, index);
+  same(current.workspace, next.workspace, index);
+  same(current.publication, next.publication, index);
+  same(current.pullRequest, next.pullRequest, index);
+  assertArtifacts(current.artifacts, next.artifacts, false, true, index);
 }

--- a/src/workflow/planning-state-transitions.ts
+++ b/src/workflow/planning-state-transitions.ts
@@ -129,24 +129,27 @@ export function assertPlanningPhaseReplacement(
     if (next.status !== "workspace-ready" && next.status !== "branch-pushed")
       fail("invalid-transition", index, ".status");
     same(current.base, next.base, index);
-    assertWorkspace(
-      current.workspace,
-      next.workspace,
-      next.status === "workspace-ready",
-      index,
-    );
-    assertArtifacts(
-      current.artifacts,
-      next.artifacts,
-      next.status === "workspace-ready",
-      false,
-      index,
-    );
+    const appendingArtifact =
+      next.status === "workspace-ready" &&
+      next.artifacts.length === current.artifacts.length + 1;
     if (
       next.status === "workspace-ready" &&
       next.artifacts.length > current.artifacts.length + 1
     )
       fail("invalid-transition", index, ".artifacts");
+    assertWorkspace(
+      current.workspace,
+      next.workspace,
+      appendingArtifact,
+      index,
+    );
+    assertArtifacts(
+      current.artifacts,
+      next.artifacts,
+      appendingArtifact,
+      false,
+      index,
+    );
     return;
   }
   if (current.status === "branch-pushed") {

--- a/src/workflow/planning-state-transitions.ts
+++ b/src/workflow/planning-state-transitions.ts
@@ -45,9 +45,12 @@ function fail(reason: string, index: number, suffix = ""): never {
 function same(left: unknown, right: unknown, index: number): void {
   if (!isDeepStrictEqual(left, right)) fail("immutable-evidence", index);
 }
-function workspaceStable(workspace: PlanningWorkspaceEvidence) {
-  const { cleanup: _cleanup, ...stable } = workspace;
-  return stable;
+function workspaceStable(
+  workspace: PlanningWorkspaceEvidence,
+  allowHeadAdvance: boolean,
+) {
+  const { cleanup: _cleanup, headOid: _headOid, ...stable } = workspace;
+  return allowHeadAdvance ? stable : { ...stable, headOid: workspace.headOid };
 }
 function assertWorkspace(
   current: PlanningWorkspaceEvidence,
@@ -55,7 +58,11 @@ function assertWorkspace(
   allowHeadAdvance: boolean,
   index: number,
 ): void {
-  same(workspaceStable(current), workspaceStable(next), index);
+  same(
+    workspaceStable(current, allowHeadAdvance),
+    workspaceStable(next, allowHeadAdvance),
+    index,
+  );
   if (!allowHeadAdvance && current.headOid !== next.headOid)
     fail("immutable-evidence", index);
   if (current.cleanup.state === next.cleanup.state) {
@@ -83,7 +90,6 @@ function assertArtifacts(
   allowMergeConversion: boolean,
   index: number,
 ): void {
-  if (allowMergeConversion) return;
   if (
     next.length < current.length ||
     (!allowAppend && next.length !== current.length)
@@ -92,12 +98,10 @@ function assertArtifacts(
   for (let offset = 0; offset < current.length; offset += 1) {
     const left = current[offset]!;
     const right = next[offset]!;
-    if (
-      left.kind !== right.kind ||
-      left.path !== right.path ||
-      left.source !== right.source
-    )
+    if (left.kind !== right.kind || left.path !== right.path)
       fail("immutable-evidence", index);
+    if (allowMergeConversion) continue;
+    if (left.source !== right.source) fail("immutable-evidence", index);
     if (
       left.commitOid !== right.commitOid &&
       !(allowAppend && left.source === "workspace")
@@ -113,7 +117,11 @@ export function assertPlanningPhaseReplacement(
   const from = phaseName(current);
   const to = phaseName(next);
   if (!allowed[from].includes(to)) fail("invalid-transition", index, ".status");
-  if (current.status === "pending" || current.status === "complete") {
+  if (current.status === "pending") {
+    if (next.status === "pending") same(current, next, index);
+    return;
+  }
+  if (current.status === "complete") {
     same(current, next, index);
     return;
   }

--- a/src/workflow/planning-state-types.ts
+++ b/src/workflow/planning-state-types.ts
@@ -2,7 +2,10 @@ import type {
   PlanningRemoteBaseSnapshot,
   PlanningWorkspaceOwnership,
 } from "../git/planning-workspaces.ts";
-import type { PullRequestReference } from "../host/pull-requests.ts";
+import type {
+  PullRequestReference,
+  RepositoryIdentity,
+} from "../host/pull-requests.ts";
 import type {
   PlanningArtifactKind,
   PlanningGateSnapshot,
@@ -17,44 +20,73 @@ export type PlanningArtifactEvidence = Readonly<{
   commitOid: string;
   source: "remote-base" | "workspace";
 }>;
-export type PlanningPullRequestEvidence = Readonly<{
-  reference: PullRequestReference;
+export type PlanningPublicationEvidence = Readonly<{
+  targetRepository: RepositoryIdentity;
+  headRepository: RepositoryIdentity;
   baseBranch: string;
   headBranch: string;
   headOid: string;
 }>;
+export type PlanningPullRequestEvidence = Readonly<{
+  reference: PullRequestReference;
+  url: string;
+}>;
+
+export type WorkspaceReadyPlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "workspace-ready";
+  base: PlanningBaseEvidence;
+  workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  artifacts: readonly PlanningArtifactEvidence[];
+}>;
+export type BranchPushedPlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "branch-pushed";
+  base: PlanningBaseEvidence;
+  workspace: PlanningWorkspaceOwnership<{ state: "ready" }>;
+  artifacts: readonly PlanningArtifactEvidence[];
+  publication: PlanningPublicationEvidence;
+}>;
+export type PullRequestOpenPlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "pull-request-open";
+  base: PlanningBaseEvidence;
+  workspace: PlanningWorkspaceOwnership;
+  artifacts: readonly PlanningArtifactEvidence[];
+  publication: PlanningPublicationEvidence;
+  pullRequest: PlanningPullRequestEvidence;
+}>;
+export type RemoteBaseCompletePlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "complete";
+  base: PlanningBaseEvidence;
+  artifacts: readonly PlanningArtifactEvidence[];
+  completion: Readonly<{ kind: "remote-base" }>;
+}>;
+export type MergedPullRequestCompletePlanningPhase = Readonly<{
+  kind: PlanningPhaseKind;
+  status: "complete";
+  base: PlanningBaseEvidence;
+  workspace: PlanningWorkspaceOwnership<{
+    state: "removed";
+    pushedHeadOid: string;
+  }>;
+  artifacts: readonly PlanningArtifactEvidence[];
+  publication: PlanningPublicationEvidence;
+  pullRequest: PlanningPullRequestEvidence;
+  completion: Readonly<{
+    kind: "merged-pull-request";
+    mergeOid: string;
+    mergedBaseOid: string;
+  }>;
+}>;
 export type PlanningPhaseStateV1 =
   | Readonly<{ kind: PlanningPhaseKind; status: "pending" }>
-  | Readonly<{
-      kind: PlanningPhaseKind;
-      status: "workspace-ready";
-      base: PlanningBaseEvidence;
-      workspace: PlanningWorkspaceEvidence;
-    }>
-  | Readonly<{
-      kind: PlanningPhaseKind;
-      status: "pull-request-open";
-      base: PlanningBaseEvidence;
-      workspace: PlanningWorkspaceEvidence;
-      artifacts: readonly PlanningArtifactEvidence[];
-      pullRequest: PlanningPullRequestEvidence;
-    }>
-  | Readonly<{
-      kind: PlanningPhaseKind;
-      status: "complete";
-      base: PlanningBaseEvidence;
-      artifacts: readonly PlanningArtifactEvidence[];
-      completion: Readonly<{ kind: "remote-base" }>;
-    }>
-  | Readonly<{
-      kind: PlanningPhaseKind;
-      status: "complete";
-      base: PlanningBaseEvidence;
-      workspace: PlanningWorkspaceEvidence;
-      artifacts: readonly PlanningArtifactEvidence[];
-      pullRequest: PlanningPullRequestEvidence;
-      completion: Readonly<{ kind: "merged-pull-request"; mergeOid: string }>;
-    }>;
+  | WorkspaceReadyPlanningPhase
+  | BranchPushedPlanningPhase
+  | PullRequestOpenPlanningPhase
+  | RemoteBaseCompletePlanningPhase
+  | MergedPullRequestCompletePlanningPhase;
 export type PlanningStateV1 = Readonly<{
   version: 1;
   workflowVersion: "planning-pr-v1";

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -8,9 +8,10 @@ import type {
   PlanningWorkspaceIdentity,
   PlanningWorkspaceOwnership,
 } from "../git/planning-workspaces.ts";
-import type {
-  PullRequestReference,
-  RepositoryIdentity,
+import {
+  sameRepositoryIdentity,
+  type PullRequestReference,
+  type RepositoryIdentity,
 } from "../host/pull-requests.ts";
 import {
   PLANNING_PR_WORKFLOW_VERSION,
@@ -29,7 +30,6 @@ import type {
 import {
   assertPlanningPublicationRepositories,
   PlanningPublicationRepositoryError,
-  sameRepositoryIdentity,
 } from "./planning-publication-repositories.ts";
 
 const UUID =

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -22,6 +22,7 @@ import {
   type PlanningGateSnapshot,
 } from "./planning-pull-requests.ts";
 import type {
+  PlanningArtifactEvidence,
   PlanningPhaseStateV1,
   PlanningStateV1,
 } from "./planning-state-types.ts";
@@ -29,7 +30,6 @@ import type {
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
-
 export class PlanningStateValidationError extends Error {
   readonly reason: string;
   readonly path: string;
@@ -72,104 +72,88 @@ const nonnegative = (value: unknown, path: string): number =>
   Number.isSafeInteger(value) && (value as number) >= 0
     ? (value as number)
     : fail("invalid-nonnegative-integer", path);
-const uuid = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return UUID.test(v) ? v : fail("invalid-uuid", path);
-};
 const oid = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return planningOid.test(v) ? v : fail("invalid-oid", path);
-};
-const timestamp = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return ISO_TIMESTAMP.test(v) &&
-    !Number.isNaN(Date.parse(v)) &&
-    new Date(v).toISOString() === v
-    ? v
-    : fail("invalid-timestamp", path);
+  const parsed = string(value, path);
+  return planningOid.test(parsed) ? parsed : fail("invalid-oid", path);
 };
 const singleLine = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return isPlanningSingleLine(v) ? v : fail("invalid-string", path);
+  const parsed = string(value, path);
+  return isPlanningSingleLine(parsed) ? parsed : fail("invalid-string", path);
 };
 const branch = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return isPlanningBranch(v) ? v : fail("invalid-branch", path);
+  const parsed = string(value, path);
+  return isPlanningBranch(parsed) ? parsed : fail("invalid-branch", path);
 };
 const artifactPath = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return isPlanningArtifactPath(v) ? v : fail("invalid-path", path);
+  const parsed = string(value, path);
+  return isPlanningArtifactPath(parsed) ? parsed : fail("invalid-path", path);
 };
-const worktreePath = (value: unknown, path: string): string => {
-  const v = string(value, path);
-  return v.length > 0 && v.length <= 4096 && !/[\0\r\n]/u.test(v)
-    ? v
-    : fail("invalid-worktree-path", path);
-};
-const canonicalWorktreePath = (path: string): string => {
-  const output: string[] = [];
-  for (const segment of path.replace(/\\/gu, "/").split("/")) {
-    if (segment === "" || segment === ".") continue;
-    if (segment === "..") {
-      if (output.length === 0 || output[output.length - 1] === "..")
-        output.push(segment);
-      else output.pop();
-    } else output.push(segment);
-  }
-  return output.join("/");
-};
-
-function gates(value: unknown, path: string): PlanningGateSnapshot {
-  const v = object(value, ["specRequired", "planRequired"], path);
-  if (
-    typeof v.specRequired !== "boolean" ||
-    typeof v.planRequired !== "boolean"
-  )
-    fail("invalid-gates", path);
+function timestamp(value: unknown, path: string): string {
+  const parsed = string(value, path);
+  return ISO_TIMESTAMP.test(parsed) &&
+    !Number.isNaN(Date.parse(parsed)) &&
+    new Date(parsed).toISOString() === parsed
+    ? parsed
+    : fail("invalid-timestamp", path);
+}
+function phase(value: unknown, path: string): PlanningPhaseKind {
+  const parsed = string(value, path);
+  return parsed === "spec" || parsed === "plan" || parsed === "implementation"
+    ? parsed
+    : fail("invalid-phase", path);
+}
+function repository(value: unknown, path: string): RepositoryIdentity {
+  const parsed = object(
+    value,
+    ["provider", "host", "owner", "repository"],
+    path,
+  );
+  const provider = string(parsed.provider, `${path}.provider`);
+  if (provider !== "github-gh" && provider !== "forgejo-tea")
+    fail("invalid-provider", `${path}.provider`);
   return {
-    specRequired: v.specRequired as boolean,
-    planRequired: v.planRequired as boolean,
-  };
+    provider,
+    host: singleLine(parsed.host, `${path}.host`),
+    owner: singleLine(parsed.owner, `${path}.owner`),
+    repository: singleLine(parsed.repository, `${path}.repository`),
+  } as RepositoryIdentity;
 }
 function candidates(
   value: unknown,
   path: string,
 ): { spec: readonly string[]; plan: readonly string[] } {
-  const v = object(value, ["spec", "plan"], path);
+  const parsed = object(value, ["spec", "plan"], path);
+  const parse = (items: unknown, child: string) => {
+    if (!Array.isArray(items)) fail("expected-array", child);
+    const paths = (items as unknown[]).map((item: unknown, index: number) =>
+      artifactPath(item, `${child}[${index}]`),
+    );
+    if (new Set(paths).size !== paths.length) fail("duplicate-value", child);
+    return paths;
+  };
   return {
-    spec: paths(v.spec, `${path}.spec`),
-    plan: paths(v.plan, `${path}.plan`),
+    spec: parse(parsed.spec, `${path}.spec`),
+    plan: parse(parsed.plan, `${path}.plan`),
   };
 }
-function paths(value: unknown, path: string): readonly string[] {
-  if (!Array.isArray(value)) fail("expected-array", path);
-  const output = (value as unknown[]).map((item, index) =>
-    artifactPath(item, `${path}[${index}]`),
+function base(value: unknown, path: string) {
+  const parsed = object(
+    value,
+    ["remote", "baseBranch", "baseOid", "artifactCandidates"],
+    path,
   );
-  if (new Set(output).size !== output.length) fail("duplicate-value", path);
-  return output;
-}
-function identity(value: unknown, path: string): PlanningWorkspaceIdentity {
-  const v = object(value, ["branch", "worktreePath"], path);
   return {
-    branch: branch(v.branch, `${path}.branch`),
-    worktreePath: worktreePath(v.worktreePath, `${path}.worktreePath`),
+    remote: singleLine(parsed.remote, `${path}.remote`),
+    baseBranch: branch(parsed.baseBranch, `${path}.baseBranch`),
+    baseOid: oid(parsed.baseOid, `${path}.baseOid`),
+    artifactCandidates: candidates(
+      parsed.artifactCandidates,
+      `${path}.artifactCandidates`,
+    ),
   };
 }
-function repository(value: unknown, path: string): RepositoryIdentity {
-  const v = object(value, ["provider", "host", "owner", "repository"], path);
-  const provider = string(v.provider, `${path}.provider`);
-  if (provider !== "github-gh" && provider !== "forgejo-tea")
-    fail("invalid-provider", `${path}.provider`);
-  return {
-    provider,
-    host: singleLine(v.host, `${path}.host`),
-    owner: singleLine(v.owner, `${path}.owner`),
-    repository: singleLine(v.repository, `${path}.repository`),
-  } as RepositoryIdentity;
-}
-function workspace(value: unknown, path: string) {
-  const v = object(
+function workspace(value: unknown, path: string): PlanningWorkspaceOwnership {
+  const parsed = object(
     value,
     [
       "runId",
@@ -183,28 +167,52 @@ function workspace(value: unknown, path: string) {
     ],
     path,
   );
-  const cleanupValue = v.cleanup as Record<string, unknown>;
+  const identity = object(
+    parsed.identity,
+    ["branch", "worktreePath"],
+    `${path}.identity`,
+  );
+  const worktreePath = string(
+    identity.worktreePath,
+    `${path}.identity.worktreePath`,
+  );
+  if (
+    worktreePath.length === 0 ||
+    worktreePath.length > 4096 ||
+    /[\0\r\n]/u.test(worktreePath)
+  )
+    fail("invalid-worktree-path", `${path}.identity.worktreePath`);
+  const cleanupRaw = parsed.cleanup as Record<string, unknown>;
   const cleanup = object(
-    cleanupValue,
-    cleanupValue?.state === "ready" ? ["state"] : ["state", "pushedHeadOid"],
+    cleanupRaw,
+    cleanupRaw?.state === "ready" ? ["state"] : ["state", "pushedHeadOid"],
     `${path}.cleanup`,
   );
-  const state = string(cleanup.state, `${path}.cleanup.state`);
-  if (state !== "ready" && state !== "worktree-removed" && state !== "removed")
+  const cleanupState = string(cleanup.state, `${path}.cleanup.state`);
+  if (
+    cleanupState !== "ready" &&
+    cleanupState !== "worktree-removed" &&
+    cleanupState !== "removed"
+  )
     fail("invalid-cleanup", `${path}.cleanup.state`);
+  const runId = string(parsed.runId, `${path}.runId`);
+  if (!UUID.test(runId)) fail("invalid-uuid", `${path}.runId`);
   return {
-    runId: uuid(v.runId, `${path}.runId`),
-    phase: phase(v.phase, `${path}.phase`),
-    identity: identity(v.identity, `${path}.identity`),
-    remote: singleLine(v.remote, `${path}.remote`),
-    baseBranch: branch(v.baseBranch, `${path}.baseBranch`),
-    baseOid: oid(v.baseOid, `${path}.baseOid`),
-    headOid: oid(v.headOid, `${path}.headOid`),
+    runId,
+    phase: phase(parsed.phase, `${path}.phase`),
+    identity: {
+      branch: branch(identity.branch, `${path}.identity.branch`),
+      worktreePath,
+    } as PlanningWorkspaceIdentity,
+    remote: singleLine(parsed.remote, `${path}.remote`),
+    baseBranch: branch(parsed.baseBranch, `${path}.baseBranch`),
+    baseOid: oid(parsed.baseOid, `${path}.baseOid`),
+    headOid: oid(parsed.headOid, `${path}.headOid`),
     cleanup:
-      state === "ready"
-        ? { state }
+      cleanupState === "ready"
+        ? { state: "ready" }
         : {
-            state,
+            state: cleanupState,
             pushedHeadOid: oid(
               cleanup.pushedHeadOid,
               `${path}.cleanup.pushedHeadOid`,
@@ -212,150 +220,259 @@ function workspace(value: unknown, path: string) {
           },
   } as PlanningWorkspaceOwnership;
 }
-function base(value: unknown, path: string) {
-  const v = object(
-    value,
-    ["remote", "baseBranch", "baseOid", "artifactCandidates"],
-    path,
-  );
-  return {
-    remote: singleLine(v.remote, `${path}.remote`),
-    baseBranch: branch(v.baseBranch, `${path}.baseBranch`),
-    baseOid: oid(v.baseOid, `${path}.baseOid`),
-    artifactCandidates: candidates(
-      v.artifactCandidates,
-      `${path}.artifactCandidates`,
-    ),
-  };
-}
-function phase(value: unknown, path: string): PlanningPhaseKind {
-  const v = string(value, path);
-  return v === "spec" || v === "plan" || v === "implementation"
-    ? v
-    : fail("invalid-phase", path);
-}
-function artifacts(value: unknown, path: string) {
+function artifacts(
+  value: unknown,
+  path: string,
+): readonly PlanningArtifactEvidence[] {
   if (!Array.isArray(value)) fail("expected-array", path);
-  const output = (value as unknown[]).map((item, i) => {
-    const v = object(
+  const parsed = (value as unknown[]).map((item: unknown, index: number) => {
+    const record = object(
       item,
       ["kind", "path", "commitOid", "source"],
-      `${path}[${i}]`,
+      `${path}[${index}]`,
     );
-    const kind = string(v.kind, `${path}[${i}].kind`);
+    const kind = string(record.kind, `${path}[${index}].kind`);
     if (kind !== "spec" && kind !== "plan")
-      fail("invalid-artifact-kind", `${path}[${i}].kind`);
-    const source = string(v.source, `${path}[${i}].source`);
+      fail("invalid-artifact-kind", `${path}[${index}].kind`);
+    const source = string(record.source, `${path}[${index}].source`);
     if (source !== "remote-base" && source !== "workspace")
-      fail("invalid-artifact-source", `${path}[${i}].source`);
+      fail("invalid-artifact-source", `${path}[${index}].source`);
     return {
       kind: kind as PlanningArtifactKind,
-      path: artifactPath(v.path, `${path}[${i}].path`),
-      commitOid: oid(v.commitOid, `${path}[${i}].commitOid`),
+      path: artifactPath(record.path, `${path}[${index}].path`),
+      commitOid: oid(record.commitOid, `${path}[${index}].commitOid`),
       source: source as "remote-base" | "workspace",
     };
   });
-  if (new Set(output.map((item) => item.kind)).size !== output.length)
+  if (
+    new Set(parsed.map((artifact: PlanningArtifactEvidence) => artifact.kind))
+      .size !== parsed.length
+  )
     fail("duplicate-artifact-kind", path);
-  return output;
+  return parsed;
 }
-function pullRequest(value: unknown, path: string) {
-  const v = object(
+function publication(value: unknown, path: string) {
+  const parsed = object(
     value,
-    ["reference", "baseBranch", "headBranch", "headOid"],
+    [
+      "targetRepository",
+      "headRepository",
+      "baseBranch",
+      "headBranch",
+      "headOid",
+    ],
     path,
   );
-  const ref = object(
-    v.reference,
+  return {
+    targetRepository: repository(
+      parsed.targetRepository,
+      `${path}.targetRepository`,
+    ),
+    headRepository: repository(parsed.headRepository, `${path}.headRepository`),
+    baseBranch: branch(parsed.baseBranch, `${path}.baseBranch`),
+    headBranch: branch(parsed.headBranch, `${path}.headBranch`),
+    headOid: oid(parsed.headOid, `${path}.headOid`),
+  };
+}
+function pullRequest(value: unknown, path: string) {
+  const parsed = object(value, ["reference", "url"], path);
+  const reference = object(
+    parsed.reference,
     ["targetRepository", "number"],
     `${path}.reference`,
   );
+  const url = string(parsed.url, `${path}.url`);
+  try {
+    const parsedUrl = new URL(url);
+    if (
+      (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") ||
+      parsedUrl.username ||
+      parsedUrl.password ||
+      parsedUrl.search ||
+      parsedUrl.hash ||
+      /[\r\n]/u.test(url)
+    )
+      fail("invalid-url", `${path}.url`);
+  } catch (error) {
+    if (error instanceof PlanningStateValidationError) throw error;
+    fail("invalid-url", `${path}.url`);
+  }
   return {
     reference: {
       targetRepository: repository(
-        ref.targetRepository,
+        reference.targetRepository,
         `${path}.reference.targetRepository`,
       ),
-      number: positive(ref.number, `${path}.reference.number`),
+      number: positive(reference.number, `${path}.reference.number`),
     } as PullRequestReference,
-    baseBranch: branch(v.baseBranch, `${path}.baseBranch`),
-    headBranch: branch(v.headBranch, `${path}.headBranch`),
-    headOid: oid(v.headOid, `${path}.headOid`),
+    url,
   };
 }
-
 function phaseState(value: unknown, path: string): PlanningPhaseStateV1 {
   const raw = value as Record<string, unknown>;
   const status = raw?.status;
-  const completion = raw?.completion as Record<string, unknown> | undefined;
   const keys =
     status === "pending"
       ? ["kind", "status"]
       : status === "workspace-ready"
-        ? ["kind", "status", "base", "workspace"]
-        : status === "pull-request-open"
-          ? ["kind", "status", "base", "workspace", "artifacts", "pullRequest"]
-          : completion?.kind === "remote-base"
-            ? ["kind", "status", "base", "artifacts", "completion"]
-            : [
+        ? ["kind", "status", "base", "workspace", "artifacts"]
+        : status === "branch-pushed"
+          ? ["kind", "status", "base", "workspace", "artifacts", "publication"]
+          : status === "pull-request-open"
+            ? [
                 "kind",
                 "status",
                 "base",
                 "workspace",
                 "artifacts",
+                "publication",
                 "pullRequest",
-                "completion",
-              ];
-  const v = object(value, keys, path);
-  const kind = phase(v.kind, `${path}.kind`);
-  if (v.status === "pending") return { kind, status: "pending" };
-  if (v.status === "workspace-ready")
+              ]
+            : raw?.completion &&
+                (raw.completion as Record<string, unknown>).kind ===
+                  "remote-base"
+              ? ["kind", "status", "base", "artifacts", "completion"]
+              : [
+                  "kind",
+                  "status",
+                  "base",
+                  "workspace",
+                  "artifacts",
+                  "publication",
+                  "pullRequest",
+                  "completion",
+                ];
+  const parsed = object(value, keys, path);
+  const kind = phase(parsed.kind, `${path}.kind`);
+  if (parsed.status === "pending") return { kind, status: "pending" };
+  if (parsed.status === "workspace-ready")
     return {
       kind,
       status: "workspace-ready",
-      base: base(v.base, `${path}.base`),
-      workspace: workspace(v.workspace, `${path}.workspace`),
+      base: base(parsed.base, `${path}.base`),
+      workspace: workspace(
+        parsed.workspace,
+        `${path}.workspace`,
+      ) as PlanningWorkspaceOwnership<{ state: "ready" }>,
+      artifacts: artifacts(parsed.artifacts, `${path}.artifacts`),
     };
-  if (v.status === "pull-request-open")
+  if (parsed.status === "branch-pushed")
+    return {
+      kind,
+      status: "branch-pushed",
+      base: base(parsed.base, `${path}.base`),
+      workspace: workspace(
+        parsed.workspace,
+        `${path}.workspace`,
+      ) as PlanningWorkspaceOwnership<{ state: "ready" }>,
+      artifacts: artifacts(parsed.artifacts, `${path}.artifacts`),
+      publication: publication(parsed.publication, `${path}.publication`),
+    };
+  if (parsed.status === "pull-request-open")
     return {
       kind,
       status: "pull-request-open",
-      base: base(v.base, `${path}.base`),
-      workspace: workspace(v.workspace, `${path}.workspace`),
-      artifacts: artifacts(v.artifacts, `${path}.artifacts`),
-      pullRequest: pullRequest(v.pullRequest, `${path}.pullRequest`),
+      base: base(parsed.base, `${path}.base`),
+      workspace: workspace(parsed.workspace, `${path}.workspace`),
+      artifacts: artifacts(parsed.artifacts, `${path}.artifacts`),
+      publication: publication(parsed.publication, `${path}.publication`),
+      pullRequest: pullRequest(parsed.pullRequest, `${path}.pullRequest`),
     };
-  if (v.status !== "complete") fail("invalid-status", `${path}.status`);
-  const c = v.completion as Record<string, unknown>;
-  if (c?.kind === "remote-base") {
-    object(c, ["kind"], `${path}.completion`);
+  if (parsed.status !== "complete") fail("invalid-status", `${path}.status`);
+  const completion = parsed.completion as Record<string, unknown>;
+  if (completion?.kind === "remote-base") {
+    object(completion, ["kind"], `${path}.completion`);
     return {
       kind,
       status: "complete",
-      base: base(v.base, `${path}.base`),
-      artifacts: artifacts(v.artifacts, `${path}.artifacts`),
+      base: base(parsed.base, `${path}.base`),
+      artifacts: artifacts(parsed.artifacts, `${path}.artifacts`),
       completion: { kind: "remote-base" },
     };
   }
-  const merged = object(c, ["kind", "mergeOid"], `${path}.completion`);
+  const merged = object(
+    completion,
+    ["kind", "mergeOid", "mergedBaseOid"],
+    `${path}.completion`,
+  );
   if (merged.kind !== "merged-pull-request")
     fail("invalid-completion", `${path}.completion.kind`);
   return {
     kind,
     status: "complete",
-    base: base(v.base, `${path}.base`),
-    workspace: workspace(v.workspace, `${path}.workspace`),
-    artifacts: artifacts(v.artifacts, `${path}.artifacts`),
-    pullRequest: pullRequest(v.pullRequest, `${path}.pullRequest`),
+    base: base(parsed.base, `${path}.base`),
+    workspace: workspace(
+      parsed.workspace,
+      `${path}.workspace`,
+    ) as PlanningWorkspaceOwnership<{
+      state: "removed";
+      pushedHeadOid: string;
+    }>,
+    artifacts: artifacts(parsed.artifacts, `${path}.artifacts`),
+    publication: publication(parsed.publication, `${path}.publication`),
+    pullRequest: pullRequest(parsed.pullRequest, `${path}.pullRequest`),
     completion: {
       kind: "merged-pull-request",
       mergeOid: oid(merged.mergeOid, `${path}.completion.mergeOid`),
+      mergedBaseOid: oid(
+        merged.mergedBaseOid,
+        `${path}.completion.mergedBaseOid`,
+      ),
     },
   };
 }
-
+function artifactEvidence(
+  phase: PlanningPhaseStateV1,
+  assigned: readonly PlanningArtifactKind[],
+  path: string,
+): void {
+  if (!("artifacts" in phase)) return;
+  const complete = phase.status !== "workspace-ready";
+  if (
+    (complete && phase.artifacts.length !== assigned.length) ||
+    phase.artifacts.some((artifact, index) => artifact.kind !== assigned[index])
+  )
+    fail("artifact-kinds", `${path}.artifacts`);
+  for (const [index, artifact] of phase.artifacts.entries()) {
+    if (
+      phase.status === "complete" &&
+      phase.completion.kind === "merged-pull-request"
+    ) {
+      if (
+        artifact.source !== "remote-base" ||
+        artifact.commitOid !== phase.completion.mergedBaseOid
+      )
+        fail("merged-artifact-mismatch", `${path}.artifacts[${index}]`);
+    } else if (artifact.source === "remote-base") {
+      if (
+        artifact.commitOid !== phase.base.baseOid ||
+        !phase.base.artifactCandidates[artifact.kind].includes(artifact.path)
+      )
+        fail("remote-artifact-mismatch", `${path}.artifacts[${index}]`);
+    } else if (
+      !("workspace" in phase) ||
+      artifact.commitOid !== phase.workspace.headOid
+    )
+      fail("workspace-artifact-mismatch", `${path}.artifacts[${index}]`);
+  }
+}
+function canonicalPath(path: string): string {
+  return path
+    .replaceAll("\\", "/")
+    .split("/")
+    .reduce<string[]>(
+      (out, part) =>
+        part === "" || part === "."
+          ? out
+          : part === ".."
+            ? (out.pop(), out)
+            : [...out, part],
+      [],
+    )
+    .join("/");
+}
 export function validatePlanningState(value: unknown): PlanningStateV1 {
-  const v = object(
+  const parsed = object(
     value,
     [
       "version",
@@ -371,132 +488,113 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
     ],
     "$",
   );
-  if (v.version !== 1) fail("unsupported-version", "$.version");
-  if (v.workflowVersion !== PLANNING_PR_WORKFLOW_VERSION)
+  if (parsed.version !== 1) fail("unsupported-version", "$.version");
+  if (parsed.workflowVersion !== PLANNING_PR_WORKFLOW_VERSION)
     fail("unsupported-workflow-version", "$.workflowVersion");
-  const parsedRunId = uuid(v.runId, "$.runId");
-  const parsedIssueNumber = positive(v.issueNumber, "$.issueNumber");
-  const parsedIssueTitle = singleLine(v.issueTitle, "$.issueTitle");
-  const parsedRevision = nonnegative(v.revision, "$.revision");
-  const createdAt = timestamp(v.createdAt, "$.createdAt");
-  const updatedAt = timestamp(v.updatedAt, "$.updatedAt");
-  if (updatedAt < createdAt) fail("timestamp-order", "$.updatedAt");
-  const parsedGates = gates(v.gates, "$.gates");
-  if (!Array.isArray(v.phases)) fail("expected-array", "$.phases");
-  const phases = (v.phases as unknown[]).map((item, i) =>
-    phaseState(item, `$.phases[${i}]`),
+  const runId = string(parsed.runId, "$.runId");
+  if (!UUID.test(runId)) fail("invalid-uuid", "$.runId");
+  const gates = object(
+    parsed.gates,
+    ["specRequired", "planRequired"],
+    "$.gates",
   );
-  const expected = planningPhasePlan(parsedGates);
+  if (
+    typeof gates.specRequired !== "boolean" ||
+    typeof gates.planRequired !== "boolean"
+  )
+    fail("invalid-gates", "$.gates");
+  if (!Array.isArray(parsed.phases)) fail("expected-array", "$.phases");
+  const phases = (parsed.phases as unknown[]).map(
+    (item: unknown, index: number) => phaseState(item, `$.phases[${index}]`),
+  );
+  const expected = planningPhasePlan(gates as PlanningGateSnapshot);
   if (
     phases.length !== expected.length ||
-    phases.some((item, i) => item.kind !== expected[i]?.kind)
+    phases.some(
+      (item: PlanningPhaseStateV1, index: number) =>
+        item.kind !== expected[index]?.kind,
+    )
   )
     fail("phase-sequence", "$.phases");
   let active = false;
   let pending = false;
   const branches = new Set<string>();
-  const worktreePaths = new Set<string>();
-  for (let i = 0; i < phases.length; i += 1) {
-    const p = phases[i]!;
-    if (p.status === "complete") {
-      if (active || pending) fail("progress-order", `$.phases[${i}]`);
-    } else if (
-      p.status === "workspace-ready" ||
-      p.status === "pull-request-open"
-    ) {
-      if (active || pending) fail("progress-order", `$.phases[${i}]`);
-      active = true;
+  const paths = new Set<string>();
+  for (const [index, item] of phases.entries()) {
+    const path = `$.phases[${index}]`;
+    if (item.status === "pending") pending = true;
+    else if (item.status === "complete") {
+      if (active || pending) fail("progress-order", path);
     } else {
-      pending = true;
+      if (active || pending) fail("progress-order", path);
+      active = true;
     }
-    const assigned = expected[i]!.artifactKinds;
+    artifactEvidence(item, expected[index]!.artifactKinds, path);
+    if (!("workspace" in item)) continue;
     if (
-      p.status !== "pending" &&
-      "artifacts" in p &&
-      (p.artifacts.length !== assigned.length ||
-        p.artifacts.some(
-          (artifact, index) => artifact.kind !== assigned[index],
-        ))
+      item.workspace.runId !== runId ||
+      item.workspace.phase !== item.kind ||
+      item.workspace.remote !== item.base.remote ||
+      item.workspace.baseBranch !== item.base.baseBranch ||
+      item.workspace.baseOid !== item.base.baseOid
     )
-      fail("artifact-kinds", `$.phases[${i}].artifacts`);
-    if ("workspace" in p) {
-      if (
-        p.workspace.runId !== parsedRunId ||
-        p.workspace.phase !== p.kind ||
-        p.workspace.remote !== p.base.remote ||
-        p.workspace.baseBranch !== p.base.baseBranch ||
-        p.workspace.baseOid !== p.base.baseOid
-      )
-        fail("workspace-mismatch", `$.phases[${i}].workspace`);
-      const normalizedPath = canonicalWorktreePath(
-        p.workspace.identity.worktreePath,
-      );
-      if (
-        branches.has(p.workspace.identity.branch) ||
-        worktreePaths.has(normalizedPath)
-      )
-        fail(
-          "duplicate-workspace-identity",
-          `$.phases[${i}].workspace.identity`,
-        );
-      branches.add(p.workspace.identity.branch);
-      worktreePaths.add(normalizedPath);
-      if (
-        (p.status === "workspace-ready" || p.status === "pull-request-open") &&
-        p.workspace.cleanup.state !== "ready"
-      )
-        fail("invalid-cleanup-progress", `$.phases[${i}].workspace.cleanup`);
-      if (
-        p.workspace.cleanup.state !== "ready" &&
-        p.workspace.cleanup.pushedHeadOid !== p.workspace.headOid
-      )
-        fail(
-          "cleanup-head-mismatch",
-          `$.phases[${i}].workspace.cleanup.pushedHeadOid`,
-        );
-    }
-    if ("artifacts" in p) {
-      for (let index = 0; index < p.artifacts.length; index += 1) {
-        const artifact = p.artifacts[index]!;
-        if (artifact.source === "remote-base") {
-          if (
-            artifact.commitOid !== p.base.baseOid ||
-            !p.base.artifactCandidates[artifact.kind].includes(artifact.path)
-          )
-            fail(
-              "remote-artifact-mismatch",
-              `$.phases[${i}].artifacts[${index}]`,
-            );
-        } else if (
-          !("workspace" in p) ||
-          artifact.commitOid !== p.workspace.headOid
-        ) {
-          fail(
-            "workspace-artifact-mismatch",
-            `$.phases[${i}].artifacts[${index}]`,
-          );
-        }
-      }
-    }
-    if ("pullRequest" in p) {
-      if (
-        !("workspace" in p) ||
-        p.pullRequest.baseBranch !== p.base.baseBranch ||
-        p.pullRequest.headBranch !== p.workspace.identity.branch ||
-        p.pullRequest.headOid !== p.workspace.headOid
-      )
-        fail("pull-request-mismatch", `$.phases[${i}].pullRequest`);
-    }
+      fail("workspace-mismatch", `${path}.workspace`);
+    if (
+      branches.has(item.workspace.identity.branch) ||
+      paths.has(canonicalPath(item.workspace.identity.worktreePath))
+    )
+      fail("duplicate-workspace-identity", `${path}.workspace.identity`);
+    branches.add(item.workspace.identity.branch);
+    paths.add(canonicalPath(item.workspace.identity.worktreePath));
+    if (
+      (item.status === "workspace-ready" || item.status === "branch-pushed") &&
+      item.workspace.cleanup.state !== "ready"
+    )
+      fail("invalid-cleanup-progress", `${path}.workspace.cleanup`);
+    if (
+      item.workspace.cleanup.state !== "ready" &&
+      item.workspace.cleanup.pushedHeadOid !== item.workspace.headOid
+    )
+      fail("cleanup-head-mismatch", `${path}.workspace.cleanup.pushedHeadOid`);
+    if (
+      "publication" in item &&
+      (item.publication.baseBranch !== item.base.baseBranch ||
+        item.publication.headBranch !== item.workspace.identity.branch ||
+        item.publication.headOid !== item.workspace.headOid)
+    )
+      fail("publication-mismatch", `${path}.publication`);
+    if (
+      ("pullRequest" in item &&
+        item.pullRequest.reference.targetRepository.provider !==
+          item.publication.targetRepository.provider) ||
+      ("pullRequest" in item &&
+        (item.pullRequest.reference.targetRepository.host.toLowerCase() !==
+          item.publication.targetRepository.host.toLowerCase() ||
+          item.pullRequest.reference.targetRepository.owner.toLowerCase() !==
+            item.publication.targetRepository.owner.toLowerCase() ||
+          item.pullRequest.reference.targetRepository.repository.toLowerCase() !==
+            item.publication.targetRepository.repository.toLowerCase()))
+    )
+      fail("pull-request-mismatch", `${path}.pullRequest`);
+    if (
+      item.status === "complete" &&
+      item.completion.kind === "merged-pull-request" &&
+      item.workspace.cleanup.state !== "removed"
+    )
+      fail("invalid-cleanup-progress", `${path}.workspace.cleanup`);
   }
+  const createdAt = timestamp(parsed.createdAt, "$.createdAt");
+  const updatedAt = timestamp(parsed.updatedAt, "$.updatedAt");
+  if (updatedAt < createdAt) fail("timestamp-order", "$.updatedAt");
   return {
     version: 1,
     workflowVersion: PLANNING_PR_WORKFLOW_VERSION,
-    runId: parsedRunId,
-    issueNumber: parsedIssueNumber,
-    issueTitle: parsedIssueTitle,
-    gates: parsedGates,
+    runId,
+    issueNumber: positive(parsed.issueNumber, "$.issueNumber"),
+    issueTitle: singleLine(parsed.issueTitle, "$.issueTitle"),
+    gates: gates as PlanningGateSnapshot,
     phases,
-    revision: parsedRevision,
+    revision: nonnegative(parsed.revision, "$.revision"),
     createdAt,
     updatedAt,
   };

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -263,12 +263,34 @@ function publication(value: unknown, path: string) {
     ],
     path,
   );
+  const targetRepository = repository(
+    parsed.targetRepository,
+    `${path}.targetRepository`,
+  );
+  const headRepository = repository(
+    parsed.headRepository,
+    `${path}.headRepository`,
+  );
+  if (targetRepository.provider !== headRepository.provider)
+    fail("publication-repository-mismatch", path);
+  if (
+    targetRepository.provider === "github-gh" &&
+    (targetRepository.host.toLowerCase() !==
+      headRepository.host.toLowerCase() ||
+      targetRepository.owner.toLowerCase() !==
+        headRepository.owner.toLowerCase() ||
+      targetRepository.repository.toLowerCase() !==
+        headRepository.repository.toLowerCase())
+  )
+    fail("publication-repository-mismatch", path);
+  if (
+    targetRepository.provider === "forgejo-tea" &&
+    targetRepository.host.toLowerCase() !== headRepository.host.toLowerCase()
+  )
+    fail("publication-repository-mismatch", path);
   return {
-    targetRepository: repository(
-      parsed.targetRepository,
-      `${path}.targetRepository`,
-    ),
-    headRepository: repository(parsed.headRepository, `${path}.headRepository`),
+    targetRepository,
+    headRepository,
     baseBranch: branch(parsed.baseBranch, `${path}.baseBranch`),
     headBranch: branch(parsed.headBranch, `${path}.headBranch`),
     headOid: oid(parsed.headOid, `${path}.headOid`),

--- a/src/workflow/planning-state-validation.ts
+++ b/src/workflow/planning-state-validation.ts
@@ -26,6 +26,11 @@ import type {
   PlanningPhaseStateV1,
   PlanningStateV1,
 } from "./planning-state-types.ts";
+import {
+  assertPlanningPublicationRepositories,
+  PlanningPublicationRepositoryError,
+  sameRepositoryIdentity,
+} from "./planning-publication-repositories.ts";
 
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -271,23 +276,13 @@ function publication(value: unknown, path: string) {
     parsed.headRepository,
     `${path}.headRepository`,
   );
-  if (targetRepository.provider !== headRepository.provider)
-    fail("publication-repository-mismatch", path);
-  if (
-    targetRepository.provider === "github-gh" &&
-    (targetRepository.host.toLowerCase() !==
-      headRepository.host.toLowerCase() ||
-      targetRepository.owner.toLowerCase() !==
-        headRepository.owner.toLowerCase() ||
-      targetRepository.repository.toLowerCase() !==
-        headRepository.repository.toLowerCase())
-  )
-    fail("publication-repository-mismatch", path);
-  if (
-    targetRepository.provider === "forgejo-tea" &&
-    targetRepository.host.toLowerCase() !== headRepository.host.toLowerCase()
-  )
-    fail("publication-repository-mismatch", path);
+  try {
+    assertPlanningPublicationRepositories({ targetRepository, headRepository });
+  } catch (error) {
+    if (error instanceof PlanningPublicationRepositoryError)
+      fail("publication-repository-mismatch", path);
+    throw error;
+  }
   return {
     targetRepository,
     headRepository,
@@ -586,16 +581,11 @@ export function validatePlanningState(value: unknown): PlanningStateV1 {
     )
       fail("publication-mismatch", `${path}.publication`);
     if (
-      ("pullRequest" in item &&
-        item.pullRequest.reference.targetRepository.provider !==
-          item.publication.targetRepository.provider) ||
-      ("pullRequest" in item &&
-        (item.pullRequest.reference.targetRepository.host.toLowerCase() !==
-          item.publication.targetRepository.host.toLowerCase() ||
-          item.pullRequest.reference.targetRepository.owner.toLowerCase() !==
-            item.publication.targetRepository.owner.toLowerCase() ||
-          item.pullRequest.reference.targetRepository.repository.toLowerCase() !==
-            item.publication.targetRepository.repository.toLowerCase()))
+      "pullRequest" in item &&
+      !sameRepositoryIdentity(
+        item.pullRequest.reference.targetRepository,
+        item.publication.targetRepository,
+      )
     )
       fail("pull-request-mismatch", `${path}.pullRequest`);
     if (

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -9,773 +9,331 @@ import {
   validatePlanningState,
 } from "./planning-state.ts";
 
+const oid = (character: string) => character.repeat(40);
 const runId = "123e4567-e89b-42d3-a456-426614174000";
-const now = "2026-09-07T12:00:00.000Z";
-const oid = "a".repeat(40);
-const gates = { specRequired: true, planRequired: true };
-
-function pullRequest(headBranch: string, headOid: string) {
-  return {
-    reference: {
-      targetRepository: {
-        provider: "github-gh",
-        host: "github.com",
-        owner: "example",
-        repository: "patchmill",
-      },
-      number: 1,
-    },
-    baseBranch: "main",
-    headBranch,
-    headOid,
-  };
-}
-
-function mergedState(
-  cleanup:
-    | { state: "ready" }
-    | { state: "worktree-removed"; pushedHeadOid: string }
-    | { state: "removed"; pushedHeadOid: string },
-): unknown {
-  const base = {
-    remote: "origin",
-    baseBranch: "main",
-    baseOid: oid,
-    artifactCandidates: { spec: [], plan: [] },
-  };
-  const branch = "agent/issue-187-implementation";
-  const workspace = {
-    runId,
-    phase: "implementation",
-    identity: {
-      branch,
-      worktreePath: ".worktrees/issue-187-implementation",
-    },
-    remote: "origin",
-    baseBranch: "main",
-    baseOid: oid,
-    headOid: oid,
-    cleanup,
-  };
-  return {
-    version: 1,
-    workflowVersion: "planning-pr-v1",
-    runId,
-    issueNumber: 187,
-    issueTitle: "Example",
-    gates: { specRequired: false, planRequired: false },
-    phases: [
-      {
-        kind: "implementation",
-        status: "complete",
-        base,
-        workspace,
-        artifacts: [
-          {
-            kind: "spec",
-            path: "docs/specs/example-issue-187-spec.md",
-            commitOid: oid,
-            source: "workspace",
-          },
-          {
-            kind: "plan",
-            path: "docs/plans/example-issue-187-plan.md",
-            commitOid: oid,
-            source: "workspace",
-          },
-        ],
-        pullRequest: pullRequest(branch, oid),
-        completion: { kind: "merged-pull-request", mergeOid: "b".repeat(40) },
-      },
-    ],
-    revision: 0,
-    createdAt: now,
-    updatedAt: now,
-  };
-}
-
-function recordAt(
-  value: unknown,
-  ...segments: readonly (string | number)[]
-): Record<string, unknown> {
-  let current = value;
-  for (const segment of segments) {
-    assert.ok(current !== null && typeof current === "object");
-    current = (current as Record<string | number, unknown>)[segment];
-  }
-  assert.ok(current !== null && typeof current === "object");
-  return current as Record<string, unknown>;
-}
-
-function completeState(): unknown {
-  const base = {
-    remote: "origin",
-    baseBranch: "main",
-    baseOid: oid,
-    artifactCandidates: {
-      spec: ["docs/specs/example-issue-187-spec.md"],
-      plan: ["docs/plans/example-issue-187-plan.md"],
-    },
-  };
-  const workspace = {
-    runId,
-    phase: "implementation",
-    identity: {
-      branch: "agent/issue-187-implementation",
-      worktreePath: ".worktrees/issue-187-implementation",
-    },
-    remote: "origin",
-    baseBranch: "main",
-    baseOid: oid,
-    headOid: oid,
-    cleanup: { state: "ready" },
-  };
-  return {
-    version: 1,
-    workflowVersion: "planning-pr-v1",
-    runId,
-    issueNumber: 187,
-    issueTitle: "Example",
-    gates,
-    revision: 0,
-    createdAt: now,
-    updatedAt: now,
-    phases: [
-      {
-        kind: "spec",
-        status: "complete",
-        base,
-        artifacts: [
-          {
-            kind: "spec",
-            path: base.artifactCandidates.spec[0],
-            commitOid: oid,
-            source: "remote-base",
-          },
-        ],
-        completion: { kind: "remote-base" },
-      },
-      {
-        kind: "plan",
-        status: "complete",
-        base,
-        artifacts: [
-          {
-            kind: "plan",
-            path: base.artifactCandidates.plan[0],
-            commitOid: oid,
-            source: "remote-base",
-          },
-        ],
-        completion: { kind: "remote-base" },
-      },
-      { kind: "implementation", status: "workspace-ready", base, workspace },
-    ],
-  };
-}
-test("creates and round-trips strict initial planning state", () => {
-  const state = createPlanningState({
-    issueNumber: 187,
-    issueTitle: "Example",
-    gates,
-    runId,
-    now,
-  });
-  assert.equal(state.revision, 0);
-  assert.equal(state.createdAt, now);
-  assert.equal(state.updatedAt, now);
-  assert.deepEqual(state.phases, [
-    { kind: "spec", status: "pending" },
-    { kind: "plan", status: "pending" },
-    { kind: "implementation", status: "pending" },
-  ]);
-  assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
+const now = "2026-09-08T12:00:00.000Z";
+const base = {
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid("a"),
+  artifactCandidates: {
+    spec: ["docs/specs/example-issue-188.md"],
+    plan: ["docs/plans/example-issue-188.md"],
+  },
+};
+const workspace = (cleanup: unknown = { state: "ready" }) => ({
+  runId,
+  phase: "spec",
+  identity: { branch: "planning/spec", worktreePath: ".worktrees/188-spec" },
+  remote: "origin",
+  baseBranch: "main",
+  baseOid: oid("a"),
+  headOid: oid("b"),
+  cleanup,
 });
-test("round-trips pull request and every cleanup discriminator", () => {
+const publication = {
+  targetRepository: {
+    provider: "github-gh",
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  },
+  headRepository: {
+    provider: "github-gh",
+    host: "github.com",
+    owner: "acme",
+    repository: "patchmill",
+  },
+  baseBranch: "main",
+  headBranch: "planning/spec",
+  headOid: oid("b"),
+};
+const artifact = (source: "remote-base" | "workspace", commitOid: string) => ({
+  kind: "spec",
+  path: "docs/specs/example-issue-188.md",
+  source,
+  commitOid,
+});
+const pullRequest = {
+  reference: { targetRepository: publication.targetRepository, number: 188 },
+  url: "https://github.com/acme/patchmill/pull/188",
+};
+function state(phase: object, revision = 0) {
+  return {
+    version: 1,
+    workflowVersion: "planning-pr-v1",
+    runId,
+    issueNumber: 188,
+    issueTitle: "Example",
+    gates: { specRequired: true, planRequired: false },
+    phases: [phase, { kind: "implementation", status: "pending" }],
+    revision,
+    createdAt: now,
+    updatedAt: revision === 0 ? now : "2026-09-08T12:00:01.000Z",
+  };
+}
+
+test("round trips every durable planning publication checkpoint", () => {
   const documents = [
-    completeState(),
-    mergedState({ state: "ready" }),
-    mergedState({ state: "worktree-removed", pushedHeadOid: oid }),
-    mergedState({ state: "removed", pushedHeadOid: oid }),
-  ];
-  const open = structuredClone(mergedState({ state: "ready" }));
-  recordAt(open, "phases", 0).status = "pull-request-open";
-  delete recordAt(open, "phases", 0).completion;
-  documents.push(open);
-  for (const document of documents) {
-    const state = validatePlanningState(document);
-    assert.deepEqual(parsePlanningState(serializePlanningState(state)), state);
-  }
-});
-
-test("rejects malformed scalars and nested state schemas with stable paths", () => {
-  const cases: ReadonlyArray<{
-    name: string;
-    reason: string;
-    path: string;
-    mutate: (document: Record<string, unknown>) => void;
-  }> = [
+    { kind: "spec", status: "pending" },
     {
-      name: "version",
-      reason: "unsupported-version",
-      path: "$.version",
-      mutate: (document) => {
-        document.version = 2;
-      },
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [],
     },
     {
-      name: "workflow version",
-      reason: "unsupported-workflow-version",
-      path: "$.workflowVersion",
-      mutate: (document) => {
-        document.workflowVersion = "planning-pr-v2";
-      },
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("remote-base", oid("a"))],
     },
     {
-      name: "run UUID",
-      reason: "invalid-uuid",
-      path: "$.runId",
-      mutate: (document) => {
-        document.runId = "not-a-uuid";
-      },
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
     },
     {
-      name: "issue number",
-      reason: "invalid-positive-integer",
-      path: "$.issueNumber",
-      mutate: (document) => {
-        document.issueNumber = 0;
-      },
+      kind: "spec",
+      status: "branch-pushed",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
     },
     {
-      name: "issue title",
-      reason: "invalid-string",
-      path: "$.issueTitle",
-      mutate: (document) => {
-        document.issueTitle = "bad\ntitle";
-      },
+      kind: "spec",
+      status: "pull-request-open",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+      pullRequest,
     },
     {
-      name: "revision",
-      reason: "invalid-nonnegative-integer",
-      path: "$.revision",
-      mutate: (document) => {
-        document.revision = -1;
-      },
-    },
-    {
-      name: "timestamp",
-      reason: "invalid-timestamp",
-      path: "$.createdAt",
-      mutate: (document) => {
-        document.createdAt = "2026-09-07";
-      },
-    },
-    {
-      name: "gates",
-      reason: "invalid-gates",
-      path: "$.gates",
-      mutate: (document) => {
-        recordAt(document, "gates").specRequired = "yes";
-      },
-    },
-    {
-      name: "status",
-      reason: "invalid-status",
-      path: "$.phases[0].status",
-      mutate: (document) => {
-        recordAt(document, "phases", 0).status = "unknown";
-      },
-    },
-    {
-      name: "completion",
-      reason: "invalid-completion",
-      path: "$.phases[0].completion.kind",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "completion").kind = "unknown";
-      },
-    },
-    {
-      name: "base OID",
-      reason: "invalid-oid",
-      path: "$.phases[0].base.baseOid",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "base").baseOid = "a".repeat(39);
-      },
-    },
-    {
-      name: "workspace branch",
-      reason: "invalid-branch",
-      path: "$.phases[0].workspace.identity.branch",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "workspace", "identity").branch =
-          "bad\u00a0branch";
-      },
-    },
-    {
-      name: "worktree path",
-      reason: "invalid-worktree-path",
-      path: "$.phases[0].workspace.identity.worktreePath",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "workspace", "identity").worktreePath =
-          "bad\0path";
-      },
-    },
-    {
-      name: "artifact path",
-      reason: "invalid-path",
-      path: "$.phases[0].artifacts[0].path",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "artifacts", 0).path = "../outside.md";
-      },
-    },
-    {
-      name: "pull request number",
-      reason: "invalid-positive-integer",
-      path: "$.phases[0].pullRequest.reference.number",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "pullRequest", "reference").number = 0;
-      },
-    },
-    {
-      name: "provider",
-      reason: "invalid-provider",
-      path: "$.phases[0].pullRequest.reference.targetRepository.provider",
-      mutate: (document) => {
-        recordAt(
-          document,
-          "phases",
-          0,
-          "pullRequest",
-          "reference",
-          "targetRepository",
-        ).provider = "unknown";
-      },
-    },
-    {
-      name: "cleanup unknown key",
-      reason: "unknown-key",
-      path: "$.phases[0].workspace.cleanup.extra",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "workspace", "cleanup").extra = true;
-      },
-    },
-    {
-      name: "candidate unknown key",
-      reason: "unknown-key",
-      path: "$.phases[0].base.artifactCandidates.extra",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "base", "artifactCandidates").extra =
-          [];
-      },
-    },
-    {
-      name: "repository unknown key",
-      reason: "unknown-key",
-      path: "$.phases[0].pullRequest.reference.targetRepository.extra",
-      mutate: (document) => {
-        recordAt(
-          document,
-          "phases",
-          0,
-          "pullRequest",
-          "reference",
-          "targetRepository",
-        ).extra = true;
-      },
-    },
-    {
-      name: "duplicate candidates",
-      reason: "duplicate-value",
-      path: "$.phases[0].base.artifactCandidates.spec",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "base", "artifactCandidates").spec = [
-          "docs/specs/a.md",
-          "docs/specs/a.md",
-        ];
-      },
-    },
-    {
-      name: "duplicate artifacts",
-      reason: "duplicate-artifact-kind",
-      path: "$.phases[0].artifacts",
-      mutate: (document) => {
-        recordAt(document, "phases", 0, "artifacts", 1).kind = "spec";
-      },
-    },
-    {
-      name: "missing top-level field",
-      reason: "missing-key",
-      path: "$.updatedAt",
-      mutate: (document) => {
-        delete document.updatedAt;
-      },
-    },
-    {
-      name: "missing gate",
-      reason: "missing-key",
-      path: "$.gates.planRequired",
-      mutate: (document) => {
-        delete recordAt(document, "gates").planRequired;
-      },
-    },
-    {
-      name: "missing candidate kind",
-      reason: "missing-key",
-      path: "$.phases[0].base.artifactCandidates.plan",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "base", "artifactCandidates")
-          .plan;
-      },
-    },
-    {
-      name: "missing workspace head",
-      reason: "missing-key",
-      path: "$.phases[0].workspace.headOid",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "workspace").headOid;
-      },
-    },
-    {
-      name: "missing identity branch",
-      reason: "missing-key",
-      path: "$.phases[0].workspace.identity.branch",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "workspace", "identity").branch;
-      },
-    },
-    {
-      name: "missing cleanup state",
-      reason: "missing-key",
-      path: "$.phases[0].workspace.cleanup.state",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "workspace", "cleanup").state;
-      },
-    },
-    {
-      name: "missing artifact source",
-      reason: "missing-key",
-      path: "$.phases[0].artifacts[0].source",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "artifacts", 0).source;
-      },
-    },
-    {
-      name: "missing pull request head",
-      reason: "missing-key",
-      path: "$.phases[0].pullRequest.headOid",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "pullRequest").headOid;
-      },
-    },
-    {
-      name: "missing repository owner",
-      reason: "missing-key",
-      path: "$.phases[0].pullRequest.reference.targetRepository.owner",
-      mutate: (document) => {
-        delete recordAt(
-          document,
-          "phases",
-          0,
-          "pullRequest",
-          "reference",
-          "targetRepository",
-        ).owner;
-      },
-    },
-    {
-      name: "missing merge OID",
-      reason: "missing-key",
-      path: "$.phases[0].completion.mergeOid",
-      mutate: (document) => {
-        delete recordAt(document, "phases", 0, "completion").mergeOid;
-      },
-    },
-    {
-      name: "forbidden pending evidence",
-      reason: "unknown-key",
-      path: "$.phases[0].base",
-      mutate: (document) => {
-        recordAt(document, "phases", 0).status = "pending";
-      },
-    },
-  ];
-  for (const item of cases) {
-    const document = structuredClone(mergedState({ state: "ready" })) as Record<
-      string,
-      unknown
-    >;
-    item.mutate(document);
-    assert.throws(
-      () => validatePlanningState(document),
-      (error: unknown) =>
-        error instanceof PlanningStateValidationError &&
-        error.reason === item.reason &&
-        error.path === item.path,
-      item.name,
-    );
-  }
-});
-
-test("forbids evidence outside each phase discriminator", () => {
-  const workspaceReady = structuredClone(completeState());
-  recordAt(workspaceReady, "phases", 2).artifacts = [];
-  const pullRequestOpen = structuredClone(mergedState({ state: "ready" }));
-  recordAt(pullRequestOpen, "phases", 0).status = "pull-request-open";
-  const remoteComplete = structuredClone(completeState());
-  recordAt(remoteComplete, "phases", 0).workspace = recordAt(
-    completeState(),
-    "phases",
-    2,
-    "workspace",
-  );
-  const mergedComplete = structuredClone(mergedState({ state: "ready" }));
-  recordAt(mergedComplete, "phases", 0).unexpected = true;
-  for (const [document, path] of [
-    [workspaceReady, "$.phases[2].artifacts"],
-    [pullRequestOpen, "$.phases[0].completion"],
-    [remoteComplete, "$.phases[0].workspace"],
-    [mergedComplete, "$.phases[0].unexpected"],
-  ] as const) {
-    assert.throws(
-      () => validatePlanningState(document),
-      (error: unknown) =>
-        error instanceof PlanningStateValidationError &&
-        error.reason === "unknown-key" &&
-        error.path === path,
-    );
-  }
-});
-
-test("rejects unknown and contradictory persisted state", () => {
-  const state = createPlanningState({
-    issueNumber: 187,
-    issueTitle: "Example",
-    gates,
-    runId,
-    now,
-  });
-  assert.throws(
-    () => validatePlanningState({ ...state, extra: true }),
-    (error: unknown) =>
-      error instanceof PlanningStateValidationError &&
-      error.reason === "unknown-key" &&
-      error.path === "$.extra",
-  );
-  assert.throws(
-    () =>
-      validatePlanningState({ ...state, phases: [...state.phases].reverse() }),
-    (error: unknown) =>
-      error instanceof PlanningStateValidationError &&
-      error.reason === "phase-sequence" &&
-      error.path === "$.phases",
-  );
-  assert.throws(
-    () => parsePlanningState("{"),
-    (error: unknown) =>
-      error instanceof PlanningStateValidationError &&
-      error.reason === "invalid-json",
-  );
-});
-test("accepts complete prefix then one active and rejects evidence contradictions", () => {
-  const state = completeState() as { phases: Array<Record<string, unknown>> };
-  assert.doesNotThrow(() => validatePlanningState(state));
-  const activeThenComplete = structuredClone(state);
-  activeThenComplete.phases[0] = {
-    kind: "spec",
-    status: "workspace-ready",
-    base: activeThenComplete.phases[0]!.base,
-    workspace: {
-      ...(activeThenComplete.phases[2]!.workspace as Record<string, unknown>),
-      phase: "spec",
-      identity: {
-        branch: "agent/issue-187-spec",
-        worktreePath: ".worktrees/issue-187-spec",
-      },
-    },
-  };
-  assert.throws(
-    () => validatePlanningState(activeThenComplete),
-    /progress-order/,
-  );
-  const wrongCandidate = structuredClone(state);
-  (
-    wrongCandidate.phases[0]!.artifacts as Array<Record<string, unknown>>
-  )[0]!.path = "docs/specs/other.md";
-  assert.throws(
-    () => validatePlanningState(wrongCandidate),
-    /remote-artifact-mismatch/,
-  );
-  const wrongCleanup = structuredClone(state);
-  (
-    (wrongCleanup.phases[2]!.workspace as Record<string, unknown>)
-      .cleanup as Record<string, unknown>
-  ).state = "worktree-removed";
-  (
-    (wrongCleanup.phases[2]!.workspace as Record<string, unknown>)
-      .cleanup as Record<string, unknown>
-  ).pushedHeadOid = "b".repeat(40);
-  assert.throws(
-    () => validatePlanningState(wrongCleanup),
-    /(?:cleanup-head-mismatch|invalid-cleanup-progress)/,
-  );
-});
-test("accepts both idempotent merged-workspace cleanup transitions", () => {
-  const ready = validatePlanningState(mergedState({ state: "ready" }));
-  const worktreeRemoved = validatePlanningState({
-    ...mergedState({ state: "worktree-removed", pushedHeadOid: oid }),
-    revision: 1,
-    updatedAt: "2026-09-07T12:00:01.000Z",
-  });
-  const removed = validatePlanningState({
-    ...mergedState({ state: "removed", pushedHeadOid: oid }),
-    revision: 2,
-    updatedAt: "2026-09-07T12:00:02.000Z",
-  });
-  assert.doesNotThrow(() =>
-    assertPlanningStateReplacement(ready, worktreeRemoved),
-  );
-  assert.doesNotThrow(() =>
-    assertPlanningStateReplacement(worktreeRemoved, removed),
-  );
-  assert.throws(
-    () =>
-      assertPlanningStateReplacement(ready, {
-        ...removed,
-        revision: 1,
-        updatedAt: "2026-09-07T12:00:01.000Z",
+      kind: "spec",
+      status: "pull-request-open",
+      base,
+      workspace: workspace({
+        state: "worktree-removed",
+        pushedHeadOid: oid("b"),
       }),
-    /(?:cleanup-transition|invalid-transition)/,
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+      pullRequest,
+    },
+    {
+      kind: "spec",
+      status: "pull-request-open",
+      base,
+      workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+      pullRequest,
+    },
+    {
+      kind: "spec",
+      status: "complete",
+      base,
+      workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+      artifacts: [artifact("remote-base", oid("c"))],
+      publication,
+      pullRequest,
+      completion: {
+        kind: "merged-pull-request",
+        mergeOid: oid("d"),
+        mergedBaseOid: oid("c"),
+      },
+    },
+  ];
+  for (const document of documents) {
+    const parsed = validatePlanningState(state(document));
+    assert.deepEqual(
+      parsePlanningState(serializePlanningState(parsed)),
+      parsed,
+    );
+  }
+  const direct = validatePlanningState(
+    state({
+      kind: "spec",
+      status: "complete",
+      base,
+      artifacts: [artifact("remote-base", oid("a"))],
+      completion: { kind: "remote-base" },
+    }),
   );
+  assert.equal(direct.phases[0]!.status, "complete");
 });
 
-test("forward transitions preserve carried workspace and pull request evidence", () => {
-  const initial = completeState() as {
-    phases: Array<Record<string, unknown>>;
-  };
-  const ready = validatePlanningState({
-    ...initial,
-    phases: [
-      initial.phases[0],
-      initial.phases[1],
-      {
-        ...initial.phases[2],
-        status: "workspace-ready",
+test("rejects incomplete publication, cleanup, URLs, and merge evidence", () => {
+  const cases: ReadonlyArray<
+    [string, (phase: Record<string, unknown>) => void]
+  > = [
+    [
+      "partial branch",
+      (phase) => {
+        phase.artifacts = [];
       },
     ],
-  });
-  const workspace = ready.phases[2]!;
-  assert.equal(workspace.status, "workspace-ready");
-  const open = validatePlanningState({
-    ...ready,
-    revision: 1,
-    updatedAt: "2026-09-07T12:00:01.000Z",
-    phases: [
-      ready.phases[0],
-      ready.phases[1],
-      {
-        ...workspace,
-        status: "pull-request-open",
-        artifacts: [],
-        pullRequest: pullRequest(workspace.workspace.identity.branch, oid),
+    [
+      "wrong publication head",
+      (phase) => {
+        (phase.publication as Record<string, unknown>).headOid = oid("e");
       },
     ],
-  });
-  assert.doesNotThrow(() => assertPlanningStateReplacement(ready, open));
-  const completed = validatePlanningState({
-    ...open,
-    revision: 2,
-    updatedAt: "2026-09-07T12:00:02.000Z",
-    phases: [
-      open.phases[0],
-      open.phases[1],
-      {
-        ...open.phases[2],
-        status: "complete",
-        completion: {
-          kind: "merged-pull-request",
-          mergeOid: "b".repeat(40),
-        },
+    [
+      "wrong reference target",
+      (phase) => {
+        (
+          (phase.pullRequest as Record<string, unknown>).reference as Record<
+            string,
+            unknown
+          >
+        ).targetRepository = {
+          ...publication.targetRepository,
+          repository: "other",
+        };
       },
     ],
-  });
-  assert.doesNotThrow(() => assertPlanningStateReplacement(open, completed));
-
-  const changedPullRequest = structuredClone(completed);
-  const phase = changedPullRequest.phases[2]!;
-  assert.ok("pullRequest" in phase);
-  phase.pullRequest.reference.number = 2;
-  assert.throws(
-    () => assertPlanningStateReplacement(open, changedPullRequest),
-    /immutable-evidence/,
-  );
-});
-
-test("rejects equivalent workspace paths across phases", () => {
-  const state = completeState() as {
-    phases: Array<Record<string, unknown>>;
-  };
-  const base = state.phases[0]!.base;
-  const merged = (
-    kind: "spec" | "plan",
-    branch: string,
-    worktreePath: string,
-  ) => ({
-    kind,
+    [
+      "unsafe URL",
+      (phase) => {
+        (phase.pullRequest as Record<string, unknown>).url =
+          "https://token@example.com/pull/188";
+      },
+    ],
+    [
+      "cleanup mismatch",
+      (phase) => {
+        (phase.workspace as Record<string, unknown>).cleanup = {
+          state: "removed",
+          pushedHeadOid: oid("e"),
+        };
+      },
+    ],
+  ];
+  for (const [, mutate] of cases) {
+    const phase: Record<string, unknown> = structuredClone({
+      kind: "spec",
+      status: "pull-request-open",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+      pullRequest,
+    });
+    mutate(phase);
+    assert.throws(
+      () => validatePlanningState(state(phase)),
+      PlanningStateValidationError,
+    );
+  }
+  const merged = {
+    kind: "spec",
     status: "complete",
     base,
-    workspace: {
-      runId,
-      phase: kind,
-      identity: { branch, worktreePath },
-      remote: "origin",
-      baseBranch: "main",
-      baseOid: oid,
-      headOid: oid,
-      cleanup: { state: "ready" },
-    },
-    artifacts: [
-      {
-        kind,
-        path: `docs/${kind}s/example-issue-187-${kind}.md`,
-        commitOid: oid,
-        source: "workspace",
-      },
-    ],
-    pullRequest: pullRequest(branch, oid),
-    completion: { kind: "merged-pull-request", mergeOid: "b".repeat(40) },
-  });
-  state.phases = [
-    merged("spec", "agent/spec", ".worktrees\\x\\..\\topic"),
-    merged("plan", "agent/plan", ".worktrees/topic"),
-    { kind: "implementation", status: "pending" },
-  ];
+    workspace: workspace({ state: "ready" }),
+    artifacts: [artifact("workspace", oid("b"))],
+    publication,
+    pullRequest,
+    completion: { kind: "merged-pull-request", mergeOid: oid("d") },
+  };
   assert.throws(
-    () => validatePlanningState(state),
-    /duplicate-workspace-identity/,
+    () => validatePlanningState(state(merged)),
+    PlanningStateValidationError,
   );
 });
 
-test("requires immutable identity and exactly one revision step", () => {
-  const state = createPlanningState({
-    issueNumber: 187,
+test("allows only one durable publication edge at a time", () => {
+  const ready = validatePlanningState(
+    state({
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [],
+    }),
+  );
+  const artifactReady = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "workspace-ready",
+        base,
+        workspace: workspace(),
+        artifacts: [artifact("workspace", oid("b"))],
+      },
+      1,
+    ),
+  );
+  assert.doesNotThrow(() =>
+    assertPlanningStateReplacement(ready, artifactReady),
+  );
+  const pushed = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "branch-pushed",
+        base,
+        workspace: workspace(),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+      },
+      2,
+    ),
+  );
+  assert.doesNotThrow(() =>
+    assertPlanningStateReplacement(artifactReady, pushed),
+  );
+  const open = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "pull-request-open",
+        base,
+        workspace: workspace(),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+        pullRequest,
+      },
+      3,
+    ),
+  );
+  assert.doesNotThrow(() => assertPlanningStateReplacement(pushed, open));
+  const removed = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "pull-request-open",
+        base,
+        workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+        pullRequest,
+      },
+      4,
+    ),
+  );
+  assert.throws(
+    () => assertPlanningStateReplacement(open, removed),
+    PlanningStateValidationError,
+  );
+});
+
+test("creates strict pending state", () => {
+  const created = createPlanningState({
+    issueNumber: 188,
     issueTitle: "Example",
-    gates,
+    gates: { specRequired: true, planRequired: false },
     runId,
     now,
   });
-  const next = { ...state, revision: 1, updatedAt: "2026-09-07T12:00:01.000Z" };
-  assert.doesNotThrow(() => assertPlanningStateReplacement(state, next));
-  assert.throws(
-    () =>
-      assertPlanningStateReplacement(state, {
-        ...next,
-        runId: "123e4567-e89b-42d3-a456-426614174001",
-      }),
-    /immutable/,
-  );
-  assert.throws(
-    () => assertPlanningStateReplacement(state, { ...next, revision: 2 }),
-    /revision/,
-  );
+  assert.deepEqual(created.phases, [
+    { kind: "spec", status: "pending" },
+    { kind: "implementation", status: "pending" },
+  ]);
 });

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -248,6 +248,38 @@ test("rejects incomplete publication, cleanup, URLs, and merge evidence", () => 
   );
 });
 
+test("allows pending phases to advance into workspace and remote-base completion", () => {
+  const pending = validatePlanningState(
+    state({ kind: "spec", status: "pending" }),
+  );
+  const ready = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "workspace-ready",
+        base,
+        workspace: workspace(),
+        artifacts: [],
+      },
+      1,
+    ),
+  );
+  const complete = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "complete",
+        base,
+        artifacts: [artifact("remote-base", oid("a"))],
+        completion: { kind: "remote-base" },
+      },
+      1,
+    ),
+  );
+  assert.doesNotThrow(() => assertPlanningStateReplacement(pending, ready));
+  assert.doesNotThrow(() => assertPlanningStateReplacement(pending, complete));
+});
+
 test("allows only one durable publication edge at a time", () => {
   const ready = validatePlanningState(
     state({
@@ -264,8 +296,8 @@ test("allows only one durable publication edge at a time", () => {
         kind: "spec",
         status: "workspace-ready",
         base,
-        workspace: workspace(),
-        artifacts: [artifact("workspace", oid("b"))],
+        workspace: { ...workspace(), headOid: oid("c") },
+        artifacts: [artifact("workspace", oid("c"))],
       },
       1,
     ),
@@ -279,9 +311,9 @@ test("allows only one durable publication edge at a time", () => {
         kind: "spec",
         status: "branch-pushed",
         base,
-        workspace: workspace(),
-        artifacts: [artifact("workspace", oid("b"))],
-        publication,
+        workspace: { ...workspace(), headOid: oid("c") },
+        artifacts: [artifact("workspace", oid("c"))],
+        publication: { ...publication, headOid: oid("c") },
       },
       2,
     ),
@@ -295,9 +327,9 @@ test("allows only one durable publication edge at a time", () => {
         kind: "spec",
         status: "pull-request-open",
         base,
-        workspace: workspace(),
-        artifacts: [artifact("workspace", oid("b"))],
-        publication,
+        workspace: { ...workspace(), headOid: oid("c") },
+        artifacts: [artifact("workspace", oid("c"))],
+        publication: { ...publication, headOid: oid("c") },
         pullRequest,
       },
       3,

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -550,3 +550,83 @@ test("freezes publication and pull request identity after branch publication", (
     );
   }
 });
+
+test("rejects unknown and missing fields for every durable phase discriminator", () => {
+  const variants: Array<Record<string, unknown>> = [
+    { kind: "spec", status: "pending" },
+    {
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [],
+    },
+    {
+      kind: "spec",
+      status: "branch-pushed",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+    },
+    {
+      kind: "spec",
+      status: "pull-request-open",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+      pullRequest,
+    },
+    {
+      kind: "spec",
+      status: "complete",
+      base,
+      artifacts: [artifact("remote-base", oid("a"))],
+      completion: { kind: "remote-base" },
+    },
+  ];
+  for (const variant of variants) {
+    const unknown = structuredClone(variant);
+    unknown.unexpected = true;
+    assert.throws(
+      () => validatePlanningState(state(unknown)),
+      PlanningStateValidationError,
+    );
+    const missing = structuredClone(variant);
+    delete missing.kind;
+    assert.throws(
+      () => validatePlanningState(state(missing)),
+      PlanningStateValidationError,
+    );
+  }
+});
+
+test("permits revision-stepped idempotence for pending and workspace-ready", () => {
+  const pending = validatePlanningState(
+    state({ kind: "spec", status: "pending" }),
+  );
+  const pendingRetry = {
+    ...pending,
+    revision: 1,
+    updatedAt: "2026-09-08T12:00:01.000Z",
+  };
+  assert.doesNotThrow(() =>
+    assertPlanningStateReplacement(pending, pendingRetry),
+  );
+  const ready = validatePlanningState(
+    state({
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [],
+    }),
+  );
+  const readyRetry = {
+    ...ready,
+    revision: 1,
+    updatedAt: "2026-09-08T12:00:01.000Z",
+  };
+  assert.doesNotThrow(() => assertPlanningStateReplacement(ready, readyRetry));
+});

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -497,7 +497,26 @@ test("permits every cleanup checkpoint and the all-at-once merged-base conversio
     [removed, merged],
   ] as const)
     assert.doesNotThrow(() => assertPlanningStateReplacement(left, right));
-  for (const document of [removed, merged]) {
+  const remoteBase = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "complete",
+        base,
+        artifacts: [artifact("remote-base", oid("a"))],
+        completion: { kind: "remote-base" },
+      },
+      6,
+    ),
+  );
+  for (const document of [
+    pushed,
+    open,
+    worktreeRemoved,
+    removed,
+    merged,
+    remoteBase,
+  ]) {
     const replacement = {
       ...document,
       revision: document.revision + 1,
@@ -584,6 +603,20 @@ test("rejects unknown and missing fields for every durable phase discriminator",
       base,
       artifacts: [artifact("remote-base", oid("a"))],
       completion: { kind: "remote-base" },
+    },
+    {
+      kind: "spec",
+      status: "complete",
+      base,
+      workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+      artifacts: [artifact("remote-base", oid("c"))],
+      publication,
+      pullRequest,
+      completion: {
+        kind: "merged-pull-request",
+        mergeOid: oid("d"),
+        mergedBaseOid: oid("c"),
+      },
     },
   ];
   for (const variant of variants) {

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -401,3 +401,152 @@ test("creates strict pending state", () => {
     { kind: "implementation", status: "pending" },
   ]);
 });
+
+test("permits every cleanup checkpoint and the all-at-once merged-base conversion", () => {
+  const ready = validatePlanningState(
+    state({
+      kind: "spec",
+      status: "workspace-ready",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+    }),
+  );
+  const pushed = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "branch-pushed",
+        base,
+        workspace: workspace(),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+      },
+      1,
+    ),
+  );
+  const open = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "pull-request-open",
+        base,
+        workspace: workspace(),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+        pullRequest,
+      },
+      2,
+    ),
+  );
+  const worktreeRemoved = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "pull-request-open",
+        base,
+        workspace: workspace({
+          state: "worktree-removed",
+          pushedHeadOid: oid("b"),
+        }),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+        pullRequest,
+      },
+      3,
+    ),
+  );
+  const removed = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "pull-request-open",
+        base,
+        workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+        artifacts: [artifact("workspace", oid("b"))],
+        publication,
+        pullRequest,
+      },
+      4,
+    ),
+  );
+  const merged = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "complete",
+        base,
+        workspace: workspace({ state: "removed", pushedHeadOid: oid("b") }),
+        artifacts: [artifact("remote-base", oid("c"))],
+        publication,
+        pullRequest,
+        completion: {
+          kind: "merged-pull-request",
+          mergeOid: oid("d"),
+          mergedBaseOid: oid("c"),
+        },
+      },
+      5,
+    ),
+  );
+  for (const [left, right] of [
+    [ready, pushed],
+    [pushed, open],
+    [open, worktreeRemoved],
+    [worktreeRemoved, removed],
+    [removed, merged],
+  ] as const)
+    assert.doesNotThrow(() => assertPlanningStateReplacement(left, right));
+  for (const document of [removed, merged]) {
+    const replacement = {
+      ...document,
+      revision: document.revision + 1,
+      updatedAt: "2026-09-08T12:00:02.000Z",
+    };
+    assert.doesNotThrow(() =>
+      assertPlanningStateReplacement(document, replacement),
+    );
+  }
+  for (const [left, right] of [
+    [open, removed],
+    [worktreeRemoved, open],
+    [pushed, removed],
+    [open, merged],
+  ] as const)
+    assert.throws(
+      () => assertPlanningStateReplacement(left, right),
+      PlanningStateValidationError,
+    );
+});
+
+test("freezes publication and pull request identity after branch publication", () => {
+  const pushed = validatePlanningState(
+    state({
+      kind: "spec",
+      status: "branch-pushed",
+      base,
+      workspace: workspace(),
+      artifacts: [artifact("workspace", oid("b"))],
+      publication,
+    }),
+  );
+  for (const mutate of [
+    (phase: Record<string, unknown>) =>
+      ((phase.publication as Record<string, unknown>).headOid = oid("c")),
+    (phase: Record<string, unknown>) =>
+      ((phase.publication as Record<string, unknown>).headBranch =
+        "planning/other"),
+    (phase: Record<string, unknown>) =>
+      ((phase.workspace as Record<string, unknown>).headOid = oid("c")),
+    (phase: Record<string, unknown>) =>
+      ((phase.artifacts as Array<Record<string, unknown>>)[0]!.commitOid =
+        oid("c")),
+  ]) {
+    const next = structuredClone(pushed.phases[0]!) as Record<string, unknown>;
+    mutate(next);
+    assert.throws(
+      () => assertPlanningStateReplacement(pushed.phases[0]!, next as never),
+      PlanningStateValidationError,
+    );
+  }
+});

--- a/src/workflow/planning-state.test.ts
+++ b/src/workflow/planning-state.test.ts
@@ -305,6 +305,38 @@ test("allows only one durable publication edge at a time", () => {
   assert.doesNotThrow(() =>
     assertPlanningStateReplacement(ready, artifactReady),
   );
+  const rewritten = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "workspace-ready",
+        base,
+        workspace: { ...workspace(), headOid: oid("d") },
+        artifacts: [],
+      },
+      1,
+    ),
+  );
+  assert.throws(
+    () => assertPlanningStateReplacement(ready, rewritten),
+    PlanningStateValidationError,
+  );
+  const rewrittenArtifact = validatePlanningState(
+    state(
+      {
+        kind: "spec",
+        status: "workspace-ready",
+        base,
+        workspace: { ...workspace(), headOid: oid("d") },
+        artifacts: [artifact("workspace", oid("d"))],
+      },
+      2,
+    ),
+  );
+  assert.throws(
+    () => assertPlanningStateReplacement(artifactReady, rewrittenArtifact),
+    PlanningStateValidationError,
+  );
   const pushed = validatePlanningState(
     state(
       {


### PR DESCRIPTION
## Summary

- Add strict durable planning publication state for partial artifacts, pushed heads, pull request identity, cleanup checkpoints, and verified merged-base completion.
- Add exact Git and pull request validation plus isolated artifact execution, recoverable publication, checkpointed cleanup, and reconciliation services.
- Add recording, failure-injection, and real-Git regression coverage for interruption recovery, typed host failures, destructive cleanup, and preservation of human-edited merged artifacts.

## Validation

- Focused issue and predecessor tests: 225 passed
- `npm run test:run-once`: 607 passed
- `npm test`: 1695 passed
- `npm run build`
- `npm run lint`
- `npm run check:types`
- `npm run check:architecture`
- `git diff --check`
- Dependency, legacy-wiring, side-effect, confidentiality, and module-boundary audits

## Reviews

- Final Codex full-worktree review: passed after accepted fixes and re-review
- Final thermo-nuclear full-worktree review: passed after accepted fixes and re-review
- Final validation-readiness review and exact-head host gate: passed

Human review is required because this is a large, cross-cutting state-machine and external-side-effect change with guarded destructive local cleanup. Direct landing is disabled for this repository.

Closes #188

<!-- patchmill-run-cost:start -->

## Patchmill run cost

| Stage | Model | Prompt tokens | Output tokens | Estimated cost (USD) |
| ----- | ----- | ------------: | ------------: | -------------------: |
| Planning | gpt-5.6-sol | 5,427,442 | 45,324 | $4.8688 |
| Development environment | gpt-5.6-sol | 741,051 | 3,480 | $0.8945 |
| Implementation | gpt-5.6-sol | 49,165,460 | 214,150 | $39.7290 |
| Implementation | gpt-5.6-terra | 50,371,306 | 135,532 | $14.5838 |
| **Implementation subtotal** |  | **99,536,766** | **349,682** | **$54.3128** |
| **Total** |  | **105,705,259** | **398,486** | **$60.0762** |

_Prompt tokens include uncached input, cache reads, and cache writes. Cost is an estimate based on Pi's recorded model pricing and includes parent and subagent sessions._

<!-- patchmill-run-cost:end -->