### PR TITLE
fix(site): update smol-toml to remediate GHSA-7w5x-hrqm-74c2

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6674,9 +6674,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"


### PR DESCRIPTION
## Summary

- Bumps `smol-toml` from 1.7.0 to 1.8.0 in `site/package-lock.json` via `npm audit fix`
- Remediates high-severity advisory [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2) (DoS via malformed TOML documents)
- Unblocks PR #220 (issue #189), which is failing the base-branch site dependency audit even though the site dependency files are unchanged by that PR

## Change

Lockfile-only change; `site/package.json` is untouched (`smol-toml` is a transitive dependency).

## Verification

- `npm --prefix site audit --audit-level=high` → 0 vulnerabilities
- `npm --prefix site run build` → 18 pages built successfully
- Nix build not rerun: the flake does not reference `site/`, so this lockfile is not part of the Nix-built package