### PR TITLE
feat(workflow): use conventional titles for planning pull requests

### DIFF
--- a/src/cli/commands/run-once/planning-phase-publisher.ts
+++ b/src/cli/commands/run-once/planning-phase-publisher.ts
@@ -136,6 +136,7 @@ export async function publishPlanningPhase(input: {
       summary = await input.host.createPullRequest({
         title: planningPullRequestTitle({
           issueNumber: state.issueNumber,
+          issueTitle: state.issueTitle,
           phase: phaseKind,
         }),
         body: planningPullRequestBody({

--- a/src/workflow/planning-pull-requests.test.ts
+++ b/src/workflow/planning-pull-requests.test.ts
@@ -303,20 +303,57 @@ test("marker parser rejects a malformed marker alongside a valid marker", () => 
 
 const closingKeyword = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/iu;
 
-test("planning title identifies the phase and issue without untrusted issue text", () => {
+test("planning title is conventional, sanitized, and non-closing", () => {
   const specTitle = planningPullRequestTitle({
     issueNumber: 184,
+    issueTitle: "bug: packhouse intake net weight stays stale",
     phase: "spec",
   });
   const planTitle = planningPullRequestTitle({
     issueNumber: 184,
+    issueTitle: "feature: customer and packaging master data",
     phase: "plan",
   });
 
-  assert.equal(specTitle, "Spec for #184");
-  assert.equal(planTitle, "Plan for #184");
+  assert.equal(
+    specTitle,
+    "docs(specs): packhouse intake net weight stays stale",
+  );
+  assert.equal(planTitle, "docs(plans): customer and packaging master data");
   assert.doesNotMatch(specTitle, closingKeyword);
   assert.doesNotMatch(planTitle, closingKeyword);
+});
+
+test("planning title neutralizes closing keywords and extra whitespace", () => {
+  const title = planningPullRequestTitle({
+    issueNumber: 184,
+    issueTitle: "backport\n fixes   #99\tregression",
+    phase: "spec",
+  });
+  assert.equal(title, "docs(specs): backport #99 regression");
+  assert.doesNotMatch(title, closingKeyword);
+});
+
+test("planning title truncates long summaries at a word boundary", () => {
+  const title = planningPullRequestTitle({
+    issueNumber: 184,
+    issueTitle:
+      "bug: packhouse intake net weight stays stale after removing pallet from crates",
+    phase: "spec",
+  });
+  assert.equal(title.length <= 72, true, title);
+  assert.match(title, /^docs\(specs\): .+…$/u);
+  assert.doesNotMatch(title, closingKeyword);
+});
+
+test("planning title falls back to the issue number for empty summaries", () => {
+  const title = planningPullRequestTitle({
+    issueNumber: 184,
+    issueTitle: "fix:",
+    phase: "plan",
+  });
+  assert.equal(title, "docs(plans): issue #184");
+  assert.doesNotMatch(title, closingKeyword);
 });
 
 test("planning body is non-closing and lists each artifact path once", () => {

--- a/src/workflow/planning-pull-requests.ts
+++ b/src/workflow/planning-pull-requests.ts
@@ -116,13 +116,46 @@ function assertPositiveIssueNumber(issueNumber: number): void {
   }
 }
 
+const CONVENTIONAL_TYPE_PREFIX = /^[A-Za-z]+(?:\([^)]*\))?!?:\s*/u;
+const CLOSING_KEYWORD_REFERENCE =
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?=#\d+)/giu;
+/** Keeps the longest scope prefix ("docs(specs): ") within 72 characters. */
+const TITLE_SUMMARY_MAX_LENGTH = 59;
+
+function planningTitleSummary(input: {
+  issueNumber: number;
+  issueTitle: string;
+}): string {
+  const withoutPrefix = input.issueTitle
+    .replace(/\s+/gu, " ")
+    .trim()
+    .replace(CONVENTIONAL_TYPE_PREFIX, "");
+  const withoutClosing = withoutPrefix
+    .replace(CLOSING_KEYWORD_REFERENCE, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (!withoutClosing) return `issue #${input.issueNumber}`;
+  if (withoutClosing.length <= TITLE_SUMMARY_MAX_LENGTH) return withoutClosing;
+  const words = withoutClosing.split(" ");
+  let summary = "";
+  for (const word of words) {
+    const candidate = summary === "" ? word : `${summary} ${word}`;
+    if (candidate.length > TITLE_SUMMARY_MAX_LENGTH - 1) break;
+    summary = candidate;
+  }
+  if (summary === "")
+    summary = withoutClosing.slice(0, TITLE_SUMMARY_MAX_LENGTH - 1);
+  return `${summary}…`;
+}
+
 export function planningPullRequestTitle(input: {
   issueNumber: number;
+  issueTitle: string;
   phase: PlanningArtifactKind;
 }): string {
   assertPositiveIssueNumber(input.issueNumber);
-  const label = input.phase === "spec" ? "Spec" : "Plan";
-  return `${label} for #${input.issueNumber}`;
+  const scope = input.phase === "spec" ? "specs" : "plans";
+  return `docs(${scope}): ${planningTitleSummary(input)}`;
 }
 
 function markdownCodeSpan(value: string): string {


### PR DESCRIPTION
## Summary

Planning pull requests for spec and plan phases were titled `Spec for #N` / `Plan for #N`. They now use conventional-commit style titles with a sanitized issue-title summary, e.g.:

`docs(specs): packhouse intake net weight stays stale`

## Details

- Scope per phase: `docs(specs)` for spec, `docs(plans)` for plan.
- Summary derives from the issue title: strips a leading conventional type prefix (`bug:`, `feat(api):`, …), neutralizes closing-keyword issue references (`fixes #99` → `#99`), collapses all whitespace to a single line, and truncates at a word boundary so titles stay within 72 characters (with `…`).
- Falls back to `issue #N` when nothing usable remains after sanitizing.
- The issue reference stays in the PR body (`Refs #N`) and the hidden planning marker comment, which remain the machine-readable identity — nothing resolves PRs by title, so this is a cosmetic change only.

## Verification

- 854 tests pass across `src/workflow` and `src/cli/commands/run-once`
- `check:types`, eslint, prettier clean
- Title contract covered by updated tests in `src/workflow/planning-pull-requests.test.ts`